### PR TITLE
chore(test): clean up tests for OTLP components in `saluki-components`

### DIFF
--- a/lib/saluki-components/src/common/otlp/traces/transform.rs
+++ b/lib/saluki-components/src/common/otlp/traces/transform.rs
@@ -2410,4 +2410,473 @@ mod tests {
             assert_eq!(meta("otel.scope.version"), None);
         }
     }
+
+    // ===============================================================================================
+    // Branching translation logic: the V2 service/operation-name/resource/span-type resolvers, the
+    // status-to-error mapping, and the full `otel_span_to_dd_span` assembly entry point.
+    //
+    // Ported from the Go trace agent's `GetOTelService`/`GetOTelOperationNameV2`/`GetOTelResourceV2`/
+    // `GetOTelSpanType`/`status2Error` in:
+    // https://github.com/DataDog/datadog-agent/blob/instrument-otlp-traffic/pkg/trace/traceutil/otel_util.go
+    // https://github.com/DataDog/datadog-agent/blob/instrument-otlp-traffic/pkg/trace/transform/transform.go
+    // ===============================================================================================
+
+    fn extraction_env() -> (GenericMapInterner, StringBuilder<GenericMapInterner>) {
+        let interner = test_interner();
+        let string_builder = StringBuilder::new().with_interner(interner.clone());
+        (interner, string_builder)
+    }
+
+    fn service_for(span_attrs: &[KeyValue], resource_attrs: &[KeyValue]) -> String {
+        let (interner, mut sb) = extraction_env();
+        get_otel_service(span_attrs, resource_attrs, true, &interner, &mut sb)
+            .as_ref()
+            .to_string()
+    }
+
+    fn operation_name_for(kind: SpanKind, span_attrs: &[KeyValue]) -> String {
+        let (interner, mut sb) = extraction_env();
+        let span = OtlpSpan {
+            kind: kind as i32,
+            ..Default::default()
+        };
+        get_otel_operation_name_v2(&span, span_attrs, &[], &interner, &mut sb)
+            .as_ref()
+            .to_string()
+    }
+
+    fn resource_name_for(kind: SpanKind, span_name: &str, span_attrs: &[KeyValue]) -> String {
+        let (interner, mut sb) = extraction_env();
+        let span = OtlpSpan {
+            name: span_name.to_string(),
+            kind: kind as i32,
+            ..Default::default()
+        };
+        get_otel_resource_v2(&span, span_attrs, &[], &interner, &mut sb)
+            .as_ref()
+            .to_string()
+    }
+
+    fn span_type_for(kind: SpanKind, span_attrs: &[KeyValue]) -> String {
+        let (interner, mut sb) = extraction_env();
+        let span = OtlpSpan {
+            kind: kind as i32,
+            ..Default::default()
+        };
+        get_otel_span_type(&span, span_attrs, &[], &interner, &mut sb)
+            .as_ref()
+            .to_string()
+    }
+
+    #[test]
+    fn get_otel_service_resolves_by_precedence_with_default_and_normalization() {
+        // No service anywhere falls back to the documented default.
+        assert_eq!(service_for(&[], &[]), "otlpresourcenoservicename");
+        // Span attributes win over resource attributes.
+        assert_eq!(service_for(&[kv_str(SERVICE_NAME, "span-svc")], &[]), "span-svc");
+        assert_eq!(service_for(&[], &[kv_str(SERVICE_NAME, "res-svc")]), "res-svc");
+        assert_eq!(
+            service_for(&[kv_str(SERVICE_NAME, "span-svc")], &[kv_str(SERVICE_NAME, "res-svc")]),
+            "span-svc"
+        );
+        // The resolved service is normalized (lowercased, illegal-character runs collapsed to `_`).
+        assert_eq!(service_for(&[kv_str(SERVICE_NAME, "My Service!")], &[]), "my_service");
+    }
+
+    #[test]
+    fn get_otel_operation_name_v2_covers_semantic_convention_branches() {
+        struct Case {
+            name: &'static str,
+            kind: SpanKind,
+            attrs: Vec<KeyValue>,
+            expected: &'static str,
+        }
+
+        let cases = vec![
+            Case {
+                name: "operation.name override",
+                kind: SpanKind::Internal,
+                attrs: vec![kv_str("operation.name", "custom.op")],
+                expected: "custom.op",
+            },
+            Case {
+                name: "http server",
+                kind: SpanKind::Server,
+                attrs: vec![kv_str("http.request.method", "GET")],
+                expected: "http.server.request",
+            },
+            Case {
+                name: "http client",
+                kind: SpanKind::Client,
+                attrs: vec![kv_str("http.request.method", "GET")],
+                expected: "http.client.request",
+            },
+            Case {
+                name: "database client",
+                kind: SpanKind::Client,
+                attrs: vec![kv_str("db.system", "postgresql")],
+                expected: "postgresql.query",
+            },
+            Case {
+                name: "messaging producer",
+                kind: SpanKind::Producer,
+                attrs: vec![
+                    kv_str("messaging.system", "kafka"),
+                    kv_str("messaging.operation", "publish"),
+                ],
+                expected: "kafka.publish",
+            },
+            Case {
+                name: "rpc client",
+                kind: SpanKind::Client,
+                attrs: vec![kv_str("rpc.system", "grpc")],
+                expected: "grpc.client.request",
+            },
+            Case {
+                name: "rpc server",
+                kind: SpanKind::Server,
+                attrs: vec![kv_str("rpc.system", "grpc")],
+                expected: "grpc.server.request",
+            },
+            Case {
+                name: "aws rpc client with service",
+                kind: SpanKind::Client,
+                // The RPC service is tag-normalized (lowercased) into the operation name.
+                attrs: vec![kv_str("rpc.system", "aws-api"), kv_str("rpc.service", "S3")],
+                expected: "aws.s3.request",
+            },
+            Case {
+                name: "aws rpc client without service",
+                kind: SpanKind::Client,
+                attrs: vec![kv_str("rpc.system", "aws-api")],
+                expected: "aws.client.request",
+            },
+            Case {
+                name: "faas client",
+                kind: SpanKind::Client,
+                attrs: vec![
+                    kv_str("faas.invoked_provider", "aws"),
+                    kv_str("faas.invoked_name", "lambda"),
+                ],
+                expected: "aws.lambda.invoke",
+            },
+            Case {
+                name: "faas server",
+                kind: SpanKind::Server,
+                attrs: vec![kv_str("faas.trigger", "http")],
+                expected: "http.invoke",
+            },
+            Case {
+                name: "graphql",
+                kind: SpanKind::Server,
+                attrs: vec![kv_str("graphql.operation.type", "query")],
+                expected: "graphql.server.request",
+            },
+            Case {
+                name: "network protocol server",
+                kind: SpanKind::Server,
+                attrs: vec![kv_str("network.protocol.name", "amqp")],
+                expected: "amqp.server.request",
+            },
+            Case {
+                name: "plain server",
+                kind: SpanKind::Server,
+                attrs: vec![],
+                expected: "server.request",
+            },
+            Case {
+                name: "plain client",
+                kind: SpanKind::Client,
+                attrs: vec![],
+                expected: "client.request",
+            },
+            Case {
+                name: "internal fallback uses capitalized span kind",
+                kind: SpanKind::Internal,
+                attrs: vec![],
+                expected: "Internal",
+            },
+        ];
+
+        for case in cases {
+            assert_eq!(
+                operation_name_for(case.kind, &case.attrs),
+                case.expected,
+                "case: {}",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn get_otel_resource_v2_covers_semantic_convention_branches() {
+        struct Case {
+            name: &'static str,
+            kind: SpanKind,
+            span_name: &'static str,
+            attrs: Vec<KeyValue>,
+            expected: &'static str,
+        }
+
+        let cases = vec![
+            Case {
+                name: "resource.name override",
+                kind: SpanKind::Server,
+                span_name: "span-name",
+                attrs: vec![kv_str("resource.name", "GET /custom")],
+                expected: "GET /custom",
+            },
+            Case {
+                name: "http server with route",
+                kind: SpanKind::Server,
+                span_name: "span-name",
+                attrs: vec![kv_str("http.request.method", "GET"), kv_str("http.route", "/users/:id")],
+                expected: "GET /users/:id",
+            },
+            Case {
+                name: "http client without route",
+                kind: SpanKind::Client,
+                span_name: "span-name",
+                attrs: vec![kv_str("http.request.method", "POST")],
+                expected: "POST",
+            },
+            Case {
+                name: "http _OTHER method",
+                kind: SpanKind::Server,
+                span_name: "span-name",
+                attrs: vec![kv_str("http.request.method", "_OTHER")],
+                expected: "HTTP",
+            },
+            Case {
+                name: "messaging operation with destination",
+                kind: SpanKind::Producer,
+                span_name: "span-name",
+                attrs: vec![
+                    kv_str("messaging.operation", "publish"),
+                    kv_str("messaging.destination", "topic"),
+                ],
+                expected: "publish topic",
+            },
+            Case {
+                name: "rpc method with service",
+                kind: SpanKind::Client,
+                span_name: "span-name",
+                attrs: vec![kv_str("rpc.method", "GetObject"), kv_str("rpc.service", "S3")],
+                expected: "GetObject S3",
+            },
+            Case {
+                name: "database statement is normalized",
+                kind: SpanKind::Client,
+                span_name: "span-name",
+                attrs: vec![kv_str("db.system", "postgresql"), kv_str("db.statement", "SELECT 1")],
+                expected: "select_1",
+            },
+            Case {
+                name: "falls back to span name",
+                kind: SpanKind::Internal,
+                span_name: "my-span",
+                attrs: vec![],
+                expected: "my-span",
+            },
+        ];
+
+        for case in cases {
+            assert_eq!(
+                resource_name_for(case.kind, case.span_name, &case.attrs),
+                case.expected,
+                "case: {}",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn get_otel_span_type_covers_kind_and_db_system_branches() {
+        struct Case {
+            name: &'static str,
+            kind: SpanKind,
+            attrs: Vec<KeyValue>,
+            expected: &'static str,
+        }
+
+        let cases = vec![
+            Case {
+                name: "span.type override",
+                kind: SpanKind::Client,
+                attrs: vec![kv_str("span.type", "myspantype")],
+                expected: "myspantype",
+            },
+            Case {
+                name: "server is web",
+                kind: SpanKind::Server,
+                attrs: vec![],
+                expected: "web",
+            },
+            Case {
+                name: "client without db is http",
+                kind: SpanKind::Client,
+                attrs: vec![],
+                expected: "http",
+            },
+            Case {
+                name: "client redis",
+                kind: SpanKind::Client,
+                attrs: vec![kv_str("db.system", "redis")],
+                expected: "redis",
+            },
+            Case {
+                name: "client sql-family db",
+                kind: SpanKind::Client,
+                attrs: vec![kv_str("db.system", "postgresql")],
+                expected: "sql",
+            },
+            Case {
+                name: "client unknown db defaults to db",
+                kind: SpanKind::Client,
+                attrs: vec![kv_str("db.system", "some-unknown-store")],
+                expected: "db",
+            },
+            Case {
+                name: "internal is custom",
+                kind: SpanKind::Internal,
+                attrs: vec![],
+                expected: "custom",
+            },
+        ];
+
+        for case in cases {
+            assert_eq!(
+                span_type_for(case.kind, &case.attrs),
+                case.expected,
+                "case: {}",
+                case.name
+            );
+        }
+    }
+
+    fn error_from_status(
+        code: StatusCode, message: &str, events: &[OtlpSpanEvent],
+    ) -> (i32, FastHashMap<MetaString, AttributeValue>) {
+        let status = OtlpStatus {
+            code: code as i32,
+            message: message.to_string(),
+        };
+        let mut attrs = FastHashMap::default();
+        let error = status_to_error(Some(&status), events, &mut attrs);
+        (error, attrs)
+    }
+
+    fn error_attr<'a>(attrs: &'a FastHashMap<MetaString, AttributeValue>, key: &str) -> Option<&'a str> {
+        attrs.get(key).and_then(AttributeValue::as_string).map(|s| s.as_ref())
+    }
+
+    #[test]
+    fn status_to_error_ignores_non_error_status() {
+        let (error, attrs) = error_from_status(StatusCode::Unset, "", &[]);
+        assert_eq!(error, 0);
+        assert!(attrs.is_empty());
+    }
+
+    #[test]
+    fn status_to_error_extracts_exception_event_fields() {
+        let exception = OtlpSpanEvent {
+            name: "exception".to_string(),
+            attributes: vec![
+                kv_str("exception.message", "boom"),
+                kv_str("exception.type", "RuntimeError"),
+                kv_str("exception.stacktrace", "at main()"),
+            ],
+            ..Default::default()
+        };
+
+        let (error, attrs) = error_from_status(StatusCode::Error, "", std::slice::from_ref(&exception));
+        assert_eq!(error, 1);
+        assert_eq!(error_attr(&attrs, "error.msg"), Some("boom"));
+        assert_eq!(error_attr(&attrs, "error.type"), Some("RuntimeError"));
+        assert_eq!(error_attr(&attrs, "error.stack"), Some("at main()"));
+    }
+
+    #[test]
+    fn status_to_error_falls_back_to_status_message() {
+        // No exception event, so the status message becomes error.msg.
+        let (error, attrs) = error_from_status(StatusCode::Error, "db failed", &[]);
+        assert_eq!(error, 1);
+        assert_eq!(error_attr(&attrs, "error.msg"), Some("db failed"));
+    }
+
+    #[test]
+    fn status_to_error_sets_error_without_message_when_none_available() {
+        let (error, attrs) = error_from_status(StatusCode::Error, "", &[]);
+        assert_eq!(error, 1);
+        assert_eq!(error_attr(&attrs, "error.msg"), None);
+    }
+
+    fn build_dd_span(
+        kind: SpanKind, span_attrs: Vec<KeyValue>, status: Option<OtlpStatus>, events: Vec<OtlpSpanEvent>,
+    ) -> DdSpan {
+        let (interner, mut sb) = extraction_env();
+        let span = OtlpSpan {
+            name: "span-name".to_string(),
+            kind: kind as i32,
+            attributes: span_attrs,
+            status,
+            events,
+            ..Default::default()
+        };
+        let resource = Resource::default();
+        otel_span_to_dd_span(&span, &resource, None, false, true, &interner, &mut sb, None)
+    }
+
+    #[test]
+    fn otel_span_to_dd_span_assembles_http_server_span() {
+        let dd_span = build_dd_span(
+            SpanKind::Server,
+            vec![
+                kv_str(SERVICE_NAME, "checkout"),
+                kv_str("http.request.method", "GET"),
+                kv_str("http.route", "/pay"),
+            ],
+            None,
+            vec![],
+        );
+
+        assert_eq!(dd_span.service(), "checkout");
+        assert_eq!(dd_span.name(), "http.server.request");
+        assert_eq!(dd_span.resource(), "GET /pay");
+        assert_eq!(dd_span.span_type(), "web");
+        assert_eq!(dd_span.error(), 0);
+    }
+
+    #[test]
+    fn otel_span_to_dd_span_assembles_db_client_error_span() {
+        let exception = OtlpSpanEvent {
+            name: "exception".to_string(),
+            attributes: vec![kv_str("exception.message", "deadlock")],
+            ..Default::default()
+        };
+        let dd_span = build_dd_span(
+            SpanKind::Client,
+            vec![kv_str("db.system", "postgresql"), kv_str("db.statement", "SELECT 1")],
+            Some(OtlpStatus {
+                code: StatusCode::Error as i32,
+                message: String::new(),
+            }),
+            vec![exception],
+        );
+
+        // No service attribute => documented default service name.
+        assert_eq!(dd_span.service(), "otlpresourcenoservicename");
+        assert_eq!(dd_span.name(), "postgresql.query");
+        assert_eq!(dd_span.resource(), "select_1");
+        assert_eq!(dd_span.span_type(), "sql");
+        assert_eq!(dd_span.error(), 1);
+        assert_eq!(
+            dd_span
+                .attributes
+                .get("error.msg")
+                .and_then(AttributeValue::as_string)
+                .map(|s| s.as_ref()),
+            Some("deadlock")
+        );
+    }
 }

--- a/lib/saluki-components/src/common/otlp/traces/translator.rs
+++ b/lib/saluki-components/src/common/otlp/traces/translator.rs
@@ -295,3 +295,158 @@ fn trace_id_hex_meta(trace_id: &[u8]) -> Option<MetaString> {
 
     Some(MetaString::from(Arc::<str>::from(hex)))
 }
+
+#[cfg(test)]
+mod tests {
+    use otlp_protos::opentelemetry::proto::common::v1::any_value::Value;
+    use otlp_protos::opentelemetry::proto::common::v1::{AnyValue, KeyValue};
+    use otlp_protos::opentelemetry::proto::resource::v1::Resource;
+    use otlp_protos::opentelemetry::proto::trace::v1::{ResourceSpans, ScopeSpans, Span as OtlpSpan};
+
+    use super::*;
+    use crate::common::otlp::config::TracesConfig;
+    use crate::common::otlp::Metrics;
+
+    fn string_kv(key: &str, value: &str) -> KeyValue {
+        KeyValue {
+            key: key.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::StringValue(value.to_string())),
+            }),
+        }
+    }
+
+    fn int_kv(key: &str, value: i64) -> KeyValue {
+        KeyValue {
+            key: key.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::IntValue(value)),
+            }),
+        }
+    }
+
+    fn span(trace_id: [u8; 16], span_id: [u8; 8], attributes: Vec<KeyValue>) -> OtlpSpan {
+        OtlpSpan {
+            trace_id: trace_id.to_vec(),
+            span_id: span_id.to_vec(),
+            name: "span".to_string(),
+            end_time_unix_nano: 2,
+            attributes,
+            ..Default::default()
+        }
+    }
+
+    fn build_resource_spans(resource_attrs: Vec<KeyValue>, spans: Vec<OtlpSpan>) -> ResourceSpans {
+        ResourceSpans {
+            resource: Some(Resource {
+                attributes: resource_attrs,
+                ..Default::default()
+            }),
+            scope_spans: vec![ScopeSpans {
+                spans,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn translate(resource_spans: ResourceSpans) -> Vec<Trace> {
+        let mut translator = OtlpTracesTranslator::new(TracesConfig::default(), NonZeroUsize::new(64 * 1024).unwrap());
+        let metrics = Metrics::for_tests();
+        translator
+            .translate_spans(resource_spans, &metrics)
+            .filter_map(Event::try_into_trace)
+            .collect()
+    }
+
+    #[test]
+    fn translate_spans_resolves_hostname_from_datadog_host_name() {
+        let rs = build_resource_spans(
+            vec![string_kv("datadog.host.name", "my-host")],
+            vec![span([1u8; 16], [1u8; 8], vec![])],
+        );
+
+        let traces = translate(rs);
+        assert_eq!(traces.len(), 1);
+        assert_eq!(traces[0].payload.hostname.as_ref(), "my-host");
+    }
+
+    #[test]
+    fn translate_spans_leaves_hostname_empty_without_datadog_host_name() {
+        // Only `datadog.host.name` is honored here (the single documented fallback); absent it, the
+        // hostname is left empty rather than guessed from other attributes.
+        let rs = build_resource_spans(
+            vec![string_kv("host.name", "ignored")],
+            vec![span([1u8; 16], [1u8; 8], vec![])],
+        );
+
+        let traces = translate(rs);
+        assert_eq!(traces.len(), 1);
+        assert!(traces[0].payload.hostname.as_ref().is_empty());
+    }
+
+    #[test]
+    fn translate_spans_groups_spans_by_trace_id() {
+        let trace_a = [0xAAu8; 16];
+        let trace_b = [0xBBu8; 16];
+        let rs = build_resource_spans(
+            vec![],
+            vec![
+                span(trace_a, [1u8; 8], vec![]),
+                span(trace_a, [2u8; 8], vec![]),
+                span(trace_b, [3u8; 8], vec![]),
+            ],
+        );
+
+        let mut traces = translate(rs);
+        assert_eq!(traces.len(), 2, "expected one trace per distinct trace ID");
+
+        traces.sort_by_key(|t| t.spans().len());
+        assert_eq!(traces[0].spans().len(), 1);
+
+        let grouped = &traces[1];
+        assert_eq!(grouped.spans().len(), 2, "spans sharing a trace ID group together");
+        // Trace ID low/high bytes are captured from the 16-byte OTLP trace ID.
+        assert_eq!(grouped.trace_id_low, u64::from_be_bytes([0xAA; 8]));
+        assert_eq!(grouped.trace_id_high, u64::from_be_bytes([0xAA; 8]));
+    }
+
+    #[test]
+    fn translate_spans_tracks_last_seen_sampling_priority() {
+        let trace = [0xCCu8; 16];
+        let rs = build_resource_spans(
+            vec![],
+            vec![
+                span(trace, [1u8; 8], vec![int_kv("sampling.priority", 1)]),
+                span(trace, [2u8; 8], vec![int_kv("sampling.priority", 2)]),
+            ],
+        );
+
+        let traces = translate(rs);
+        assert_eq!(traces.len(), 1);
+        assert_eq!(traces[0].priority, Some(2), "the last span's sampling priority wins");
+    }
+
+    #[test]
+    fn translate_spans_populates_resource_metadata() {
+        let rs = build_resource_spans(
+            vec![
+                string_kv("deployment.environment", "prod"),
+                string_kv("service.version", "1.2.3"),
+                string_kv("container.id", "abc123"),
+                string_kv("telemetry.sdk.language", "go"),
+                string_kv("telemetry.sdk.version", "1.0"),
+            ],
+            vec![span([1u8; 16], [1u8; 8], vec![])],
+        );
+
+        let traces = translate(rs);
+        assert_eq!(traces.len(), 1);
+        let payload = &traces[0].payload;
+        assert_eq!(payload.env.as_ref(), "prod");
+        assert_eq!(payload.app_version.as_ref(), "1.2.3");
+        assert_eq!(payload.container_id.as_ref(), "abc123");
+        assert_eq!(payload.language_name.as_ref(), "go");
+        assert_eq!(payload.tracer_version.as_ref(), "1.0");
+    }
+}

--- a/lib/saluki-components/src/sources/otlp/metrics/cache.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/cache.rs
@@ -206,9 +206,9 @@ fn is_not_first_point(start_ts: u64, ts: u64, old_start_ts: u64) -> bool {
 
 #[cfg(test)]
 mod tests {
-    // TODO: Port `TestPutAndGetExtrema` from the Go `ttlcache_test.go` to test the logic
-    // for `put_and_check_min` and `put_and_check_max` when histogram support is added.
-
+    // These tests port the `monotonic`/extrema behavior verified by the Go opentelemetry-mapping-go
+    // point cache (`TestMonotonicDiff`, `TestDiff`, `TestPutAndGetExtrema` in `ttlcache_test.go`):
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/internal/utils/ttlcache_test.go
     use super::*;
     use crate::sources::otlp::metrics::dimensions::Dimensions;
 
@@ -221,9 +221,33 @@ mod tests {
         message: &'static str,
     }
 
-    #[test]
-    fn test_monotonic_diff_unknown_start() {
-        let points = vec![
+    fn test_dims() -> Dimensions {
+        Dimensions {
+            name: "test".to_string(),
+            tags: Default::default(),
+            host: None,
+            origin_id: None,
+        }
+    }
+
+    /// Feeds each point through `monotonic_diff`, asserting the documented first-point/drop-point
+    /// flags per point, and returns the diff of the last non-dropped point.
+    #[track_caller]
+    fn run_monotonic_diff(cache: &mut PointsCache, dims: &Dimensions, points: &[Point]) -> f64 {
+        let mut dx = 0.0;
+        for point in points {
+            let (result_dx, first_point, drop_point) = cache.monotonic_diff(dims, point.start_ts, point.ts, point.val);
+            assert_eq!(point.expect_first_point, first_point, "{}", point.message);
+            assert_eq!(point.expect_drop_point, drop_point, "{}", point.message);
+            if !drop_point {
+                dx = result_dx;
+            }
+        }
+        dx
+    }
+
+    fn unknown_start_points() -> Vec<Point> {
+        vec![
             Point {
                 start_ts: 0,
                 ts: 1,
@@ -264,32 +288,11 @@ mod tests {
                 expect_drop_point: false,
                 message: "valid point",
             },
-        ];
-
-        let mut prev_pts = PointsCache::for_tests();
-        let dims = Dimensions {
-            name: "test".to_string(),
-            tags: Default::default(),
-            host: None,
-            origin_id: None,
-        };
-        let mut dx = 0.0;
-
-        for point in points {
-            let (result_dx, first_point, drop_point) =
-                prev_pts.monotonic_diff(&dims, point.start_ts, point.ts, point.val);
-            assert_eq!(point.expect_first_point, first_point, "{}", point.message);
-            assert_eq!(point.expect_drop_point, drop_point, "{}", point.message);
-            if !drop_point {
-                dx = result_dx;
-            }
-        }
-        assert_eq!(4.0, dx, "expected diff 4.0");
+        ]
     }
 
-    #[test]
-    fn test_monotonic_diff_known_start() {
-        let initial_points = vec![
+    fn known_start_initial_points() -> Vec<Point> {
+        vec![
             Point {
                 start_ts: 1,
                 ts: 1,
@@ -330,9 +333,11 @@ mod tests {
                 expect_drop_point: false,
                 message: "valid point",
             },
-        ];
+        ]
+    }
 
-        let points_after_reset = vec![
+    fn known_start_reset_points() -> Vec<Point> {
+        vec![
             Point {
                 start_ts: 4,
                 ts: 4,
@@ -349,9 +354,11 @@ mod tests {
                 expect_drop_point: false,
                 message: "same startTs, old >= new",
             },
-        ];
+        ]
+    }
 
-        let points_after_second_reset = vec![
+    fn known_start_second_reset_points() -> Vec<Point> {
+        vec![
             Point {
                 start_ts: 8,
                 ts: 9,
@@ -368,63 +375,48 @@ mod tests {
                 expect_drop_point: false,
                 message: "same startTs, old >= new",
             },
-        ];
-
-        let mut prev_pts = PointsCache::for_tests();
-        let dims = Dimensions {
-            name: "test".to_string(),
-            tags: Default::default(),
-            host: None,
-            origin_id: None,
-        };
-        let mut dx = 0.0;
-
-        for point in initial_points {
-            let (result_dx, first_point, drop_point) =
-                prev_pts.monotonic_diff(&dims, point.start_ts, point.ts, point.val);
-            assert_eq!(point.expect_first_point, first_point, "{}", point.message);
-            assert_eq!(point.expect_drop_point, drop_point, "{}", point.message);
-            if !drop_point {
-                dx = result_dx;
-            }
-        }
-        assert_eq!(4.0, dx, "expected diff 4.0");
-
-        // reset
-        for point in points_after_reset {
-            let (result_dx, first_point, drop_point) =
-                prev_pts.monotonic_diff(&dims, point.start_ts, point.ts, point.val);
-            assert_eq!(point.expect_first_point, first_point, "{}", point.message);
-            assert_eq!(point.expect_drop_point, drop_point, "{}", point.message);
-            if !drop_point {
-                dx = result_dx;
-            }
-        }
-        assert_eq!(4.0, dx, "expected diff 4.0");
-
-        // second reset
-        for point in points_after_second_reset {
-            let (result_dx, first_point, drop_point) =
-                prev_pts.monotonic_diff(&dims, point.start_ts, point.ts, point.val);
-            assert_eq!(point.expect_first_point, first_point, "{}", point.message);
-            assert_eq!(point.expect_drop_point, drop_point, "{}", point.message);
-            if !drop_point {
-                dx = result_dx;
-            }
-        }
-        assert_eq!(9.0, dx, "expected diff 9.0");
+        ]
     }
 
     #[test]
-    fn test_diff_unknown_start() {
+    fn monotonic_diff_unknown_start_computes_final_delta() {
+        let mut cache = PointsCache::for_tests();
+        let dx = run_monotonic_diff(&mut cache, &test_dims(), &unknown_start_points());
+        assert_eq!(4.0, dx, "expected diff 4.0");
+    }
+
+    #[test]
+    fn monotonic_diff_known_start_computes_final_delta() {
+        let mut cache = PointsCache::for_tests();
+        let dx = run_monotonic_diff(&mut cache, &test_dims(), &known_start_initial_points());
+        assert_eq!(4.0, dx, "expected diff 4.0");
+    }
+
+    #[test]
+    fn monotonic_diff_known_start_recovers_after_reset() {
+        let mut cache = PointsCache::for_tests();
+        let dims = test_dims();
+        // Prime the cache with the initial series so a cached point exists before the reset.
+        run_monotonic_diff(&mut cache, &dims, &known_start_initial_points());
+        let dx = run_monotonic_diff(&mut cache, &dims, &known_start_reset_points());
+        assert_eq!(4.0, dx, "expected diff 4.0 after reset");
+    }
+
+    #[test]
+    fn monotonic_diff_known_start_recovers_after_second_reset() {
+        let mut cache = PointsCache::for_tests();
+        let dims = test_dims();
+        run_monotonic_diff(&mut cache, &dims, &known_start_initial_points());
+        run_monotonic_diff(&mut cache, &dims, &known_start_reset_points());
+        let dx = run_monotonic_diff(&mut cache, &dims, &known_start_second_reset_points());
+        assert_eq!(9.0, dx, "expected diff 9.0 after second reset");
+    }
+
+    #[test]
+    fn diff_unknown_start_reports_deltas() {
         let start_ts = 0;
         let mut prev_pts = PointsCache::for_tests();
-        let dims = Dimensions {
-            name: "test".to_string(),
-            tags: Default::default(),
-            host: None,
-            origin_id: None,
-        };
+        let dims = test_dims();
 
         let (_, ok) = prev_pts.diff(&dims, start_ts, 1, 5.0);
         assert!(!ok, "expected no diff: first point");
@@ -442,15 +434,10 @@ mod tests {
     }
 
     #[test]
-    fn test_diff_known_start() {
+    fn diff_known_start_reports_deltas() {
         let mut start_ts = 1;
         let mut prev_pts = PointsCache::for_tests();
-        let dims = Dimensions {
-            name: "test".to_string(),
-            tags: Default::default(),
-            host: None,
-            origin_id: None,
-        };
+        let dims = test_dims();
 
         let (_, ok) = prev_pts.diff(&dims, start_ts, 1, 5.0);
         assert!(!ok, "expected no diff: first point");
@@ -481,5 +468,130 @@ mod tests {
         let (dx, ok) = prev_pts.diff(&dims, start_ts, 8, 10.0);
         assert!(ok, "expected diff: same startTs, not monotonic");
         assert_eq!(9.0, dx, "expected diff 9.0 with (6,7,1) value");
+    }
+
+    /// A single extrema case: submits `val` at `(start_ts, ts)` and asserts whether the cache reports
+    /// the extrema as carried over from a prior time window (`from_last_window`).
+    struct ExtremaCase {
+        start_ts: u64,
+        ts: u64,
+        val: f64,
+        expected: bool,
+        message: &'static str,
+    }
+
+    #[track_caller]
+    fn run_min(cache: &mut PointsCache, dims: &Dimensions, cases: &[ExtremaCase]) {
+        for case in cases {
+            let result = cache.put_and_check_min(dims, case.start_ts, case.ts, case.val);
+            assert_eq!(case.expected, result, "{}", case.message);
+        }
+    }
+
+    #[track_caller]
+    fn run_max(cache: &mut PointsCache, dims: &Dimensions, cases: &[ExtremaCase]) {
+        for case in cases {
+            let result = cache.put_and_check_max(dims, case.start_ts, case.ts, case.val);
+            assert_eq!(case.expected, result, "{}", case.message);
+        }
+    }
+
+    #[test]
+    fn put_and_check_min_tracks_extrema_across_windows() {
+        let mut cache = PointsCache::for_tests();
+        run_min(
+            &mut cache,
+            &test_dims(),
+            &[
+                ExtremaCase {
+                    start_ts: 1,
+                    ts: 1,
+                    val: 5.0,
+                    expected: false,
+                    message: "first point has no prior extrema",
+                },
+                ExtremaCase {
+                    start_ts: 1,
+                    ts: 2,
+                    val: 3.0,
+                    expected: true,
+                    message: "a lower min within the same series is flagged",
+                },
+                ExtremaCase {
+                    start_ts: 4,
+                    ts: 4,
+                    val: 10.0,
+                    expected: true,
+                    message: "after a reset, the lower prior-window min is flagged",
+                },
+                ExtremaCase {
+                    start_ts: 4,
+                    ts: 5,
+                    val: 8.0,
+                    expected: true,
+                    message: "a lower min after the reset is flagged",
+                },
+                ExtremaCase {
+                    start_ts: 4,
+                    ts: 6,
+                    val: 8.0,
+                    expected: false,
+                    message: "an unchanged min is not flagged",
+                },
+                ExtremaCase {
+                    start_ts: 4,
+                    ts: 3,
+                    val: 1.0,
+                    expected: false,
+                    message: "an out-of-order timestamp is dropped",
+                },
+            ],
+        );
+    }
+
+    #[test]
+    fn put_and_check_max_tracks_extrema_across_windows() {
+        let mut cache = PointsCache::for_tests();
+        run_max(
+            &mut cache,
+            &test_dims(),
+            &[
+                ExtremaCase {
+                    start_ts: 1,
+                    ts: 1,
+                    val: 5.0,
+                    expected: false,
+                    message: "first point has no prior extrema",
+                },
+                ExtremaCase {
+                    start_ts: 1,
+                    ts: 2,
+                    val: 7.0,
+                    expected: true,
+                    message: "a higher max within the same series is flagged",
+                },
+                ExtremaCase {
+                    start_ts: 4,
+                    ts: 4,
+                    val: 2.0,
+                    expected: true,
+                    message: "after a reset, the higher prior-window max is flagged",
+                },
+                ExtremaCase {
+                    start_ts: 4,
+                    ts: 5,
+                    val: 2.0,
+                    expected: false,
+                    message: "an unchanged max is not flagged",
+                },
+                ExtremaCase {
+                    start_ts: 4,
+                    ts: 3,
+                    val: 100.0,
+                    expected: false,
+                    message: "an out-of-order timestamp is dropped",
+                },
+            ],
+        );
     }
 }

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -137,3 +137,51 @@ impl Default for OtlpMetricsTranslatorConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Ports the `TestConfig`/`(*Config).validate` rejection rule from the Go
+    // opentelemetry-mapping-go implementation: "no buckets" histogram mode is only valid when
+    // count/sum aggregations are also being sent.
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/config.go
+    #[test]
+    fn validate_rejects_no_buckets_mode_without_histogram_aggregations() {
+        let config = OtlpMetricsTranslatorConfig::default()
+            .with_histogram_mode(HistogramMode::NoBuckets)
+            .with_send_histogram_aggregations(false);
+
+        let err = config
+            .validate()
+            .expect_err("no-buckets histogram mode without aggregations must be rejected");
+        assert_eq!(
+            err.to_string(),
+            "no buckets mode and no send count sum are incompatible"
+        );
+    }
+
+    #[test]
+    fn validate_allows_no_buckets_mode_with_histogram_aggregations() {
+        // The rejection is specific to the missing aggregations: enabling them makes the same
+        // histogram mode valid.
+        let config = OtlpMetricsTranslatorConfig::default()
+            .with_histogram_mode(HistogramMode::NoBuckets)
+            .with_send_histogram_aggregations(true);
+
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_allows_bucketed_modes_regardless_of_aggregations() {
+        // Only the `NoBuckets`/`!send_histogram_aggregations` pair is incompatible; the bucketed
+        // modes are accepted even without aggregations.
+        for hist_mode in [HistogramMode::Counters, HistogramMode::Distributions] {
+            let config = OtlpMetricsTranslatorConfig::default()
+                .with_histogram_mode(hist_mode)
+                .with_send_histogram_aggregations(false);
+
+            assert!(config.validate().is_ok(), "expected {hist_mode:?} to validate");
+        }
+    }
+}

--- a/lib/saluki-components/src/sources/otlp/metrics/internal/instrumentationlibrary/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/internal/instrumentationlibrary/mod.rs
@@ -14,3 +14,40 @@ pub fn tags_from_instrumentation_library_metadata(scope: &otlp_common::Instrumen
         utils::format_key_value_tag(LIBRARY_VERSION_TAG, &scope.version),
     ]
 }
+
+#[cfg(test)]
+mod tests {
+    use otlp_protos::opentelemetry::proto::common::v1::InstrumentationScope;
+
+    use super::*;
+
+    #[test]
+    fn library_tags_use_scope_name_and_version() {
+        let scope = InstrumentationScope {
+            name: "lib.name".to_string(),
+            version: "0.9".to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            tags_from_instrumentation_library_metadata(&scope),
+            vec![
+                "instrumentation_library:lib.name".to_string(),
+                "instrumentation_library_version:0.9".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn library_tags_replace_empty_values_with_na() {
+        let scope = InstrumentationScope::default();
+
+        assert_eq!(
+            tags_from_instrumentation_library_metadata(&scope),
+            vec![
+                "instrumentation_library:n/a".to_string(),
+                "instrumentation_library_version:n/a".to_string(),
+            ]
+        );
+    }
+}

--- a/lib/saluki-components/src/sources/otlp/metrics/internal/instrumentationscope/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/internal/instrumentationscope/mod.rs
@@ -29,3 +29,75 @@ pub fn tags_from_empty_instrumentation_scope() -> Vec<String> {
         utils::format_key_value_tag(SCOPE_VERSION_TAG, ""),
     ]
 }
+
+#[cfg(test)]
+mod tests {
+    use otlp_protos::opentelemetry::proto::common::v1::{AnyValue, InstrumentationScope, KeyValue};
+
+    use super::*;
+
+    fn string_kv(key: &str, value: &str) -> KeyValue {
+        KeyValue {
+            key: key.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::StringValue(value.to_string())),
+            }),
+        }
+    }
+
+    fn int_kv(key: &str, value: i64) -> KeyValue {
+        KeyValue {
+            key: key.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::IntValue(value)),
+            }),
+        }
+    }
+
+    #[test]
+    fn populated_scope_emits_name_version_and_string_attributes() {
+        let scope = InstrumentationScope {
+            name: "my.instrumentation".to_string(),
+            version: "1.2.3".to_string(),
+            // The int attribute is deliberately included to confirm non-string attributes are skipped,
+            // matching the Go implementation which only converts string-valued scope attributes to tags.
+            attributes: vec![string_kv("build.id", "abc"), int_kv("workers", 4)],
+            ..Default::default()
+        };
+
+        let tags = tags_from_instrumentation_scope_metadata(&scope);
+        assert_eq!(
+            tags,
+            vec![
+                "instrumentation_scope:my.instrumentation".to_string(),
+                "instrumentation_scope_version:1.2.3".to_string(),
+                "build.id:abc".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn populated_scope_with_empty_name_and_version_uses_na_placeholders() {
+        let scope = InstrumentationScope::default();
+
+        let tags = tags_from_instrumentation_scope_metadata(&scope);
+        assert_eq!(
+            tags,
+            vec![
+                "instrumentation_scope:n/a".to_string(),
+                "instrumentation_scope_version:n/a".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_scope_fallback_uses_na_placeholders() {
+        assert_eq!(
+            tags_from_empty_instrumentation_scope(),
+            vec![
+                "instrumentation_scope:n/a".to_string(),
+                "instrumentation_scope_version:n/a".to_string(),
+            ]
+        );
+    }
+}

--- a/lib/saluki-components/src/sources/otlp/metrics/remap.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/remap.rs
@@ -628,3 +628,200 @@ static KAFKA_METRICS_TO_RENAME: LazyLock<HashSet<&'static str>> = LazyLock::new(
     m.insert("kafka.producer.record-error-rate");
     m
 });
+
+#[cfg(test)]
+mod tests {
+    // These tests port the input->output mappings verified by the Go opentelemetry-mapping-go
+    // remapping/renaming suite:
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/remapping_test.go
+    use otlp_protos::opentelemetry::proto::common::v1::AnyValue;
+    use otlp_protos::opentelemetry::proto::metrics::v1::{Gauge, Sum};
+
+    use super::*;
+
+    fn string_attr(key: &str, value: &str) -> KeyValue {
+        KeyValue {
+            key: key.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::StringValue(value.to_string())),
+            }),
+        }
+    }
+
+    fn double_dp(value: f64, attrs: &[KeyValue]) -> OtlpNumberDataPoint {
+        OtlpNumberDataPoint {
+            value: Some(OtlpNumberValue::AsDouble(value)),
+            attributes: attrs.to_vec(),
+            ..Default::default()
+        }
+    }
+
+    fn gauge_metric(name: &str, data_points: Vec<OtlpNumberDataPoint>) -> OtlpMetric {
+        OtlpMetric {
+            name: name.to_string(),
+            data: Some(OtlpMetricData::Gauge(Gauge { data_points })),
+            ..Default::default()
+        }
+    }
+
+    fn sum_metric(name: &str, data_points: Vec<OtlpNumberDataPoint>) -> OtlpMetric {
+        OtlpMetric {
+            name: name.to_string(),
+            data: Some(OtlpMetricData::Sum(Sum {
+                data_points,
+                is_monotonic: true,
+                aggregation_temporality: 0,
+            })),
+            ..Default::default()
+        }
+    }
+
+    fn data_points(metric: &OtlpMetric) -> &[OtlpNumberDataPoint] {
+        match metric.data.as_ref().expect("metric data") {
+            OtlpMetricData::Gauge(g) => &g.data_points,
+            OtlpMetricData::Sum(s) => &s.data_points,
+            _ => panic!("unexpected metric data type"),
+        }
+    }
+
+    fn first_double_value(metric: &OtlpMetric) -> f64 {
+        match data_points(metric)[0].value.as_ref().expect("data point value") {
+            OtlpNumberValue::AsDouble(d) => *d,
+            OtlpNumberValue::AsInt(i) => *i as f64,
+        }
+    }
+
+    fn attr_value<'a>(dp: &'a OtlpNumberDataPoint, key: &str) -> Option<&'a str> {
+        dp.attributes.iter().find(|kv| kv.key == key).and_then(|kv| {
+            match kv.value.as_ref().and_then(|v| v.value.as_ref()) {
+                Some(Value::StringValue(s)) => Some(s.as_str()),
+                _ => None,
+            }
+        })
+    }
+
+    fn remapped_by_name(metric: &OtlpMetric) -> HashMap<String, OtlpMetric> {
+        let mut new_metrics = Vec::new();
+        remap_metrics(&mut new_metrics, metric);
+        new_metrics.into_iter().map(|m| (m.name.clone(), m)).collect()
+    }
+
+    #[test]
+    fn remap_system_load_average_copies_value_unchanged() {
+        let metric = gauge_metric("system.cpu.load_average.1m", vec![double_dp(0.75, &[])]);
+        let remapped = remapped_by_name(&metric);
+
+        assert_eq!(remapped.len(), 1);
+        assert_eq!(first_double_value(&remapped["system.load.1"]), 0.75);
+    }
+
+    #[test]
+    fn remap_cpu_utilization_splits_by_state_and_scales_to_percentage() {
+        // `system.cpu.utilization` is reported as a fraction (0.0-1.0); the Datadog `system.cpu.*`
+        // metrics are percentages, so each state is divided by DIV_PERCENTAGE (0.01), i.e. scaled x100,
+        // and each output keeps only the data point whose `state` attribute matches.
+        let metric = gauge_metric(
+            "system.cpu.utilization",
+            vec![
+                double_dp(0.5, &[string_attr("state", "idle")]),
+                double_dp(0.3, &[string_attr("state", "user")]),
+                double_dp(0.1, &[string_attr("state", "system")]),
+                double_dp(0.05, &[string_attr("state", "wait")]),
+                double_dp(0.04, &[string_attr("state", "steal")]),
+            ],
+        );
+        let remapped = remapped_by_name(&metric);
+
+        assert_eq!(remapped.len(), 5);
+        assert!((first_double_value(&remapped["system.cpu.idle"]) - 50.0).abs() < 1e-9);
+        assert!((first_double_value(&remapped["system.cpu.user"]) - 30.0).abs() < 1e-9);
+        assert!((first_double_value(&remapped["system.cpu.system"]) - 10.0).abs() < 1e-9);
+        assert!((first_double_value(&remapped["system.cpu.iowait"]) - 5.0).abs() < 1e-9);
+        assert!((first_double_value(&remapped["system.cpu.stolen"]) - 4.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn remap_container_cpu_usage_sets_nanocore_unit() {
+        let metric = sum_metric("container.cpu.usage.total", vec![double_dp(123.0, &[])]);
+        let remapped = remapped_by_name(&metric);
+
+        assert_eq!(remapped.len(), 1);
+        let usage = &remapped["container.cpu.usage"];
+        assert_eq!(first_double_value(usage), 123.0);
+        assert_eq!(usage.unit, "nanocore");
+    }
+
+    #[test]
+    fn remap_kafka_consumer_lag_copies_group_into_consumer_group() {
+        let metric = gauge_metric(
+            "kafka.consumer.records_lag",
+            vec![double_dp(5.0, &[string_attr("group", "my-group")])],
+        );
+        let remapped = remapped_by_name(&metric);
+
+        assert_eq!(remapped.len(), 1);
+        let lag = &remapped["kafka.consumer_lag"];
+        let dp = &data_points(lag)[0];
+        // The dynamic attribute mapping copies `group` to a new `consumer_group` attribute while
+        // leaving the original in place.
+        assert_eq!(attr_value(dp, "group"), Some("my-group"));
+        assert_eq!(attr_value(dp, "consumer_group"), Some("my-group"));
+    }
+
+    #[test]
+    fn remap_jvm_memory_committed_splits_heap_and_non_heap() {
+        let metric = gauge_metric(
+            "jvm.memory.committed",
+            vec![
+                double_dp(100.0, &[string_attr("pool", "heap")]),
+                double_dp(50.0, &[string_attr("pool", "non-heap")]),
+            ],
+        );
+        let remapped = remapped_by_name(&metric);
+
+        assert_eq!(remapped.len(), 2);
+        assert_eq!(first_double_value(&remapped["jvm.heap_memory_committed"]), 100.0);
+        assert_eq!(first_double_value(&remapped["jvm.non_heap_memory_committed"]), 50.0);
+    }
+
+    #[test]
+    fn remap_ignores_unmapped_metric() {
+        let metric = gauge_metric("custom.app.metric", vec![double_dp(1.0, &[])]);
+        let remapped = remapped_by_name(&metric);
+
+        assert!(remapped.is_empty());
+    }
+
+    #[test]
+    fn rename_host_metrics_add_otel_prefix() {
+        for name in ["system.cpu.time", "process.cpu.time"] {
+            let mut metric = gauge_metric(name, vec![]);
+            rename_metric(&mut metric);
+            assert_eq!(metric.name, format!("otel.{name}"));
+        }
+    }
+
+    #[test]
+    fn rename_listed_kafka_metric_adds_otel_prefix() {
+        let mut metric = gauge_metric("kafka.producer.request-rate", vec![]);
+        rename_metric(&mut metric);
+        assert_eq!(metric.name, "otel.kafka.producer.request-rate");
+    }
+
+    #[test]
+    fn rename_agent_internal_metrics_add_otelcol_prefix() {
+        for name in ["datadog_trace_agent.receiver.spans", "datadog_otlp.something"] {
+            let mut metric = gauge_metric(name, vec![]);
+            rename_metric(&mut metric);
+            assert_eq!(metric.name, format!("otelcol_{name}"));
+        }
+    }
+
+    #[test]
+    fn rename_leaves_unmapped_metric_unchanged() {
+        let mut metric = gauge_metric("kafka.consumer.records_lag", vec![]);
+        rename_metric(&mut metric);
+        // Not a host metric, not in the kafka-rename set, and not agent-internal.
+        assert_eq!(metric.name, "kafka.consumer.records_lag");
+    }
+}

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -1486,7 +1486,8 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use otlp_protos::opentelemetry::proto::metrics::v1::{
-        number_data_point::Value as OtlpNumberDataPointValue, NumberDataPoint as OtlpNumberDataPoint,
+        number_data_point::Value as OtlpNumberDataPointValue, summary_data_point::ValueAtQuantile, Gauge,
+        NumberDataPoint as OtlpNumberDataPoint, ScopeMetrics, Sum,
     };
     use saluki_context::tags::Tag;
 
@@ -1704,10 +1705,38 @@ mod tests {
         assert_bucket_events(&cumulative_events, &[3.0, 4.0], 3);
     }
 
-    // Ported from the Go OTLP mapping tests:
+    /// Drives `map_number_monotonic_metrics` for a metric named `name`, hiding the repeated
+    /// `Dimensions` + `TranslationContext` construction shared across the monotonic-mapping tests.
+    fn run_monotonic(
+        translator: &mut OtlpMetricsTranslator, name: &str, data_points: Vec<OtlpNumberDataPoint>, metrics: &Metrics,
+    ) -> Vec<Event> {
+        let dims = Dimensions {
+            name: name.to_string(),
+            ..Default::default()
+        };
+        let context = TranslationContext {
+            resource_attributes: &[],
+            metrics,
+        };
+        translator.map_number_monotonic_metrics(dims, data_points, &context)
+    }
+
+    /// Drives `map_number_metrics` for the given `dims`/`data_type`, hiding the repeated
+    /// `TranslationContext` construction shared across the number-mapping tests.
+    fn run_number(
+        translator: &mut OtlpMetricsTranslator, dims: Dimensions, data_points: Vec<OtlpNumberDataPoint>,
+        data_type: DataType, metrics: &Metrics,
+    ) -> Vec<Event> {
+        let context = TranslationContext {
+            resource_attributes: &[],
+            metrics,
+        };
+        translator.map_number_metrics(dims, data_points, data_type, &context)
+    }
+
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L2225
     #[test]
-    fn go_float_matches_go_format_float() {
+    fn format_float_matches_go_strconv_formatting() {
         let tests = [
             (0.0, "0"),
             (0.001, "0.001"),
@@ -2374,295 +2403,213 @@ mod tests {
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L296
     #[test]
-    fn test_map_int_monotonic_metrics() {
+    fn int_monotonic_diff_emits_one_counter_delta_per_point() {
         let metrics = Metrics::for_tests();
         let deltas = vec![1, 2, 200, 3, 7, 0];
+        let mut translator = OtlpMetricsTranslator::for_tests();
 
-        // Test Case 1: "diff" mode (standard cumulative to delta)
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let slice = build_monotonic_int_points(&deltas);
-            let dims = Dimensions {
-                name: "metric.example".to_string(),
-                ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
+        let events = run_monotonic(
+            &mut translator,
+            "metric.example",
+            build_monotonic_int_points(&deltas),
+            &metrics,
+        );
 
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-
-            assert_eq!(events.len(), deltas.len(), "Expected one event for each delta");
-
-            for (i, event) in events.iter().enumerate() {
-                let metric = event.try_as_metric().unwrap();
-                assert_eq!(
-                    metric.values(),
-                    &MetricValues::counter((((i + 1) * 10) as u64, deltas[i] as f64))
-                );
-            }
-        }
-
-        // Test Case 2: "rate" mode
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let slice = build_monotonic_int_points(&deltas);
-            let dims = Dimensions {
-                name: "kafka.net.bytes_out.rate".to_string(),
-                ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-
+        assert_eq!(events.len(), deltas.len(), "Expected one event for each delta");
+        for (i, event) in events.iter().enumerate() {
+            let metric = event.try_as_metric().unwrap();
             assert_eq!(
-                events.len(),
-                deltas.len(),
-                "Expected one event for each delta in rate mode"
+                metric.values(),
+                &MetricValues::counter((((i + 1) * 10) as u64, deltas[i] as f64))
             );
-
-            for (i, event) in events.iter().enumerate() {
-                let metric = event.try_as_metric().unwrap();
-                // The rate is delta / 10s interval
-                assert_eq!(
-                    metric.values(),
-                    &MetricValues::gauge((((i + 1) * 10) as u64, deltas[i] as f64 / 10.0),)
-                );
-            }
         }
+    }
+
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L296
+    #[test]
+    fn int_monotonic_rate_emits_per_second_gauge_per_point() {
+        let metrics = Metrics::for_tests();
+        let deltas = vec![1, 2, 200, 3, 7, 0];
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        let events = run_monotonic(
+            &mut translator,
+            "kafka.net.bytes_out.rate",
+            build_monotonic_int_points(&deltas),
+            &metrics,
+        );
+
+        assert_eq!(
+            events.len(),
+            deltas.len(),
+            "Expected one event for each delta in rate mode"
+        );
+        for (i, event) in events.iter().enumerate() {
+            let metric = event.try_as_metric().unwrap();
+            // The rate is delta / 10s interval.
+            assert_eq!(
+                metric.values(),
+                &MetricValues::gauge((((i + 1) * 10) as u64, deltas[i] as f64 / 10.0))
+            );
+        }
+    }
+
+    /// Three int data points where the second duplicates the first point's timestamp (dropped).
+    fn int_equal_timestamp_drop_slice(start_ts: u64) -> Vec<OtlpNumberDataPoint> {
+        vec![
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsInt(10)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(2),
+                ..Default::default()
+            },
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsInt(20)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(2),
+                ..Default::default()
+            },
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsInt(40)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(4),
+                ..Default::default()
+            },
+        ]
+    }
+
+    /// Three int data points where the second is older than the first point's timestamp (dropped).
+    fn int_older_timestamp_drop_slice(start_ts: u64) -> Vec<OtlpNumberDataPoint> {
+        vec![
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsInt(10)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(3),
+                ..Default::default()
+            },
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsInt(25)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(2),
+                ..Default::default()
+            },
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsInt(40)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(5),
+                ..Default::default()
+            },
+        ]
     }
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L549
     #[test]
-    fn test_map_int_monotonic_drop_point_within_slice() {
+    fn int_monotonic_diff_drops_equal_timestamp_point() {
         let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        let start_ts = translator.process_start_time_ns + 1;
 
-        // Test Case 1: "equal" timestamp.
-        // Verifies that a point is dropped if its timestamp is the same as the previous point.
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let start_ts = translator.process_start_time_ns + 1;
+        let events = run_monotonic(
+            &mut translator,
+            "metric.example",
+            int_equal_timestamp_drop_slice(start_ts),
+            &metrics,
+        );
+        assert_eq!(events.len(), 2, "Expected two metrics after dropping a point");
 
-            let slice = vec![
-                // First point
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsInt(10)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(2),
-                    ..Default::default()
-                },
-                // Second point - DUPLICATE timestamp. This should be dropped.
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsInt(20)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(2),
-                    ..Default::default()
-                },
-                // Third point
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsInt(40)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(4),
-                    ..Default::default()
-                },
-            ];
+        // First metric: the initial value of the counter.
+        let metric = events[0].try_as_metric().unwrap();
+        let expected_ts_s = (start_ts + nanos_from_seconds(2)) / 1_000_000_000;
+        assert_eq!(metric.values(), &MetricValues::counter((expected_ts_s, 10.0)));
 
-            let dims = Dimensions {
-                name: "metric.example".to_string(),
-                ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        // Second metric: the delta between the third and first points.
+        let metric = events[1].try_as_metric().unwrap();
+        let expected_ts_s = (start_ts + nanos_from_seconds(4)) / 1_000_000_000;
+        assert_eq!(metric.values(), &MetricValues::counter((expected_ts_s, 30.0)));
+    }
 
-            assert_eq!(events.len(), 2, "Expected two metrics after dropping a point");
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L549
+    #[test]
+    fn int_monotonic_rate_drops_equal_timestamp_point() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        let start_ts = translator.process_start_time_ns + 1;
 
-            // First metric: the initial value of the counter.
-            let metric = events[0].try_as_metric().unwrap();
-            let expected_ts_s = (start_ts + nanos_from_seconds(2)) / 1_000_000_000;
-            assert_eq!(metric.values(), &MetricValues::counter((expected_ts_s, 10.0)));
+        // The first point is consumed but produces no rate; the second is dropped; the third
+        // produces a rate based on the delta from the first.
+        let events = run_monotonic(
+            &mut translator,
+            "kafka.net.bytes_out.rate",
+            int_equal_timestamp_drop_slice(start_ts),
+            &metrics,
+        );
+        assert_eq!(events.len(), 1, "Expected one metric for equal-rate test");
 
-            // Second metric: the delta between the third and first points.
-            let metric = events[1].try_as_metric().unwrap();
-            let expected_ts_s = (start_ts + nanos_from_seconds(4)) / 1_000_000_000;
-            assert_eq!(metric.values(), &MetricValues::counter((expected_ts_s, 30.0)));
-        }
+        let metric = events[0].try_as_metric().unwrap();
+        // rate is (40-10) / (4s-2s) = 30 / 2 = 15
+        let expected_ts_s = (start_ts + nanos_from_seconds(4)) / 1_000_000_000;
+        assert_eq!(metric.values(), &MetricValues::gauge((expected_ts_s, 15.0)));
+    }
 
-        // Test Case 2: "equal-rate" timestamp.
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let start_ts = translator.process_start_time_ns + 1;
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L549
+    #[test]
+    fn int_monotonic_diff_drops_older_timestamp_point() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        let start_ts = translator.process_start_time_ns + 1;
 
-            let slice = vec![
-                // First point
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsInt(10)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(2),
-                    ..Default::default()
-                },
-                // Second point - DUPLICATE timestamp. This should be dropped.
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsInt(20)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(2),
-                    ..Default::default()
-                },
-                // Third point
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsInt(40)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(4),
-                    ..Default::default()
-                },
-            ];
+        let events = run_monotonic(
+            &mut translator,
+            "metric.example",
+            int_older_timestamp_drop_slice(start_ts),
+            &metrics,
+        );
+        assert_eq!(events.len(), 2, "Expected two metrics after dropping an older point");
 
-            let dims = Dimensions {
-                name: "kafka.net.bytes_out.rate".to_string(),
-                ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        let metric = events[0].try_as_metric().unwrap();
+        let expected_ts_s = (start_ts + nanos_from_seconds(3)) / 1_000_000_000;
+        assert_eq!(metric.values(), &MetricValues::counter((expected_ts_s, 10.0)));
 
-            // The first point is consumed but produces no metric for rates.
-            // The second is dropped.
-            // The third produces a rate based on the delta from the first.
-            assert_eq!(events.len(), 1, "Expected one metric for equal-rate test");
+        let metric = events[1].try_as_metric().unwrap();
+        let expected_ts_s = (start_ts + nanos_from_seconds(5)) / 1_000_000_000;
+        assert_eq!(metric.values(), &MetricValues::counter((expected_ts_s, 30.0)));
+    }
 
-            let metric = events[0].try_as_metric().unwrap();
-            // rate is (40-10) / (4s-2s) = 30 / 2 = 15
-            let expected_ts_s = (start_ts + nanos_from_seconds(4)) / 1_000_000_000;
-            assert_eq!(metric.values(), &MetricValues::gauge((expected_ts_s, 15.0)));
-        }
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L549
+    #[test]
+    fn int_monotonic_rate_drops_older_timestamp_point() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        let start_ts = translator.process_start_time_ns + 1;
 
-        // Test Case 3: "older" timestamp.
-        // Verifies that a point is dropped if its timestamp is older than the previous point.
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let start_ts = translator.process_start_time_ns + 1;
+        let events = run_monotonic(
+            &mut translator,
+            "kafka.net.bytes_out.rate",
+            int_older_timestamp_drop_slice(start_ts),
+            &metrics,
+        );
+        assert_eq!(
+            events.len(),
+            1,
+            "Expected one metric after dropping an older rate point"
+        );
 
-            let slice = vec![
-                // First point
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsInt(10)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(3),
-                    ..Default::default()
-                },
-                // Second point - OLDER timestamp. This should be dropped.
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsInt(25)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(2),
-                    ..Default::default()
-                },
-                // Third point
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsInt(40)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(5),
-                    ..Default::default()
-                },
-            ];
-
-            let dims = Dimensions {
-                name: "metric.example".to_string(),
-                ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-            assert_eq!(events.len(), 2, "Expected two metrics after dropping an older point");
-
-            let metric = events[0].try_as_metric().unwrap();
-            let expected_ts_s = (start_ts + nanos_from_seconds(3)) / 1_000_000_000;
-            assert_eq!(metric.values(), &MetricValues::counter((expected_ts_s, 10.0)));
-
-            let metric = events[1].try_as_metric().unwrap();
-            let expected_ts_s = (start_ts + nanos_from_seconds(5)) / 1_000_000_000;
-            assert_eq!(metric.values(), &MetricValues::counter((expected_ts_s, 30.0)));
-        }
-
-        // Test Case 4: "older-rate" timestamp.
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let start_ts = translator.process_start_time_ns + 1;
-
-            let slice = vec![
-                // First point
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsInt(10)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(3),
-                    ..Default::default()
-                },
-                // Second point - OLDER timestamp. This should be dropped.
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsInt(25)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(2),
-                    ..Default::default()
-                },
-                // Third point
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsInt(40)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(5),
-                    ..Default::default()
-                },
-            ];
-
-            let dims = Dimensions {
-                name: "kafka.net.bytes_out.rate".to_string(),
-                ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-            assert_eq!(
-                events.len(),
-                1,
-                "Expected one metric after dropping an older rate point"
-            );
-
-            let metric = events[0].try_as_metric().unwrap();
-            // rate is (40-10) / (5s-3s) = 30 / 2 = 15
-            let expected_ts_s = (start_ts + nanos_from_seconds(5)) / 1_000_000_000;
-            assert_eq!(metric.values(), &MetricValues::gauge((expected_ts_s, 15.0)));
-        }
+        let metric = events[0].try_as_metric().unwrap();
+        // rate is (40-10) / (5s-3s) = 30 / 2 = 15
+        let expected_ts_s = (start_ts + nanos_from_seconds(5)) / 1_000_000_000;
+        assert_eq!(metric.values(), &MetricValues::gauge((expected_ts_s, 15.0)));
     }
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L884
     #[test]
-    fn test_map_int_monotonic_report_first_value() {
+    fn int_monotonic_reports_first_value_from_new_series() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
 
-        let dims = Dimensions {
-            name: "metric.example".to_string(),
-            ..Default::default()
-        };
         let slice = build_test_cumulative_monotonic_int_points(&translator, &[10, 15, 20], false);
         let start_ts = slice[0].start_time_unix_nano;
 
-        let context = TranslationContext {
-            resource_attributes: &[],
-            metrics: &metrics,
-        };
-        let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        let events = run_monotonic(&mut translator, "metric.example", slice, &metrics);
 
         assert_eq!(events.len(), 3, "Expected three metrics for a new cumulative series");
 
@@ -2684,7 +2631,7 @@ mod tests {
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1411
     #[test]
-    fn test_map_int_monotonic_out_of_order() {
+    fn int_monotonic_drops_out_of_order_point() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
 
@@ -2700,15 +2647,7 @@ mod tests {
             });
         }
 
-        let dims = Dimensions {
-            name: "metric.example".to_string(),
-            ..Default::default()
-        };
-        let context = TranslationContext {
-            resource_attributes: &[],
-            metrics: &metrics,
-        };
-        let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        let events = run_monotonic(&mut translator, "metric.example", slice, &metrics);
 
         // Expected metrics:
         // 1. First valid point is (ts: 1, val: 0). The point at ts: 0 is dropped. The first point is
@@ -2730,7 +2669,7 @@ mod tests {
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L332
     #[test]
-    fn test_map_int_monotonic_different_dimensions() {
+    fn int_monotonic_separates_series_by_dimensions() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
 
@@ -2789,15 +2728,7 @@ mod tests {
             ..Default::default()
         });
 
-        let dims = Dimensions {
-            name: "metric.example".to_string(),
-            ..Default::default()
-        };
-        let context = TranslationContext {
-            resource_attributes: &[],
-            metrics: &metrics,
-        };
-        let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        let events = run_monotonic(&mut translator, "metric.example", slice, &metrics);
         assert_eq!(events.len(), 3, "Expected three distinct metrics");
 
         assert_eq!(
@@ -2818,290 +2749,267 @@ mod tests {
         assert_eq!(metric3.values(), &MetricValues::counter((1, 40.0)));
     }
 
+    /// A single integer data point at "now" and its second-resolution timestamp.
+    fn single_int_point() -> (Vec<OtlpNumberDataPoint>, u64) {
+        let ts = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64;
+        (
+            vec![OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsInt(17)),
+                time_unix_nano: ts,
+                ..Default::default()
+            }],
+            ts / 1_000_000_000,
+        )
+    }
+
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L201
     #[test]
-    fn test_map_number_metrics() {
+    fn number_gauge_emits_untagged_gauge() {
         let metrics = Metrics::for_tests();
-        // Setup test data that will be reused
-        let ts = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64;
-        let ts_s = ts / 1_000_000_000;
-
-        let slice = vec![OtlpNumberDataPoint {
-            value: Some(OtlpNumberDataPointValue::AsInt(17)),
-            time_unix_nano: ts,
+        let (slice, ts_s) = single_int_point();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        let dims = Dimensions {
+            name: "int64.test".to_string(),
             ..Default::default()
-        }];
+        };
 
-        // Test Case 1: Gauge
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let dims = Dimensions {
-                name: "int64.test".to_string(),
-                ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_metrics(dims, slice.clone(), DataType::Gauge, &context);
+        let events = run_number(&mut translator, dims, slice, DataType::Gauge, &metrics);
 
-            assert_eq!(events.len(), 1, "Expected one event for the gauge test");
-            let metric = events[0].try_as_metric().unwrap();
-            assert_eq!(metric.context().name(), "int64.test");
-            assert_eq!(metric.values(), &MetricValues::gauge((ts_s, 17.0)));
-            assert!(
-                metric.context().tags().is_empty(),
-                "Expected no tags for the simple gauge test"
-            );
-        }
+        assert_eq!(events.len(), 1, "Expected one event for the gauge test");
+        let metric = events[0].try_as_metric().unwrap();
+        assert_eq!(metric.context().name(), "int64.test");
+        assert_eq!(metric.values(), &MetricValues::gauge((ts_s, 17.0)));
+        assert!(
+            metric.context().tags().is_empty(),
+            "Expected no tags for the simple gauge test"
+        );
+    }
 
-        // Test Case 2: Count
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let dims = Dimensions {
-                name: "int64.delta.test".to_string(),
-                ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_metrics(dims, slice.clone(), DataType::Count, &context);
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L201
+    #[test]
+    fn number_count_emits_untagged_counter() {
+        let metrics = Metrics::for_tests();
+        let (slice, ts_s) = single_int_point();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        let dims = Dimensions {
+            name: "int64.delta.test".to_string(),
+            ..Default::default()
+        };
 
-            assert_eq!(events.len(), 1, "Expected one event for the count test");
-            let metric = events[0].try_as_metric().unwrap();
-            assert_eq!(metric.context().name(), "int64.delta.test");
-            assert_eq!(metric.values(), &MetricValues::counter((ts_s, 17.0)));
-            assert!(
-                metric.context().tags().is_empty(),
-                "Expected no tags for the simple count test"
-            );
-        }
+        let events = run_number(&mut translator, dims, slice, DataType::Count, &metrics);
 
-        // Test Case 3: Gauge with Tags
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let mut tags = TagSet::default();
-            tags.insert_tag("attribute_tag:attribute_value");
-            let dims = Dimensions {
-                name: "int64.test".to_string(),
-                tags: tags.into_shared(),
-                ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_metrics(dims, slice.clone(), DataType::Gauge, &context);
+        assert_eq!(events.len(), 1, "Expected one event for the count test");
+        let metric = events[0].try_as_metric().unwrap();
+        assert_eq!(metric.context().name(), "int64.delta.test");
+        assert_eq!(metric.values(), &MetricValues::counter((ts_s, 17.0)));
+        assert!(
+            metric.context().tags().is_empty(),
+            "Expected no tags for the simple count test"
+        );
+    }
 
-            assert_eq!(events.len(), 1, "Expected one event for the gauge with tags test");
-            let metric = events[0].try_as_metric().unwrap();
-            assert_eq!(metric.context().name(), "int64.test");
-            assert_eq!(metric.values(), &MetricValues::gauge((ts_s, 17.0)));
-            assert_eq!(
-                metric.context().tags().get_single_tag("attribute_tag"),
-                Some(&Tag::from("attribute_tag:attribute_value"))
-            );
-        }
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L201
+    #[test]
+    fn number_gauge_preserves_dimension_tags() {
+        let metrics = Metrics::for_tests();
+        let (slice, ts_s) = single_int_point();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        let mut tags = TagSet::default();
+        tags.insert_tag("attribute_tag:attribute_value");
+        let dims = Dimensions {
+            name: "int64.test".to_string(),
+            tags: tags.into_shared(),
+            ..Default::default()
+        };
+
+        let events = run_number(&mut translator, dims, slice, DataType::Gauge, &metrics);
+
+        assert_eq!(events.len(), 1, "Expected one event for the gauge with tags test");
+        let metric = events[0].try_as_metric().unwrap();
+        assert_eq!(metric.context().name(), "int64.test");
+        assert_eq!(metric.values(), &MetricValues::gauge((ts_s, 17.0)));
+        assert_eq!(
+            metric.context().tags().get_single_tag("attribute_tag"),
+            Some(&Tag::from("attribute_tag:attribute_value"))
+        );
     }
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L395
     #[test]
-    fn test_map_int_monotonic_with_reboot_within_slice() {
+    fn int_monotonic_diff_handles_reboot_within_slice() {
         let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
 
-        // Test Case 1: "diff" mode with reset
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let slice = build_monotonic_int_reboot_points();
-            let dims = Dimensions {
-                name: "metric.example".to_string(),
+        let events = run_monotonic(
+            &mut translator,
+            "metric.example",
+            build_monotonic_int_reboot_points(),
+            &metrics,
+        );
+
+        assert_eq!(events.len(), 2, "Expected two metrics after a reboot");
+        assert_eq!(
+            events[0].try_as_metric().unwrap().values(),
+            &MetricValues::counter((10, 30.0))
+        );
+        assert_eq!(
+            events[1].try_as_metric().unwrap().values(),
+            &MetricValues::counter((30, 20.0))
+        );
+    }
+
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L395
+    #[test]
+    fn int_monotonic_rate_handles_reboot_within_slice() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        let events = run_monotonic(
+            &mut translator,
+            "kafka.net.bytes_out.rate",
+            build_monotonic_int_reboot_points(),
+            &metrics,
+        );
+
+        assert_eq!(events.len(), 2, "Expected two metrics for rate after a reboot");
+        // 30 / 10s and 20 / 10s.
+        assert_eq!(
+            events[0].try_as_metric().unwrap().values(),
+            &MetricValues::gauge((10, 3.0))
+        );
+        assert_eq!(
+            events[1].try_as_metric().unwrap().values(),
+            &MetricValues::gauge((30, 2.0))
+        );
+    }
+
+    /// A single double data point (`PI`) at "now" and its second-resolution timestamp.
+    fn single_double_point() -> (Vec<OtlpNumberDataPoint>, u64) {
+        let ts = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64;
+        (
+            vec![OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsDouble(std::f64::consts::PI)),
+                time_unix_nano: ts,
                 ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-
-            assert_eq!(events.len(), 2, "Expected two metrics after a reboot");
-
-            let metric = events[0].try_as_metric().unwrap();
-            assert_eq!(metric.values(), &MetricValues::counter((10, 30.0)));
-
-            let metric = events[1].try_as_metric().unwrap();
-            assert_eq!(metric.values(), &MetricValues::counter((30, 20.0)));
-        }
-
-        // Test Case 2: "rate" mode with reset
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let slice = build_monotonic_int_reboot_points();
-            let dims = Dimensions {
-                name: "kafka.net.bytes_out.rate".to_string(),
-                ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-
-            assert_eq!(events.len(), 2, "Expected two metrics for rate after a reboot");
-
-            let metric = events[0].try_as_metric().unwrap();
-            assert_eq!(
-                metric.values(),
-                &MetricValues::gauge((10, 3.0)) // 30 / 10s
-            );
-
-            let metric = events[1].try_as_metric().unwrap();
-            assert_eq!(
-                metric.values(),
-                &MetricValues::gauge((30, 2.0)) // 20 / 10s
-            );
-        }
+            }],
+            ts / 1_000_000_000,
+        )
     }
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L236
     #[test]
-    fn test_map_double_metrics() {
+    fn double_gauge_emits_gauge() {
         let metrics = Metrics::for_tests();
-        let ts = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64;
-        let ts_s = ts / 1_000_000_000;
-
-        let slice = vec![OtlpNumberDataPoint {
-            value: Some(OtlpNumberDataPointValue::AsDouble(std::f64::consts::PI)),
-            time_unix_nano: ts,
+        let (slice, ts_s) = single_double_point();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        let dims = Dimensions {
+            name: "float64.test".to_string(),
             ..Default::default()
-        }];
+        };
 
-        // Test Case 1: Gauge
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let dims = Dimensions {
-                name: "float64.test".to_string(),
-                ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_metrics(dims, slice.clone(), DataType::Gauge, &context);
+        let events = run_number(&mut translator, dims, slice, DataType::Gauge, &metrics);
 
-            assert_eq!(events.len(), 1, "Expected one event for the gauge test");
-            let metric = events[0].try_as_metric().unwrap();
-            assert_eq!(metric.context().name(), "float64.test");
-            assert_eq!(metric.values(), &MetricValues::gauge((ts_s, std::f64::consts::PI)));
-        }
+        assert_eq!(events.len(), 1, "Expected one event for the gauge test");
+        let metric = events[0].try_as_metric().unwrap();
+        assert_eq!(metric.context().name(), "float64.test");
+        assert_eq!(metric.values(), &MetricValues::gauge((ts_s, std::f64::consts::PI)));
+    }
 
-        // Test Case 2: Count
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let dims = Dimensions {
-                name: "float64.delta.test".to_string(),
-                ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_metrics(dims, slice.clone(), DataType::Count, &context);
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L236
+    #[test]
+    fn double_count_emits_counter() {
+        let metrics = Metrics::for_tests();
+        let (slice, ts_s) = single_double_point();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        let dims = Dimensions {
+            name: "float64.delta.test".to_string(),
+            ..Default::default()
+        };
 
-            assert_eq!(events.len(), 1, "Expected one event for the count test");
-            let metric = events[0].try_as_metric().unwrap();
-            assert_eq!(metric.context().name(), "float64.delta.test");
-            assert_eq!(metric.values(), &MetricValues::counter((ts_s, std::f64::consts::PI)));
-        }
+        let events = run_number(&mut translator, dims, slice, DataType::Count, &metrics);
 
-        // Test Case 3: Gauge with Tags
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let mut tags = TagSet::default();
-            tags.insert_tag("attribute_tag:attribute_value");
-            let dims = Dimensions {
-                name: "float64.test".to_string(),
-                tags: tags.into_shared(),
-                ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_metrics(dims, slice.clone(), DataType::Gauge, &context);
+        assert_eq!(events.len(), 1, "Expected one event for the count test");
+        let metric = events[0].try_as_metric().unwrap();
+        assert_eq!(metric.context().name(), "float64.delta.test");
+        assert_eq!(metric.values(), &MetricValues::counter((ts_s, std::f64::consts::PI)));
+    }
 
-            assert_eq!(events.len(), 1, "Expected one event for the gauge with tags test");
-            let metric = events[0].try_as_metric().unwrap();
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L236
+    #[test]
+    fn double_gauge_preserves_dimension_tags() {
+        let metrics = Metrics::for_tests();
+        let (slice, ts_s) = single_double_point();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        let mut tags = TagSet::default();
+        tags.insert_tag("attribute_tag:attribute_value");
+        let dims = Dimensions {
+            name: "float64.test".to_string(),
+            tags: tags.into_shared(),
+            ..Default::default()
+        };
+
+        let events = run_number(&mut translator, dims, slice, DataType::Gauge, &metrics);
+
+        assert_eq!(events.len(), 1, "Expected one event for the gauge with tags test");
+        let metric = events[0].try_as_metric().unwrap();
+        assert_eq!(
+            metric.context().tags().get_single_tag("attribute_tag"),
+            Some(&Tag::from("attribute_tag:attribute_value"))
+        );
+        assert_eq!(metric.values(), &MetricValues::gauge((ts_s, std::f64::consts::PI)));
+    }
+
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1456
+    #[test]
+    fn double_monotonic_diff_emits_one_counter_delta_per_point() {
+        let metrics = Metrics::for_tests();
+        let deltas = vec![1.0, 2.0, 200.0, 3.0, 7.0, 0.0];
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        let events = run_monotonic(
+            &mut translator,
+            "metric.example",
+            build_monotonic_double_points(&deltas),
+            &metrics,
+        );
+
+        assert_eq!(events.len(), deltas.len());
+        for (i, event) in events.iter().enumerate() {
+            let metric = event.try_as_metric().unwrap();
             assert_eq!(
-                metric.context().tags().get_single_tag("attribute_tag"),
-                Some(&Tag::from("attribute_tag:attribute_value"))
+                metric.values(),
+                &MetricValues::counter((((i + 1) * 10) as u64, deltas[i]))
             );
-            assert_eq!(metric.values(), &MetricValues::gauge((ts_s, std::f64::consts::PI)));
         }
     }
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1456
     #[test]
-    fn test_map_double_monotonic_metrics() {
+    fn double_monotonic_rate_emits_per_second_gauge_per_point() {
         let metrics = Metrics::for_tests();
         let deltas = vec![1.0, 2.0, 200.0, 3.0, 7.0, 0.0];
+        let mut translator = OtlpMetricsTranslator::for_tests();
 
-        // Test Case 1: "diff" mode
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let slice = build_monotonic_double_points(&deltas);
-            let dims = Dimensions {
-                name: "metric.example".to_string(),
-                ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
+        let events = run_monotonic(
+            &mut translator,
+            "kafka.net.bytes_out.rate",
+            build_monotonic_double_points(&deltas),
+            &metrics,
+        );
 
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-            assert_eq!(events.len(), deltas.len());
-
-            for (i, event) in events.iter().enumerate() {
-                let metric = event.try_as_metric().unwrap();
-                assert_eq!(
-                    metric.values(),
-                    &MetricValues::counter((((i + 1) * 10) as u64, deltas[i]))
-                );
-            }
-        }
-
-        // Test Case 2: "rate" mode
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let slice = build_monotonic_double_points(&deltas);
-            let dims = Dimensions {
-                name: "kafka.net.bytes_out.rate".to_string(),
-                ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-            assert_eq!(events.len(), deltas.len());
-
-            for (i, event) in events.iter().enumerate() {
-                let metric = event.try_as_metric().unwrap();
-                assert_eq!(
-                    metric.values(),
-                    &MetricValues::gauge((((i + 1) * 10) as u64, deltas[i] / 10.0),)
-                );
-            }
+        assert_eq!(events.len(), deltas.len());
+        for (i, event) in events.iter().enumerate() {
+            let metric = event.try_as_metric().unwrap();
+            assert_eq!(
+                metric.values(),
+                &MetricValues::gauge((((i + 1) * 10) as u64, deltas[i] / 10.0))
+            );
         }
     }
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1493
     #[test]
-    fn test_map_double_monotonic_different_dimensions() {
+    fn double_monotonic_separates_series_by_dimensions() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
 
@@ -3160,15 +3068,7 @@ mod tests {
             ..Default::default()
         });
 
-        let dims = Dimensions {
-            name: "metric.example".to_string(),
-            ..Default::default()
-        };
-        let context = TranslationContext {
-            resource_attributes: &[],
-            metrics: &metrics,
-        };
-        let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        let events = run_monotonic(&mut translator, "metric.example", slice, &metrics);
         assert_eq!(events.len(), 3);
 
         assert_eq!(
@@ -3191,165 +3091,143 @@ mod tests {
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1555
     #[test]
-    fn test_map_double_monotonic_with_reboot_within_slice() {
+    fn double_monotonic_diff_handles_reboot_within_slice() {
         let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
 
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let slice = build_monotonic_double_reboot_points();
-            let dims = Dimensions {
-                name: "metric.example".to_string(),
-                ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
+        let events = run_monotonic(
+            &mut translator,
+            "metric.example",
+            build_monotonic_double_reboot_points(),
+            &metrics,
+        );
 
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-            assert_eq!(events.len(), 2);
-            assert_eq!(
-                events[0].try_as_metric().unwrap().values(),
-                &MetricValues::counter((10, 30.0))
-            );
-            assert_eq!(
-                events[1].try_as_metric().unwrap().values(),
-                &MetricValues::counter((30, 20.0))
-            );
-        }
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events[0].try_as_metric().unwrap().values(),
+            &MetricValues::counter((10, 30.0))
+        );
+        assert_eq!(
+            events[1].try_as_metric().unwrap().values(),
+            &MetricValues::counter((30, 20.0))
+        );
+    }
 
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let slice = build_monotonic_double_reboot_points();
-            let dims = Dimensions {
-                name: "kafka.net.bytes_out.rate".to_string(),
-                ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1555
+    #[test]
+    fn double_monotonic_rate_handles_reboot_within_slice() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
 
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-            assert_eq!(events.len(), 2);
-            assert_eq!(
-                events[0].try_as_metric().unwrap().values(),
-                &MetricValues::gauge((10, 3.0))
-            );
-            assert_eq!(
-                events[1].try_as_metric().unwrap().values(),
-                &MetricValues::gauge((30, 2.0))
-            );
-        }
+        let events = run_monotonic(
+            &mut translator,
+            "kafka.net.bytes_out.rate",
+            build_monotonic_double_reboot_points(),
+            &metrics,
+        );
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events[0].try_as_metric().unwrap().values(),
+            &MetricValues::gauge((10, 3.0))
+        );
+        assert_eq!(
+            events[1].try_as_metric().unwrap().values(),
+            &MetricValues::gauge((30, 2.0))
+        );
     }
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1678
     #[test]
-    fn test_map_double_monotonic_drop_point_within_slice() {
+    fn double_monotonic_diff_drops_equal_timestamp_point() {
         let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        let start_ts = translator.process_start_time_ns + 1;
 
-        // Test Case 1: "equal" timestamp.
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let start_ts = translator.process_start_time_ns + 1;
-
-            let slice = vec![
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsDouble(10.0)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(2),
-                    ..Default::default()
-                },
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsDouble(20.0)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(2),
-                    ..Default::default()
-                },
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsDouble(40.0)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(4),
-                    ..Default::default()
-                },
-            ];
-
-            let dims = Dimensions {
-                name: "metric.example".to_string(),
+        // The second point duplicates the first point's timestamp and is dropped.
+        let slice = vec![
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsDouble(10.0)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(2),
                 ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-            assert_eq!(events.len(), 2);
-
-            let expected_ts_s_1 = (start_ts + nanos_from_seconds(2)) / 1_000_000_000;
-            assert_eq!(
-                events[0].try_as_metric().unwrap().values(),
-                &MetricValues::counter((expected_ts_s_1, 10.0))
-            );
-            let expected_ts_s_2 = (start_ts + nanos_from_seconds(4)) / 1_000_000_000;
-            assert_eq!(
-                events[1].try_as_metric().unwrap().values(),
-                &MetricValues::counter((expected_ts_s_2, 30.0))
-            );
-        }
-
-        // Test Case 2: "older" timestamp.
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let start_ts = translator.process_start_time_ns + 1;
-
-            let slice = vec![
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsDouble(10.0)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(3),
-                    ..Default::default()
-                },
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsDouble(25.0)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(2),
-                    ..Default::default()
-                },
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsDouble(40.0)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(5),
-                    ..Default::default()
-                },
-            ];
-
-            let dims = Dimensions {
-                name: "metric.example".to_string(),
+            },
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsDouble(20.0)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(2),
                 ..Default::default()
-            };
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-            assert_eq!(events.len(), 2);
+            },
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsDouble(40.0)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(4),
+                ..Default::default()
+            },
+        ];
 
-            let expected_ts_s_1 = (start_ts + nanos_from_seconds(3)) / 1_000_000_000;
-            assert_eq!(
-                events[0].try_as_metric().unwrap().values(),
-                &MetricValues::counter((expected_ts_s_1, 10.0))
-            );
-            let expected_ts_s_2 = (start_ts + nanos_from_seconds(5)) / 1_000_000_000;
-            assert_eq!(
-                events[1].try_as_metric().unwrap().values(),
-                &MetricValues::counter((expected_ts_s_2, 30.0))
-            );
-        }
+        let events = run_monotonic(&mut translator, "metric.example", slice, &metrics);
+        assert_eq!(events.len(), 2);
+
+        let expected_ts_s_1 = (start_ts + nanos_from_seconds(2)) / 1_000_000_000;
+        assert_eq!(
+            events[0].try_as_metric().unwrap().values(),
+            &MetricValues::counter((expected_ts_s_1, 10.0))
+        );
+        let expected_ts_s_2 = (start_ts + nanos_from_seconds(4)) / 1_000_000_000;
+        assert_eq!(
+            events[1].try_as_metric().unwrap().values(),
+            &MetricValues::counter((expected_ts_s_2, 30.0))
+        );
+    }
+
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1678
+    #[test]
+    fn double_monotonic_diff_drops_older_timestamp_point() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        let start_ts = translator.process_start_time_ns + 1;
+
+        // The second point is older than the first point's timestamp and is dropped.
+        let slice = vec![
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsDouble(10.0)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(3),
+                ..Default::default()
+            },
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsDouble(25.0)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(2),
+                ..Default::default()
+            },
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsDouble(40.0)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(5),
+                ..Default::default()
+            },
+        ];
+
+        let events = run_monotonic(&mut translator, "metric.example", slice, &metrics);
+        assert_eq!(events.len(), 2);
+
+        let expected_ts_s_1 = (start_ts + nanos_from_seconds(3)) / 1_000_000_000;
+        assert_eq!(
+            events[0].try_as_metric().unwrap().values(),
+            &MetricValues::counter((expected_ts_s_1, 10.0))
+        );
+        let expected_ts_s_2 = (start_ts + nanos_from_seconds(5)) / 1_000_000_000;
+        assert_eq!(
+            events[1].try_as_metric().unwrap().values(),
+            &MetricValues::counter((expected_ts_s_2, 30.0))
+        );
     }
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L2033
     #[test]
-    fn test_map_double_monotonic_out_of_order() {
+    fn double_monotonic_drops_out_of_order_point() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
 
@@ -3365,15 +3243,7 @@ mod tests {
             });
         }
 
-        let dims = Dimensions {
-            name: "metric.example".to_string(),
-            ..Default::default()
-        };
-        let context = TranslationContext {
-            resource_attributes: &[],
-            metrics: &metrics,
-        };
-        let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        let events = run_monotonic(&mut translator, "metric.example", slice, &metrics);
         assert_eq!(events.len(), 2);
 
         assert_eq!(
@@ -3388,122 +3258,105 @@ mod tests {
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L464
     #[test]
-    fn test_map_int_monotonic_with_reboot_beginning_of_slice() {
-        let metrics = Metrics::for_tests();
-
-        // Test Case 1: "diff" mode
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let start_ts = translator.process_start_time_ns + 1;
-            let dims = Dimensions {
-                name: "metric.example".to_string(),
-                ..Default::default()
-            };
-
-            // Prime the cache with a previous point.
-            translator
-                .prev_pts
-                .monotonic_diff(&dims, start_ts, start_ts + nanos_from_seconds(2), 10.0);
-
-            // Create a new payload where the first point is a reset.
-            let slice = vec![
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsInt(5)), // Reset: 5 < 10
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(3),
-                    ..Default::default()
-                },
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsInt(30)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(4),
-                    ..Default::default()
-                },
-            ];
-
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-            assert_eq!(events.len(), 2, "Expected two metrics after reset");
-
-            // The reset point should be emitted as a new "first value".
-            let metric1 = events[0].try_as_metric().unwrap();
-            let expected_ts_s_1 = (start_ts + nanos_from_seconds(3)) / 1_000_000_000;
-            assert_eq!(metric1.values(), &MetricValues::counter((expected_ts_s_1, 5.0)));
-
-            // The next point should be a delta from the reset value.
-            let metric2 = events[1].try_as_metric().unwrap();
-            let expected_ts_s_2 = (start_ts + nanos_from_seconds(4)) / 1_000_000_000;
-            assert_eq!(
-                metric2.values(),
-                &MetricValues::counter((expected_ts_s_2, 25.0)) // 30 - 5
-            );
-        }
-
-        // Test Case 2: "rate" mode
-        {
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let start_ts = translator.process_start_time_ns + 1;
-            let dims = Dimensions {
-                name: "kafka.net.bytes_out.rate".to_string(),
-                ..Default::default()
-            };
-
-            // Prime the cache.
-            translator
-                .prev_pts
-                .monotonic_rate(&dims, start_ts, start_ts + nanos_from_seconds(2), 10.0);
-
-            // Create a new payload where the first point is a reset.
-            let slice = vec![
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsInt(5)), // Reset: 5 < 10
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(3),
-                    ..Default::default()
-                },
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsInt(30)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(4),
-                    ..Default::default()
-                },
-            ];
-
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-            assert_eq!(events.len(), 1, "Expected one metric for rate after reset");
-
-            let metric = events[0].try_as_metric().unwrap();
-            let expected_ts_s = (start_ts + nanos_from_seconds(4)) / 1_000_000_000;
-            // rate = (30 - 5) / (4s - 3s) = 25 / 1 = 25
-            assert_eq!(metric.values(), &MetricValues::gauge((expected_ts_s, 25.0)));
-        }
-    }
-
-    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L901
-    #[test]
-    fn test_map_int_monotonic_rate_dont_report_first_value() {
+    fn int_monotonic_diff_reports_reset_at_beginning_of_slice() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
+        let start_ts = translator.process_start_time_ns + 1;
 
+        // Prime the cache with a previous point so the first point in the slice is a reset (5 < 10).
+        let dims = Dimensions {
+            name: "metric.example".to_string(),
+            ..Default::default()
+        };
+        translator
+            .prev_pts
+            .monotonic_diff(&dims, start_ts, start_ts + nanos_from_seconds(2), 10.0);
+
+        let slice = vec![
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsInt(5)), // Reset: 5 < 10
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(3),
+                ..Default::default()
+            },
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsInt(30)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(4),
+                ..Default::default()
+            },
+        ];
+
+        let events = run_monotonic(&mut translator, "metric.example", slice, &metrics);
+        assert_eq!(events.len(), 2, "Expected two metrics after reset");
+
+        // The reset point should be emitted as a new "first value".
+        let expected_ts_s_1 = (start_ts + nanos_from_seconds(3)) / 1_000_000_000;
+        assert_eq!(
+            events[0].try_as_metric().unwrap().values(),
+            &MetricValues::counter((expected_ts_s_1, 5.0))
+        );
+
+        // The next point should be a delta from the reset value: 30 - 5.
+        let expected_ts_s_2 = (start_ts + nanos_from_seconds(4)) / 1_000_000_000;
+        assert_eq!(
+            events[1].try_as_metric().unwrap().values(),
+            &MetricValues::counter((expected_ts_s_2, 25.0))
+        );
+    }
+
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L464
+    #[test]
+    fn int_monotonic_rate_reports_reset_at_beginning_of_slice() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        let start_ts = translator.process_start_time_ns + 1;
+
+        // Prime the cache so the first point in the slice is a reset (5 < 10).
         let dims = Dimensions {
             name: "kafka.net.bytes_out.rate".to_string(),
             ..Default::default()
         };
+        translator
+            .prev_pts
+            .monotonic_rate(&dims, start_ts, start_ts + nanos_from_seconds(2), 10.0);
+
+        let slice = vec![
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsInt(5)), // Reset: 5 < 10
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(3),
+                ..Default::default()
+            },
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsInt(30)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(4),
+                ..Default::default()
+            },
+        ];
+
+        let events = run_monotonic(&mut translator, "kafka.net.bytes_out.rate", slice, &metrics);
+        assert_eq!(events.len(), 1, "Expected one metric for rate after reset");
+
+        let expected_ts_s = (start_ts + nanos_from_seconds(4)) / 1_000_000_000;
+        // rate = (30 - 5) / (4s - 3s) = 25 / 1 = 25
+        assert_eq!(
+            events[0].try_as_metric().unwrap().values(),
+            &MetricValues::gauge((expected_ts_s, 25.0))
+        );
+    }
+
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L901
+    #[test]
+    fn int_monotonic_rate_does_not_report_first_value() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
         let slice = build_test_cumulative_monotonic_int_points(&translator, &[10, 15, 20], false);
         let start_ts_s = slice[0].start_time_unix_nano / 1_000_000_000;
 
-        let context = TranslationContext {
-            resource_attributes: &[],
-            metrics: &metrics,
-        };
-        let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        let events = run_monotonic(&mut translator, "kafka.net.bytes_out.rate", slice, &metrics);
 
         // For rates, the first value is consumed by the cache but doesn't produce a metric.
         assert_eq!(events.len(), 2, "Expected two metrics for a new rate series");
@@ -3521,22 +3374,14 @@ mod tests {
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L917
     #[test]
-    fn test_map_int_monotonic_not_report_first_value_if_start_ts_match_ts() {
+    fn int_monotonic_does_not_report_first_value_when_start_ts_matches_ts() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
 
-        let dims = Dimensions {
-            name: "metric.example".to_string(),
-            ..Default::default()
-        };
-        // ts_match = true, so start_time_unix_nano will equal time_unix_nano
+        // ts_match = true, so start_time_unix_nano will equal time_unix_nano.
         let slice = build_test_cumulative_monotonic_int_points(&translator, &[10, 15, 20], true);
 
-        let context = TranslationContext {
-            resource_attributes: &[],
-            metrics: &metrics,
-        };
-        let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        let events = run_monotonic(&mut translator, "metric.example", slice, &metrics);
 
         assert!(
             events.is_empty(),
@@ -3546,22 +3391,14 @@ mod tests {
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L926
     #[test]
-    fn test_map_int_monotonic_rate_not_report_first_value_if_start_ts_match_ts() {
+    fn int_monotonic_rate_does_not_report_first_value_when_start_ts_matches_ts() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
 
-        let dims = Dimensions {
-            name: "kafka.net.bytes_out.rate".to_string(),
-            ..Default::default()
-        };
-        // ts_match = true, so start_time_unix_nano will equal time_unix_nano
+        // ts_match = true, so start_time_unix_nano will equal time_unix_nano.
         let slice = build_test_cumulative_monotonic_int_points(&translator, &[10, 15, 20], true);
 
-        let context = TranslationContext {
-            resource_attributes: &[],
-            metrics: &metrics,
-        };
-        let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        let events = run_monotonic(&mut translator, "kafka.net.bytes_out.rate", slice, &metrics);
 
         assert!(
             events.is_empty(),
@@ -3571,7 +3408,7 @@ mod tests {
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L935
     #[test]
-    fn test_map_int_monotonic_report_diff_for_first_value() {
+    fn int_monotonic_reports_diff_for_first_value_against_cached_point() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
 
@@ -3589,11 +3426,7 @@ mod tests {
         let slice = build_test_cumulative_monotonic_int_points(&translator, &[10, 15, 20], false);
         let start_ts_s = slice[0].start_time_unix_nano / 1_000_000_000;
 
-        let context = TranslationContext {
-            resource_attributes: &[],
-            metrics: &metrics,
-        };
-        let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        let events = run_monotonic(&mut translator, "metric.example", slice, &metrics);
 
         assert_eq!(
             events.len(),
@@ -3619,7 +3452,7 @@ mod tests {
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L955
     #[test]
-    fn test_map_int_monotonic_report_rate_for_first_value() {
+    fn int_monotonic_reports_rate_for_first_value_against_cached_point() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
 
@@ -3637,11 +3470,7 @@ mod tests {
         let slice = build_test_cumulative_monotonic_int_points(&translator, &[10, 15, 20], false);
         let start_ts_s = slice[0].start_time_unix_nano / 1_000_000_000;
 
-        let context = TranslationContext {
-            resource_attributes: &[],
-            metrics: &metrics,
-        };
-        let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        let events = run_monotonic(&mut translator, "kafka.net.bytes_out.rate", slice, &metrics);
 
         assert_eq!(
             events.len(),
@@ -3667,7 +3496,7 @@ mod tests {
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L429
     #[test]
-    fn test_map_int_monotonic_with_no_recorded_value_within_slice() {
+    fn int_monotonic_skips_no_recorded_value_points() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
 
@@ -3703,15 +3532,7 @@ mod tests {
             },
         ];
 
-        let dims = Dimensions {
-            name: "metric.example".to_string(),
-            ..Default::default()
-        };
-        let context = TranslationContext {
-            resource_attributes: &[],
-            metrics: &metrics,
-        };
-        let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        let events = run_monotonic(&mut translator, "metric.example", slice, &metrics);
 
         assert_eq!(
             events.len(),
@@ -3731,208 +3552,183 @@ mod tests {
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1589
     #[test]
-    fn test_map_double_monotonic_with_reboot_beginning_of_slice() {
-        // Test Case 1: "diff" mode
-        {
-            let metrics = Metrics::for_tests();
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let start_ts = translator.process_start_time_ns + 1;
-            let dims = Dimensions {
-                name: "metric.example".to_string(),
-                ..Default::default()
-            };
-
-            // Pre-populate cache to establish a previous value
-            translator
-                .prev_pts
-                .monotonic_diff(&dims, start_ts, start_ts + nanos_from_seconds(2), 10.0);
-
-            let slice = vec![
-                // Point is smaller than previous point. This is a reset. Cache this point and submit as new value.
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsDouble(5.0)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(3),
-                    ..Default::default()
-                },
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsDouble(30.0)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(4),
-                    ..Default::default()
-                },
-            ];
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-
-            assert_eq!(events.len(), 2, "Expected two metrics for reboot diff test");
-
-            let start_ts_s = start_ts / 1_000_000_000;
-            let metric1 = events[0].try_as_metric().unwrap();
-            assert_eq!(metric1.values(), &MetricValues::counter((start_ts_s + 3, 5.0)));
-
-            let metric2 = events[1].try_as_metric().unwrap();
-            assert_eq!(metric2.values(), &MetricValues::counter((start_ts_s + 4, 25.0)));
-        }
-
-        // Test Case 2: "rate" mode
-        {
-            let metrics = Metrics::for_tests();
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let start_ts = translator.process_start_time_ns + 1;
-            let dims = Dimensions {
-                name: "kafka.net.bytes_out.rate".to_string(),
-                ..Default::default()
-            };
-
-            // Pre-populate cache to establish a previous value
-            translator
-                .prev_pts
-                .monotonic_rate(&dims, start_ts, start_ts + nanos_from_seconds(2), 10.0);
-
-            let slice = vec![
-                // Point is smaller than previous point. This is a reset. Cache this point and DON'T submit.
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsDouble(5.0)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(3),
-                    ..Default::default()
-                },
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsDouble(30.0)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(4),
-                    ..Default::default()
-                },
-            ];
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-
-            assert_eq!(events.len(), 1, "Expected one metric for reboot rate test");
-
-            let start_ts_s = start_ts / 1_000_000_000;
-            let metric1 = events[0].try_as_metric().unwrap();
-            // Rate is (30-5)/(4-3) = 25
-            assert_eq!(metric1.values(), &MetricValues::gauge((start_ts_s + 4, 25.0)));
-        }
-    }
-
-    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1848
-    #[test]
-    fn test_map_double_monotonic_drop_point_beginning_of_slice() {
-        // Test Case 1: "equal"
-        {
-            let metrics = Metrics::for_tests();
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let start_ts = translator.process_start_time_ns + 1;
-            let dims = Dimensions {
-                name: "metric.example".to_string(),
-                ..Default::default()
-            };
-
-            // Pre-populate cache
-            translator
-                .prev_pts
-                .monotonic_diff(&dims, start_ts, start_ts + nanos_from_seconds(2), 10.0);
-
-            let slice = vec![
-                // Duplicate timestamp, should be dropped
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsDouble(20.0)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(2),
-                    ..Default::default()
-                },
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsDouble(40.0)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(4),
-                    ..Default::default()
-                },
-            ];
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-
-            assert_eq!(events.len(), 1, "Expected one metric for drop equal test");
-            let start_ts_s = start_ts / 1_000_000_000;
-            let metric1 = events[0].try_as_metric().unwrap();
-            assert_eq!(
-                metric1.values(),
-                &MetricValues::counter((start_ts_s + 4, 30.0)) // 40 - 10
-            );
-        }
-
-        // Test Case 2: "older"
-        {
-            let metrics = Metrics::for_tests();
-            let mut translator = OtlpMetricsTranslator::for_tests();
-            let start_ts = translator.process_start_time_ns + 1;
-            let dims = Dimensions {
-                name: "metric.example".to_string(),
-                ..Default::default()
-            };
-
-            // Pre-populate cache
-            translator
-                .prev_pts
-                .monotonic_diff(&dims, start_ts, start_ts + nanos_from_seconds(3), 10.0);
-
-            let slice = vec![
-                // Older timestamp, should be dropped
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsDouble(20.0)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(2),
-                    ..Default::default()
-                },
-                OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsDouble(40.0)),
-                    start_time_unix_nano: start_ts,
-                    time_unix_nano: start_ts + nanos_from_seconds(5),
-                    ..Default::default()
-                },
-            ];
-            let context = TranslationContext {
-                resource_attributes: &[],
-                metrics: &metrics,
-            };
-            let events = translator.map_number_monotonic_metrics(dims, slice, &context);
-
-            assert_eq!(events.len(), 1, "Expected one metric for drop older test");
-            let start_ts_s = start_ts / 1_000_000_000;
-            let metric1 = events[0].try_as_metric().unwrap();
-            assert_eq!(
-                metric1.values(),
-                &MetricValues::counter((start_ts_s + 5, 30.0)) // 40 - 10
-            );
-        }
-    }
-
-    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1932
-    #[test]
-    fn test_map_double_monotonic_report_first_value() {
+    fn double_monotonic_diff_reports_reset_at_beginning_of_slice() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
+        let start_ts = translator.process_start_time_ns + 1;
+
+        // Pre-populate the cache to establish a previous value so the first point is a reset (5 < 10).
         let dims = Dimensions {
             name: "metric.example".to_string(),
             ..Default::default()
         };
+        translator
+            .prev_pts
+            .monotonic_diff(&dims, start_ts, start_ts + nanos_from_seconds(2), 10.0);
+
+        let slice = vec![
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsDouble(5.0)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(3),
+                ..Default::default()
+            },
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsDouble(30.0)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(4),
+                ..Default::default()
+            },
+        ];
+
+        let events = run_monotonic(&mut translator, "metric.example", slice, &metrics);
+        assert_eq!(events.len(), 2, "Expected two metrics for reboot diff test");
+
+        let start_ts_s = start_ts / 1_000_000_000;
+        assert_eq!(
+            events[0].try_as_metric().unwrap().values(),
+            &MetricValues::counter((start_ts_s + 3, 5.0))
+        );
+        assert_eq!(
+            events[1].try_as_metric().unwrap().values(),
+            &MetricValues::counter((start_ts_s + 4, 25.0))
+        );
+    }
+
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1589
+    #[test]
+    fn double_monotonic_rate_reports_reset_at_beginning_of_slice() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        let start_ts = translator.process_start_time_ns + 1;
+
+        // Pre-populate the cache so the first point is a reset (5 < 10).
+        let dims = Dimensions {
+            name: "kafka.net.bytes_out.rate".to_string(),
+            ..Default::default()
+        };
+        translator
+            .prev_pts
+            .monotonic_rate(&dims, start_ts, start_ts + nanos_from_seconds(2), 10.0);
+
+        let slice = vec![
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsDouble(5.0)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(3),
+                ..Default::default()
+            },
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsDouble(30.0)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(4),
+                ..Default::default()
+            },
+        ];
+
+        let events = run_monotonic(&mut translator, "kafka.net.bytes_out.rate", slice, &metrics);
+        assert_eq!(events.len(), 1, "Expected one metric for reboot rate test");
+
+        let start_ts_s = start_ts / 1_000_000_000;
+        // Rate is (30-5)/(4-3) = 25.
+        assert_eq!(
+            events[0].try_as_metric().unwrap().values(),
+            &MetricValues::gauge((start_ts_s + 4, 25.0))
+        );
+    }
+
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1848
+    #[test]
+    fn double_monotonic_diff_drops_equal_timestamp_at_beginning_of_slice() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        let start_ts = translator.process_start_time_ns + 1;
+
+        // Pre-populate the cache; the first slice point duplicates the cached timestamp and is dropped.
+        let dims = Dimensions {
+            name: "metric.example".to_string(),
+            ..Default::default()
+        };
+        translator
+            .prev_pts
+            .monotonic_diff(&dims, start_ts, start_ts + nanos_from_seconds(2), 10.0);
+
+        let slice = vec![
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsDouble(20.0)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(2),
+                ..Default::default()
+            },
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsDouble(40.0)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(4),
+                ..Default::default()
+            },
+        ];
+
+        let events = run_monotonic(&mut translator, "metric.example", slice, &metrics);
+        assert_eq!(events.len(), 1, "Expected one metric for drop equal test");
+
+        let start_ts_s = start_ts / 1_000_000_000;
+        // 40 - 10 (delta from the cached point).
+        assert_eq!(
+            events[0].try_as_metric().unwrap().values(),
+            &MetricValues::counter((start_ts_s + 4, 30.0))
+        );
+    }
+
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1848
+    #[test]
+    fn double_monotonic_diff_drops_older_timestamp_at_beginning_of_slice() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        let start_ts = translator.process_start_time_ns + 1;
+
+        // Pre-populate the cache; the first slice point is older than the cached timestamp and is dropped.
+        let dims = Dimensions {
+            name: "metric.example".to_string(),
+            ..Default::default()
+        };
+        translator
+            .prev_pts
+            .monotonic_diff(&dims, start_ts, start_ts + nanos_from_seconds(3), 10.0);
+
+        let slice = vec![
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsDouble(20.0)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(2),
+                ..Default::default()
+            },
+            OtlpNumberDataPoint {
+                value: Some(OtlpNumberDataPointValue::AsDouble(40.0)),
+                start_time_unix_nano: start_ts,
+                time_unix_nano: start_ts + nanos_from_seconds(5),
+                ..Default::default()
+            },
+        ];
+
+        let events = run_monotonic(&mut translator, "metric.example", slice, &metrics);
+        assert_eq!(events.len(), 1, "Expected one metric for drop older test");
+
+        let start_ts_s = start_ts / 1_000_000_000;
+        // 40 - 10 (delta from the cached point).
+        assert_eq!(
+            events[0].try_as_metric().unwrap().values(),
+            &MetricValues::counter((start_ts_s + 5, 30.0))
+        );
+    }
+
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1932
+    #[test]
+    fn double_monotonic_reports_first_value_from_new_series() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
         let slice = build_test_cumulative_monotonic_double_points(&translator, &[10.0, 15.0, 20.0], false);
         let start_ts_s = slice[0].start_time_unix_nano / 1_000_000_000;
-        let context = TranslationContext {
-            resource_attributes: &[],
-            metrics: &metrics,
-        };
-        let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        let events = run_monotonic(&mut translator, "metric.example", slice, &metrics);
         assert_eq!(events.len(), 3);
         let metric1 = events[0].try_as_metric().unwrap();
         assert_eq!(metric1.values(), &MetricValues::counter((start_ts_s + 2, 10.0)));
@@ -3944,20 +3740,12 @@ mod tests {
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1948
     #[test]
-    fn test_map_double_monotonic_rate_dont_report_first_value() {
+    fn double_monotonic_rate_does_not_report_first_value() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
-        let dims = Dimensions {
-            name: "kafka.net.bytes_out.rate".to_string(),
-            ..Default::default()
-        };
         let slice = build_test_cumulative_monotonic_double_points(&translator, &[10.0, 15.0, 20.0], false);
         let start_ts_s = slice[0].start_time_unix_nano / 1_000_000_000;
-        let context = TranslationContext {
-            resource_attributes: &[],
-            metrics: &metrics,
-        };
-        let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        let events = run_monotonic(&mut translator, "kafka.net.bytes_out.rate", slice, &metrics);
         assert_eq!(events.len(), 2);
         let metric1 = events[0].try_as_metric().unwrap();
         assert_eq!(metric1.values(), &MetricValues::gauge((start_ts_s + 3, 5.0)));
@@ -3967,25 +3755,17 @@ mod tests {
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1964
     #[test]
-    fn test_map_double_monotonic_not_report_first_value_if_start_ts_match_ts() {
+    fn double_monotonic_does_not_report_first_value_when_start_ts_matches_ts() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
-        let dims = Dimensions {
-            name: "metric.example".to_string(),
-            ..Default::default()
-        };
         let slice = build_test_cumulative_monotonic_double_points(&translator, &[10.0, 15.0, 20.0], true);
-        let context = TranslationContext {
-            resource_attributes: &[],
-            metrics: &metrics,
-        };
-        let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        let events = run_monotonic(&mut translator, "metric.example", slice, &metrics);
         assert!(events.is_empty());
     }
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L1994
     #[test]
-    fn test_map_double_monotonic_report_diff_for_first_value() {
+    fn double_monotonic_reports_diff_for_first_value_against_cached_point() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
         let dims = Dimensions {
@@ -3998,11 +3778,7 @@ mod tests {
             .monotonic_diff(&dims, start_ts, start_ts + nanos_from_seconds(1), 1.0);
         let slice = build_test_cumulative_monotonic_double_points(&translator, &[10.0, 15.0, 20.0], false);
         let start_ts_s = slice[0].start_time_unix_nano / 1_000_000_000;
-        let context = TranslationContext {
-            resource_attributes: &[],
-            metrics: &metrics,
-        };
-        let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        let events = run_monotonic(&mut translator, "metric.example", slice, &metrics);
         assert_eq!(events.len(), 3);
         let metric1 = events[0].try_as_metric().unwrap();
         assert_eq!(metric1.values(), &MetricValues::counter((start_ts_s + 2, 9.0)));
@@ -4014,7 +3790,7 @@ mod tests {
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L2013
     #[test]
-    fn test_map_double_monotonic_report_rate_for_first_value() {
+    fn double_monotonic_reports_rate_for_first_value_against_cached_point() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
         let dims = Dimensions {
@@ -4027,11 +3803,7 @@ mod tests {
             .monotonic_diff(&dims, start_ts, start_ts + nanos_from_seconds(1), 1.0);
         let slice = build_test_cumulative_monotonic_double_points(&translator, &[10.0, 15.0, 20.0], false);
         let start_ts_s = slice[0].start_time_unix_nano / 1_000_000_000;
-        let context = TranslationContext {
-            resource_attributes: &[],
-            metrics: &metrics,
-        };
-        let events = translator.map_number_monotonic_metrics(dims, slice, &context);
+        let events = run_monotonic(&mut translator, "kafka.net.bytes_out.rate", slice, &metrics);
         assert_eq!(events.len(), 3);
         let metric1 = events[0].try_as_metric().unwrap();
         assert_eq!(metric1.values(), &MetricValues::gauge((start_ts_s + 2, 9.0)));
@@ -4039,5 +3811,509 @@ mod tests {
         assert_eq!(metric2.values(), &MetricValues::gauge((start_ts_s + 3, 5.0)));
         let metric3 = events[2].try_as_metric().unwrap();
         assert_eq!(metric3.values(), &MetricValues::gauge((start_ts_s + 4, 5.0)));
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Histogram translation (`map_histogram_metrics`).
+    //
+    // Mirrors the Go `mapHistogramMetrics` histogram-mode dispatch:
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator.go
+    // -----------------------------------------------------------------------------------------------
+
+    fn run_histogram(
+        translator: &mut OtlpMetricsTranslator, name: &str, data_points: Vec<OtlpHistogramDataPoint>, delta: bool,
+        metrics: &Metrics,
+    ) -> Vec<Event> {
+        let dims = Dimensions {
+            name: name.to_string(),
+            ..Default::default()
+        };
+        let context = TranslationContext {
+            resource_attributes: &[],
+            metrics,
+        };
+        translator.map_histogram_metrics(dims, data_points, delta, &context)
+    }
+
+    fn distribution_sketch(metric: &Metric) -> &DDSketch {
+        match metric.values() {
+            MetricValues::Distribution(points) => {
+                points
+                    .into_iter()
+                    .next()
+                    .expect("distribution should carry one sketch point")
+                    .1
+            }
+            _ => panic!("expected a distribution metric"),
+        }
+    }
+
+    #[test]
+    fn histogram_counters_mode_emits_one_counter_per_bucket() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        translator.config = translator.config.with_histogram_mode(HistogramMode::Counters);
+
+        let dp = OtlpHistogramDataPoint {
+            count: 6,
+            sum: Some(10.0),
+            bucket_counts: vec![1, 2, 3],
+            explicit_bounds: vec![1.0, 2.0],
+            time_unix_nano: nanos_from_seconds(1),
+            ..Default::default()
+        };
+
+        let events = run_histogram(&mut translator, "otlp.histogram", vec![dp], true, &metrics);
+        assert_eq!(events.len(), 3, "expected one counter per explicit bucket");
+
+        // (-inf, 1.0], (1.0, 2.0], (2.0, +inf) with counts 1, 2, 3.
+        let expected = [("-inf", "1.0", 1.0), ("1.0", "2.0", 2.0), ("2.0", "inf", 3.0)];
+        for (event, (lower, upper, value)) in events.iter().zip(expected) {
+            let metric = event.try_as_metric().unwrap();
+            assert_eq!(metric.context().name(), "otlp.histogram.bucket");
+            assert_eq!(
+                metric.context().tags().get_single_tag("lower_bound"),
+                Some(&Tag::from(format!("lower_bound:{lower}").as_str()))
+            );
+            assert_eq!(
+                metric.context().tags().get_single_tag("upper_bound"),
+                Some(&Tag::from(format!("upper_bound:{upper}").as_str()))
+            );
+            assert_eq!(metric.values(), &MetricValues::counter((1, value)));
+        }
+    }
+
+    #[test]
+    fn histogram_aggregations_emit_count_sum_min_max() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        translator.config = translator
+            .config
+            .with_histogram_mode(HistogramMode::NoBuckets)
+            .with_send_histogram_aggregations(true);
+
+        let dp = OtlpHistogramDataPoint {
+            count: 6,
+            sum: Some(12.0),
+            min: Some(0.5),
+            max: Some(9.0),
+            bucket_counts: vec![1, 2, 3],
+            explicit_bounds: vec![1.0, 2.0],
+            time_unix_nano: nanos_from_seconds(1),
+            ..Default::default()
+        };
+
+        // NoBuckets mode emits only the aggregations (count/sum as counters, min/max as gauges for delta).
+        let events = run_histogram(&mut translator, "otlp.histogram", vec![dp], true, &metrics);
+        assert_eq!(events.len(), 4, "expected count, sum, min, and max aggregations");
+
+        let count = events[0].try_as_metric().unwrap();
+        assert_eq!(count.context().name(), "otlp.histogram.count");
+        assert_eq!(count.values(), &MetricValues::counter((1, 6.0)));
+
+        let sum = events[1].try_as_metric().unwrap();
+        assert_eq!(sum.context().name(), "otlp.histogram.sum");
+        assert_eq!(sum.values(), &MetricValues::counter((1, 12.0)));
+
+        let min = events[2].try_as_metric().unwrap();
+        assert_eq!(min.context().name(), "otlp.histogram.min");
+        assert_eq!(min.values(), &MetricValues::gauge((1, 0.5)));
+
+        let max = events[3].try_as_metric().unwrap();
+        assert_eq!(max.context().name(), "otlp.histogram.max");
+        assert_eq!(max.values(), &MetricValues::gauge((1, 9.0)));
+    }
+
+    #[test]
+    fn histogram_distributions_mode_emits_single_sketch() {
+        let metrics = Metrics::for_tests();
+        // `for_tests` defaults to `HistogramMode::Distributions`.
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        let dp = OtlpHistogramDataPoint {
+            count: 6,
+            sum: Some(10.0),
+            bucket_counts: vec![1, 2, 3],
+            explicit_bounds: vec![1.0, 2.0],
+            time_unix_nano: nanos_from_seconds(1),
+            ..Default::default()
+        };
+
+        let events = run_histogram(&mut translator, "otlp.histogram", vec![dp], true, &metrics);
+        assert_eq!(events.len(), 1, "distributions mode emits a single sketch");
+
+        let metric = events[0].try_as_metric().unwrap();
+        assert_eq!(metric.context().name(), "otlp.histogram");
+        assert_eq!(
+            distribution_sketch(metric).count(),
+            6,
+            "sketch count should match the histogram count"
+        );
+    }
+
+    #[test]
+    fn histogram_cumulative_first_point_emits_nothing() {
+        // A cumulative histogram's first point has no previous value to diff against, so neither a
+        // sketch nor aggregations can be produced.
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        let dp = OtlpHistogramDataPoint {
+            count: 6,
+            sum: Some(10.0),
+            bucket_counts: vec![1, 2, 3],
+            explicit_bounds: vec![1.0, 2.0],
+            time_unix_nano: nanos_from_seconds(1),
+            ..Default::default()
+        };
+
+        let events = run_histogram(&mut translator, "otlp.histogram", vec![dp], false, &metrics);
+        assert!(events.is_empty());
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Summary translation (`map_summary_metrics`).
+    // -----------------------------------------------------------------------------------------------
+
+    fn run_summary(
+        translator: &mut OtlpMetricsTranslator, name: &str, data_points: Vec<OtlpSummaryDataPoint>, metrics: &Metrics,
+    ) -> Vec<Event> {
+        let dims = Dimensions {
+            name: name.to_string(),
+            ..Default::default()
+        };
+        let context = TranslationContext {
+            resource_attributes: &[],
+            metrics,
+        };
+        translator.map_summary_metrics(dims, data_points, &context)
+    }
+
+    fn summary_dp(count: u64, sum: f64, ts_secs: u64, quantiles: &[(f64, f64)]) -> OtlpSummaryDataPoint {
+        OtlpSummaryDataPoint {
+            count,
+            sum,
+            time_unix_nano: nanos_from_seconds(ts_secs),
+            quantile_values: quantiles
+                .iter()
+                .map(|&(quantile, value)| ValueAtQuantile { quantile, value })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn summary_count_and_sum_emit_counter_deltas() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        // Count is treated as a cumulative monotonic series and sum as a cumulative (non-monotonic)
+        // diff, so the first point only primes the cache and the second yields the deltas.
+        let data_points = vec![summary_dp(5, 100.0, 1, &[]), summary_dp(10, 250.0, 2, &[])];
+        let events = run_summary(&mut translator, "otlp.summary", data_points, &metrics);
+
+        assert_eq!(events.len(), 2);
+        let count = events[0].try_as_metric().unwrap();
+        assert_eq!(count.context().name(), "otlp.summary.count");
+        assert_eq!(count.values(), &MetricValues::counter((2, 5.0))); // 10 - 5
+
+        let sum = events[1].try_as_metric().unwrap();
+        assert_eq!(sum.context().name(), "otlp.summary.sum");
+        assert_eq!(sum.values(), &MetricValues::counter((2, 150.0))); // 250 - 100
+    }
+
+    #[test]
+    fn summary_quantiles_emit_gauges_tagged_with_quantile() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        translator.config.quantiles = true;
+
+        // A single data point produces no count/sum delta, leaving only the quantile gauges.
+        let data_points = vec![summary_dp(3, 30.0, 1, &[(0.5, 1.0), (0.99, 9.0)])];
+        let events = run_summary(&mut translator, "otlp.summary", data_points, &metrics);
+
+        assert_eq!(events.len(), 2);
+        let q50 = events[0].try_as_metric().unwrap();
+        assert_eq!(q50.context().name(), "otlp.summary.quantile");
+        assert_eq!(
+            q50.context().tags().get_single_tag("quantile"),
+            Some(&Tag::from("quantile:0.5"))
+        );
+        assert_eq!(q50.values(), &MetricValues::gauge((1, 1.0)));
+
+        let q99 = events[1].try_as_metric().unwrap();
+        assert_eq!(
+            q99.context().tags().get_single_tag("quantile"),
+            Some(&Tag::from("quantile:0.99"))
+        );
+        assert_eq!(q99.values(), &MetricValues::gauge((1, 9.0)));
+    }
+
+    #[test]
+    fn summary_skips_no_recorded_value_points() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        translator.config.quantiles = true;
+
+        let dp = OtlpSummaryDataPoint {
+            count: 5,
+            sum: 100.0,
+            flags: DataPointFlags::NoRecordedValueMask as u32,
+            time_unix_nano: nanos_from_seconds(1),
+            quantile_values: vec![ValueAtQuantile {
+                quantile: 0.5,
+                value: 1.0,
+            }],
+            ..Default::default()
+        };
+
+        let events = run_summary(&mut translator, "otlp.summary", vec![dp], &metrics);
+        assert!(events.is_empty());
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // ExponentialHistogram translation (`map_exponential_histogram_metrics`).
+    // -----------------------------------------------------------------------------------------------
+
+    fn run_exponential_histogram(
+        translator: &mut OtlpMetricsTranslator, name: &str, data_points: Vec<OtlpExponentialHistogramDataPoint>,
+        delta: bool, metrics: &Metrics,
+    ) -> Vec<Event> {
+        let dims = Dimensions {
+            name: name.to_string(),
+            ..Default::default()
+        };
+        let context = TranslationContext {
+            resource_attributes: &[],
+            metrics,
+        };
+        translator.map_exponential_histogram_metrics(dims, data_points, delta, &context)
+    }
+
+    fn exp_histogram_dp(count: u64, sum: f64, min: Option<f64>, max: Option<f64>) -> OtlpExponentialHistogramDataPoint {
+        OtlpExponentialHistogramDataPoint {
+            count,
+            sum: Some(sum),
+            min,
+            max,
+            scale: 0,
+            zero_count: 0,
+            positive: Some(OtlpExponentialHistogramBuckets {
+                offset: 0,
+                bucket_counts: vec![1, 1, 1],
+            }),
+            negative: None,
+            time_unix_nano: nanos_from_seconds(1),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn exponential_histogram_delta_emits_single_sketch() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        let dp = exp_histogram_dp(3, 6.0, None, None);
+        let events = run_exponential_histogram(&mut translator, "otlp.exphist", vec![dp], true, &metrics);
+
+        assert_eq!(events.len(), 1, "delta exponential histogram emits a single sketch");
+        let metric = events[0].try_as_metric().unwrap();
+        assert_eq!(metric.context().name(), "otlp.exphist");
+        assert_eq!(
+            distribution_sketch(metric).count(),
+            3,
+            "sketch count should match the histogram count"
+        );
+    }
+
+    #[test]
+    fn exponential_histogram_aggregations_emit_count_sum_min_max_and_sketch() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        translator.config = translator.config.with_send_histogram_aggregations(true);
+
+        let dp = exp_histogram_dp(3, 6.0, Some(0.5), Some(4.0));
+        let events = run_exponential_histogram(&mut translator, "otlp.exphist", vec![dp], true, &metrics);
+
+        // count, sum, min, max, then the sketch.
+        assert_eq!(events.len(), 5);
+        let count = events[0].try_as_metric().unwrap();
+        assert_eq!(count.context().name(), "otlp.exphist.count");
+        assert_eq!(count.values(), &MetricValues::counter((1, 3.0)));
+
+        let sum = events[1].try_as_metric().unwrap();
+        assert_eq!(sum.context().name(), "otlp.exphist.sum");
+        assert_eq!(sum.values(), &MetricValues::counter((1, 6.0)));
+
+        let min = events[2].try_as_metric().unwrap();
+        assert_eq!(min.context().name(), "otlp.exphist.min");
+        assert_eq!(min.values(), &MetricValues::gauge((1, 0.5)));
+
+        let max = events[3].try_as_metric().unwrap();
+        assert_eq!(max.context().name(), "otlp.exphist.max");
+        assert_eq!(max.values(), &MetricValues::gauge((1, 4.0)));
+
+        let sketch = events[4].try_as_metric().unwrap();
+        assert_eq!(sketch.context().name(), "otlp.exphist");
+        assert_eq!(distribution_sketch(sketch).count(), 3);
+    }
+
+    #[test]
+    fn exponential_histogram_cumulative_is_dropped() {
+        // Only delta temporality is supported; cumulative exponential histograms are dropped.
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        let dp = exp_histogram_dp(3, 6.0, None, None);
+        let events = run_exponential_histogram(&mut translator, "otlp.exphist", vec![dp], false, &metrics);
+
+        assert!(events.is_empty());
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Runtime metric mapping (`runtime_metrics.rs` tables consumed by `translate_metrics` and the
+    // `map_*_runtime_metric_with_attributes` helpers).
+    // -----------------------------------------------------------------------------------------------
+
+    fn resource_metrics_with_metric(metric: OtlpMetric) -> OtlpResourceMetrics {
+        OtlpResourceMetrics {
+            resource: None,
+            scope_metrics: vec![ScopeMetrics {
+                metrics: vec![metric],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn metric_by_name<'a>(events: &'a [Event], name: &str) -> &'a Metric {
+        events
+            .iter()
+            .filter_map(|e| e.try_as_metric())
+            .find(|m| m.context().name() == name)
+            .unwrap_or_else(|| panic!("no metric named {name}"))
+    }
+
+    fn int_dp_with_attr(value: i64, key: &str, attr_value: &str) -> OtlpNumberDataPoint {
+        OtlpNumberDataPoint {
+            value: Some(OtlpNumberDataPointValue::AsInt(value)),
+            time_unix_nano: nanos_from_seconds(1),
+            attributes: vec![OtlpKeyValue {
+                key: key.to_string(),
+                value: Some(otlp_protos::opentelemetry::proto::common::v1::AnyValue {
+                    value: Some(
+                        otlp_protos::opentelemetry::proto::common::v1::any_value::Value::StringValue(
+                            attr_value.to_string(),
+                        ),
+                    ),
+                }),
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn translate_metrics_renames_runtime_metric_without_attributes() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        // `process.runtime.go.goroutines` maps (with no attribute matching) to `runtime.go.num_goroutine`.
+        let metric = OtlpMetric {
+            name: "process.runtime.go.goroutines".to_string(),
+            data: Some(OtlpMetricData::Gauge(Gauge {
+                data_points: vec![OtlpNumberDataPoint {
+                    value: Some(OtlpNumberDataPointValue::AsInt(5)),
+                    time_unix_nano: nanos_from_seconds(1),
+                    ..Default::default()
+                }],
+            })),
+            ..Default::default()
+        };
+
+        let events = translator
+            .translate_metrics(resource_metrics_with_metric(metric), &metrics)
+            .expect("translation should succeed")
+            .collect::<Vec<_>>();
+
+        let renamed = metric_by_name(&events, "runtime.go.num_goroutine");
+        assert_eq!(renamed.values(), &MetricValues::gauge((1, 5.0)));
+    }
+
+    #[test]
+    fn translate_metrics_maps_runtime_gauge_by_attribute() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        // `process.runtime.jvm.memory.usage` fans out by the `type` attribute: heap -> jvm.heap_memory,
+        // non_heap -> jvm.non_heap_memory. The `type` attribute is stripped from the mapped metric.
+        let metric = OtlpMetric {
+            name: "process.runtime.jvm.memory.usage".to_string(),
+            data: Some(OtlpMetricData::Gauge(Gauge {
+                data_points: vec![
+                    int_dp_with_attr(100, "type", "heap"),
+                    int_dp_with_attr(50, "type", "non_heap"),
+                ],
+            })),
+            ..Default::default()
+        };
+
+        let events = translator
+            .translate_metrics(resource_metrics_with_metric(metric), &metrics)
+            .expect("translation should succeed")
+            .collect::<Vec<_>>();
+
+        let heap = metric_by_name(&events, "jvm.heap_memory");
+        assert_eq!(heap.values(), &MetricValues::gauge((1, 100.0)));
+        assert!(
+            heap.context().tags().get_single_tag("type").is_none(),
+            "the matched `type` attribute should be stripped from the mapped metric"
+        );
+
+        let non_heap = metric_by_name(&events, "jvm.non_heap_memory");
+        assert_eq!(non_heap.values(), &MetricValues::gauge((1, 50.0)));
+    }
+
+    #[test]
+    fn sum_runtime_metric_maps_matching_attribute_and_strips_it() {
+        // `process.runtime.dotnet.gc.heap.size` fans out by the `generation` attribute.
+        let mapping_set = RUNTIME_METRICS_MAPPINGS
+            .get("process.runtime.dotnet.gc.heap.size")
+            .expect("runtime mapping should exist");
+        let gen0_mapping = mapping_set
+            .iter()
+            .find(|m| m.mapped_name == "runtime.dotnet.gc.size.gen0")
+            .expect("gen0 mapping should exist");
+
+        let metric = OtlpMetric {
+            name: "process.runtime.dotnet.gc.heap.size".to_string(),
+            data: Some(OtlpMetricData::Sum(Sum {
+                data_points: vec![
+                    int_dp_with_attr(42, "generation", "gen0"),
+                    int_dp_with_attr(7, "generation", "gen1"),
+                ],
+                is_monotonic: true,
+                aggregation_temporality: AggregationTemporality::Cumulative as i32,
+            })),
+            ..Default::default()
+        };
+
+        let mut new_metrics = Vec::new();
+        map_sum_runtime_metric_with_attributes(&metric, &mut new_metrics, gen0_mapping);
+
+        assert_eq!(new_metrics.len(), 1, "only the gen0 data point should match");
+        assert_eq!(new_metrics[0].name, "runtime.dotnet.gc.size.gen0");
+        let Some(OtlpMetricData::Sum(sum)) = &new_metrics[0].data else {
+            panic!("expected a sum metric");
+        };
+        assert_eq!(sum.data_points.len(), 1);
+        assert_eq!(
+            sum.data_points[0].value,
+            Some(OtlpNumberDataPointValue::AsInt(42)),
+            "the matched data point's value should be preserved"
+        );
+        assert!(
+            sum.data_points[0].attributes.is_empty(),
+            "the matched `generation` attribute should be stripped"
+        );
     }
 }

--- a/test/CLEANUP_PLAN.md
+++ b/test/CLEANUP_PLAN.md
@@ -209,7 +209,7 @@ otherwise keep hand-rolling the thing it replaces.
   - [low/small] `PendingTransactions::flush`'s shutdown/disk-persistence path, and `transaction.rs`'s `size_bytes`
     and consumed-body panic/error paths, are untested.
 
-- [ ] **G13 — otlp traces & metrics translation test cleanup** (AU-03/AU-06)
+- [x] **G13 — otlp traces & metrics translation test cleanup** (AU-03/AU-06)
   (`tobz/test-cleanup-otlp-translation-test-cleanup`, `test(components)`)
   - [medium/medium] `traces/transform.rs`'s ported Go-agent branching translation logic is largely untested;
     `otlp/traces/translator.rs`'s documented single-fallback hostname resolution and trace-grouping entry point are


### PR DESCRIPTION
## Summary

This PR cleans up tests/shared test code for the OTLP source, and some of the shared/common OTLP component code.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New and existing unit tests.

## References

DADP-2
