### PR TITLE
chore(test): clean up tests for ADP-specific components

### DIFF
--- a/bin/agent-data-plane/src/components/apm_onboarding/install_info.rs
+++ b/bin/agent-data-plane/src/components/apm_onboarding/install_info.rs
@@ -95,3 +95,52 @@ fn infer_install_type_from_environment() -> MetaString {
         _ => INSTALL_TYPE_DEFAULT.clone(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_type_inference_maps_each_documented_env_combination() {
+        // `infer_install_type_from_environment` keys off DOCKER_DD_AGENT and DD_APM_ENABLED. These are
+        // process-global env vars; nextest isolates every test in its own process, and this test restores the
+        // original values when it finishes.
+        let orig_docker = std::env::var("DOCKER_DD_AGENT").ok();
+        let orig_apm = std::env::var("DD_APM_ENABLED").ok();
+
+        fn set(key: &str, value: Option<&str>) {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+
+        // Not containerized -> "manual", regardless of the APM flag.
+        set("DOCKER_DD_AGENT", None);
+        set("DD_APM_ENABLED", None);
+        assert_eq!(infer_install_type_from_environment(), MetaString::from("manual"));
+
+        set("DD_APM_ENABLED", Some("true"));
+        assert_eq!(infer_install_type_from_environment(), MetaString::from("manual"));
+
+        // Containerized without single-step APM -> "docker_manual".
+        set("DOCKER_DD_AGENT", Some("true"));
+        set("DD_APM_ENABLED", None);
+        assert_eq!(infer_install_type_from_environment(), MetaString::from("docker_manual"));
+
+        // Containerized with single-step APM -> "docker_single_step".
+        set("DD_APM_ENABLED", Some("true"));
+        assert_eq!(
+            infer_install_type_from_environment(),
+            MetaString::from("docker_single_step")
+        );
+
+        // An empty DOCKER_DD_AGENT counts as unset -> "manual".
+        set("DOCKER_DD_AGENT", Some(""));
+        set("DD_APM_ENABLED", None);
+        assert_eq!(infer_install_type_from_environment(), MetaString::from("manual"));
+
+        set("DOCKER_DD_AGENT", orig_docker.as_deref());
+        set("DD_APM_ENABLED", orig_apm.as_deref());
+    }
+}

--- a/bin/agent-data-plane/src/components/apm_onboarding/mod.rs
+++ b/bin/agent-data-plane/src/components/apm_onboarding/mod.rs
@@ -158,3 +158,181 @@ fn add_meta_entry_if_missing(span: &mut Span, key: &MetaString, value: &MetaStri
             .insert(key.clone(), AttributeValue::String(value.clone()));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use saluki_common::collections::FastHashMap;
+    use saluki_core::data_model::event::Event;
+
+    use super::*;
+
+    fn span(service: &str, span_id: u64, parent_id: u64) -> Span {
+        Span::new(service, "op", "res", "web", span_id, parent_id, 0, 0, 0)
+    }
+
+    fn test_install_info() -> InstallInfo {
+        InstallInfo {
+            install_id: MetaString::from("install-123"),
+            install_type: MetaString::from("manual"),
+            install_time: 1_234_567_890,
+        }
+    }
+
+    /// Collects the string-valued attributes of the span with `span_id` from every trace in `buffer`.
+    fn span_attrs_by_id(buffer: &EventsBuffer, span_id: u64) -> HashMap<String, String> {
+        let mut out = HashMap::new();
+        for event in buffer {
+            if let Event::Trace(trace) = event {
+                for span in trace.spans() {
+                    if span.span_id() == span_id {
+                        for (k, v) in span.attributes.iter() {
+                            if let AttributeValue::String(s) = v {
+                                out.insert(k.as_ref().to_string(), s.as_ref().to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Pushes `trace` through `onboarding.transform_buffer` and returns the resulting buffer.
+    fn enrich(onboarding: &mut ApmOnboarding, trace: Trace) -> EventsBuffer {
+        let mut buffer = EventsBuffer::default();
+        assert!(
+            buffer.try_push(Event::Trace(trace)).is_none(),
+            "buffer should have capacity"
+        );
+        onboarding.transform_buffer(&mut buffer);
+        buffer
+    }
+
+    #[test]
+    fn root_span_lookup_returns_none_for_empty_trace() {
+        let mut trace = Trace::new(vec![]);
+        assert!(get_root_span_from_trace_mut(&mut trace).is_none());
+    }
+
+    #[test]
+    fn root_span_lookup_finds_parentless_span_reported_last() {
+        // Common case: the root (parent_id 0) is reported last, so the reverse scan returns it immediately.
+        let mut trace = Trace::new(vec![span("web", 2, 1), span("web", 1, 0)]);
+        let root = get_root_span_from_trace_mut(&mut trace).expect("a root span should be found");
+        assert_eq!(root.span_id(), 1, "the parent_id==0 span is the root");
+    }
+
+    #[test]
+    fn root_span_lookup_uses_dangling_parent_when_no_parentless_span() {
+        // No span has parent_id 0; the root's parent points outside the trace (id 99). That single dangling
+        // reference is what identifies the root.
+        let mut trace = Trace::new(vec![span("web", 1, 99), span("web", 2, 1)]);
+        let root = get_root_span_from_trace_mut(&mut trace).expect("a root span should be found");
+        assert_eq!(root.span_id(), 1);
+    }
+
+    #[test]
+    fn root_span_lookup_falls_back_to_last_span_for_malformed_trace() {
+        // A parent/child cycle has no parent_id==0 span and no dangling parent, so nothing identifies the
+        // root: the function falls back to the last span in the trace.
+        let mut trace = Trace::new(vec![span("web", 1, 2), span("web", 2, 1)]);
+        let root = get_root_span_from_trace_mut(&mut trace).expect("fallback should return the last span");
+        assert_eq!(root.span_id(), 2, "a malformed trace falls back to the last span");
+    }
+
+    #[test]
+    fn enriches_only_the_root_span_of_a_new_service() {
+        let mut onboarding = ApmOnboarding::from_install_info(Some(test_install_info()));
+        // Child reported first, root (parent_id 0) reported last.
+        let buffer = enrich(&mut onboarding, Trace::new(vec![span("web", 2, 1), span("web", 1, 0)]));
+
+        let root_attrs = span_attrs_by_id(&buffer, 1);
+        assert_eq!(
+            root_attrs.get("_dd.install.id").map(String::as_str),
+            Some("install-123")
+        );
+        assert_eq!(root_attrs.get("_dd.install.type").map(String::as_str), Some("manual"));
+        assert_eq!(
+            root_attrs.get("_dd.install.time").map(String::as_str),
+            Some("1234567890")
+        );
+
+        assert!(
+            span_attrs_by_id(&buffer, 2).is_empty(),
+            "non-root spans must not be enriched"
+        );
+    }
+
+    #[test]
+    fn only_the_first_trace_per_service_is_enriched() {
+        let mut onboarding = ApmOnboarding::from_install_info(Some(test_install_info()));
+
+        let first = enrich(&mut onboarding, Trace::new(vec![span("web", 1, 0)]));
+        assert!(span_attrs_by_id(&first, 1).contains_key("_dd.install.id"));
+
+        // The same service again: its root is not enriched a second time.
+        let second = enrich(&mut onboarding, Trace::new(vec![span("web", 3, 0)]));
+        assert!(
+            span_attrs_by_id(&second, 3).is_empty(),
+            "a service already seen must not be enriched again"
+        );
+
+        // A different service is still enriched.
+        let third = enrich(&mut onboarding, Trace::new(vec![span("api", 4, 0)]));
+        assert!(span_attrs_by_id(&third, 4).contains_key("_dd.install.id"));
+    }
+
+    #[test]
+    fn existing_install_metadata_is_preserved() {
+        let mut onboarding = ApmOnboarding::from_install_info(Some(test_install_info()));
+
+        // A tracer already set the install id; the transform must not overwrite it, but still fills in the
+        // entries that are missing.
+        let mut attrs = FastHashMap::default();
+        attrs.insert(
+            META_TAG_INSTALL_ID.clone(),
+            AttributeValue::String(MetaString::from("tracer-set-id")),
+        );
+        let root = Span::new("web", "op", "res", "web", 1, 0, 0, 0, 0).with_attributes(attrs);
+
+        let buffer = enrich(&mut onboarding, Trace::new(vec![root]));
+        let root_attrs = span_attrs_by_id(&buffer, 1);
+        assert_eq!(
+            root_attrs.get("_dd.install.id").map(String::as_str),
+            Some("tracer-set-id"),
+            "an install id already set by a tracer must not be overwritten"
+        );
+        assert_eq!(root_attrs.get("_dd.install.type").map(String::as_str), Some("manual"));
+        assert_eq!(
+            root_attrs.get("_dd.install.time").map(String::as_str),
+            Some("1234567890")
+        );
+    }
+
+    #[test]
+    fn missing_install_info_leaves_traces_untouched() {
+        let mut onboarding = ApmOnboarding::from_install_info(None);
+        let buffer = enrich(&mut onboarding, Trace::new(vec![span("web", 1, 0)]));
+        assert!(
+            span_attrs_by_id(&buffer, 1).is_empty(),
+            "with no install info, transform_buffer must be a no-op"
+        );
+    }
+
+    #[test]
+    fn empty_trace_is_skipped_and_later_traces_still_enriched() {
+        // A trace with no spans has no root span, so `enrich_trace` returns early (before touching
+        // `install_info`); the loop must continue and still enrich the following non-empty trace.
+        let mut onboarding = ApmOnboarding::from_install_info(Some(test_install_info()));
+        let mut buffer = EventsBuffer::default();
+        assert!(buffer.try_push(Event::Trace(Trace::new(vec![]))).is_none());
+        assert!(buffer
+            .try_push(Event::Trace(Trace::new(vec![span("web", 1, 0)])))
+            .is_none());
+        onboarding.transform_buffer(&mut buffer);
+
+        assert!(span_attrs_by_id(&buffer, 1).contains_key("_dd.install.id"));
+    }
+}

--- a/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/mod.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/mod.rs
@@ -515,12 +515,16 @@ mod tests {
 
     #[test]
     fn invalid_percentiles_are_rejected() {
-        let histogram_aggregates = Vec::new();
-        let histogram_percentiles = vec!["1.1".to_string()];
+        // `HistogramSuffixes::from_configuration` documents two rejection branches: a value that isn't a
+        // number, and a numeric value outside the [0.0, 1.0] range. Both must produce an error.
+        let non_numeric = HistogramSuffixes::from_configuration(&[], &["abc".to_string()]);
+        assert!(non_numeric.is_err(), "a non-numeric percentile must be rejected");
 
-        let result = HistogramSuffixes::from_configuration(&histogram_aggregates, &histogram_percentiles);
+        let above_range = HistogramSuffixes::from_configuration(&[], &["1.1".to_string()]);
+        assert!(above_range.is_err(), "a percentile above 1.0 must be rejected");
 
-        assert!(result.is_err());
+        let below_range = HistogramSuffixes::from_configuration(&[], &["-0.1".to_string()]);
+        assert!(below_range.is_err(), "a percentile below 0.0 must be rejected");
     }
 
     // Mirrors Datadog Agent time-sampler filtering, which filters series while keeping sketches:

--- a/bin/agent-data-plane/src/components/dogstatsd_prefix_filter/mod.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_prefix_filter/mod.rs
@@ -349,16 +349,74 @@ mod tests {
 
     use super::*;
 
+    /// Builds a [`DogStatsDPrefixFilter`] for tests, defaulting every field and overriding only what a
+    /// given test varies. Replaces the fully hand-rolled struct literals the tests previously repeated.
+    struct FilterBuilder {
+        metric_prefix: String,
+        metric_prefix_blocklist: Vec<String>,
+        matcher: Blocklist,
+        effective_filterlist: EffectiveFilterlist,
+        telemetry: FilterlistTelemetry,
+        configuration: Option<GenericConfiguration>,
+    }
+
+    impl FilterBuilder {
+        fn new() -> Self {
+            Self {
+                metric_prefix: String::new(),
+                metric_prefix_blocklist: Vec::new(),
+                matcher: Blocklist::default(),
+                effective_filterlist: EffectiveFilterlist::default(),
+                telemetry: FilterlistTelemetry::noop(),
+                configuration: None,
+            }
+        }
+
+        fn prefix(mut self, prefix: &str) -> Self {
+            self.metric_prefix = prefix.to_string();
+            self
+        }
+
+        fn prefix_blocklist(mut self, entries: &[&str]) -> Self {
+            self.metric_prefix_blocklist = entries.iter().map(|s| s.to_string()).collect();
+            self
+        }
+
+        fn matcher(mut self, matcher: Blocklist) -> Self {
+            self.matcher = matcher;
+            self
+        }
+
+        fn effective_filterlist(mut self, effective_filterlist: EffectiveFilterlist) -> Self {
+            self.effective_filterlist = effective_filterlist;
+            self
+        }
+
+        fn telemetry(mut self, telemetry: FilterlistTelemetry) -> Self {
+            self.telemetry = telemetry;
+            self
+        }
+
+        fn configuration(mut self, configuration: GenericConfiguration) -> Self {
+            self.configuration = Some(configuration);
+            self
+        }
+
+        fn build(self) -> DogStatsDPrefixFilter {
+            DogStatsDPrefixFilter {
+                metric_prefix: self.metric_prefix,
+                metric_prefix_blocklist: self.metric_prefix_blocklist,
+                matcher: self.matcher,
+                effective_filterlist: self.effective_filterlist,
+                telemetry: self.telemetry,
+                configuration: self.configuration,
+            }
+        }
+    }
+
     #[test]
-    fn test_metric_prefix_add() {
-        let filter = DogStatsDPrefixFilter {
-            metric_prefix: "foo.".to_string(),
-            metric_prefix_blocklist: vec![],
-            matcher: Blocklist::default(),
-            effective_filterlist: EffectiveFilterlist::default(),
-            telemetry: FilterlistTelemetry::noop(),
-            configuration: None,
-        };
+    fn prefix_is_prepended_to_metric_name() {
+        let filter = FilterBuilder::new().prefix("foo.").build();
 
         let mut metric = Metric::gauge("bar", 1.0);
         assert!(filter.process_metric(&mut metric));
@@ -366,15 +424,11 @@ mod tests {
     }
 
     #[test]
-    fn test_metric_prefix_blocklist() {
-        let filter = DogStatsDPrefixFilter {
-            metric_prefix: "foo".to_string(),
-            metric_prefix_blocklist: vec!["foo".to_string(), "bar".to_string()],
-            matcher: Blocklist::default(),
-            effective_filterlist: EffectiveFilterlist::default(),
-            telemetry: FilterlistTelemetry::noop(),
-            configuration: None,
-        };
+    fn metric_already_matching_prefix_blocklist_is_not_prefixed() {
+        let filter = FilterBuilder::new()
+            .prefix("foo")
+            .prefix_blocklist(&["foo", "bar"])
+            .build();
 
         let mut metric = Metric::gauge("barbar", 1.0);
         assert!(filter.process_metric(&mut metric));
@@ -382,15 +436,10 @@ mod tests {
     }
 
     #[test]
-    fn test_metric_blocklist() {
-        let filter = DogStatsDPrefixFilter {
-            metric_prefix: "".to_string(),
-            metric_prefix_blocklist: vec![],
-            matcher: Blocklist::new(["foobar", "test"], false),
-            effective_filterlist: EffectiveFilterlist::default(),
-            telemetry: FilterlistTelemetry::noop(),
-            configuration: None,
-        };
+    fn metric_on_blocklist_is_dropped_and_others_pass() {
+        let filter = FilterBuilder::new()
+            .matcher(Blocklist::new(["foobar", "test"], false))
+            .build();
 
         let mut metric = Metric::gauge("foobar", 1.0);
         assert!(!filter.process_metric(&mut metric));
@@ -401,27 +450,18 @@ mod tests {
     }
 
     #[test]
-    fn test_metric_blocklist_with_metric_prefix() {
-        let filter = DogStatsDPrefixFilter {
-            metric_prefix: "foo.".to_string(),
-            metric_prefix_blocklist: vec![],
-            matcher: Blocklist::new(["foo.bar", "test"], false),
-            effective_filterlist: EffectiveFilterlist::default(),
-            telemetry: FilterlistTelemetry::noop(),
-            configuration: None,
-        };
+    fn blocklist_matches_against_the_prefixed_name() {
+        let filter = FilterBuilder::new()
+            .prefix("foo.")
+            .matcher(Blocklist::new(["foo.bar", "test"], false))
+            .build();
 
+        // "bar" is prefixed to "foo.bar", which the blocklist matches.
         let mut metric = Metric::gauge("bar", 1.0);
         assert!(!filter.process_metric(&mut metric));
 
-        let filter = DogStatsDPrefixFilter {
-            metric_prefix: "foo.".to_string(),
-            metric_prefix_blocklist: vec!["foo".to_string()],
-            matcher: Blocklist::default(),
-            effective_filterlist: EffectiveFilterlist::default(),
-            telemetry: FilterlistTelemetry::noop(),
-            configuration: None,
-        };
+        // A metric already on the prefix blocklist keeps its name, so the added prefix is skipped and it passes.
+        let filter = FilterBuilder::new().prefix("foo.").prefix_blocklist(&["foo"]).build();
 
         let mut metric = Metric::gauge("foo", 1.0);
         assert!(filter.process_metric(&mut metric));
@@ -429,15 +469,10 @@ mod tests {
     }
 
     #[test]
-    fn test_metric_match_prefix_without_added_prefix() {
-        let filter = DogStatsDPrefixFilter {
-            metric_prefix: "".to_string(),
-            metric_prefix_blocklist: vec![],
-            matcher: Blocklist::new(["b", "test"], true),
-            effective_filterlist: EffectiveFilterlist::default(),
-            telemetry: FilterlistTelemetry::noop(),
-            configuration: None,
-        };
+    fn prefix_matching_blocklist_drops_metrics_by_prefix() {
+        let filter = FilterBuilder::new()
+            .matcher(Blocklist::new(["b", "test"], true))
+            .build();
 
         // match prefix is true, "bar" has prefix "b"
         let mut metric = Metric::gauge("bar", 1.0);
@@ -449,15 +484,11 @@ mod tests {
     }
 
     #[test]
-    fn test_metric_match_prefix_with_added_prefix() {
-        let filter = DogStatsDPrefixFilter {
-            metric_prefix: "foo".to_string(),
-            metric_prefix_blocklist: vec![],
-            matcher: Blocklist::new(["fo", "test"], true),
-            effective_filterlist: EffectiveFilterlist::default(),
-            telemetry: FilterlistTelemetry::noop(),
-            configuration: None,
-        };
+    fn prefix_matching_blocklist_applies_after_prefixing() {
+        let filter = FilterBuilder::new()
+            .prefix("foo")
+            .matcher(Blocklist::new(["fo", "test"], true))
+            .build();
 
         // new_metric is "foo.bar", match prefix is true, "foo.bar" has prefix "fo"
         let mut metric = Metric::gauge("bar", 1.0);
@@ -465,7 +496,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_metric_blocklist_dynamic_update() {
+    async fn blocklist_and_filterlist_dynamic_updates_are_applied() {
         let (cfg, sender) = ConfigurationLoader::for_tests(Some(serde_json::json!({})), None, true).await;
         let sender = sender.expect("sender should exist");
         sender
@@ -475,19 +506,16 @@ mod tests {
 
         cfg.ready().await;
 
-        let mut filter = DogStatsDPrefixFilter {
-            metric_prefix: "".to_string(),
-            metric_prefix_blocklist: vec![],
-            matcher: Blocklist::new(["foobar", "test"], false),
-            effective_filterlist: EffectiveFilterlist::new(
+        let mut filter = FilterBuilder::new()
+            .matcher(Blocklist::new(["foobar", "test"], false))
+            .effective_filterlist(EffectiveFilterlist::new(
                 Vec::new(),
                 false,
                 vec!["foobar".to_string(), "test".to_string()],
                 false,
-            ),
-            telemetry: FilterlistTelemetry::noop(),
-            configuration: Some(cfg.clone()),
-        };
+            ))
+            .configuration(cfg.clone())
+            .build();
 
         let mut metric = Metric::gauge("foobar", 1.0);
         assert!(!filter.process_metric(&mut metric));
@@ -554,7 +582,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_metric_filterlist_match_prefix_dynamic_update_is_applied() {
+    async fn filterlist_match_prefix_dynamic_update_is_applied() {
         let (cfg, sender) = ConfigurationLoader::for_tests(
             Some(serde_json::json!({
                 "metric_filterlist": ["foo"],
@@ -572,14 +600,16 @@ mod tests {
             .unwrap();
         cfg.ready().await;
 
-        let mut filter = DogStatsDPrefixFilter {
-            metric_prefix: "".to_string(),
-            metric_prefix_blocklist: vec![],
-            matcher: Blocklist::new(["foo"], false),
-            effective_filterlist: EffectiveFilterlist::new(vec!["foo".to_string()], false, Vec::new(), false),
-            telemetry: FilterlistTelemetry::noop(),
-            configuration: Some(cfg.clone()),
-        };
+        let mut filter = FilterBuilder::new()
+            .matcher(Blocklist::new(["foo"], false))
+            .effective_filterlist(EffectiveFilterlist::new(
+                vec!["foo".to_string()],
+                false,
+                Vec::new(),
+                false,
+            ))
+            .configuration(cfg.clone())
+            .build();
 
         let mut metric = Metric::gauge("foo.bar", 1.0);
         assert!(filter.process_metric(&mut metric));
@@ -616,19 +646,15 @@ mod tests {
         let _local = set_default_local_recorder(&recorder);
 
         let telemetry = FilterlistTelemetry::new(&MetricsBuilder::default());
-        let mut filter = DogStatsDPrefixFilter {
-            metric_prefix: "".to_string(),
-            metric_prefix_blocklist: vec![],
-            matcher: Blocklist::default(),
-            effective_filterlist: EffectiveFilterlist::new(
+        let mut filter = FilterBuilder::new()
+            .effective_filterlist(EffectiveFilterlist::new(
                 vec!["preferred".to_string()],
                 false,
                 vec!["legacy".to_string()],
                 false,
-            ),
-            telemetry,
-            configuration: None,
-        };
+            ))
+            .telemetry(telemetry)
+            .build();
 
         filter.sync_effective_blocklist(false);
         filter.update_metric_blocklist(vec!["ignored".to_string(), "still_ignored".to_string()]);
@@ -657,14 +683,15 @@ mod tests {
         let _local = set_default_local_recorder(&recorder);
 
         let telemetry = FilterlistTelemetry::new(&MetricsBuilder::default());
-        let mut filter = DogStatsDPrefixFilter {
-            metric_prefix: "".to_string(),
-            metric_prefix_blocklist: vec![],
-            matcher: Blocklist::default(),
-            effective_filterlist: EffectiveFilterlist::new(vec!["foo".to_string()], true, Vec::new(), false),
-            telemetry,
-            configuration: None,
-        };
+        let mut filter = FilterBuilder::new()
+            .effective_filterlist(EffectiveFilterlist::new(
+                vec!["foo".to_string()],
+                true,
+                Vec::new(),
+                false,
+            ))
+            .telemetry(telemetry)
+            .build();
 
         filter.sync_effective_blocklist(false);
         filter.update_metric_filterlist(vec!["foo".to_string(), "foobar".to_string()]);
@@ -682,14 +709,10 @@ mod tests {
         let _local = set_default_local_recorder(&recorder);
 
         let telemetry = FilterlistTelemetry::new(&MetricsBuilder::default());
-        let filter = DogStatsDPrefixFilter {
-            metric_prefix: "".to_string(),
-            metric_prefix_blocklist: vec![],
-            matcher: Blocklist::new(["foo", "bar"], true),
-            effective_filterlist: EffectiveFilterlist::default(),
-            telemetry,
-            configuration: None,
-        };
+        let filter = FilterBuilder::new()
+            .matcher(Blocklist::new(["foo", "bar"], true))
+            .telemetry(telemetry)
+            .build();
 
         let mut exact_metric = Metric::gauge("foo", 1.0);
         assert!(!filter.process_metric(&mut exact_metric));

--- a/bin/agent-data-plane/src/components/mod.rs
+++ b/bin/agent-data-plane/src/components/mod.rs
@@ -6,3 +6,6 @@ pub mod host_tags;
 pub mod ottl_filter_processor;
 pub mod ottl_transform_processor;
 pub mod tag_filterlist;
+
+#[cfg(test)]
+mod test_support;

--- a/bin/agent-data-plane/src/components/ottl_filter_processor/config.rs
+++ b/bin/agent-data-plane/src/components/ottl_filter_processor/config.rs
@@ -26,7 +26,7 @@ pub enum ErrorMode {
     Propagate,
 }
 
-/// Traces filter configuration (span and span event conditions).
+/// Traces filter configuration (span conditions).
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TracesFilterConfig {
@@ -66,7 +66,7 @@ pub struct OttlFilterConfig {
     #[serde(default)]
     pub error_mode: ErrorMode,
 
-    /// Trace-level filters (span and span event conditions).
+    /// Trace-level filters (span conditions).
     ///
     /// Defaults to empty (no trace-level filtering).
     #[serde(default)]

--- a/bin/agent-data-plane/src/components/ottl_filter_processor/mod.rs
+++ b/bin/agent-data-plane/src/components/ottl_filter_processor/mod.rs
@@ -1,7 +1,7 @@
 //! OTTL filter processor component.
 //!
-//! Drops spans (and optionally span events) when OTTL conditions match, following the
-//! [OpenTelemetry filterprocessor] spec.
+//! Drops spans when OTTL conditions match, following the [OpenTelemetry filterprocessor] spec.
+//! Only span-level conditions (`traces.span`) are implemented; span-event filtering is not.
 //!
 //! [OpenTelemetry filterprocessor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/release/v0.144.x/processor/filterprocessor
 
@@ -150,43 +150,16 @@ impl SynchronousTransform for OttlFilter {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::Arc;
 
-    use saluki_common::collections::FastHashMap;
     use saluki_config::ConfigurationLoader;
     use saluki_core::{
         components::{transforms::*, ComponentContext},
-        data_model::event::{
-            trace::{AttributeValue, Span, Trace},
-            Event,
-        },
+        data_model::event::{trace::AttributeValue, Event},
         topology::EventsBuffer,
     };
-    use stringtheory::MetaString;
 
     use super::*;
-
-    fn make_span(_trace_id: u64, span_id: u64, meta: HashMap<String, String>) -> Span {
-        let mut attr_map = FastHashMap::default();
-        for (k, v) in meta {
-            attr_map.insert(MetaString::from(k), AttributeValue::String(MetaString::from(v)));
-        }
-        Span::new("svc", "op", "res", "web", span_id, 0, 0, 0, 0).with_attributes(attr_map)
-    }
-
-    fn make_trace(spans: Vec<Span>, resource_tags: Option<Vec<&'static str>>) -> Trace {
-        let mut trace = Trace::new(spans);
-        if let Some(tags) = resource_tags {
-            let mut attrs = FastHashMap::default();
-            for t in tags {
-                if let Some((k, v)) = t.split_once(':') {
-                    attrs.insert(MetaString::from(k), AttributeValue::String(MetaString::from(v)));
-                }
-            }
-            trace.attributes = Arc::new(attrs);
-        }
-        trace
-    }
+    use crate::components::test_support::{make_span, make_trace};
 
     fn span_count_in_buffer(buffer: &EventsBuffer) -> usize {
         buffer
@@ -420,67 +393,95 @@ mod tests {
         );
     }
 
-    /// With `error_mode: ignore`, when condition evaluation errors (for example, type mismatch), the span is kept.
+    /// When a condition errors, `error_mode` decides the span's fate: ignore/silent keep it, propagate drops
+    /// it. One case per `ErrorMode` arm.
     #[tokio::test]
-    async fn error_mode_ignore_eval_error_keeps_span() {
-        let cfg_json = serde_json::json!({
-            "ottl_filter_config": {
-                "error_mode": "ignore",
-                "traces": { "span": ["attributes[\"x\"] > 1"] }
-            }
-        });
-        let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
-        let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = test_component_context();
-        let mut transform = ottl_config.build(ctx).await.unwrap();
-        let span = make_span(1, 1, HashMap::from([("x".into(), "string".into())]));
-        let trace = make_trace(vec![span], None);
-        let mut buffer = EventsBuffer::default();
-        assert!(buffer.try_push(Event::Trace(trace)).is_none());
-        transform.transform_buffer(&mut buffer);
-        assert_eq!(span_count_in_buffer(&buffer), 1);
+    async fn error_mode_controls_span_fate_when_a_condition_errors() {
+        struct Case {
+            error_mode: &'static str,
+            expected_span_count: usize,
+        }
+
+        let cases = [
+            Case {
+                error_mode: "ignore",
+                expected_span_count: 1,
+            },
+            Case {
+                error_mode: "silent",
+                expected_span_count: 1,
+            },
+            Case {
+                error_mode: "propagate",
+                expected_span_count: 0,
+            },
+        ];
+
+        for case in cases {
+            let cfg_json = serde_json::json!({
+                "ottl_filter_config": {
+                    "error_mode": case.error_mode,
+                    // `x` is a string, so `attributes["x"] > 1` errors during evaluation.
+                    "traces": { "span": ["attributes[\"x\"] > 1"] }
+                }
+            });
+            let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
+            let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
+            let mut transform = ottl_config.build(test_component_context()).await.unwrap();
+            let span = make_span(1, 1, HashMap::from([("x".into(), "string".into())]));
+            let trace = make_trace(vec![span], None);
+            let mut buffer = EventsBuffer::default();
+            assert!(buffer.try_push(Event::Trace(trace)).is_none());
+            transform.transform_buffer(&mut buffer);
+            assert_eq!(
+                span_count_in_buffer(&buffer),
+                case.expected_span_count,
+                "error_mode={}",
+                case.error_mode
+            );
+        }
     }
 
-    /// With `error_mode: silent`, when condition evaluation errors, the span is kept (no log).
+    /// With `error_mode` omitted, the documented default (`Propagate`) drops the span when a condition errors.
     #[tokio::test]
-    async fn error_mode_silent_eval_error_keeps_span() {
+    async fn omitted_error_mode_defaults_to_propagate() {
         let cfg_json = serde_json::json!({
-            "ottl_filter_config": {
-                "error_mode": "silent",
-                "traces": { "span": ["attributes[\"x\"] > 1"] }
-            }
+            "ottl_filter_config": { "traces": { "span": ["attributes[\"x\"] > 1"] } }
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
-        let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = test_component_context();
-        let mut transform = ottl_config.build(ctx).await.unwrap();
+        let ottl_config = OttlFilterConfiguration::from_configuration(&config).expect("config should parse");
+        assert_eq!(
+            ottl_config.config.error_mode,
+            ErrorMode::Propagate,
+            "omitted error_mode must default to Propagate"
+        );
+
+        let mut transform = ottl_config
+            .build(test_component_context())
+            .await
+            .expect("build should succeed");
+        // `x` is a string, so `attributes["x"] > 1` errors during evaluation; propagate drops the span.
         let span = make_span(1, 1, HashMap::from([("x".into(), "string".into())]));
         let trace = make_trace(vec![span], None);
         let mut buffer = EventsBuffer::default();
         assert!(buffer.try_push(Event::Trace(trace)).is_none());
         transform.transform_buffer(&mut buffer);
-        assert_eq!(span_count_in_buffer(&buffer), 1);
+        assert_eq!(
+            span_count_in_buffer(&buffer),
+            0,
+            "default (propagate) must drop the span when a condition errors"
+        );
     }
 
-    /// With `error_mode: propagate`, when condition evaluation errors, the span is dropped.
+    /// `error_mode` accepts only ignore/silent/propagate; any other value must fail deserialization.
     #[tokio::test]
-    async fn error_mode_propagate_eval_error_drops_span() {
+    async fn invalid_error_mode_value_is_rejected() {
         let cfg_json = serde_json::json!({
-            "ottl_filter_config": {
-                "error_mode": "propagate",
-                "traces": { "span": ["attributes[\"x\"] > 1"] }
-            }
+            "ottl_filter_config": { "error_mode": "explode" }
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
-        let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = test_component_context();
-        let mut transform = ottl_config.build(ctx).await.unwrap();
-        let span = make_span(1, 1, HashMap::from([("x".into(), "string".into())]));
-        let trace = make_trace(vec![span], None);
-        let mut buffer = EventsBuffer::default();
-        assert!(buffer.try_push(Event::Trace(trace)).is_none());
-        transform.transform_buffer(&mut buffer);
-        assert_eq!(span_count_in_buffer(&buffer), 0);
+        let result = OttlFilterConfiguration::from_configuration(&config);
+        assert!(result.is_err(), "an unrecognized error_mode value must be rejected");
     }
 
     /// `transform_buffer` removes only spans that match the condition; remaining spans are unchanged and in order.

--- a/bin/agent-data-plane/src/components/ottl_transform_processor/mod.rs
+++ b/bin/agent-data-plane/src/components/ottl_transform_processor/mod.rs
@@ -152,15 +152,13 @@ impl SynchronousTransform for OttlTransform {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::Arc;
 
-    use saluki_common::collections::FastHashMap;
     use saluki_config::ConfigurationLoader;
     use saluki_core::{
         components::{transforms::*, ComponentContext},
         data_model::event::{
             service_check::{CheckStatus, ServiceCheck},
-            trace::{AttributeValue, Span, Trace},
+            trace::AttributeValue,
             Event,
         },
         topology::EventsBuffer,
@@ -168,30 +166,9 @@ mod tests {
     use stringtheory::MetaString;
 
     use super::*;
+    use crate::components::test_support::{make_span, make_trace};
 
     // ---- Helpers ----
-
-    fn make_span(_trace_id: u64, span_id: u64, meta: HashMap<String, String>) -> Span {
-        let mut attr_map = FastHashMap::default();
-        for (k, v) in meta {
-            attr_map.insert(MetaString::from(k), AttributeValue::String(MetaString::from(v)));
-        }
-        Span::new("svc", "op", "res", "web", span_id, 0, 0, 0, 0).with_attributes(attr_map)
-    }
-
-    fn make_trace(spans: Vec<Span>, resource_tags: Option<Vec<&'static str>>) -> Trace {
-        let mut trace = Trace::new(spans);
-        if let Some(tags) = resource_tags {
-            let mut attrs = FastHashMap::default();
-            for t in tags {
-                if let Some((k, v)) = t.split_once(':') {
-                    attrs.insert(MetaString::from(k), AttributeValue::String(MetaString::from(v)));
-                }
-            }
-            trace.attributes = Arc::new(attrs);
-        }
-        trace
-    }
 
     fn get_span_attr(buffer: &EventsBuffer, span_index: usize, key: &str) -> Option<String> {
         buffer
@@ -288,19 +265,57 @@ mod tests {
     // ---- Group 2: Core set functionality ----
 
     #[tokio::test]
-    async fn set_new_attribute() {
-        let cfg_json = serde_json::json!({
-            "ottl_transform_config": {
-                "trace_statements": ["set(attributes[\"newkey\"], \"newval\")"]
-            }
-        });
-        let mut transform = build_transform(Some(cfg_json)).await;
-        let span = make_span(1, 1, HashMap::new());
-        let trace = make_trace(vec![span], None);
-        let mut buffer = EventsBuffer::default();
-        assert!(buffer.try_push(Event::Trace(trace)).is_none());
-        transform.transform_buffer(&mut buffer);
-        assert_eq!(get_span_attr(&buffer, 0, "newkey").as_deref(), Some("newval"));
+    async fn set_stores_each_literal_value_type_as_a_string() {
+        // `set` creates a new span attribute and stores every scalar literal type as a string. One case per
+        // supported OTTL literal type; the string case also covers new-attribute creation on an empty span.
+        struct Case {
+            name: &'static str,
+            // The literal exactly as written in the OTTL statement (the string case keeps its quotes).
+            literal: &'static str,
+            expected: &'static str,
+        }
+
+        let cases = [
+            Case {
+                name: "string",
+                literal: "\"newval\"",
+                expected: "newval",
+            },
+            Case {
+                name: "int",
+                literal: "42",
+                expected: "42",
+            },
+            Case {
+                name: "float",
+                literal: "6.14",
+                expected: "6.14",
+            },
+            Case {
+                name: "bool",
+                literal: "true",
+                expected: "true",
+            },
+        ];
+
+        for case in cases {
+            let statement = format!("set(attributes[\"k\"], {})", case.literal);
+            let cfg_json = serde_json::json!({
+                "ottl_transform_config": { "trace_statements": [statement] }
+            });
+            let mut transform = build_transform(Some(cfg_json)).await;
+            let span = make_span(1, 1, HashMap::new());
+            let trace = make_trace(vec![span], None);
+            let mut buffer = EventsBuffer::default();
+            assert!(buffer.try_push(Event::Trace(trace)).is_none());
+            transform.transform_buffer(&mut buffer);
+            assert_eq!(
+                get_span_attr(&buffer, 0, "k").as_deref(),
+                Some(case.expected),
+                "{}",
+                case.name
+            );
+        }
     }
 
     #[tokio::test]
@@ -337,56 +352,6 @@ mod tests {
             None,
             "setting to a non-existent attribute (Nil) should remove the key"
         );
-    }
-
-    #[tokio::test]
-    async fn set_int_value_converts_to_string() {
-        //"The answer to the Ultimate Question of Life, the Universe, and Everything"
-        //The Hitchhiker's Guide to the Galaxy ;)
-        let cfg_json = serde_json::json!({
-            "ottl_transform_config": {
-                "trace_statements": ["set(attributes[\"num\"], 42)"]
-            }
-        });
-        let mut transform = build_transform(Some(cfg_json)).await;
-        let span = make_span(1, 1, HashMap::new());
-        let trace = make_trace(vec![span], None);
-        let mut buffer = EventsBuffer::default();
-        assert!(buffer.try_push(Event::Trace(trace)).is_none());
-        transform.transform_buffer(&mut buffer);
-        assert_eq!(get_span_attr(&buffer, 0, "num").as_deref(), Some("42"));
-    }
-
-    #[tokio::test]
-    async fn set_float_value_converts_to_string() {
-        let cfg_json = serde_json::json!({
-            "ottl_transform_config": {
-                "trace_statements": ["set(attributes[\"not_pi\"], 6.14)"]
-            }
-        });
-        let mut transform = build_transform(Some(cfg_json)).await;
-        let span = make_span(1, 1, HashMap::new());
-        let trace = make_trace(vec![span], None);
-        let mut buffer = EventsBuffer::default();
-        assert!(buffer.try_push(Event::Trace(trace)).is_none());
-        transform.transform_buffer(&mut buffer);
-        assert_eq!(get_span_attr(&buffer, 0, "not_pi").as_deref(), Some("6.14"));
-    }
-
-    #[tokio::test]
-    async fn set_bool_value_converts_to_string() {
-        let cfg_json = serde_json::json!({
-            "ottl_transform_config": {
-                "trace_statements": ["set(attributes[\"flag\"], true)"]
-            }
-        });
-        let mut transform = build_transform(Some(cfg_json)).await;
-        let span = make_span(1, 1, HashMap::new());
-        let trace = make_trace(vec![span], None);
-        let mut buffer = EventsBuffer::default();
-        assert!(buffer.try_push(Event::Trace(trace)).is_none());
-        transform.transform_buffer(&mut buffer);
-        assert_eq!(get_span_attr(&buffer, 0, "flag").as_deref(), Some("true"));
     }
 
     #[tokio::test]
@@ -532,75 +497,111 @@ mod tests {
     // ---- Group 5: Error modes ----
 
     #[tokio::test]
-    async fn error_mode_ignore_continues_processing() {
-        let cfg_json = serde_json::json!({
-            "ottl_transform_config": {
-                "error_mode": "ignore",
-                "trace_statements": [
-                    "set(resource.attributes[\"x\"], \"fail\")",
-                    "set(attributes[\"ok\"], \"yes\")"
-                ]
+    async fn error_mode_controls_processing_after_a_statement_error() {
+        // After a statement errors, `error_mode` decides whether later statements still run: ignore/silent
+        // continue, propagate stops processing the span. One case per `ErrorMode` arm. The first statement
+        // (setting a read-only resource attribute) always errors.
+        struct Case {
+            error_mode: &'static str,
+            later_statement_runs: bool,
+        }
+
+        let cases = [
+            Case {
+                error_mode: "ignore",
+                later_statement_runs: true,
+            },
+            Case {
+                error_mode: "silent",
+                later_statement_runs: true,
+            },
+            Case {
+                error_mode: "propagate",
+                later_statement_runs: false,
+            },
+        ];
+
+        for case in cases {
+            let cfg_json = serde_json::json!({
+                "ottl_transform_config": {
+                    "error_mode": case.error_mode,
+                    "trace_statements": [
+                        "set(resource.attributes[\"x\"], \"fail\")",
+                        "set(attributes[\"after\"], \"yes\")"
+                    ]
+                }
+            });
+            let mut transform = build_transform(Some(cfg_json)).await;
+            let span = make_span(1, 1, HashMap::new());
+            let trace = make_trace(vec![span], None);
+            let mut buffer = EventsBuffer::default();
+            assert!(buffer.try_push(Event::Trace(trace)).is_none());
+            transform.transform_buffer(&mut buffer);
+
+            let after = get_span_attr(&buffer, 0, "after");
+            if case.later_statement_runs {
+                assert_eq!(
+                    after.as_deref(),
+                    Some("yes"),
+                    "error_mode={}: later statement should still execute",
+                    case.error_mode
+                );
+            } else {
+                assert_eq!(
+                    after, None,
+                    "error_mode={}: later statement should be skipped",
+                    case.error_mode
+                );
             }
-        });
-        let mut transform = build_transform(Some(cfg_json)).await;
-        let span = make_span(1, 1, HashMap::new());
-        let trace = make_trace(vec![span], None);
-        let mut buffer = EventsBuffer::default();
-        assert!(buffer.try_push(Event::Trace(trace)).is_none());
-        transform.transform_buffer(&mut buffer);
-        assert_eq!(
-            get_span_attr(&buffer, 0, "ok").as_deref(),
-            Some("yes"),
-            "ignore mode: subsequent statement should still execute after error"
-        );
+        }
     }
 
     #[tokio::test]
-    async fn error_mode_silent_continues_processing() {
+    async fn omitted_error_mode_defaults_to_propagate() {
+        // Per the transform processor spec, an omitted `error_mode` defaults to `Propagate`. Behaviorally,
+        // that means a statement error stops the rest of the span's statements (unlike ignore/silent, which
+        // continue). The config key is omitted here to exercise that default path.
         let cfg_json = serde_json::json!({
             "ottl_transform_config": {
-                "error_mode": "silent",
                 "trace_statements": [
                     "set(resource.attributes[\"x\"], \"fail\")",
-                    "set(attributes[\"ok\"], \"yes\")"
+                    "set(attributes[\"after\"], \"yes\")"
                 ]
             }
         });
-        let mut transform = build_transform(Some(cfg_json)).await;
-        let span = make_span(1, 1, HashMap::new());
-        let trace = make_trace(vec![span], None);
-        let mut buffer = EventsBuffer::default();
-        assert!(buffer.try_push(Event::Trace(trace)).is_none());
-        transform.transform_buffer(&mut buffer);
+        let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
+        let ottl_config = OttlTransformConfiguration::from_configuration(&config).expect("config should parse");
         assert_eq!(
-            get_span_attr(&buffer, 0, "ok").as_deref(),
-            Some("yes"),
-            "silent mode: subsequent statement should still execute after error"
+            ottl_config.config.error_mode,
+            ErrorMode::Propagate,
+            "omitted error_mode must default to Propagate"
         );
-    }
 
-    #[tokio::test]
-    async fn error_mode_propagate_stops_span_processing() {
-        let cfg_json = serde_json::json!({
-            "ottl_transform_config": {
-                "error_mode": "propagate",
-                "trace_statements": [
-                    "set(resource.attributes[\"x\"], \"fail\")",
-                    "set(attributes[\"should_not_appear\"], \"yes\")"
-                ]
-            }
-        });
-        let mut transform = build_transform(Some(cfg_json)).await;
+        let mut transform = ottl_config
+            .build(test_component_context())
+            .await
+            .expect("build should succeed");
         let span = make_span(1, 1, HashMap::new());
         let trace = make_trace(vec![span], None);
         let mut buffer = EventsBuffer::default();
         assert!(buffer.try_push(Event::Trace(trace)).is_none());
         transform.transform_buffer(&mut buffer);
         assert_eq!(
-            get_span_attr(&buffer, 0, "should_not_appear"),
+            get_span_attr(&buffer, 0, "after"),
             None,
-            "propagate mode: processing should stop after the first error"
+            "default (propagate) must stop processing after the first statement error"
         );
+    }
+
+    #[tokio::test]
+    async fn invalid_error_mode_value_is_rejected() {
+        // `error_mode` accepts only ignore/silent/propagate; any other value must fail deserialization.
+        let cfg_json = serde_json::json!({
+            "ottl_transform_config": { "error_mode": "explode" }
+        });
+        let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
+        let result = OttlTransformConfiguration::from_configuration(&config);
+        assert!(result.is_err(), "an unrecognized error_mode value must be rejected");
     }
 
     // ---- Group 6: Multi-span and multi-trace (integration) ----

--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -400,51 +400,82 @@ mod tests {
     }
 
     #[test]
-    fn exclude_removes_listed_tags() {
-        let entries = vec![MetricTagFilterEntry {
-            metric_name: "my.dist".to_string(),
-            action: FilterAction::Exclude,
-            tags: vec!["env".to_string(), "host".to_string()],
-        }];
-        let filters = compile_filters(&entries);
+    fn filter_metric_tags_treats_distribution_and_count_metrics_identically() {
+        // `filter_metric_tags` applies the same rule logic to distribution (sketch) and count metrics. The
+        // run-loop type guard (exercised by `run_loop_enforces_type_guard_and_exercises_context_cache`) is what
+        // restricts which metric types ever reach this function; the function itself never branches on the type.
+        // Each case is asserted against both a distribution and a counter, and against both the resulting tags
+        // and the returned outcome, so the two paths can't silently drift apart.
+        struct Case {
+            name: &'static str,
+            action: FilterAction,
+            filter_metric_name: &'static str,
+            filter_tags: &'static [&'static str],
+            input_tags: &'static [&'static str],
+            expected_tags: &'static [&'static str],
+            expected_outcome: FilterMetricTagsOutcome,
+        }
 
-        let mut metric = distribution_metric("my.dist", &["env:prod", "service:web", "host:h1"]);
-        let mut state = TagSetMutViewState::default();
-        filter_metric_tags(&mut metric, &mut state, &filters);
+        let cases = [
+            Case {
+                name: "exclude removes the listed tags",
+                action: FilterAction::Exclude,
+                filter_metric_name: "my.metric",
+                filter_tags: &["env", "host"],
+                input_tags: &["env:prod", "service:web", "host:h1"],
+                expected_tags: &["service:web"],
+                expected_outcome: FilterMetricTagsOutcome::Modified { removed_tags: 2 },
+            },
+            Case {
+                name: "include keeps only the listed tags",
+                action: FilterAction::Include,
+                filter_metric_name: "my.metric",
+                filter_tags: &["env"],
+                input_tags: &["env:prod", "service:web", "host:h1"],
+                expected_tags: &["env:prod"],
+                expected_outcome: FilterMetricTagsOutcome::Modified { removed_tags: 2 },
+            },
+            Case {
+                name: "a rule for a different metric name is a miss",
+                action: FilterAction::Exclude,
+                filter_metric_name: "other.metric",
+                filter_tags: &["env"],
+                input_tags: &["env:prod", "service:web"],
+                expected_tags: &["env:prod", "service:web"],
+                expected_outcome: FilterMetricTagsOutcome::RuleMiss,
+            },
+            Case {
+                name: "a matching rule that removes no tags is a no-op",
+                action: FilterAction::Exclude,
+                filter_metric_name: "my.metric",
+                filter_tags: &["region"],
+                input_tags: &["env:prod", "service:web"],
+                expected_tags: &["env:prod", "service:web"],
+                expected_outcome: FilterMetricTagsOutcome::NoChange,
+            },
+        ];
 
-        assert_eq!(tag_names(&metric), vec!["service:web"]);
-    }
+        type MetricBuilder = fn(&'static str, &[&'static str]) -> Metric;
+        let builders: [(&str, MetricBuilder); 2] = [("distribution", distribution_metric), ("counter", counter_metric)];
 
-    #[test]
-    fn include_keeps_only_listed_tags() {
-        let entries = vec![MetricTagFilterEntry {
-            metric_name: "my.dist".to_string(),
-            action: FilterAction::Include,
-            tags: vec!["env".to_string()],
-        }];
-        let filters = compile_filters(&entries);
+        for case in &cases {
+            let entries = vec![MetricTagFilterEntry {
+                metric_name: case.filter_metric_name.to_string(),
+                action: case.action,
+                tags: case.filter_tags.iter().map(|s| s.to_string()).collect(),
+            }];
+            let filters = compile_filters(&entries);
 
-        let mut metric = distribution_metric("my.dist", &["env:prod", "service:web", "host:h1"]);
-        let mut state = TagSetMutViewState::default();
-        filter_metric_tags(&mut metric, &mut state, &filters);
+            for (kind, build) in builders {
+                let mut metric = build("my.metric", case.input_tags);
+                let mut state = TagSetMutViewState::default();
+                let outcome = filter_metric_tags(&mut metric, &mut state, &filters);
 
-        assert_eq!(tag_names(&metric), vec!["env:prod"]);
-    }
-
-    #[test]
-    fn non_matching_metric_unchanged() {
-        let entries = vec![MetricTagFilterEntry {
-            metric_name: "other.dist".to_string(),
-            action: FilterAction::Exclude,
-            tags: vec!["env".to_string()],
-        }];
-        let filters = compile_filters(&entries);
-
-        let mut metric = distribution_metric("my.dist", &["env:prod", "service:web"]);
-        let mut state = TagSetMutViewState::default();
-        filter_metric_tags(&mut metric, &mut state, &filters);
-
-        assert_eq!(tag_names(&metric), vec!["env:prod", "service:web"]);
+                let expected_tags: Vec<String> = case.expected_tags.iter().map(|s| s.to_string()).collect();
+                assert_eq!(tag_names(&metric), expected_tags, "{kind}: {}", case.name);
+                assert_eq!(outcome, case.expected_outcome, "{kind}: {}", case.name);
+            }
+        }
     }
 
     #[test]
@@ -452,74 +483,6 @@ mod tests {
         let metric = counter_metric("my.counter", &["env:prod", "service:web"]);
         assert!(!metric.values().is_sketch(), "counter should not be a sketch");
         assert_eq!(tag_names(&metric), vec!["env:prod", "service:web"]);
-    }
-
-    #[test]
-    fn count_exclude_removes_listed_tags() {
-        let entries = vec![MetricTagFilterEntry {
-            metric_name: "my.counter".to_string(),
-            action: FilterAction::Exclude,
-            tags: vec!["env".to_string(), "host".to_string()],
-        }];
-        let filters = compile_filters(&entries);
-
-        let mut metric = counter_metric("my.counter", &["env:prod", "service:web", "host:h1"]);
-        let mut state = TagSetMutViewState::default();
-        let outcome = filter_metric_tags(&mut metric, &mut state, &filters);
-
-        assert_eq!(tag_names(&metric), vec!["service:web"]);
-        assert_eq!(outcome, FilterMetricTagsOutcome::Modified { removed_tags: 2 });
-    }
-
-    #[test]
-    fn count_include_keeps_only_listed_tags() {
-        let entries = vec![MetricTagFilterEntry {
-            metric_name: "my.counter".to_string(),
-            action: FilterAction::Include,
-            tags: vec!["env".to_string()],
-        }];
-        let filters = compile_filters(&entries);
-
-        let mut metric = counter_metric("my.counter", &["env:prod", "service:web", "host:h1"]);
-        let mut state = TagSetMutViewState::default();
-        let outcome = filter_metric_tags(&mut metric, &mut state, &filters);
-
-        assert_eq!(tag_names(&metric), vec!["env:prod"]);
-        assert_eq!(outcome, FilterMetricTagsOutcome::Modified { removed_tags: 2 });
-    }
-
-    #[test]
-    fn count_non_matching_metric_unchanged() {
-        let entries = vec![MetricTagFilterEntry {
-            metric_name: "other.counter".to_string(),
-            action: FilterAction::Exclude,
-            tags: vec!["env".to_string()],
-        }];
-        let filters = compile_filters(&entries);
-
-        let mut metric = counter_metric("my.counter", &["env:prod", "service:web"]);
-        let mut state = TagSetMutViewState::default();
-        let outcome = filter_metric_tags(&mut metric, &mut state, &filters);
-
-        assert_eq!(tag_names(&metric), vec!["env:prod", "service:web"]);
-        assert_eq!(outcome, FilterMetricTagsOutcome::RuleMiss);
-    }
-
-    #[test]
-    fn count_no_change_outcome_when_filter_matches_no_tags() {
-        let entries = vec![MetricTagFilterEntry {
-            metric_name: "my.counter".to_string(),
-            action: FilterAction::Exclude,
-            tags: vec!["region".to_string()],
-        }];
-        let filters = compile_filters(&entries);
-
-        let mut metric = counter_metric("my.counter", &["env:prod", "service:web"]);
-        let mut state = TagSetMutViewState::default();
-        let outcome = filter_metric_tags(&mut metric, &mut state, &filters);
-
-        assert_eq!(tag_names(&metric), vec!["env:prod", "service:web"]);
-        assert_eq!(outcome, FilterMetricTagsOutcome::NoChange);
     }
 
     #[test]
@@ -669,26 +632,91 @@ mod tests {
     }
 
     #[test]
-    fn missing_action_defaults_to_exclude() {
-        let entry: MetricTagFilterEntry = serde_json::from_value(json!({
-            "metric_name": "my.dist",
-            "tags": ["env"]
-        }))
-        .unwrap();
+    fn filter_action_deserialize_maps_each_documented_branch() {
+        // `FilterAction`'s custom `Deserialize` recognizes exactly `"include"`; the empty string, an explicit
+        // null, and any unrecognized value all resolve to the documented `Exclude` default, and an omitted key
+        // falls back to `Exclude` via `#[serde(default)]`. One case per branch.
+        enum Action {
+            Missing,
+            Null,
+            Value(&'static str),
+        }
 
-        assert_eq!(entry.action, FilterAction::Exclude);
+        struct Case {
+            name: &'static str,
+            action: Action,
+            expected: FilterAction,
+        }
+
+        let cases = [
+            Case {
+                name: "explicit include",
+                action: Action::Value("include"),
+                expected: FilterAction::Include,
+            },
+            Case {
+                name: "explicit exclude",
+                action: Action::Value("exclude"),
+                expected: FilterAction::Exclude,
+            },
+            Case {
+                name: "empty string",
+                action: Action::Value(""),
+                expected: FilterAction::Exclude,
+            },
+            Case {
+                name: "unrecognized value",
+                action: Action::Value("invalid"),
+                expected: FilterAction::Exclude,
+            },
+            Case {
+                name: "explicit null",
+                action: Action::Null,
+                expected: FilterAction::Exclude,
+            },
+            Case {
+                name: "omitted key",
+                action: Action::Missing,
+                expected: FilterAction::Exclude,
+            },
+        ];
+
+        for case in cases {
+            let mut value = json!({ "metric_name": "my.dist", "tags": ["env"] });
+            match case.action {
+                Action::Missing => {}
+                Action::Null => value["action"] = serde_json::Value::Null,
+                Action::Value(action) => value["action"] = json!(action),
+            }
+
+            let entry: MetricTagFilterEntry =
+                serde_json::from_value(value).unwrap_or_else(|e| panic!("{}: deserialize failed: {e}", case.name));
+
+            assert_eq!(entry.action, case.expected, "{}", case.name);
+        }
     }
 
-    #[test]
-    fn invalid_action_defaults_to_exclude() {
-        let entry: MetricTagFilterEntry = serde_json::from_value(json!({
-            "metric_name": "my.dist",
-            "action": "invalid",
-            "tags": ["env"]
-        }))
-        .unwrap();
+    #[tokio::test]
+    async fn context_cache_capacity_defaults_to_100k_and_can_be_overridden() {
+        // With no `data_plane.dogstatsd.aggregator_tag_filter_cache_capacity` key present, the capacity falls
+        // back to the documented default of 100,000.
+        let (default_config, _) = ConfigurationLoader::for_tests(Some(json!({})), None, false).await;
+        let default_builder =
+            TagFilterlistConfiguration::from_configuration(&default_config).expect("config should parse");
+        assert_eq!(default_builder.context_cache_capacity, 100_000);
 
-        assert_eq!(entry.action, FilterAction::Exclude);
+        // Setting the key overrides the default with the configured value.
+        let (override_config, _) = ConfigurationLoader::for_tests(
+            Some(json!({
+                "data_plane": { "dogstatsd": { "aggregator_tag_filter_cache_capacity": 512 } }
+            })),
+            None,
+            false,
+        )
+        .await;
+        let override_builder =
+            TagFilterlistConfiguration::from_configuration(&override_config).expect("config should parse");
+        assert_eq!(override_builder.context_cache_capacity, 512);
     }
 
     #[test]

--- a/bin/agent-data-plane/src/components/test_support.rs
+++ b/bin/agent-data-plane/src/components/test_support.rs
@@ -1,0 +1,40 @@
+//! Shared test fixtures for the agent-data-plane trace-processing components.
+//!
+//! The `make_span`/`make_trace` builders were previously copy-pasted verbatim across the OTTL
+//! transform and filter processor test modules. Centralizing them here keeps the fixtures from
+//! drifting apart and gives new trace components (for example, `apm_onboarding`) one place to reuse.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use saluki_common::collections::FastHashMap;
+use saluki_core::data_model::event::trace::{AttributeValue, Span, Trace};
+use stringtheory::MetaString;
+
+/// Builds a span whose attributes come from `meta` as string values.
+///
+/// The span is created with service `"svc"` and `parent_id` 0 (that is, a root span). When a test
+/// needs a specific topology or service, chain the `Span` builder methods (`with_service`,
+/// `with_parent_id`, and so on) onto the result.
+pub(crate) fn make_span(_trace_id: u64, span_id: u64, meta: HashMap<String, String>) -> Span {
+    let mut attr_map = FastHashMap::default();
+    for (k, v) in meta {
+        attr_map.insert(MetaString::from(k), AttributeValue::String(MetaString::from(v)));
+    }
+    Span::new("svc", "op", "res", "web", span_id, 0, 0, 0, 0).with_attributes(attr_map)
+}
+
+/// Builds a trace from `spans`, optionally seeding resource attributes from `key:value` strings.
+pub(crate) fn make_trace(spans: Vec<Span>, resource_tags: Option<Vec<&'static str>>) -> Trace {
+    let mut trace = Trace::new(spans);
+    if let Some(tags) = resource_tags {
+        let mut attrs = FastHashMap::default();
+        for t in tags {
+            if let Some((k, v)) = t.split_once(':') {
+                attrs.insert(MetaString::from(k), AttributeValue::String(MetaString::from(v)));
+            }
+        }
+        trace.attributes = Arc::new(attrs);
+    }
+    trace
+}

--- a/test/CLEANUP_PLAN.md
+++ b/test/CLEANUP_PLAN.md
@@ -231,7 +231,7 @@ otherwise keep hand-rolling the thing it replaces.
     `Point`-table + `monotonic_diff` loop harness. Split the multi-case bodies into focused tests and extract the
     shared driver.
 
-- [ ] **G14 — agent-data-plane filter components & OTTL processors test cleanup** (AU-25/AU-26)
+- [x] **G14 — agent-data-plane filter components & OTTL processors test cleanup** (AU-25/AU-26)
   (`tobz/test-cleanup-adp-filters-ottl-processors-tests`, `test(agent-data-plane)`)
   - [medium/small] `tag_filterlist`'s `count_*` tests duplicate the distribution-metric tests, differing only by
     metric type and one extra assertion — these should be merged, not kept as separate near-duplicates (KI-10).


### PR DESCRIPTION
## Summary

This PR cleans up tests/test code for all of the ADP-specific components that live solely in the `agent_data_plane` binary crate.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New and existing unit tests.

## References

DADP-2
