### PR TITLE
chore(test): clean up tests in `saluki-io`

### DIFF
--- a/lib/saluki-io/src/compression.rs
+++ b/lib/saluki-io/src/compression.rs
@@ -315,6 +315,9 @@ impl CompressionEstimator {
 
 #[cfg(test)]
 mod tests {
+    use async_compression::tokio::bufread::{GzipDecoder, ZlibDecoder, ZstdDecoder};
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
     use super::*;
 
     struct MockCompressor {
@@ -437,5 +440,143 @@ mod tests {
         // We use the compressed length when calling `would_write_exceed_threshold` because it uses the uncompressed length as the worst-case
         // scenario, which is that the write would not be compressed at all.
         assert!(!estimator.would_write_exceed_threshold(THIRD_WRITE_LEN, MAX_COMPRESSED_LEN));
+    }
+
+    // A payload that's long and repetitive enough that every real compression scheme actually shrinks it.
+    const COMPRESSIBLE_PAYLOAD: &[u8] =
+        b"the quick brown fox jumps over the lazy dog. the quick brown fox jumps over the lazy dog. \
+          the quick brown fox jumps over the lazy dog. the quick brown fox jumps over the lazy dog.";
+
+    async fn compress_all(scheme: CompressionScheme, data: &[u8]) -> (Vec<u8>, Option<HeaderValue>) {
+        // Drive the compressor exactly like the request-builder does: write, flush, shutdown, then recover the writer.
+        let mut compressor = Compressor::from_scheme(scheme, Vec::new());
+        compressor.write_all(data).await.expect("write should succeed");
+        compressor.flush().await.expect("flush should succeed");
+        compressor.shutdown().await.expect("shutdown should succeed");
+
+        let encoding = compressor.content_encoding();
+        (compressor.into_inner(), encoding)
+    }
+
+    async fn decompress(scheme: CompressionScheme, compressed: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        match scheme {
+            CompressionScheme::Noop => return compressed.to_vec(),
+            CompressionScheme::Gzip(_) => GzipDecoder::new(compressed)
+                .read_to_end(&mut out)
+                .await
+                .expect("gzip decode should succeed"),
+            CompressionScheme::Zlib(_) => ZlibDecoder::new(compressed)
+                .read_to_end(&mut out)
+                .await
+                .expect("zlib decode should succeed"),
+            CompressionScheme::Zstd(_) => ZstdDecoder::new(compressed)
+                .read_to_end(&mut out)
+                .await
+                .expect("zstd decode should succeed"),
+        };
+        out
+    }
+
+    #[test]
+    fn compression_scheme_constructors_select_expected_variant() {
+        assert!(matches!(CompressionScheme::noop(), CompressionScheme::Noop));
+        assert!(matches!(
+            CompressionScheme::gzip_default(),
+            CompressionScheme::Gzip(Level::Default)
+        ));
+        assert!(matches!(
+            CompressionScheme::zlib_default(),
+            CompressionScheme::Zlib(Level::Default)
+        ));
+        assert!(matches!(
+            CompressionScheme::zstd_default(),
+            CompressionScheme::Zstd(Level::Default)
+        ));
+    }
+
+    #[test]
+    fn compression_scheme_new_maps_string_and_level() {
+        // gzip and zstd carry the caller-provided precise level...
+        match CompressionScheme::new("gzip", 5) {
+            CompressionScheme::Gzip(Level::Precise(level)) => assert_eq!(level, 5),
+            other => panic!("expected gzip with precise level, got {other:?}"),
+        }
+        match CompressionScheme::new("zstd", 7) {
+            CompressionScheme::Zstd(Level::Precise(level)) => assert_eq!(level, 7),
+            other => panic!("expected zstd with precise level, got {other:?}"),
+        }
+
+        // ...zlib ignores the level and uses its default...
+        assert!(matches!(
+            CompressionScheme::new("zlib", 9),
+            CompressionScheme::Zlib(Level::Default)
+        ));
+
+        // ...and any unrecognized scheme falls back to zstd at the default level.
+        assert!(matches!(
+            CompressionScheme::new("brotli", 9),
+            CompressionScheme::Zstd(Level::Default)
+        ));
+    }
+
+    #[tokio::test]
+    async fn compressor_round_trips_and_reports_encoding_for_each_scheme() {
+        // Each scheme must round-trip byte-for-byte and advertise its documented `Content-Encoding`.
+        let cases: [(CompressionScheme, Option<&str>); 4] = [
+            (CompressionScheme::noop(), None),
+            (CompressionScheme::gzip_default(), Some("gzip")),
+            (CompressionScheme::zlib_default(), Some("deflate")),
+            (CompressionScheme::zstd_default(), Some("zstd")),
+        ];
+
+        for (scheme, expected_encoding) in cases {
+            let (compressed, encoding) = compress_all(scheme, COMPRESSIBLE_PAYLOAD).await;
+            assert_eq!(
+                encoding.as_ref().map(|value| value.to_str().unwrap()),
+                expected_encoding,
+                "unexpected content-encoding for {scheme:?}"
+            );
+
+            if matches!(scheme, CompressionScheme::Noop) {
+                // No-op compression emits the input verbatim.
+                assert_eq!(compressed, COMPRESSIBLE_PAYLOAD);
+            } else {
+                // A real scheme against a compressible payload must actually shrink it.
+                assert!(
+                    compressed.len() < COMPRESSIBLE_PAYLOAD.len(),
+                    "{scheme:?} did not shrink the payload ({} >= {})",
+                    compressed.len(),
+                    COMPRESSIBLE_PAYLOAD.len()
+                );
+            }
+
+            let decompressed = decompress(scheme, &compressed).await;
+            assert_eq!(decompressed, COMPRESSIBLE_PAYLOAD, "round-trip mismatch for {scheme:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn counting_writer_tracks_total_bytes_written() {
+        let mut writer = CountingWriter::new(Vec::new());
+        assert_eq!(writer.total_written(), 0);
+
+        writer.write_all(b"hello").await.expect("write should succeed");
+        assert_eq!(writer.total_written(), 5);
+
+        writer.write_all(b"!!!").await.expect("write should succeed");
+        assert_eq!(writer.total_written(), 8);
+
+        // The counter is pure bookkeeping: the wrapped writer still holds the actual bytes.
+        assert_eq!(writer.into_inner(), b"hello!!!");
+    }
+
+    #[tokio::test]
+    async fn noop_compressor_write_statistics_count_all_bytes() {
+        // The no-op compressor writes bytes through unchanged, so its `WriteStatistics` total is the input length.
+        let mut compressor = Compressor::from_scheme(CompressionScheme::noop(), Vec::new());
+        compressor.write_all(b"1234567890").await.expect("write should succeed");
+
+        assert_eq!(WriteStatistics::total_written(&compressor), 10);
     }
 }

--- a/lib/saluki-io/src/deser/codec/dogstatsd/event.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/event.rs
@@ -366,6 +366,28 @@ mod tests {
     }
 
     #[test]
+    fn event_rejects_empty_title_or_text() {
+        use nom::error::ErrorKind;
+
+        // Title and text are the two required fields of an event: a declared length of zero for either one is a
+        // structural error, so the parser rejects the frame with a `Verify` error rather than emitting an event with
+        // an empty title/text.
+        let config = DogStatsDCodecConfiguration::default();
+
+        match parse_dogstatsd_event(b"_e{0,4}:|text", &config) {
+            Err(nom::Err::Error(e)) => assert_eq!(e.code, ErrorKind::Verify),
+            Err(other) => panic!("expected Verify error for empty title, got {other:?}"),
+            Ok(_) => panic!("empty title must be rejected"),
+        }
+
+        match parse_dogstatsd_event(b"_e{5,0}:title|", &config) {
+            Err(nom::Err::Error(e)) => assert_eq!(e.code, ErrorKind::Verify),
+            Err(other) => panic!("expected Verify error for empty text, got {other:?}"),
+            Ok(_) => panic!("empty text must be rejected"),
+        }
+    }
+
+    #[test]
     fn client_origin_fields_ignored_when_disabled() {
         let local_data = "abcdef123456";
         let external_data = "it-false,cn-redis,pu-810fe89d-da47-410b-8979-9154a40f8183";

--- a/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
@@ -223,3 +223,69 @@ impl DogStatsDCodec {
         Ok(service_check)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn codec() -> DogStatsDCodec {
+        DogStatsDCodec::from_configuration(DogStatsDCodecConfiguration::default())
+    }
+
+    #[test]
+    fn parse_message_type_routes_by_leading_marker() {
+        // Only the exact `_e{` and `_sc|` prefixes select the event/service-check parsers; everything else — including
+        // payloads that merely start with `_e`/`_sc` but lack the structural marker — is treated as a metric sample.
+        assert!(matches!(parse_message_type(b"_e{5,4}:title|text"), MessageType::Event));
+        assert!(matches!(parse_message_type(b"_sc|svc|0"), MessageType::ServiceCheck));
+
+        assert!(matches!(
+            parse_message_type(b"page.views:1|c"),
+            MessageType::MetricSample
+        ));
+        // `_events` / `_scope` share a leading substring with the markers but aren't the markers themselves.
+        assert!(matches!(parse_message_type(b"_events:1|c"), MessageType::MetricSample));
+        assert!(matches!(parse_message_type(b"_scope:1|c"), MessageType::MetricSample));
+        assert!(matches!(parse_message_type(b""), MessageType::MetricSample));
+    }
+
+    #[test]
+    fn decode_packet_dispatches_to_the_matching_parser() {
+        let codec = codec();
+
+        // A metric sample is routed to the metric parser.
+        match codec.decode_packet(b"page.views:1|c").expect("metric should decode") {
+            ParsedPacket::Metric(metric) => assert_eq!(metric.metric_name, "page.views"),
+            _ => panic!("expected a metric packet"),
+        }
+
+        // An `_e{`-prefixed payload is routed to the event parser.
+        match codec.decode_packet(b"_e{5,4}:title|text").expect("event should decode") {
+            ParsedPacket::Event(event) => {
+                assert_eq!(&*event.title, "title");
+                assert_eq!(&*event.text, "text");
+            }
+            _ => panic!("expected an event packet"),
+        }
+
+        // An `_sc|`-prefixed payload is routed to the service-check parser.
+        match codec
+            .decode_packet(b"_sc|my.check|0")
+            .expect("service check should decode")
+        {
+            ParsedPacket::ServiceCheck(service_check) => assert_eq!(&*service_check.name, "my.check"),
+            _ => panic!("expected a service-check packet"),
+        }
+    }
+
+    #[test]
+    fn decode_packet_propagates_parser_errors_from_the_selected_path() {
+        // Dispatch happens before parsing, so a payload with the event marker but an invalid body is routed to the
+        // event parser and surfaces that parser's error rather than being silently retried as a metric.
+        let codec = codec();
+        match codec.decode_packet(b"_e{0,4}:|text") {
+            Err(err) => assert_eq!(err.kind, nom::error::ErrorKind::Verify),
+            Ok(_) => panic!("empty-title event must fail to decode"),
+        }
+    }
+}

--- a/lib/saluki-io/src/deser/framing/newline.rs
+++ b/lib/saluki-io/src/deser/framing/newline.rs
@@ -164,6 +164,35 @@ mod tests {
     }
 
     #[test]
+    fn newline_framing_retains_carriage_returns() {
+        // Documented behavior: only the line-feed (0x0A) delimits frames. Any carriage-return (0x0D) bytes are part
+        // of the frame contents and must be preserved, not stripped, so a CRLF-delimited stream yields frames that
+        // still carry the trailing `\r`.
+        let mut buf: VecDeque<u8> = b"foo\r\nbar\r\n".iter().copied().collect();
+        let mut framer = NewlineFramer::default();
+
+        let first = framer
+            .next_frame(&mut buf, false)
+            .expect("should not fail to read from payload")
+            .expect("should extract first frame");
+        assert_eq!(&first[..], b"foo\r");
+
+        let second = framer
+            .next_frame(&mut buf, false)
+            .expect("should not fail to read from payload")
+            .expect("should extract second frame");
+        assert_eq!(&second[..], b"bar\r");
+
+        assert!(buf.is_empty());
+        assert_eq!(
+            framer
+                .next_frame(&mut buf, false)
+                .expect("should not fail to read from empty payload"),
+            None
+        );
+    }
+
+    #[test]
     fn no_newline_eof_required_on_eof() {
         let payload = b"hello, world!";
         let mut buf = get_delimited_payload(payload, false);

--- a/lib/saluki-io/src/net/unix/ancillary.rs
+++ b/lib/saluki-io/src/net/unix/ancillary.rs
@@ -150,3 +150,82 @@ const fn get_ucred_struct_size() -> usize {
     // down to a bunch of `size_of` calls and arithmetic for ensuring the values take alignment into consideration, etc.
     unsafe { libc::CMSG_SPACE(ucred_raw_size) as usize }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::mem;
+
+    use super::*;
+
+    // Builds an ancillary-data buffer of `len` initialized (zeroed) bytes. Zeroing first keeps the later
+    // `messages()`/CMSG walk from ever reading uninitialized memory when the buffer is deliberately undersized.
+    fn zeroed_ancillary(len: usize) -> SocketCredentialsAncillaryData {
+        let mut ancillary = SocketCredentialsAncillaryData::new();
+        for byte in ancillary.as_mut_uninit() {
+            byte.write(0);
+        }
+
+        // SAFETY: every byte of the buffer was just initialized above, and `len` never exceeds its length.
+        unsafe {
+            ancillary.set_len(len);
+        }
+        ancillary
+    }
+
+    #[test]
+    fn credentials_parsed_from_exact_ucred_payload() {
+        // A control-message payload that's exactly `ucred`-sized is decoded field-for-field. The bytes point at a
+        // real `ucred`, so the reinterpretation in `as_credentials` reads correctly-aligned memory.
+        let creds = libc::ucred {
+            pid: 4242,
+            uid: 1000,
+            gid: 2000,
+        };
+        let bytes = unsafe {
+            std::slice::from_raw_parts(
+                (&creds as *const libc::ucred).cast::<u8>(),
+                mem::size_of::<libc::ucred>(),
+            )
+        };
+
+        match ControlMessage::as_credentials(bytes) {
+            Some(ControlMessage::Credentials(parsed)) => {
+                assert_eq!(parsed.pid, 4242);
+                assert_eq!(parsed.uid, 1000);
+                assert_eq!(parsed.gid, 2000);
+            }
+            None => panic!("a correctly-sized ucred payload should parse into credentials"),
+        }
+    }
+
+    #[test]
+    fn credentials_rejected_when_payload_length_is_wrong() {
+        // Untrusted, adversarial control data: a payload whose length doesn't exactly match `ucred` must be rejected
+        // (`None`), never reinterpreted as a `ucred` (which would be an out-of-bounds read or a garbage identity).
+        let ucred_len = mem::size_of::<libc::ucred>();
+        for bad_len in [0, 1, ucred_len - 1, ucred_len + 1] {
+            let buf = vec![0u8; bad_len];
+            assert!(
+                ControlMessage::as_credentials(&buf).is_none(),
+                "payload of {bad_len} bytes should be rejected (ucred is {ucred_len} bytes)"
+            );
+        }
+    }
+
+    #[test]
+    fn truncated_ancillary_buffer_yields_no_messages() {
+        // A control buffer too small to hold even a single `cmsghdr` (as can happen with truncated/garbage ancillary
+        // data) must produce zero control messages — `CMSG_FIRSTHDR` returns null — rather than panicking or
+        // fabricating a credential.
+        for len in [0usize, 1, mem::size_of::<libc::cmsghdr>() - 1] {
+            let ancillary = zeroed_ancillary(len);
+
+            // SAFETY: the buffer is fully initialized and its length was set to `len` above.
+            let mut messages = unsafe { ancillary.messages() };
+            assert!(
+                messages.next().is_none(),
+                "a {len}-byte control buffer should yield no control messages"
+            );
+        }
+    }
+}

--- a/lib/saluki-io/src/net/unix/linux.rs
+++ b/lib/saluki-io/src/net/unix/linux.rs
@@ -183,7 +183,64 @@ fn sendmsg_with_ucred(fd: libc::c_int, payload: &[u8], creds: &libc::ucred) -> i
 mod tests {
     use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 
+    use bytes::BytesMut;
+
     use super::*;
+
+    // Creates a connected AF_UNIX/SOCK_DGRAM socket pair, returning `(sender, receiver)`.
+    fn unix_dgram_socketpair() -> (Socket, Socket) {
+        let mut fds: [libc::c_int; 2] = [-1, -1];
+        let rc = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_DGRAM, 0, fds.as_mut_ptr()) };
+        assert_eq!(rc, 0, "socketpair failed: {}", io::Error::last_os_error());
+
+        // SAFETY: `socketpair` succeeded, so both descriptors are valid and owned by us.
+        unsafe { (Socket::from_raw_fd(fds[0]), Socket::from_raw_fd(fds[1])) }
+    }
+
+    #[test]
+    fn uds_recvmsg_reads_peer_credentials() {
+        // With SO_PASSCRED enabled on the receiver, the kernel attaches the sender's real PID/UID/GID as an
+        // SCM_CREDENTIALS control message, which `uds_recvmsg` must parse into `ProcessIdentity::Credentials`.
+        let (sender, receiver) = unix_dgram_socketpair();
+        enable_uds_socket_credentials(&receiver).expect("enabling SO_PASSCRED should succeed");
+
+        let payload = b"origin-detection-payload";
+        let sent = sender.send(payload).expect("send should succeed");
+        assert_eq!(sent, payload.len());
+
+        let mut buf = BytesMut::with_capacity(128);
+        let (n, addr) = uds_recvmsg(&receiver, &mut buf).expect("recvmsg should succeed");
+        assert_eq!(n, payload.len());
+        assert_eq!(&buf[..], payload);
+
+        let creds = addr
+            .process_credentials()
+            .expect("peer credentials should be present after SO_PASSCRED");
+        assert_eq!(creds.pid, std::process::id() as libc::pid_t);
+        assert_eq!(creds.uid, unsafe { libc::getuid() });
+        assert_eq!(creds.gid, unsafe { libc::getgid() });
+    }
+
+    #[test]
+    fn uds_recvmsg_without_passcred_reports_unavailable() {
+        // Without SO_PASSCRED, no ancillary credentials are delivered: control length is zero, so the identity is
+        // `Unavailable` (a "no origin info" state), not an error and not fabricated credentials.
+        let (sender, receiver) = unix_dgram_socketpair();
+
+        let payload = b"no-creds-payload";
+        sender.send(payload).expect("send should succeed");
+
+        let mut buf = BytesMut::with_capacity(128);
+        let (n, addr) = uds_recvmsg(&receiver, &mut buf).expect("recvmsg should succeed");
+        assert_eq!(n, payload.len());
+        assert_eq!(&buf[..], payload);
+
+        assert!(matches!(
+            addr,
+            ConnectionAddress::ProcessLike(ProcessIdentity::Unavailable)
+        ));
+        assert!(addr.process_credentials().is_none());
+    }
 
     #[test]
     fn sendmsg_with_current_credentials_round_trips_payload() {

--- a/lib/saluki-io/src/net/util/retry/lifecycle/http.rs
+++ b/lib/saluki-io/src/net/util/retry/lifecycle/http.rs
@@ -176,3 +176,75 @@ impl DynError for Box<dyn std::error::Error + Send + Sync> {
         &**self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use http::{Response, StatusCode, Uri};
+
+    use super::*;
+
+    type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+    fn categorize(res: Result<Response<()>, BoxError>) -> String {
+        CategorizedError::try_categorize(&res).to_string()
+    }
+
+    #[test]
+    fn categorizes_http_status_response() {
+        // A response (any `Ok`) is categorized by its status code, and non-success codes render with the code value.
+        let res: Result<Response<()>, BoxError> = Ok(Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(())
+            .unwrap());
+        assert_eq!(categorize(res), "Server responded with non-success status code 500.");
+    }
+
+    #[test]
+    fn categorizes_standalone_io_error_as_other() {
+        // A bare transport error that isn't a hyper/rustls/nested error falls through to the generic "Other" bucket.
+        let err: BoxError = Box::new(io::Error::from(io::ErrorKind::ConnectionRefused));
+        assert_eq!(categorize(Err(err)), "Request failed: connection refused");
+    }
+
+    #[test]
+    fn categorizes_rustls_certificate_error_as_tls() {
+        // A rustls certificate error is specialized into a TLS category with a human-readable reason.
+        let err: BoxError = Box::new(rustls::Error::InvalidCertificate(rustls::CertificateError::Expired));
+        assert_eq!(
+            categorize(Err(err)),
+            "Request failed due to a TLS error: peer certificate is invalid: certificate expired (current time is after notAfter time)"
+        );
+    }
+
+    #[test]
+    fn categorizes_io_wrapped_rustls_error_by_unwrapping_source() {
+        // An io::Error that wraps a rustls error is unwrapped via its source and categorized as TLS, not reported as
+        // a generic io failure.
+        let inner = rustls::Error::InvalidCertificate(rustls::CertificateError::Revoked);
+        let err: BoxError = Box::new(io::Error::other(inner));
+        assert_eq!(
+            categorize(Err(err)),
+            "Request failed due to a TLS error: peer certificate is invalid: certificate has been revoked"
+        );
+    }
+
+    #[test]
+    fn sanitized_request_uri_display() {
+        // Scheme, host, explicit port, and path are all rendered.
+        let uri: Uri = "http://localhost:8125/foo/bar".parse().unwrap();
+        assert_eq!(SanitizedRequestUri(&uri).to_string(), "http://localhost:8125/foo/bar");
+
+        // A default (implicit) port is omitted.
+        let uri: Uri = "https://api.datadoghq.com/api/v1/series".parse().unwrap();
+        assert_eq!(
+            SanitizedRequestUri(&uri).to_string(),
+            "https://api.datadoghq.com/api/v1/series"
+        );
+
+        // With neither scheme nor host, only the path is rendered.
+        let uri: Uri = "/health".parse().unwrap();
+        assert_eq!(SanitizedRequestUri(&uri).to_string(), "/health");
+    }
+}

--- a/lib/saluki-io/src/net/util/retry/policy/rolling_exponential.rs
+++ b/lib/saluki-io/src/net/util/retry/policy/rolling_exponential.rs
@@ -139,3 +139,70 @@ where
         Some(req.clone())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::atomic::Ordering::Relaxed, time::Duration};
+
+    use tower::retry::Policy;
+
+    use super::*;
+    use crate::net::util::retry::ExponentialBackoff;
+
+    // Classifier that retries iff the response is an `Err`, letting a single test drive both the failure path
+    // (error-count increment) and the success path (decrease/reset) via the response value it passes in.
+    struct ErrIsRetriable;
+
+    impl RetryClassifier<(), ()> for ErrIsRetriable {
+        fn should_retry(&self, response: &Result<(), ()>) -> bool {
+            response.is_err()
+        }
+    }
+
+    type TestPolicy = RollingExponentialBackoffRetryPolicy<ErrIsRetriable, DefaultDebugRetryLifecycle>;
+
+    fn test_policy(recovery_error_decrease_factor: Option<u32>) -> TestPolicy {
+        let backoff = ExponentialBackoff::new(Duration::from_millis(1), Duration::from_millis(100));
+        RollingExponentialBackoffRetryPolicy::new(ErrIsRetriable, backoff)
+            .with_recovery_error_decrease_factor(recovery_error_decrease_factor)
+    }
+
+    // Drives one classification and returns whether a retry (backoff sleep) was requested.
+    fn drive(policy: &mut TestPolicy, mut response: Result<(), ()>) -> bool {
+        Policy::<(), (), ()>::retry(policy, &mut (), &mut response).is_some()
+    }
+
+    #[tokio::test]
+    async fn recovery_decrease_factor_reduces_error_count_by_fixed_amount() {
+        let mut policy = test_policy(Some(3));
+
+        // Each failure increments the error count by one and requests a retry.
+        for expected in 1..=5u32 {
+            assert!(drive(&mut policy, Err(())), "a failure should request a retry");
+            assert_eq!(policy.error_count.load(Relaxed), expected);
+        }
+
+        // A success decreases the count by the factor (5 -> 2), not all the way back to zero, so a subsequent
+        // failure still backs off from near where it left off.
+        assert!(!drive(&mut policy, Ok(())), "a success should not request a retry");
+        assert_eq!(policy.error_count.load(Relaxed), 2);
+
+        // A second success saturates at zero (2 - 3 -> 0) rather than underflowing.
+        assert!(!drive(&mut policy, Ok(())));
+        assert_eq!(policy.error_count.load(Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn no_recovery_factor_resets_error_count_to_zero_on_success() {
+        let mut policy = test_policy(None);
+
+        for _ in 0..4 {
+            assert!(drive(&mut policy, Err(())));
+        }
+        assert_eq!(policy.error_count.load(Relaxed), 4);
+
+        // Without a recovery factor, a single success resets the count all the way to zero.
+        assert!(!drive(&mut policy, Ok(())));
+        assert_eq!(policy.error_count.load(Relaxed), 0);
+    }
+}

--- a/test/CLEANUP_PLAN.md
+++ b/test/CLEANUP_PLAN.md
@@ -249,7 +249,7 @@ otherwise keep hand-rolling the thing it replaces.
   - [low/trivial] A module doc comment overstates implemented capability (span-event filtering is documented but
     not implemented, hence untestable) — fix the doc, not the test.
 
-- [ ] **G15 — saluki-io test cleanup: dogstatsd codec/compression/framing + unix-socket credentials/retry** (AU-28/AU-29)
+- [x] **G15 — saluki-io test cleanup: dogstatsd codec/compression/framing + unix-socket credentials/retry** (AU-28/AU-29)
   (`tobz/test-cleanup-saluki-io-test-cleanup`, `test(io)`)
   - [medium/medium] `Compressor`, `CompressionScheme`, and `CountingWriter` are fully documented but have zero
     direct test coverage in saluki-io's compression module.


### PR DESCRIPTION
## Summary

This PR cleans up tests/test code for a number of areas in the `saluki-io` crate.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New and existing unit tests.

## References

DADP-2
