### PR TITLE
chore(test): clean up tests in `saluki-common` and `saluki-context`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4280,6 +4280,7 @@ dependencies = [
  "indexmap",
  "itoa",
  "libc",
+ "metrics",
  "papaya",
  "pin-project",
  "proptest",

--- a/lib/saluki-common/Cargo.toml
+++ b/lib/saluki-common/Cargo.toml
@@ -36,6 +36,8 @@ libc = { workspace = true }
 
 [dev-dependencies]
 http-body-util = { workspace = true }
+metrics = { workspace = true }
 proptest = { workspace = true }
+saluki-metrics = { workspace = true, features = ["test"] }
 serde_json = { workspace = true }
 tokio-test = { workspace = true }

--- a/lib/saluki-common/src/cache/expiry.rs
+++ b/lib/saluki-common/src/cache/expiry.rs
@@ -273,3 +273,145 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicU64, Ordering::SeqCst},
+        Arc,
+    };
+
+    use quick_cache::Lifecycle;
+    use saluki_metrics::reexport::metrics::{Counter, CounterFn};
+
+    use super::*;
+
+    /// A `CounterFn` that records the running total so tests can assert the documented
+    /// eviction-counter side effects without installing a full metrics recorder.
+    #[derive(Default)]
+    struct RecordingCounter(AtomicU64);
+
+    impl CounterFn for RecordingCounter {
+        fn increment(&self, value: u64) {
+            self.0.fetch_add(value, SeqCst);
+        }
+
+        fn absolute(&self, value: u64) {
+            self.0.store(value, SeqCst);
+        }
+    }
+
+    /// Builds a `Counter` alongside a handle for reading its current total.
+    fn recording_counter() -> (Counter, Arc<RecordingCounter>) {
+        let storage = Arc::new(RecordingCounter::default());
+        (Counter::from_arc(Arc::clone(&storage)), storage)
+    }
+
+    /// Invokes the lifecycle's `on_evict` for the given key, using `()` as the value type.
+    fn trigger_eviction<K>(lifecycle: &ExpiryCapableLifecycle<K>, key: K)
+    where
+        K: Eq + std::hash::Hash,
+    {
+        <ExpiryCapableLifecycle<K> as Lifecycle<K, ()>>::on_evict(lifecycle, &mut (), key, ());
+    }
+
+    #[test]
+    fn disabled_expiration_never_drains() {
+        let (counter, _storage) = recording_counter();
+        let (expiration, _lifecycle) = ExpirationBuilder::<&str>::new(counter).build();
+
+        expiration.mark_entry_accessed("only");
+
+        let mut expired = Vec::new();
+        expiration.drain_expired_items(&mut expired);
+        assert!(
+            expired.is_empty(),
+            "expiration is disabled, so nothing should ever drain"
+        );
+    }
+
+    #[test]
+    fn time_to_idle_drains_stale_entries_and_retains_fresh() {
+        let (counter, _storage) = recording_counter();
+        let (expiration, _lifecycle) = ExpirationBuilder::<&str>::new(counter)
+            .with_time_to_idle(Duration::from_secs(60))
+            .build();
+
+        expiration.mark_entry_accessed("fresh");
+        expiration.mark_entry_accessed("stale");
+
+        // The first drain flushes the queued access ops into the last-seen map. Both entries were
+        // just accessed, so neither is beyond the 60s time-to-idle window yet.
+        let mut expired = Vec::new();
+        expiration.drain_expired_items(&mut expired);
+        assert!(expired.is_empty(), "freshly accessed entries must not expire");
+
+        // Force one entry's last-access timestamp far into the past, beyond the time-to-idle window,
+        // while leaving the other untouched.
+        {
+            let state = expiration.state.as_ref().expect("expiration is enabled");
+            let mut inner = state.inner.lock().unwrap();
+            inner
+                .last_seen
+                .get_mut("stale")
+                .expect("stale entry is tracked")
+                .last_accessed = 0;
+        }
+
+        expiration.drain_expired_items(&mut expired);
+        assert_eq!(expired, vec!["stale"], "only the idle entry should be drained");
+
+        // The idle entry is removed from tracking; the fresh entry remains tracked.
+        let state = expiration.state.as_ref().unwrap();
+        let inner = state.inner.lock().unwrap();
+        assert!(inner.last_seen.contains_key("fresh"));
+        assert!(!inner.last_seen.contains_key("stale"));
+    }
+
+    #[test]
+    fn eviction_increments_counter_and_untracks_entry() {
+        let (counter, storage) = recording_counter();
+        let (expiration, lifecycle) = ExpirationBuilder::<&str>::new(counter)
+            .with_time_to_idle(Duration::from_secs(60))
+            .build();
+
+        // Track an entry, then flush the queued access op into the last-seen map.
+        expiration.mark_entry_accessed("evicted");
+        let mut expired = Vec::new();
+        expiration.drain_expired_items(&mut expired);
+        assert!(expired.is_empty());
+
+        // Simulate the underlying cache evicting the entry: the counter is bumped and the entry is
+        // queued for removal from expiration tracking.
+        trigger_eviction(&lifecycle, "evicted");
+        assert_eq!(
+            storage.0.load(SeqCst),
+            1,
+            "on_evict must increment the eviction counter"
+        );
+
+        // Draining processes the queued removal, so the evicted key is no longer tracked.
+        expiration.drain_expired_items(&mut expired);
+        assert!(expired.is_empty());
+
+        let state = expiration.state.as_ref().unwrap();
+        let inner = state.inner.lock().unwrap();
+        assert!(
+            !inner.last_seen.contains_key("evicted"),
+            "eviction must untrack the entry"
+        );
+    }
+
+    #[test]
+    fn eviction_counter_increments_even_when_expiration_disabled() {
+        // The documented contract is that `on_evict` counts every capacity-driven eviction, even
+        // when time-to-idle tracking is disabled (the lifecycle then has no state to update).
+        let (counter, storage) = recording_counter();
+        let lifecycle = ExpiryCapableLifecycle::<&str>::disabled(counter);
+
+        trigger_eviction(&lifecycle, "one");
+        trigger_eviction(&lifecycle, "two");
+
+        assert_eq!(storage.0.load(SeqCst), 2);
+    }
+}

--- a/lib/saluki-common/src/deser.rs
+++ b/lib/saluki-common/src/deser.rs
@@ -119,14 +119,18 @@ mod tests {
         PermissiveBool::deserialize_as(v.into_deserializer())
     }
 
-    // Native boolean
-    #[test]
-    fn native_true() {
-        assert!(parse_bool(true).unwrap());
+    fn parse_uint(v: u64) -> Result<bool, serde::de::value::Error> {
+        PermissiveBool::deserialize_as(v.into_deserializer())
     }
 
+    fn parse_float(v: f64) -> Result<bool, serde::de::value::Error> {
+        PermissiveBool::deserialize_as(v.into_deserializer())
+    }
+
+    // Native boolean
     #[test]
-    fn native_false() {
+    fn native_bool_is_passed_through() {
+        assert!(parse_bool(true).unwrap());
         assert!(!parse_bool(false).unwrap());
     }
 
@@ -154,14 +158,41 @@ mod tests {
         assert!(parse_str("").is_err());
     }
 
-    // Integer variants
+    // Integer variants (both signed and unsigned deserializer paths).
     #[test]
-    fn int_true() {
+    fn integer_accepts_zero_and_one() {
+        assert!(!parse_int(0).unwrap());
         assert!(parse_int(1).unwrap());
+        assert!(!parse_uint(0).unwrap());
+        assert!(parse_uint(1).unwrap());
     }
 
     #[test]
-    fn int_false() {
-        assert!(!parse_int(0).unwrap());
+    fn integer_rejects_values_other_than_zero_or_one() {
+        // Signed values outside {0, 1}, including negatives and extremes, are rejected (visit_i64).
+        for v in [-1, 2, i64::MIN, i64::MAX] {
+            assert!(parse_int(v).is_err(), "expected signed {v} to be rejected");
+        }
+
+        // Unsigned values outside {0, 1} are rejected (visit_u64).
+        for v in [2u64, u64::MAX] {
+            assert!(parse_uint(v).is_err(), "expected unsigned {v} to be rejected");
+        }
+    }
+
+    // Floating-point variants (visit_f64 path).
+    #[test]
+    fn float_accepts_zero_and_one() {
+        assert!(!parse_float(0.0).unwrap());
+        assert!(parse_float(1.0).unwrap());
+    }
+
+    #[test]
+    fn float_rejects_values_other_than_zero_or_one() {
+        // Any floating-point value other than exactly 0.0 or 1.0 is rejected, including fractional,
+        // out-of-range, and non-finite values.
+        for v in [0.5, 2.0, -1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(parse_float(v).is_err(), "expected float {v} to be rejected");
+        }
     }
 }

--- a/lib/saluki-common/src/strings.rs
+++ b/lib/saluki-common/src/strings.rs
@@ -333,4 +333,53 @@ mod tests {
             "hello, world! it's me, steve from blues clues. i've got 5 apples."
         );
     }
+
+    #[test]
+    fn unsigned_integer_to_string_formats_decimal_value() {
+        let cases = [
+            (0u64, "0"),
+            (7, "7"),
+            (42, "42"),
+            (1_000_000, "1000000"),
+            (u64::MAX, "18446744073709551615"),
+        ];
+
+        for (value, expected) in cases {
+            assert_eq!(unsigned_integer_to_string(value), expected, "value: {value}");
+        }
+    }
+
+    #[test]
+    fn to_meta_string_inlines_short_strings() {
+        // Short strings are inlined by `MetaString::from_interner` before the interner is even
+        // consulted, so the result matches the buffer contents regardless of interner capacity.
+        let mut builder = build_interned_string_builder(128);
+        assert_eq!(builder.push_str("short"), Some(()));
+
+        assert_eq!(builder.to_meta_string(), "short");
+    }
+
+    #[test]
+    fn to_meta_string_interns_long_strings_when_capacity_allows() {
+        // A string too long to inline is interned when the interner has room for it.
+        let long = "this string is far too long to ever be inlined into a MetaString";
+        let mut builder = build_interned_string_builder(256);
+        assert_eq!(builder.push_str(long), Some(()));
+
+        assert_eq!(builder.to_meta_string(), long);
+    }
+
+    #[test]
+    fn to_meta_string_falls_back_to_owned_when_interner_full() {
+        // A string too long to inline and too large for the interner falls back to an owned
+        // allocation, which still yields the same string contents.
+        let long = "this string is far too long to ever be inlined into a MetaString";
+        let mut builder = build_interned_string_builder_with_limit(8, long.len() + 1);
+        assert_eq!(builder.push_str(long), Some(()));
+
+        // The interner cannot hold the string, but `to_meta_string` still returns it (unlike
+        // `try_intern`, which would return `None`).
+        assert_eq!(builder.try_intern(), None);
+        assert_eq!(builder.to_meta_string(), long);
+    }
 }

--- a/lib/saluki-common/src/task/instrument.rs
+++ b/lib/saluki-common/src/task/instrument.rs
@@ -74,3 +74,86 @@ where
         result
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future::Future,
+        pin::Pin,
+        sync::Arc,
+        task::{Context, Poll, Wake, Waker},
+    };
+
+    use saluki_metrics::test::TestRecorder;
+
+    use super::*;
+
+    /// A future that returns `Pending` a fixed number of times before completing, letting a test
+    /// drive a known number of polls.
+    struct PendsThenReady {
+        pending_polls: usize,
+    }
+
+    impl Future for PendsThenReady {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
+            if self.pending_polls == 0 {
+                Poll::Ready(())
+            } else {
+                self.pending_polls -= 1;
+                Poll::Pending
+            }
+        }
+    }
+
+    struct NoopWaker;
+
+    impl Wake for NoopWaker {
+        fn wake(self: Arc<Self>) {}
+    }
+
+    #[test]
+    fn poll_records_one_duration_sample_per_poll() {
+        let recorder = TestRecorder::default();
+        let _guard = metrics::set_default_local_recorder(&recorder);
+
+        // Two `Pending` polls followed by one `Ready` poll: three polls total.
+        let task = PendsThenReady { pending_polls: 2 }.with_task_instrumentation("poll_duration_test".to_string());
+        let mut task = Box::pin(task);
+
+        let waker = Waker::from(Arc::new(NoopWaker));
+        let mut cx = Context::from_waker(&waker);
+
+        let mut polls = 0;
+        loop {
+            polls += 1;
+            if task.as_mut().poll(&mut cx).is_ready() {
+                break;
+            }
+        }
+        assert_eq!(polls, 3);
+
+        // The documented behavior is that every poll records one `poll_duration_seconds` sample,
+        // tagged with the task name provided to `with_task_instrumentation`.
+        let samples = recorder
+            .histogram((
+                Telemetry::poll_duration_seconds_name(),
+                &[("task_name", "poll_duration_test")],
+            ))
+            .expect("poll-duration histogram should be registered");
+        assert_eq!(samples.len(), 3, "each poll must record one duration sample");
+        assert!(
+            samples.iter().all(|&sample| sample >= 0.0),
+            "recorded poll durations must be non-negative"
+        );
+
+        // NOTE: `poll_count` is declared in the telemetry block but is never incremented by
+        // `InstrumentedTask::poll` (only the histogram is recorded). This assertion pins that
+        // current gap; if poll counting is ever wired up, this test should be updated to match.
+        assert_eq!(
+            recorder.counter((Telemetry::poll_count_name(), &[("task_name", "poll_duration_test")])),
+            Some(0)
+        );
+    }
+}

--- a/lib/saluki-common/src/task/mod.rs
+++ b/lib/saluki-common/src/task/mod.rs
@@ -155,3 +155,64 @@ pub fn get_caller_location_as_string() -> String {
     let caller = std::panic::Location::caller();
     format!("file-{}@{}-{}", caller.file(), caller.line(), caller.column())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn caller_location_uses_documented_format() {
+        // Because `get_caller_location_as_string` is `#[track_caller]`, this records _this_ call
+        // site, so the file segment matches this source file.
+        let location = get_caller_location_as_string();
+
+        // NOTE: the doc comment describes the format as `file:line:column`, but the implementation
+        // actually produces `file-<file>@<line>-<column>`. We assert the real, current format.
+        let prefix = format!("file-{}@", file!());
+        assert!(
+            location.starts_with(&prefix),
+            "expected {location:?} to start with {prefix:?}"
+        );
+
+        // Exactly one `@` separates the file from the position, and the trailing portion is two
+        // decimal numbers (line and column) joined by `-`.
+        assert_eq!(location.matches('@').count(), 1);
+        let (_, line_col) = location.split_once('@').unwrap();
+        let (line, column) = line_col.split_once('-').expect("line and column separated by '-'");
+        assert!(line.parse::<u32>().is_ok(), "line segment {line:?} should be numeric");
+        assert!(
+            column.parse::<u32>().is_ok(),
+            "column segment {column:?} should be numeric"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_traced_runs_future_to_completion() {
+        assert_eq!(spawn_traced(async { 7u32 }).await.unwrap(), 7);
+        assert_eq!(spawn_traced_named("named-task", async { 9u32 }).await.unwrap(), 9);
+    }
+
+    #[tokio::test]
+    async fn join_set_ext_runs_traced_tasks_to_completion() {
+        let mut set = JoinSet::new();
+        set.spawn_traced(async { 1u32 });
+        set.spawn_traced_named("set-task", async { 2u32 });
+
+        let mut results = Vec::new();
+        while let Some(result) = set.join_next().await {
+            results.push(result.unwrap());
+        }
+        results.sort_unstable();
+        assert_eq!(results, vec![1, 2]);
+    }
+
+    #[tokio::test]
+    async fn handle_ext_runs_traced_tasks_to_completion() {
+        let handle = Handle::current();
+        assert_eq!(handle.spawn_traced(async { 4u32 }).await.unwrap(), 4);
+        assert_eq!(
+            handle.spawn_traced_named("handle-task", async { 5u32 }).await.unwrap(),
+            5
+        );
+    }
+}

--- a/lib/saluki-common/src/time.rs
+++ b/lib/saluki-common/src/time.rs
@@ -57,3 +57,78 @@ pub fn get_coarse_unix_timestamp() -> u64 {
 
     COARSE_TIME.load(Relaxed)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{thread::sleep, time::Duration};
+
+    use super::*;
+
+    #[test]
+    fn coarse_timestamp_never_exceeds_accurate_timestamp() {
+        // The documented contract is that the coarse timestamp is never _ahead_ of the true time:
+        // it is only ever equal to it or lagging behind it, because it is a cached snapshot of a
+        // previous `get_unix_timestamp()` call. Sample repeatedly to make an accidental "ahead"
+        // read unlikely to slip through.
+        for _ in 0..1_000 {
+            let coarse = get_coarse_unix_timestamp();
+            let accurate = get_unix_timestamp();
+            assert!(
+                coarse <= accurate,
+                "coarse timestamp {coarse} must never be ahead of accurate timestamp {accurate}"
+            );
+        }
+    }
+
+    #[test]
+    fn coarse_timestamp_is_monotonically_non_decreasing() {
+        // The coarse timestamp is only ever replaced with a newer `get_unix_timestamp()` value, so
+        // successive reads must never go backwards, including across an update-interval boundary.
+        let first = get_coarse_unix_timestamp();
+
+        let mut previous = first;
+        for _ in 0..1_000 {
+            let current = get_coarse_unix_timestamp();
+            assert!(
+                current >= previous,
+                "coarse timestamp went backwards: {previous} -> {current}"
+            );
+            previous = current;
+        }
+
+        // Sleep past a couple of update intervals so the background updater runs, then confirm the
+        // value has not regressed.
+        sleep(COARSE_TIME_UPDATE_INTERVAL * 3);
+        let after_sleep = get_coarse_unix_timestamp();
+        assert!(
+            after_sleep >= previous,
+            "coarse timestamp regressed after update: {previous} -> {after_sleep}"
+        );
+    }
+
+    #[test]
+    fn coarse_timestamp_tracks_accurate_within_staleness_bound() {
+        // The documented staleness bound is that the coarse value may lag true time by at most
+        // ~250ms, i.e. in whole seconds it is either `t` or `t-1`. Once the background updater is
+        // running, the difference against the accurate timestamp should therefore be no more than
+        // one second. Retry across a short window to absorb one-off scheduling jitter on busy CI.
+        get_coarse_unix_timestamp();
+        sleep(COARSE_TIME_UPDATE_INTERVAL * 2);
+
+        let mut within_bound = false;
+        for _ in 0..20 {
+            let accurate = get_unix_timestamp();
+            let coarse = get_coarse_unix_timestamp();
+            if accurate - coarse <= 1 {
+                within_bound = true;
+                break;
+            }
+            sleep(Duration::from_millis(100));
+        }
+
+        assert!(
+            within_bound,
+            "coarse timestamp never came within one second of the accurate timestamp"
+        );
+    }
+}

--- a/lib/saluki-context/src/context.rs
+++ b/lib/saluki-context/src/context.rs
@@ -1117,4 +1117,44 @@ mod tests {
         assert_eq!(via_two, via_one);
         assert_eq!(via_two, via_direct);
     }
+
+    #[test]
+    fn with_tag_sets_mut_mutates_both_and_recomputes_key() {
+        // `with_tag_sets_mut` mutates both tag sets and recomputes the context key a single time
+        // for the combined change. The observable guarantee is that the result matches a context
+        // built from scratch with the combined tags, and matches applying the same two mutations
+        // via separate `with_tags`/`with_origin_tags` calls (which would each rehash).
+        let mut combined = context_with_origin("metric", &["env:prod"], &["origin:a"]);
+        combined.with_tag_sets_mut(|tags, origin_tags| {
+            tags.insert_tag(Tag::from("service:web"));
+            origin_tags.insert_tag(Tag::from("origin:b"));
+        });
+
+        // Both tag sets were updated in the single call.
+        assert!(combined.tags().has_tag("env:prod"));
+        assert!(combined.tags().has_tag("service:web"));
+        assert!(combined.origin_tags().has_tag("origin:a"));
+        assert!(combined.origin_tags().has_tag("origin:b"));
+
+        // The recomputed key matches a freshly-built context with the same final state.
+        let expected = context_with_origin("metric", &["env:prod", "service:web"], &["origin:a", "origin:b"]);
+        assert_eq!(combined, expected);
+
+        // ...and matches applying the two mutations separately (i.e. via two rehashes).
+        let separate = context_with_origin("metric", &["env:prod"], &["origin:a"])
+            .with_tags(tag_set(&["env:prod", "service:web"]))
+            .with_origin_tags(tag_set(&["origin:a", "origin:b"]));
+        assert_eq!(combined, separate);
+    }
+
+    #[test]
+    fn display_renders_name_and_instrumented_tags() {
+        // With no tags, only the metric name is rendered.
+        assert_eq!(Context::from_static_name("metric").to_string(), "metric");
+
+        // With tags, they are rendered in a brace-delimited, comma-space-separated list in
+        // insertion order. Origin tags are intentionally not part of the `Display` output.
+        let context = Context::from_static_parts("metric", &["env:prod", "service:web"]);
+        assert_eq!(context.to_string(), "metric{env:prod, service:web}");
+    }
 }

--- a/lib/saluki-context/src/origin.rs
+++ b/lib/saluki-context/src/origin.rs
@@ -450,4 +450,118 @@ mod tests {
             assert_eq!(external_data_hash, external_data_ref_hash);
         }
     }
+
+    /// Parses `raw` and projects the result into a comparable tuple of its fields.
+    fn parsed(raw: &str) -> Option<(&str, &str, bool)> {
+        RawExternalData::try_from_str(raw).map(|data| (data.pod_uid, data.container_name, data.init_container))
+    }
+
+    #[test]
+    fn try_from_str_parses_valid_and_malformed_external_data() {
+        let cases: &[(&str, Option<(&str, &str, bool)>)] = &[
+            // Empty input is the only case that yields no data at all.
+            ("", None),
+            // All three keys, in any order, populate their respective fields.
+            ("pu-podid,cn-web,it-true", Some(("podid", "web", true))),
+            ("it-false,cn-web,pu-podid", Some(("podid", "web", false))),
+            // A single key populates just that field; the others keep their empty/false defaults.
+            ("pu-podid", Some(("podid", "", false))),
+            ("cn-web", Some(("", "web", false))),
+            // The `it-` value is parsed as a bool; any non-bool value falls back to false.
+            ("it-true", Some(("", "", true))),
+            ("it-notabool", Some(("", "", false))),
+            // Parts shorter than four characters (no room for an `xx-` prefix plus a value) are
+            // skipped, but a non-empty input still parses to defaults rather than `None`.
+            ("x", Some(("", "", false))),
+            ("abc", Some(("", "", false))),
+            // Unknown keys are ignored.
+            ("zz-whatever", Some(("", "", false))),
+            // Short/garbage parts are skipped while valid parts are still parsed.
+            ("pu-podid,z,cn-web", Some(("podid", "web", false))),
+            // Duplicate keys: the last occurrence wins.
+            ("pu-first,pu-second", Some(("second", "", false))),
+        ];
+
+        for (raw, expected) in cases {
+            assert_eq!(parsed(raw), *expected, "input: {raw:?}");
+        }
+    }
+
+    #[test]
+    fn origin_tag_cardinality_displays_lowercase_name() {
+        let cases = [
+            (OriginTagCardinality::None, "none"),
+            (OriginTagCardinality::Low, "low"),
+            (OriginTagCardinality::Orchestrator, "orchestrator"),
+            (OriginTagCardinality::High, "high"),
+        ];
+
+        for (cardinality, expected) in cases {
+            assert_eq!(cardinality.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn raw_external_data_display_lists_all_fields() {
+        let data = RawExternalData::try_from_str("pu-podid,cn-web,it-true").unwrap();
+        assert_eq!(data.to_string(), "pu-podid,cn-web,it-true");
+    }
+
+    #[test]
+    fn raw_external_data_display_round_trips_through_parser() {
+        // Display always emits the canonical `pu-,cn-,it-` form, which the parser accepts verbatim,
+        // regardless of the field order in the original input.
+        let original = RawExternalData::try_from_str("cn-web,pu-podid,it-true").unwrap();
+        let rendered = original.to_string();
+        let reparsed = RawExternalData::try_from_str(&rendered).unwrap();
+        assert_eq!(reparsed, original);
+    }
+
+    #[test]
+    fn raw_origin_display_empty() {
+        assert_eq!(RawOrigin::default().to_string(), "RawOrigin()");
+    }
+
+    #[test]
+    fn raw_origin_display_individual_fields() {
+        let mut process_id = RawOrigin::default();
+        process_id.set_process_id(1234);
+        assert_eq!(process_id.to_string(), "RawOrigin(process_id=1234)");
+
+        let mut local_data = RawOrigin::default();
+        local_data.set_local_data("abc");
+        assert_eq!(local_data.to_string(), "RawOrigin(local_data=abc)");
+
+        let mut pod_uid = RawOrigin::default();
+        pod_uid.set_pod_uid("pod-1");
+        assert_eq!(pod_uid.to_string(), "RawOrigin(pod_uid=pod-1)");
+
+        let mut cardinality = RawOrigin::default();
+        cardinality.set_cardinality(OriginTagCardinality::Low);
+        assert_eq!(cardinality.to_string(), "RawOrigin(cardinality=low)");
+
+        let mut external_data = RawOrigin::default();
+        external_data.set_external_data("pu-podid,cn-web,it-true");
+        assert_eq!(
+            external_data.to_string(),
+            "RawOrigin(external_data=pu-podid,cn-web,it-true)"
+        );
+    }
+
+    #[test]
+    fn raw_origin_display_combines_present_fields() {
+        let mut origin = RawOrigin::default();
+        origin.set_process_id(1234);
+        origin.set_local_data("abc");
+        origin.set_pod_uid("pod-1");
+        origin.set_cardinality(OriginTagCardinality::Low);
+
+        // NOTE: the `process_id` branch does not set the internal `has_written` flag, so the first
+        // separator space is dropped and `process_id` runs directly into `local_data`. This asserts
+        // the current (buggy) spacing so a future fix has to update the expectation deliberately.
+        assert_eq!(
+            origin.to_string(),
+            "RawOrigin(process_id=1234local_data=abc pod_uid=pod-1 cardinality=low)"
+        );
+    }
 }

--- a/lib/saluki-context/src/tags/mod.rs
+++ b/lib/saluki-context/src/tags/mod.rs
@@ -190,3 +190,59 @@ impl hash::Hash for BorrowedTag<'_> {
         self.raw.hash(state);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn borrowed_tag_splits_name_and_value() {
+        // (raw, expected name, expected value)
+        let cases: &[(&str, &str, Option<&str>)] = &[
+            // Key/value tag: split on the first colon.
+            ("service:web", "service", Some("web")),
+            // Bare tag: the whole string is the name, and there is no value.
+            ("production", "production", None),
+            // Empty value: the value is present but empty.
+            ("key:", "key", Some("")),
+            // Multiple colons: only the first colon splits; the rest stays in the value.
+            ("a:b:c", "a", Some("b:c")),
+            // Leading colon: empty name, value is the remainder.
+            (":foo", "", Some("foo")),
+            // Just a colon: empty name and empty value.
+            (":", "", Some("")),
+            // Empty string: empty name, no value.
+            ("", "", None),
+        ];
+
+        for (raw, name, value) in cases {
+            let borrowed = BorrowedTag::from(*raw);
+            assert_eq!(borrowed.name(), *name, "name for {raw:?}");
+            assert_eq!(borrowed.value(), *value, "value for {raw:?}");
+            assert_eq!(borrowed.name_and_value(), (*name, *value), "name_and_value for {raw:?}");
+
+            // `Tag` re-implements the same split independently (via `split_once`), so the two must
+            // agree on every input.
+            let owned = Tag::from(*raw);
+            assert_eq!(owned.name(), *name, "Tag::name for {raw:?}");
+            assert_eq!(owned.value(), *value, "Tag::value for {raw:?}");
+        }
+    }
+
+    #[test]
+    fn borrowed_tag_is_empty_and_len() {
+        let empty = BorrowedTag::from("");
+        assert!(empty.is_empty());
+        assert_eq!(empty.len(), 0);
+
+        let tag = BorrowedTag::from("service:web");
+        assert!(!tag.is_empty());
+        assert_eq!(tag.len(), "service:web".len());
+    }
+
+    #[test]
+    fn tag_display_renders_full_tag_string() {
+        assert_eq!(Tag::from("service:web").to_string(), "service:web");
+        assert_eq!(Tag::from("bare").to_string(), "bare");
+    }
+}

--- a/lib/saluki-context/src/tags/tagset/frozen.rs
+++ b/lib/saluki-context/src/tags/tagset/frozen.rs
@@ -83,3 +83,16 @@ impl fmt::Display for FrozenTagSet {
         write!(f, "]")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_renders_comma_separated_tags() {
+        let frozen = FrozenTagSet::from_iter([Tag::from("a:1"), Tag::from("b:2")]);
+        assert_eq!(frozen.to_string(), "[a:1,b:2]");
+
+        assert_eq!(FrozenTagSet::default().to_string(), "[]");
+    }
+}

--- a/lib/saluki-context/src/tags/tagset/owned.rs
+++ b/lib/saluki-context/src/tags/tagset/owned.rs
@@ -926,6 +926,29 @@ mod tests {
         assert_eq!(collect_sorted(&ts), vec!["a:1", "b:2"]);
     }
 
+    #[test]
+    fn merge_shared_does_not_deduplicate_tags() {
+        // Unlike `merge_missing_shared`, `merge_shared` documents that it does NOT avoid adding
+        // duplicate tags: the shared set is chained onto the base wholesale.
+        let base = shared_from(&["a:1", "b:2"]);
+        let mut ts = TagSet::from(base);
+
+        let other = shared_from(&["b:2", "c:3"]);
+        ts.merge_shared(&other);
+
+        // b:2 is present in both the base and the merged set, and both copies are retained.
+        assert_eq!(ts.len(), 4);
+        assert_eq!(collect_sorted(&ts), vec!["a:1", "b:2", "b:2", "c:3"]);
+    }
+
+    #[test]
+    fn display_renders_comma_separated_tags() {
+        let ts: TagSet = vec![Tag::from("a:1"), Tag::from("b:2")].into_iter().collect();
+        assert_eq!(ts.to_string(), "[a:1,b:2]");
+
+        assert_eq!(TagSet::default().to_string(), "[]");
+    }
+
     // --- to_mutable convenience ---
 
     #[test]

--- a/lib/saluki-context/src/tags/tagset/shared.rs
+++ b/lib/saluki-context/src/tags/tagset/shared.rs
@@ -243,3 +243,47 @@ impl<'a> Iterator for SharedTagSetIterator<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn shared_from(tags: &[&str]) -> SharedTagSet {
+        tags.iter().map(|s| Tag::from(*s)).collect()
+    }
+
+    #[test]
+    fn extend_from_shared_skips_structurally_shared_sets() {
+        // Extending with a set that shares the same underlying `FrozenTagSet` (by `Arc` identity)
+        // is a no-op: the identical frozen set is not appended a second time.
+        let base = shared_from(&["x:1", "y:2"]);
+        let mut extended = base.clone();
+        extended.extend_from_shared(&base);
+
+        assert_eq!(extended.len(), 2);
+        assert_eq!(extended, base);
+    }
+
+    #[test]
+    fn extend_from_shared_keeps_duplicate_tags_across_distinct_sets() {
+        // Two independently-built sets don't share an `Arc`, so extending appends the second frozen
+        // set wholesale even when it repeats a tag: there is no cross-set de-duplication of
+        // individual tags (unlike the `Arc`-identity skip above).
+        let mut base = shared_from(&["x:1"]);
+        let other = shared_from(&["x:1", "y:2"]);
+        base.extend_from_shared(&other);
+
+        assert_eq!(base.len(), 3, "the duplicate x:1 is retained across the two sets");
+        assert!(base.has_tag("x:1"));
+        assert!(base.has_tag("y:2"));
+
+        let x_count = base.into_iter().filter(|tag| tag.as_str() == "x:1").count();
+        assert_eq!(x_count, 2, "x:1 appears once per source set");
+    }
+
+    #[test]
+    fn display_renders_comma_space_separated_tags() {
+        assert_eq!(shared_from(&[]).to_string(), "[]");
+        assert_eq!(shared_from(&["a:1", "b:2"]).to_string(), "[a:1, b:2]");
+    }
+}

--- a/test/CLEANUP_PLAN.md
+++ b/test/CLEANUP_PLAN.md
@@ -261,8 +261,14 @@ otherwise keep hand-rolling the thing it replaces.
   - [medium/small] `RollingExponentialBackoffRetryPolicy`'s documented recovery-error-decrease-factor behavior, and
     `StandardHttpRetryLifecycle`'s documented error-categorization/`Display` logic, are both untested.
 
-- [ ] **G16 — saluki-common & saluki-context test cleanup** (AU-30/AU-31)
+- [x] **G16 — saluki-common & saluki-context test cleanup** (AU-30/AU-31)
   (`tobz/test-cleanup-saluki-common-context-test-cleanup`, `test(common)`)
+  _Surfaced 4 latent production defects (pinned by characterization tests + NOTE comments, NOT fixed — a test
+  cleanup pass doesn't change production behavior): `RawOrigin::Display` drops a separator space between
+  `process_id` and `local_data`; `get_caller_location_as_string` doc says `file:line:column` but emits
+  `file-<file>@<line>-<column>`; `task/instrument.rs`'s `poll_count` debug counter is registered but never
+  incremented; `RawExternalData::try_from_str` byte-slices `part[0..3]` which would panic on a non-ASCII char
+  boundary. Worth follow-up production fixes outside this test effort._
   - [high/medium] Cache time-to-idle eviction (`cache/expiry.rs`) and its underlying timestamp primitives
     (`time.rs`) are both untested, including the documented eviction-counter side effects.
   - [medium/medium] `spawn_traced` task-spawning helpers and poll-duration instrumentation


### PR DESCRIPTION
## Summary

This PR cleans up tests/test code for a number of areas in the `saluki-common` and `saluki-context` crates.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New and existing unit tests.

## References

DADP-2
