### PR TITLE
chore(test): clean up tests in a number of Datadog-specific and testing crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,6 +1267,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tinytemplate",
+ "tokio",
 ]
 
 [[package]]
@@ -1309,6 +1310,7 @@ dependencies = [
  "protobuf-codegen",
  "serde",
  "serde_bytes",
+ "serde_json",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",

--- a/bin/correctness/panoramic/src/config.rs
+++ b/bin/correctness/panoramic/src/config.rs
@@ -1001,7 +1001,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_duration() {
+    fn parse_duration_handles_units_and_combinations() {
         assert_eq!(parse_duration("10s").unwrap(), Duration::from_secs(10));
         assert_eq!(parse_duration("1m").unwrap(), Duration::from_secs(60));
         assert_eq!(parse_duration("500ms").unwrap(), Duration::from_millis(500));
@@ -1012,7 +1012,25 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_port_spec() {
+    fn parse_duration_treats_a_trailing_unitless_number_as_seconds() {
+        // Documented no-unit fallback: a trailing number with no unit is interpreted as seconds, both on
+        // its own and after a unit-qualified component.
+        assert_eq!(parse_duration("42").unwrap(), Duration::from_secs(42));
+        assert_eq!(parse_duration("1m30").unwrap(), Duration::from_secs(90));
+    }
+
+    #[test]
+    fn parse_duration_rejects_a_zero_duration() {
+        // Documented zero-duration rejection: a total of zero is an error regardless of how it is spelled.
+        let unitless = parse_duration("0").expect_err("a bare zero should be rejected");
+        assert!(unitless.contains("greater than zero"), "unexpected error: {unitless}");
+
+        let with_unit = parse_duration("0s").expect_err("an explicit zero-second duration should be rejected");
+        assert!(with_unit.contains("greater than zero"), "unexpected error: {with_unit}");
+    }
+
+    #[test]
+    fn parse_port_spec_parses_valid_specs_and_rejects_invalid_ones() {
         let (port, protocol) = parse_port_spec("8125/udp").unwrap();
         assert_eq!(port, 8125);
         assert_eq!(protocol, "udp");
@@ -1026,7 +1044,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_file_spec() {
+    fn parse_file_spec_splits_on_first_colon() {
         let (host, container) = parse_file_spec("./config.yaml:/etc/config.yaml").unwrap();
         assert_eq!(host, "./config.yaml");
         assert_eq!(container, "/etc/config.yaml");
@@ -1035,7 +1053,7 @@ mod tests {
     }
 
     #[test]
-    fn test_target_exec_action_deserializes_command() {
+    fn target_exec_action_deserializes_command() {
         let action: ActionConfig = serde_yaml::from_str(
             r#"
 action: target_exec
@@ -1053,7 +1071,7 @@ timeout: 12s
     }
 
     #[test]
-    fn test_windows_runtime_is_valid_for_integration_discovery() {
+    fn windows_runtime_is_valid_for_integration_discovery() {
         let base_dir = create_test_case_dir(
             "windows-smoke",
             r#"
@@ -1073,7 +1091,7 @@ procedure: []
     }
 
     #[test]
-    fn test_windows_runtime_reports_harness_owned_container_image() {
+    fn windows_runtime_reports_harness_owned_container_image() {
         let base_dir = create_test_case_dir(
             "windows-smoke",
             r#"
@@ -1092,7 +1110,7 @@ procedure: []
     }
 
     #[test]
-    fn test_linux_runtime_reports_harness_owned_container_image() {
+    fn linux_runtime_reports_harness_owned_container_image() {
         let base_dir = create_test_case_dir(
             "linux-smoke",
             r#"
@@ -1108,6 +1126,115 @@ procedure: []
         let images = tests[0].images();
 
         assert_eq!(images.get("container"), Some(&DEFAULT_LINUX_TARGET_IMAGE.to_string()));
+    }
+
+    fn dynamic_vars(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+    }
+
+    #[test]
+    fn core_agent_config_set_resolves_placeholders_in_all_string_fields() {
+        let vars = dynamic_vars(&[("KEY", "resolved_key"), ("VAL", "resolved_val"), ("EP", "resolved_ep")]);
+        let mut action = ActionConfig::CoreAgentConfigSet {
+            key: "prefix.{{PANORAMIC_DYNAMIC_KEY}}".to_string(),
+            value: Value::String("{{PANORAMIC_DYNAMIC_VAL}}".to_string()),
+            endpoint: "http://agent/{{PANORAMIC_DYNAMIC_EP}}".to_string(),
+            timeout: HumanDuration(Duration::from_secs(1)),
+        };
+
+        assert!(
+            !action.unresolved_placeholders().is_empty(),
+            "placeholders should be detected before resolution"
+        );
+        action.resolve_dynamic_vars(&vars);
+
+        let ActionConfig::CoreAgentConfigSet {
+            key, value, endpoint, ..
+        } = action
+        else {
+            panic!("expected core_agent_config_set action");
+        };
+        assert_eq!(key, "prefix.resolved_key");
+        assert_eq!(value, Value::String("resolved_val".to_string()));
+        assert_eq!(endpoint, "http://agent/resolved_ep");
+    }
+
+    #[test]
+    fn target_exec_resolves_placeholders_in_each_command_argument() {
+        let vars = dynamic_vars(&[("IP", "10.0.0.5")]);
+        let mut action = ActionConfig::TargetExec {
+            command: vec!["ping".to_string(), "{{PANORAMIC_DYNAMIC_IP}}".to_string()],
+            timeout: HumanDuration(Duration::from_secs(1)),
+        };
+
+        action.resolve_dynamic_vars(&vars);
+
+        let ActionConfig::TargetExec { command, .. } = action else {
+            panic!("expected target_exec action");
+        };
+        assert_eq!(command, vec!["ping".to_string(), "10.0.0.5".to_string()]);
+    }
+
+    #[test]
+    fn assertion_variants_resolve_placeholders_in_their_documented_fields() {
+        let vars = dynamic_vars(&[("IP", "10.0.0.5"), ("PORT", "8125")]);
+
+        let mut log = AssertionConfig::LogContains {
+            pattern: "listen:{{PANORAMIC_DYNAMIC_IP}}".to_string(),
+            regex: false,
+            timeout: HumanDuration(Duration::from_secs(1)),
+            stream: LogStream::default(),
+        };
+        log.resolve_dynamic_vars(&vars);
+        let AssertionConfig::LogContains { pattern, .. } = &log else {
+            panic!("expected log_contains");
+        };
+        assert_eq!(pattern, "listen:10.0.0.5");
+        assert!(log.unresolved_placeholders().is_empty());
+
+        let mut http = AssertionConfig::HttpCheck {
+            endpoint: "http://{{PANORAMIC_DYNAMIC_IP}}:{{PANORAMIC_DYNAMIC_PORT}}/health".to_string(),
+            status: HttpStatusMatcher::Equal(200),
+            insecure_skip_verify: false,
+            timeout: HumanDuration(Duration::from_secs(1)),
+        };
+        http.resolve_dynamic_vars(&vars);
+        let AssertionConfig::HttpCheck { endpoint, .. } = &http else {
+            panic!("expected http_check");
+        };
+        assert_eq!(endpoint, "http://10.0.0.5:8125/health");
+
+        let mut file = AssertionConfig::FileContains {
+            path: "/run/{{PANORAMIC_DYNAMIC_IP}}.pid".to_string(),
+            pattern: Some("addr={{PANORAMIC_DYNAMIC_IP}}".to_string()),
+            regex: false,
+            timeout: HumanDuration(Duration::from_secs(1)),
+        };
+        file.resolve_dynamic_vars(&vars);
+        let AssertionConfig::FileContains { path, pattern, .. } = &file else {
+            panic!("expected file_contains");
+        };
+        assert_eq!(path, "/run/10.0.0.5.pid");
+        assert_eq!(pattern.as_deref(), Some("addr=10.0.0.5"));
+    }
+
+    #[test]
+    fn unresolved_placeholders_reports_a_reference_with_no_matching_variable() {
+        // A variant that references a variable that was never provided must still report the leftover
+        // placeholder — this is how the runner fails a test that used an undefined dynamic variable.
+        let mut assertion = AssertionConfig::LogContains {
+            pattern: "value={{PANORAMIC_DYNAMIC_MISSING}}".to_string(),
+            regex: false,
+            timeout: HumanDuration(Duration::from_secs(1)),
+            stream: LogStream::default(),
+        };
+
+        assertion.resolve_dynamic_vars(&dynamic_vars(&[("PRESENT", "x")]));
+
+        assert_eq!(
+            assertion.unresolved_placeholders(),
+            vec!["{{PANORAMIC_DYNAMIC_MISSING}}".to_string()]
+        );
     }
 
     struct TestCaseDir {

--- a/bin/correctness/panoramic/src/dynamic_vars.rs
+++ b/bin/correctness/panoramic/src/dynamic_vars.rs
@@ -172,3 +172,79 @@ pub fn find_unresolved(s: &str, out: &mut Vec<String>) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a minimal integration config whose `env` map contains exactly the given keys (each with a
+    /// placeholder command value, which the Windows resolver never actually executes).
+    fn config_with_env_keys(keys: &[&str]) -> IntegrationConfig {
+        let env_block = keys.iter().map(|k| format!("  {k}: \"cmd\"\n")).collect::<String>();
+        let yaml = format!("name: t\ntimeout: 10s\nprocedure: []\nenv:\n{env_block}");
+        serde_yaml::from_str(&yaml).expect("minimal integration config should deserialize")
+    }
+
+    #[tokio::test]
+    async fn resolve_windows_vars_supports_container_ip_and_custom_hostname() {
+        // The two documented Windows variants: CONTAINER_IP echoes the provided container IP, and
+        // CUSTOM_HOSTNAME resolves to the fixed sentinel value.
+        let config = config_with_env_keys(&["PANORAMIC_DYNAMIC_CONTAINER_IP", "PANORAMIC_DYNAMIC_CUSTOM_HOSTNAME"]);
+
+        let vars = resolve_windows_vars(&config, Some("172.17.0.2"))
+            .await
+            .expect("supported variables should resolve");
+
+        assert_eq!(vars.get("CONTAINER_IP"), Some(&"172.17.0.2".to_string()));
+        assert_eq!(vars.get("CUSTOM_HOSTNAME"), Some(&"foo.local".to_string()));
+    }
+
+    #[tokio::test]
+    async fn resolve_windows_vars_errors_when_container_ip_unavailable() {
+        let config = config_with_env_keys(&["PANORAMIC_DYNAMIC_CONTAINER_IP"]);
+
+        let err = resolve_windows_vars(&config, None)
+            .await
+            .expect_err("CONTAINER_IP with no available IP should error");
+        assert!(
+            err.to_string().contains("Container IP unavailable"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_windows_vars_rejects_unsupported_variables() {
+        let config = config_with_env_keys(&["PANORAMIC_DYNAMIC_SOMETHING_ELSE"]);
+
+        let err = resolve_windows_vars(&config, Some("172.17.0.2"))
+            .await
+            .expect_err("an unsupported Windows dynamic variable should error");
+        assert!(
+            err.to_string()
+                .contains("Unsupported Windows dynamic variable PANORAMIC_DYNAMIC_SOMETHING_ELSE"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_placeholders_replaces_every_occurrence() {
+        let vars = HashMap::from([("IP".to_string(), "10.0.0.5".to_string())]);
+        let mut s = "a={{PANORAMIC_DYNAMIC_IP}} b={{PANORAMIC_DYNAMIC_IP}}".to_string();
+
+        resolve_placeholders(&mut s, &vars);
+
+        assert_eq!(s, "a=10.0.0.5 b=10.0.0.5");
+    }
+
+    #[test]
+    fn find_unresolved_collects_only_the_remaining_placeholders() {
+        let vars = HashMap::from([("KNOWN".to_string(), "v".to_string())]);
+        let mut s = "known={{PANORAMIC_DYNAMIC_KNOWN}} missing={{PANORAMIC_DYNAMIC_MISSING}}".to_string();
+        resolve_placeholders(&mut s, &vars);
+
+        let mut out = Vec::new();
+        find_unresolved(&s, &mut out);
+
+        assert_eq!(out, vec!["{{PANORAMIC_DYNAMIC_MISSING}}".to_string()]);
+    }
+}

--- a/bin/correctness/stele/src/metrics.rs
+++ b/bin/correctness/stele/src/metrics.rs
@@ -1133,4 +1133,222 @@ mod tests {
         let dict_tagsets = vec![1, -5];
         assert!(parse_tagsets(&dict_tagsets, &tags_dict).is_err());
     }
+
+    /// Builds a V3 payload with a single scalar (non-sketch) metric carrying a single point at timestamp
+    /// 1000. The point value is read from whichever of the three value columns matches `value_type`.
+    fn single_scalar_payload(type_field: u64, sint64: Vec<i64>, float32: Vec<f32>, float64: Vec<f64>) -> V3Payload {
+        use datadog_protos::metrics::v3::{MetricData, Payload};
+
+        let mut data = MetricData::new();
+        data.dictNameStr = length_prefixed_strings(["m"]);
+        data.types = vec![type_field];
+        data.nameRefs = vec![1];
+        data.tagsetRefs = vec![0];
+        data.resourcesRefs = vec![0];
+        data.intervals = vec![10];
+        data.numPoints = vec![1];
+        data.timestamps = vec![1000];
+        data.valsSint64 = sint64;
+        data.valsFloat32 = float32;
+        data.valsFloat64 = float64;
+
+        let mut payload = Payload::new();
+        payload.metricData = Some(data).into();
+        payload
+    }
+
+    #[test]
+    fn try_from_v3_decodes_all_scalar_type_and_value_combinations() {
+        // The 12 non-sketch branches: {COUNT, RATE, GAUGE} x {ZERO, SINT64, FLOAT32, FLOAT64}. The metric
+        // type selects the `MetricValue` variant, the value type selects the source column (ZERO is an
+        // implicit 0.0 stored in no column). RATE additionally carries the interval (10, from `intervals`).
+        // FLOAT32 uses 1.5 and FLOAT64 uses 2.25 — both exactly representable — so widening is lossless.
+        struct Case {
+            name: &'static str,
+            value_type: u64,
+            sint64: Vec<i64>,
+            float32: Vec<f32>,
+            float64: Vec<f64>,
+            value: f64,
+        }
+
+        let value_cases = [
+            Case {
+                name: "zero",
+                value_type: V3_VALUE_TYPE_ZERO,
+                sint64: vec![],
+                float32: vec![],
+                float64: vec![],
+                value: 0.0,
+            },
+            Case {
+                name: "sint64",
+                value_type: V3_VALUE_TYPE_SINT64,
+                sint64: vec![7],
+                float32: vec![],
+                float64: vec![],
+                value: 7.0,
+            },
+            Case {
+                name: "float32",
+                value_type: V3_VALUE_TYPE_FLOAT32,
+                sint64: vec![],
+                float32: vec![1.5],
+                float64: vec![],
+                value: 1.5,
+            },
+            Case {
+                name: "float64",
+                value_type: V3_VALUE_TYPE_FLOAT64,
+                sint64: vec![],
+                float32: vec![],
+                float64: vec![2.25],
+                value: 2.25,
+            },
+        ];
+
+        for case in &value_cases {
+            let expectations: [(&str, u64, MetricValue); 3] = [
+                ("count", V3_METRIC_TYPE_COUNT, MetricValue::Count { value: case.value }),
+                (
+                    "rate",
+                    V3_METRIC_TYPE_RATE,
+                    MetricValue::Rate {
+                        interval: 10,
+                        value: case.value,
+                    },
+                ),
+                ("gauge", V3_METRIC_TYPE_GAUGE, MetricValue::Gauge { value: case.value }),
+            ];
+
+            for (metric_name, metric_type, expected) in expectations {
+                let label = format!("{metric_name}/{}", case.name);
+                let payload = single_scalar_payload(
+                    metric_type | case.value_type,
+                    case.sint64.clone(),
+                    case.float32.clone(),
+                    case.float64.clone(),
+                );
+                let metrics =
+                    Metric::try_from_v3(payload).unwrap_or_else(|e| panic!("{label}: decode should succeed: {e}"));
+                assert_eq!(metrics.len(), 1, "{label}: metric count");
+                assert_eq!(metrics[0].values.len(), 1, "{label}: point count");
+                assert_eq!(metrics[0].values[0].0, 1000, "{label}: timestamp");
+                assert_eq!(metrics[0].values[0].1, expected, "{label}: value");
+            }
+        }
+    }
+
+    #[test]
+    fn try_from_v3_decodes_sketch_summaries_across_value_encodings() {
+        // Sketch decoding reads sum/min/max via the same value-type dispatch as scalars (SINT64 is covered
+        // by `try_from_v3_decodes_integer_sketch_summary_order`); this covers the remaining ZERO, FLOAT32,
+        // and FLOAT64 encodings. The count is always read from `valsSint64` regardless of value type.
+        use datadog_protos::metrics::v3::{MetricData, Payload};
+
+        struct SketchCase {
+            name: &'static str,
+            value_type: u64,
+            sint64: Vec<i64>,
+            float32: Vec<f32>,
+            float64: Vec<f64>,
+            expected_sum: f64,
+            expected_min: f64,
+            expected_max: f64,
+        }
+
+        let cases = [
+            SketchCase {
+                name: "zero",
+                value_type: V3_VALUE_TYPE_ZERO,
+                sint64: vec![4], // count only; sum/min/max are implicit 0.0
+                float32: vec![],
+                float64: vec![],
+                expected_sum: 0.0,
+                expected_min: 0.0,
+                expected_max: 0.0,
+            },
+            SketchCase {
+                name: "float32",
+                value_type: V3_VALUE_TYPE_FLOAT32,
+                sint64: vec![4],               // count
+                float32: vec![10.0, 1.0, 4.0], // sum, min, max
+                float64: vec![],
+                expected_sum: 10.0,
+                expected_min: 1.0,
+                expected_max: 4.0,
+            },
+            SketchCase {
+                name: "float64",
+                value_type: V3_VALUE_TYPE_FLOAT64,
+                sint64: vec![4], // count
+                float32: vec![],
+                float64: vec![10.0, 1.0, 4.0], // sum, min, max
+                expected_sum: 10.0,
+                expected_min: 1.0,
+                expected_max: 4.0,
+            },
+        ];
+
+        for case in &cases {
+            let mut data = MetricData::new();
+            data.dictNameStr = length_prefixed_strings(["s"]);
+            data.types = vec![V3_METRIC_TYPE_SKETCH | case.value_type];
+            data.nameRefs = vec![1];
+            data.tagsetRefs = vec![0];
+            data.resourcesRefs = vec![0];
+            data.intervals = vec![0];
+            data.numPoints = vec![1];
+            data.timestamps = vec![123];
+            data.valsSint64 = case.sint64.clone();
+            data.valsFloat32 = case.float32.clone();
+            data.valsFloat64 = case.float64.clone();
+            data.sketchNumBins = vec![1];
+            data.sketchBinKeys = vec![0];
+            data.sketchBinCnts = vec![4];
+
+            let mut payload = Payload::new();
+            payload.metricData = Some(data).into();
+
+            let metrics =
+                Metric::try_from_v3(payload).unwrap_or_else(|e| panic!("{}: decode should succeed: {e}", case.name));
+            assert_eq!(metrics.len(), 1, "{}: metric count", case.name);
+
+            let MetricValue::Sketch { sketch } = &metrics[0].values[0].1 else {
+                panic!("{}: expected a sketch value", case.name);
+            };
+            assert_eq!(sketch.count(), 4, "{}: count", case.name);
+            assert_eq!(sketch.sum(), Some(case.expected_sum), "{}: sum", case.name);
+            assert_eq!(sketch.min(), Some(case.expected_min), "{}: min", case.name);
+            assert_eq!(sketch.max(), Some(case.expected_max), "{}: max", case.name);
+        }
+    }
+
+    #[test]
+    fn metric_value_equality_honors_the_documented_ratio_tolerance() {
+        // `MetricValue` compares floats by ratio: two values are equal iff `(larger - smaller) / larger`
+        // is strictly less than 0.00000001 (1e-8). This checks just inside and just outside that boundary.
+        const RATIO: f64 = 0.00000001;
+        let base = 1_000.0;
+        let within = base * (1.0 - RATIO / 2.0); // relative difference 0.5e-8 -> within tolerance
+        let outside = base * (1.0 - RATIO * 2.0); // relative difference 2e-8 -> outside tolerance
+
+        assert_eq!(
+            MetricValue::Count { value: base },
+            MetricValue::Count { value: within },
+            "difference just inside the ratio tolerance must compare equal"
+        );
+        assert_ne!(
+            MetricValue::Count { value: base },
+            MetricValue::Count { value: outside },
+            "difference just outside the ratio tolerance must compare not-equal"
+        );
+
+        // The same ratio tolerance governs gauges (and rates, whose intervals must additionally match).
+        assert_eq!(MetricValue::Gauge { value: base }, MetricValue::Gauge { value: within });
+        assert_ne!(
+            MetricValue::Gauge { value: base },
+            MetricValue::Gauge { value: outside }
+        );
+    }
 }

--- a/lib/datadog-agent/commons/src/ipc/config.rs
+++ b/lib/datadog-agent/commons/src/ipc/config.rs
@@ -261,7 +261,8 @@ mod tests {
     async fn get_remote_agent_config(
         ipc_cert_file_path: Option<&Path>, auth_token_file_path: Option<&Path>,
     ) -> RemoteAgentClientConfiguration {
-        // Set the values in the config map if provided.
+        // Set the values in the config map if provided, then defer to the shared loader helper so both
+        // entry points build the configuration the exact same way.
         let mut values = serde_json::Map::new();
         if let Some(path) = ipc_cert_file_path {
             values.insert(
@@ -276,9 +277,7 @@ mod tests {
             );
         }
 
-        let (base_config, _) =
-            ConfigurationLoader::for_tests(Some(serde_json::Value::Object(values)), None, false).await;
-        RemoteAgentClientConfiguration::from_configuration(&base_config).unwrap()
+        config_from_values(values).await
     }
 
     #[tokio::test]

--- a/lib/datadog-agent/commons/src/ipc/session.rs
+++ b/lib/datadog-agent/commons/src/ipc/session.rs
@@ -101,3 +101,72 @@ impl SessionIdHandle {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::time::timeout;
+
+    use super::{SessionId, SessionIdHandle};
+
+    // Bound every await so that a regression reintroducing the lost-wakeup race fails fast instead of
+    // hanging the test suite forever.
+    const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+    #[tokio::test]
+    async fn wait_for_update_returns_immediately_when_value_already_set() {
+        // When a value is already present, `wait_for_update` must return it on the first loop iteration
+        // without ever awaiting a change notification.
+        let handle = SessionIdHandle::empty();
+        handle.update(Some(SessionId::new("already-set").unwrap()));
+
+        let session_id = timeout(TEST_TIMEOUT, handle.wait_for_update())
+            .await
+            .expect("should return without waiting on a notification");
+        assert_eq!(session_id.as_str(), "already-set");
+    }
+
+    #[tokio::test]
+    async fn wait_for_update_wakes_on_concurrent_update() {
+        // This exercises the documented race-avoidance idiom: `wait_for_update` registers the change
+        // notification *before* it reads the current value, so an update applied while a caller is parked
+        // is delivered rather than lost.
+        let handle = SessionIdHandle::empty();
+        let waiter = handle.clone();
+        let waiter_task = tokio::spawn(async move { waiter.wait_for_update().await });
+
+        // Let the spawned task advance to (and park on) its notification await while the value is still
+        // empty, then apply the update.
+        tokio::task::yield_now().await;
+        handle.update(Some(SessionId::new("session-123").unwrap()));
+
+        let session_id = timeout(TEST_TIMEOUT, waiter_task)
+            .await
+            .expect("waiter should wake within the timeout")
+            .expect("waiter task should not panic");
+        assert_eq!(session_id.as_str(), "session-123");
+    }
+
+    #[tokio::test]
+    async fn wait_for_update_ignores_clears_and_returns_first_non_empty_value() {
+        // `update(None)` still notifies waiters, but `wait_for_update` documents that it waits for a
+        // *non-empty* value, so a clear must not cause it to return early — it must keep waiting until a
+        // real session ID arrives.
+        let handle = SessionIdHandle::empty();
+        let waiter = handle.clone();
+        let waiter_task = tokio::spawn(async move { waiter.wait_for_update().await });
+
+        tokio::task::yield_now().await;
+        // Notifies waiters, but leaves the value empty: the waiter must loop and keep waiting.
+        handle.update(None);
+        tokio::task::yield_now().await;
+        handle.update(Some(SessionId::new("finally").unwrap()));
+
+        let session_id = timeout(TEST_TIMEOUT, waiter_task)
+            .await
+            .expect("waiter should wake within the timeout")
+            .expect("waiter task should not panic");
+        assert_eq!(session_id.as_str(), "finally");
+    }
+}

--- a/lib/datadog-agent/config-overlay-model/src/lib.rs
+++ b/lib/datadog-agent/config-overlay-model/src/lib.rs
@@ -816,4 +816,221 @@ excluded: {}
             "unexpected error: {err}"
         );
     }
+
+    // The per-entry validation rules (`validate_entries`) are documented in `VALIDATION_RULES` and
+    // enforced independently of the schema cross-check, so these tests deserialize an overlay in
+    // isolation (via `from_yaml`) and run only that pass — no matching core schema is needed.
+    fn validate_entries_of(overlay: &str) -> Result<(), Error> {
+        SchemaOverlay::from_yaml(overlay)
+            .expect("overlay should deserialize")
+            .validate_entries()
+    }
+
+    #[test]
+    fn per_entry_validation_accepts_a_well_formed_entry_of_every_kind() {
+        // Keys are alphabetically ordered (full < partial < unknown < unsupported) so the YAML lint
+        // pass is satisfied and only per-entry validation is under test.
+        let overlay = "\
+inventory:
+  full_key:
+    support: full
+    pipelines: [dogstatsd]
+    description: \"Fully supported key\"
+    test_support:
+      used_by: [ForwarderConfiguration]
+      additional_yaml_paths: [full_alias]
+  partial_key:
+    support: partial
+    pipelines: [traces]
+    description: \"Partially supported key\"
+    documentation: \"Behaves differently from the core agent.\"
+    test_support:
+      used_by: [ForwarderConfiguration]
+  unknown_key:
+    support: unknown
+    description: \"Not yet classified\"
+  unsupported_key:
+    support: none
+    pipelines: [checks]
+    description: \"Unsupported key\"
+    severity: high
+    planned: true
+    issue: \"1234\"
+excluded: {}
+";
+        validate_entries_of(overlay).expect("a well-formed overlay should pass per-entry validation");
+    }
+
+    #[test]
+    fn per_entry_validation_rejects_over_long_description_for_every_entry_kind() {
+        // A 60-character description exceeds the documented 50-char cap. Each entry kind that carries a
+        // description enforces the same limit, so this walks all four.
+        let long = "x".repeat(60);
+        let cases: &[(&str, String)] = &[
+            (
+                "full",
+                format!(
+                    "inventory:\n  key_a:\n    support: full\n    pipelines: [dogstatsd]\n    \
+                     description: \"{long}\"\n    test_support:\n      used_by: [ForwarderConfiguration]\nexcluded: {{}}\n"
+                ),
+            ),
+            (
+                "partial",
+                format!(
+                    "inventory:\n  key_a:\n    support: partial\n    pipelines: [dogstatsd]\n    \
+                     description: \"{long}\"\n    documentation: \"diverges\"\n    test_support:\n      \
+                     used_by: [ForwarderConfiguration]\nexcluded: {{}}\n"
+                ),
+            ),
+            (
+                "unsupported",
+                format!(
+                    "inventory:\n  key_a:\n    support: none\n    pipelines: [dogstatsd]\n    \
+                     description: \"{long}\"\n    severity: low\n    planned: false\nexcluded: {{}}\n"
+                ),
+            ),
+            (
+                "unknown",
+                format!("inventory:\n  key_a:\n    support: unknown\n    description: \"{long}\"\nexcluded: {{}}\n"),
+            ),
+        ];
+
+        for (kind, overlay) in cases {
+            let err = validate_entries_of(overlay).expect_err(&format!("{kind} entry should be rejected"));
+            assert!(
+                err.to_string().contains("description exceeds 50 chars"),
+                "{kind}: unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn per_entry_validation_rejects_empty_used_by_for_full_and_partial_entries() {
+        let full = "\
+inventory:
+  key_a:
+    support: full
+    pipelines: [dogstatsd]
+    description: \"Key A\"
+    test_support:
+      used_by: []
+excluded: {}
+";
+        let err = validate_entries_of(full).expect_err("full entry with empty used_by should be rejected");
+        assert!(
+            err.to_string().contains("full key 'key_a': used_by must be non-empty"),
+            "unexpected error: {err}"
+        );
+
+        let partial = "\
+inventory:
+  key_a:
+    support: partial
+    pipelines: [dogstatsd]
+    description: \"Key A\"
+    documentation: \"diverges\"
+    test_support:
+      used_by: []
+excluded: {}
+";
+        let err = validate_entries_of(partial).expect_err("partial entry with empty used_by should be rejected");
+        assert!(
+            err.to_string()
+                .contains("partial key 'key_a': used_by must be non-empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn per_entry_validation_rejects_planned_unsupported_entry_without_issue() {
+        let overlay = "\
+inventory:
+  key_a:
+    support: none
+    pipelines: [dogstatsd]
+    description: \"Key A\"
+    severity: medium
+    planned: true
+excluded: {}
+";
+        let err = validate_entries_of(overlay).expect_err("planned unsupported entry without issue should be rejected");
+        assert!(
+            err.to_string()
+                .contains("unsupported key 'key_a': planned requires an issue"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn per_entry_validation_rejects_duplicate_additional_yaml_path() {
+        let overlay = "\
+inventory:
+  key_a:
+    support: full
+    pipelines: [dogstatsd]
+    description: \"Key A\"
+    test_support:
+      used_by: [ForwarderConfiguration]
+      additional_yaml_paths: [dup_alias, dup_alias]
+excluded: {}
+";
+        let err = validate_entries_of(overlay).expect_err("duplicate additional_yaml_path should be rejected");
+        assert!(
+            err.to_string()
+                .contains("key 'key_a': duplicate additional_yaml_path 'dup_alias'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn per_entry_validation_rejects_dotted_additional_yaml_path() {
+        // Dotted aliases can't be represented as a serde field alias on the generated struct, so they're
+        // rejected outright.
+        let overlay = "\
+inventory:
+  key_a:
+    support: full
+    pipelines: [dogstatsd]
+    description: \"Key A\"
+    test_support:
+      used_by: [ForwarderConfiguration]
+      additional_yaml_paths: [\"nested.alias\"]
+excluded: {}
+";
+        let err = validate_entries_of(overlay).expect_err("dotted additional_yaml_path should be rejected");
+        assert!(
+            err.to_string()
+                .contains("additional_yaml_path 'nested.alias' contains a dot"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn per_entry_validation_rejects_additional_yaml_path_colliding_with_canonical_key() {
+        // `alpha`'s alias `beta` collides with the canonical key `beta`; two fields would deserialize
+        // from the same YAML key. Keys are alphabetically ordered so the YAML lint pass is satisfied.
+        let overlay = "\
+inventory:
+  alpha:
+    support: full
+    pipelines: [dogstatsd]
+    description: \"Alpha\"
+    test_support:
+      used_by: [ForwarderConfiguration]
+      additional_yaml_paths: [beta]
+  beta:
+    support: full
+    pipelines: [dogstatsd]
+    description: \"Beta\"
+    test_support:
+      used_by: [ForwarderConfiguration]
+excluded: {}
+";
+        let err = validate_entries_of(overlay).expect_err("aliasing a canonical key should be rejected");
+        assert!(
+            err.to_string()
+                .contains("additional_yaml_path 'beta' collides with a canonical"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/lib/datadog-agent/config-testing/Cargo.toml
+++ b/lib/datadog-agent/config-testing/Cargo.toml
@@ -12,6 +12,9 @@ saluki-config = { workspace = true, features = ["test-util"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+
 [build-dependencies]
 datadog-agent-config-overlay-model = { workspace = true }
 indexmap = { workspace = true }

--- a/lib/datadog-agent/config-testing/src/lib.rs
+++ b/lib/datadog-agent/config-testing/src/lib.rs
@@ -1,6 +1,6 @@
-// This crate's build.rs generates both the test-support config registry annotations AND the
-// configuration documentation markdown. Doc generation lives here (not in the config crate)
-// because it is a dev/CI concern, not a prod build artifact.
+//! This crate's build.rs generates both the test-support config registry annotations AND the configuration
+//! documentation in Markdown format. Doc generation lives here (not in the config crate) because it is a dev/CI
+//! concern, not a prod build artifact.
 pub mod config_registry;
 
 mod smoke_test;

--- a/lib/datadog-agent/config-testing/src/smoke_test.rs
+++ b/lib/datadog-agent/config-testing/src/smoke_test.rs
@@ -298,3 +298,133 @@ pub async fn run_config_smoke_tests<T, Factory, P, PF>(
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Meta-tests for the [`run_config_smoke_tests`] harness itself.
+    //!
+    //! [`run_config_smoke_tests`] documents three guarantees (supported keys, unsupported keys, full
+    //! field coverage). These tests verify the harness actually *enforces* each guarantee by feeding it a
+    //! `config_factory` that deliberately violates exactly one and asserting the harness reports that
+    //! guarantee's specific failure, plus one case where no guarantee is violated and the harness passes.
+    //!
+    //! We drive the negative cases against a struct name with no registered keys (so every registered key
+    //! is "foreign") or an ignore-everything factory, rather than a real config type. Faithfully
+    //! reproducing a *passing* struct here would require the production env-var remapper, which lives in
+    //! `saluki-components` and isn't a dependency of this crate; the guarantee-1 passing path is therefore
+    //! left to the real per-component smoke tests that call this harness.
+
+    use saluki_config::GenericConfiguration;
+    use serde_json::json;
+
+    use super::run_config_smoke_tests;
+    use crate::config_registry::structs;
+
+    /// Struct name that no annotation's `used_by` references, so every registered key is "foreign" to it.
+    const UNREGISTERED_STRUCT: &str = "NonExistentConfiguration";
+
+    fn empty_provider() -> figment::providers::Serialized<serde_json::Value> {
+        figment::providers::Serialized::defaults(json!({}))
+    }
+
+    fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+        payload
+            .downcast_ref::<String>()
+            .cloned()
+            .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
+            .unwrap_or_else(|| "<non-string panic payload>".to_string())
+    }
+
+    #[tokio::test]
+    async fn flags_a_supported_key_that_never_changes_the_struct() {
+        // `PROXY_CONFIGURATION` has registered (supported) keys. A factory that ignores the config
+        // entirely means each supported key "produces the default struct", violating the supported-key
+        // guarantee, which the harness must flag.
+        let outcome = tokio::spawn(async {
+            run_config_smoke_tests(
+                structs::PROXY_CONFIGURATION,
+                &[],
+                json!({}),
+                |_cfg: GenericConfiguration| json!({}),
+                &[],
+                empty_provider,
+            )
+            .await
+        })
+        .await;
+
+        let panic = outcome.expect_err("harness should panic when a supported key never changes the struct");
+        let message = panic_message(panic.into_panic());
+        assert!(
+            message.contains("did not change from its default"),
+            "expected supported-key failure, got: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn flags_a_foreign_key_that_changes_the_struct() {
+        // For a struct with no registered keys, every key is foreign and must leave the struct at its
+        // default. A factory that reflects the entire merged config changes for any foreign key, violating
+        // the unsupported-key guarantee.
+        let outcome = tokio::spawn(async {
+            run_config_smoke_tests(
+                UNREGISTERED_STRUCT,
+                &[],
+                json!({}),
+                |cfg: GenericConfiguration| cfg.as_typed::<serde_json::Value>().unwrap_or(serde_json::Value::Null),
+                &[],
+                empty_provider,
+            )
+            .await
+        })
+        .await;
+
+        let panic = outcome.expect_err("harness should panic when a foreign key changes the struct");
+        let message = panic_message(panic.into_panic());
+        assert!(
+            message.contains("unexpectedly changed the struct"),
+            "expected unsupported-key failure, got: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn flags_a_serialized_field_no_key_ever_changes() {
+        // A factory that always serializes a constant field means that field is never driven by any
+        // registered key, violating the full-field-coverage guarantee.
+        let outcome = tokio::spawn(async {
+            run_config_smoke_tests(
+                UNREGISTERED_STRUCT,
+                &[],
+                json!({}),
+                |_cfg: GenericConfiguration| json!({ "phantom": "constant" }),
+                &[],
+                empty_provider,
+            )
+            .await
+        })
+        .await;
+
+        let panic = outcome.expect_err("harness should panic about a serialized field no key changes");
+        let message = panic_message(panic.into_panic());
+        assert!(
+            message.contains("never changed by any registered config key"),
+            "expected full-field-coverage failure, got: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn passes_when_no_guarantee_is_violated() {
+        // A factory that ignores every (foreign) key and serializes no fields satisfies both the
+        // unsupported-key and full-field-coverage guarantees for a struct with no registered keys, so the
+        // harness returns without panicking.
+        run_config_smoke_tests(
+            UNREGISTERED_STRUCT,
+            &[],
+            json!({}),
+            |_cfg: GenericConfiguration| json!({}),
+            &[],
+            empty_provider,
+        )
+        .await;
+    }
+}

--- a/lib/protos/datadog/Cargo.toml
+++ b/lib/protos/datadog/Cargo.toml
@@ -19,6 +19,9 @@ serde_bytes = { workspace = true, features = ["std"] }
 tonic = { workspace = true, features = ["codegen"] }
 tonic-prost = { workspace = true }
 
+[dev-dependencies]
+serde_json = { workspace = true }
+
 [build-dependencies]
 piecemeal-build = { workspace = true }
 protobuf = { workspace = true }

--- a/lib/protos/datadog/src/serde.rs
+++ b/lib/protos/datadog/src/serde.rs
@@ -98,3 +98,86 @@ pub fn serialize_proto_bytes<S: Serializer>(bytes: &Vec<u8>, s: S) -> Result<S::
 pub fn deserialize_proto_bytes<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
     serde_bytes::ByteBuf::deserialize(d).map(|bb| bb.into_vec())
 }
+
+#[cfg(test)]
+mod tests {
+    use serde::de::IntoDeserializer as _;
+
+    use super::*;
+    use crate::metrics::MetricType;
+
+    #[derive(Serialize)]
+    struct EnumHolder {
+        #[serde(serialize_with = "serialize_proto_enum")]
+        value: EnumOrUnknown<MetricType>,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct BytesHolder {
+        #[serde(
+            serialize_with = "serialize_proto_bytes",
+            deserialize_with = "deserialize_proto_bytes",
+            default
+        )]
+        data: Vec<u8>,
+    }
+
+    #[test]
+    fn serialize_proto_enum_emits_the_wire_integer_for_known_and_unknown_values() {
+        // `MetricType::RATE` has wire value 2; an unknown discriminant is emitted verbatim.
+        let known = serde_json::to_value(EnumHolder {
+            value: EnumOrUnknown::from(MetricType::RATE),
+        })
+        .unwrap();
+        assert_eq!(known["value"], serde_json::json!(2));
+
+        let unknown = serde_json::to_value(EnumHolder {
+            value: EnumOrUnknown::from_i32(99),
+        })
+        .unwrap();
+        assert_eq!(unknown["value"], serde_json::json!(99));
+    }
+
+    #[test]
+    fn deserialize_proto_enum_maps_each_integer_width_through_from_i32() {
+        use serde::de::value::{Error as ValueError, I16Deserializer, I32Deserializer, U8Deserializer};
+
+        // The hand-written visitor accepts several integer widths and routes them all through
+        // `EnumOrUnknown::from_i32`, resolving known discriminants and preserving unknown ones. Each
+        // case below is fed through the matching narrow-integer serde deserializer so the corresponding
+        // `visit_*` arm is exercised directly.
+        let u8_de: U8Deserializer<ValueError> = 1u8.into_deserializer();
+        let from_u8: EnumOrUnknown<MetricType> =
+            deserialize_proto_enum(u8_de).expect("u8 discriminant should deserialize");
+        assert_eq!(from_u8.enum_value(), Ok(MetricType::COUNT));
+
+        let i16_de: I16Deserializer<ValueError> = 3i16.into_deserializer();
+        let from_i16: EnumOrUnknown<MetricType> =
+            deserialize_proto_enum(i16_de).expect("i16 discriminant should deserialize");
+        assert_eq!(from_i16.enum_value(), Ok(MetricType::GAUGE));
+
+        let i32_de: I32Deserializer<ValueError> = 2i32.into_deserializer();
+        let from_i32: EnumOrUnknown<MetricType> =
+            deserialize_proto_enum(i32_de).expect("i32 discriminant should deserialize");
+        assert_eq!(from_i32.enum_value(), Ok(MetricType::RATE));
+
+        // An unrecognized discriminant is retained as `Unknown`, not rejected or clamped.
+        let unknown_de: I32Deserializer<ValueError> = 99i32.into_deserializer();
+        let unknown: EnumOrUnknown<MetricType> =
+            deserialize_proto_enum(unknown_de).expect("unknown discriminant should still deserialize");
+        assert_eq!(unknown.value(), 99);
+        assert_eq!(unknown.enum_value(), Err(99));
+    }
+
+    #[test]
+    fn proto_bytes_round_trip_preserves_the_exact_byte_sequence() {
+        // The bytes helpers bridge protobuf's `Vec<u8>` fields to `serde_bytes`; a full round-trip must
+        // reproduce every byte, including a zero and a high byte.
+        let original = BytesHolder {
+            data: vec![0, 1, 2, 254, 255],
+        };
+        let encoded = serde_json::to_value(&original).unwrap();
+        let decoded: BytesHolder = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded.data, vec![0, 1, 2, 254, 255]);
+    }
+}

--- a/lib/saluki-error/src/lib.rs
+++ b/lib/saluki-error/src/lib.rs
@@ -83,3 +83,112 @@ where
         <Self as anyhow::Context<T, E>>::with_context(self, context)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+    use std::fmt;
+
+    use super::ErrorContext as _;
+
+    /// A leaf error with no source of its own.
+    #[derive(Debug)]
+    struct LeafError;
+
+    impl fmt::Display for LeafError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "leaf failure")
+        }
+    }
+
+    impl std::error::Error for LeafError {}
+
+    /// An error that carries [`LeafError`] as its source.
+    #[derive(Debug)]
+    struct WrappingError {
+        source: LeafError,
+    }
+
+    impl fmt::Display for WrappingError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "wrapping failure")
+        }
+    }
+
+    impl std::error::Error for WrappingError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            Some(&self.source)
+        }
+    }
+
+    #[test]
+    fn generic_error_from_string_literal_uses_message_as_display() {
+        let err = generic_error!("boom");
+        assert_eq!(err.to_string(), "boom");
+    }
+
+    #[test]
+    fn generic_error_from_format_string_interpolates_arguments() {
+        let err = generic_error!("value {} out of range {}", 42, "here");
+        assert_eq!(err.to_string(), "value 42 out of range here");
+    }
+
+    #[test]
+    fn generic_error_from_error_value_forwards_source_chain() {
+        // Documented contract: when the value implements `std::error::Error`, the source of that error
+        // becomes part of the constructed `GenericError`'s chain, so the root cause is the wrapped
+        // error's own source rather than the wrapper itself.
+        let err = generic_error!(WrappingError { source: LeafError });
+        assert_eq!(err.to_string(), "wrapping failure");
+        assert_eq!(err.root_cause().to_string(), "leaf failure");
+    }
+
+    #[test]
+    fn error_context_passes_through_ok_unchanged() {
+        let result: Result<i32, std::io::Error> = Ok(7);
+        let contextualized = result.error_context("this context should never appear");
+        assert_eq!(contextualized.unwrap(), 7);
+    }
+
+    #[test]
+    fn error_context_wraps_err_with_context_and_preserves_source() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "permission denied");
+        let result: Result<(), std::io::Error> = Err(io_err);
+
+        let err = result.error_context("while loading config").unwrap_err();
+        assert_eq!(err.to_string(), "while loading config");
+        assert_eq!(err.root_cause().to_string(), "permission denied");
+    }
+
+    #[test]
+    fn with_error_context_is_not_evaluated_on_ok() {
+        let called = Cell::new(false);
+        let result: Result<i32, std::io::Error> = Ok(1);
+
+        let contextualized = result.with_error_context(|| {
+            called.set(true);
+            "lazy context"
+        });
+
+        assert_eq!(contextualized.unwrap(), 1);
+        assert!(!called.get(), "context closure must not run on the Ok path");
+    }
+
+    #[test]
+    fn with_error_context_is_evaluated_and_applied_on_err() {
+        let called = Cell::new(false);
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "missing");
+        let result: Result<(), std::io::Error> = Err(io_err);
+
+        let err = result
+            .with_error_context(|| {
+                called.set(true);
+                "lazy context"
+            })
+            .unwrap_err();
+
+        assert!(called.get(), "context closure must run on the Err path");
+        assert_eq!(err.to_string(), "lazy context");
+        assert_eq!(err.root_cause().to_string(), "missing");
+    }
+}


### PR DESCRIPTION
## Summary

This PR cleans up tests/test code for a number of areas in a bunch of different crates: `panoramic`, `stele`, `datadog-agent-commons`, `datadog-agent-config-overlay-nodel`, `datadog-agent-config-testing`, `datadog-protos`, and `saluki-error`.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New and existing unit tests.

## References

DADP-2
