### PR TITLE
feat(otlp): honor histogram translation mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4300,6 +4300,7 @@ dependencies = [
 name = "saluki-components"
 version = "0.1.0"
 dependencies = [
+ "agent-data-plane-config",
  "arc-swap",
  "async-trait",
  "axum",

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -234,6 +234,7 @@ default values.
 | `log_level`                            | Log verbosity directives                  |
 | `min_tls_version`                      | Minimum TLS version for HTTPS connections |
 | `multi_region_failover.enabled`        | Enable multi-region failover mode         |
+| `otlp_config.metrics.histograms.mode`  | OTLP histogram bucket reporting mode      |
 | `serializer_zstd_compressor_level`     | Zstd compression level (Agent)            |
 | `skip_ssl_validation`                  | Skip TLS cert validation                  |
 | `statsd_forward_host`                  | UDP packet forwarding destination host    |
@@ -370,6 +371,12 @@ is enabled.
 | `multi_region_failover.api_key`          | API key for the failover-region endpoint.                                  | unset   |
 | `multi_region_failover.site`             | Datadog site for the failover region, used as `https://app.mrf.<site>`.    | unset   |
 | `multi_region_failover.dd_url`           | Explicit failover intake URL. Takes precedence over `site` when set.       | unset   |
+
+### `otlp_config.metrics.histograms.mode`
+
+ADP supports the `counters` and `distributions` modes. The `nobuckets` mode requires
+`otlp_config.metrics.histograms.send_aggregation_metrics` to be enabled, but ADP does not yet
+read that setting, so selecting `nobuckets` prevents the OTLP source from starting.
 
 ### `serializer_zstd_compressor_level`
 
@@ -761,3 +768,4 @@ compressed wire payload bytes.
 [#1753]: https://github.com/DataDog/saluki/issues/1753
 [#1754]: https://github.com/DataDog/saluki/issues/1754
 [#1755]: https://github.com/DataDog/saluki/issues/1755
+[#2021]: https://github.com/DataDog/saluki/issues/2021

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -23,6 +23,7 @@ use agent_data_plane_config::control::ListenAddress;
 use agent_data_plane_config::domains::dogstatsd::{
     FilterAction, MapperProfile, MetricMapping, MetricTagFilterEntry, OriginTagCardinality,
 };
+use agent_data_plane_config::domains::otlp::HistogramMode;
 use agent_data_plane_config::shared::ForwarderHttpProtocol;
 use agent_data_plane_config::SalukiConfiguration;
 use bytesize::ByteSize;
@@ -875,6 +876,13 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
         self.config.domains.otlp.receiver.metrics_enabled = value;
     }
 
+    fn consume_otlp_config_metrics_histograms_mode(&mut self, value: String) {
+        match value.parse::<HistogramMode>() {
+            Ok(mode) => self.config.domains.otlp.metrics.histogram_mode = mode,
+            Err(error) => self.record_error(TranslateError::new("otlp_config.metrics.histograms.mode", error)),
+        }
+    }
+
     fn consume_otlp_config_metrics_resource_attributes_as_tags(&mut self, value: bool) {
         self.config.domains.otlp.metrics.resource_attributes_as_tags = value;
     }
@@ -1096,6 +1104,7 @@ mod tests {
     use std::time::Duration;
 
     use agent_data_plane_config::domains::dogstatsd::OriginTagCardinality;
+    use agent_data_plane_config::domains::otlp::HistogramMode;
     use datadog_agent_config::DatadogConfiguration;
     use serde_json::json;
 
@@ -1145,6 +1154,50 @@ mod tests {
         );
         // Seeded Saluki-only field.
         assert_eq!(config.domains.dogstatsd.listeners.tcp_port, 8126);
+    }
+
+    #[test]
+    fn otlp_histogram_modes_translate_to_typed_model() {
+        let cases = [
+            ("nobuckets", HistogramMode::NoBuckets),
+            ("counters", HistogramMode::Counters),
+            ("distributions", HistogramMode::Distributions),
+        ];
+
+        for (value, expected) in cases {
+            let datadog: DatadogConfiguration = serde_json::from_value(json!({
+                "otlp_config": {
+                    "metrics": {
+                        "histograms": {
+                            "mode": value
+                        }
+                    }
+                }
+            }))
+            .expect("datadog source deserializes");
+
+            let (config, errors) = DatadogTranslator::new(&datadog).translate();
+            assert!(errors.is_none());
+            assert_eq!(config.domains.otlp.metrics.histogram_mode, expected);
+        }
+    }
+
+    #[test]
+    fn invalid_otlp_histogram_mode_records_error_and_keeps_default() {
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "otlp_config": {
+                "metrics": {
+                    "histograms": {
+                        "mode": "invalid"
+                    }
+                }
+            }
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, errors) = DatadogTranslator::new(&datadog).translate();
+        assert!(errors.is_some());
+        assert_eq!(config.domains.otlp.metrics.histogram_mode, HistogramMode::Distributions);
     }
 
     #[test]

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -1157,50 +1157,6 @@ mod tests {
     }
 
     #[test]
-    fn otlp_histogram_modes_translate_to_typed_model() {
-        let cases = [
-            ("nobuckets", HistogramMode::NoBuckets),
-            ("counters", HistogramMode::Counters),
-            ("distributions", HistogramMode::Distributions),
-        ];
-
-        for (value, expected) in cases {
-            let datadog: DatadogConfiguration = serde_json::from_value(json!({
-                "otlp_config": {
-                    "metrics": {
-                        "histograms": {
-                            "mode": value
-                        }
-                    }
-                }
-            }))
-            .expect("datadog source deserializes");
-
-            let (config, errors) = DatadogTranslator::new(&datadog).translate();
-            assert!(errors.is_none());
-            assert_eq!(config.domains.otlp.metrics.histogram_mode, expected);
-        }
-    }
-
-    #[test]
-    fn invalid_otlp_histogram_mode_records_error_and_keeps_default() {
-        let datadog: DatadogConfiguration = serde_json::from_value(json!({
-            "otlp_config": {
-                "metrics": {
-                    "histograms": {
-                        "mode": "invalid"
-                    }
-                }
-            }
-        }))
-        .expect("datadog source deserializes");
-
-        let (config, errors) = DatadogTranslator::new(&datadog).translate();
-        assert!(errors.is_some());
-        assert_eq!(config.domains.otlp.metrics.histogram_mode, HistogramMode::Distributions);
-    }
-
-    #[test]
     fn dd_url_at_default_is_dropped_so_site_wins() {
         // The Core Agent sends `dd_url` at its default intake even when the user only set
         // `site`. Translation must treat that default as unset so downstream endpoint resolution

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -1104,7 +1104,6 @@ mod tests {
     use std::time::Duration;
 
     use agent_data_plane_config::domains::dogstatsd::OriginTagCardinality;
-    use agent_data_plane_config::domains::otlp::HistogramMode;
     use datadog_agent_config::DatadogConfiguration;
     use serde_json::json;
 

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -1,7 +1,11 @@
 //! OTLP domain: the OTLP receiver (gRPC/HTTP transports, logs/metrics activation), the OTLP proxy
 //! gating, and OTLP context sizing. OTLP trace handling lives in the `traces` domain.
 
+use std::str::FromStr;
+
 use serde::Serialize;
+
+use crate::Error;
 
 /// Resolved OTLP configuration.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
@@ -22,12 +26,44 @@ pub struct Domain {
 /// OTLP metrics translation settings.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct Metrics {
+    /// How explicit histogram buckets are reported.
+    pub histogram_mode: HistogramMode,
+
     /// Whether every resource attribute is added as a raw metric tag, in addition to the
     /// semantic-convention mappings that are always applied.
     pub resource_attributes_as_tags: bool,
 
     /// Comma-separated list of tags to add to every emitted metric.
     pub tags: String,
+}
+
+/// How explicit OTLP histogram buckets are reported.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub enum HistogramMode {
+    /// Omit bucket metrics.
+    NoBuckets,
+
+    /// Report each bucket as a counter.
+    Counters,
+
+    /// Report buckets as distributions.
+    #[default]
+    Distributions,
+}
+
+impl FromStr for HistogramMode {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "nobuckets" => Ok(Self::NoBuckets),
+            "counters" => Ok(Self::Counters),
+            "distributions" => Ok(Self::Distributions),
+            other => Err(Error::new_without_source(format!(
+                "unknown histogram mode `{other}`; expected `nobuckets`, `counters`, or `distributions`"
+            ))),
+        }
+    }
 }
 
 /// OTLP receiver transports and per-signal activation.

--- a/lib/agent-data-plane-config/src/lib.rs
+++ b/lib/agent-data-plane-config/src/lib.rs
@@ -12,6 +12,8 @@
 //! source serde (these structs are serialized for the `/config/internal` view but never
 //! deserialized from a source language; that is the source adapter's job).
 
+use std::fmt;
+
 use serde::Serialize;
 
 pub mod control;
@@ -37,4 +39,58 @@ pub struct SalukiConfiguration {
     pub shared: SharedConfiguration,
     /// Per-domain resolved config, grouped by ownership domain.
     pub domains: DomainConfiguration,
+}
+
+/// An error produced while translating a `DatadogConfiguration` or `SalukiOnly` value into a
+/// `SalukiConfiguration` value.
+#[derive(Debug)]
+pub struct Error {
+    context: String,
+    error: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+}
+
+/// A boxed source error that can cross thread boundaries.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+impl Error {
+    /// Create an error that wraps an underlying error.
+    ///
+    /// Displays `{context}: {error}`.
+    pub fn new<S, E>(context: S, error: E) -> Self
+    where
+        S: Into<String>,
+        E: Into<BoxError>,
+    {
+        Self {
+            context: context.into(),
+            error: Some(error.into()),
+        }
+    }
+
+    /// Create an error without an underlying source error.
+    pub fn new_without_source<S>(context: S) -> Self
+    where
+        S: Into<String>,
+    {
+        Self {
+            context: context.into(),
+            error: None,
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.context)?;
+        if let Some(error) = &self.error {
+            write!(f, ": {error}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.error.as_deref().map(|s| s as &(dyn std::error::Error + 'static))
+    }
 }

--- a/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
@@ -256,6 +256,17 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
     };
+    /// `otlp_config.metrics.histograms.mode`-OTLP histogram bucket reporting mode
+    OTLP_CONFIG_METRICS_HISTOGRAMS_MODE = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_METRICS_HISTOGRAMS_MODE,
+        support_level: SupportLevel::Partial,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::OTLP_CONFIGURATION],
+        value_type_override: None,
+        test_json: Some(r#""counters""#),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
     /// `otlp_config.metrics.resource_attributes_as_tags`-Add scalar resource attributes as raw tags.
     OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS = SalukiAnnotation {
         schema: &schema::OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -2001,6 +2001,21 @@ inventory:
       additional_attributes:
         config_registry_filename: otlp.rs
 
+  otlp_config.metrics.histograms.mode:
+    support: partial
+    pipelines: [otlp]
+    description: "OTLP histogram bucket reporting mode"
+    documentation: |-
+      ADP supports the `counters` and `distributions` modes. The `nobuckets` mode requires
+      `otlp_config.metrics.histograms.send_aggregation_metrics` to be enabled, but ADP does not yet
+      read that setting, so selecting `nobuckets` prevents the OTLP source from starting.
+    issue: "#2021"
+    test_support:
+      used_by: [OtlpConfiguration]
+      test_json: '"counters"'
+      additional_attributes:
+        config_registry_filename: otlp.rs
+
   otlp_config.metrics.resource_attributes_as_tags:
     support: full
     pipelines: [otlp]
@@ -3895,7 +3910,6 @@ excluded:
   otlp_config.metrics.batch.max_size: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.batch.min_size: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.delta_ttl: "ignored in initial audit 2026-04-23"
-  otlp_config.metrics.histograms.mode: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.histograms.send_aggregation_metrics: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.histograms.send_count_sum_metrics: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.instrumentation_scope_metadata_as_tags: "ignored in initial audit 2026-04-23"

--- a/lib/datadog-agent/config/src/generated/datadog_configuration.rs
+++ b/lib/datadog-agent/config/src/generated/datadog_configuration.rs
@@ -1277,6 +1277,9 @@ pub struct OtlpConfigMetrics {
     pub enabled: bool,
 
     #[serde(default)]
+    pub histograms: OtlpConfigMetricsHistograms,
+
+    #[serde(default)]
     pub resource_attributes_as_tags: bool,
 
     #[serde(default)]
@@ -1287,8 +1290,25 @@ impl Default for OtlpConfigMetrics {
     fn default() -> Self {
         Self {
             enabled: defaults::default_bool::<true>(),
+            histograms: Default::default(),
             resource_attributes_as_tags: Default::default(),
             tags: Default::default(),
+        }
+    }
+}
+
+#[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+pub struct OtlpConfigMetricsHistograms {
+    #[serde(
+        default = "defaults::datadog_configuration_otlp_config_metrics_histograms_mode"
+    )]
+    pub mode: String,
+}
+
+impl Default for OtlpConfigMetricsHistograms {
+    fn default() -> Self {
+        Self {
+            mode: defaults::datadog_configuration_otlp_config_metrics_histograms_mode(),
         }
     }
 }
@@ -1736,6 +1756,9 @@ pub mod defaults {
     }
     pub(super) fn datadog_configuration_data_plane_otlp_proxy_receiver_protocols_grpc_endpoint() -> String {
         "127.0.0.1:4319".to_string()
+    }
+    pub(super) fn datadog_configuration_otlp_config_metrics_histograms_mode() -> String {
+        "distributions".to_string()
     }
     pub(super) fn datadog_configuration_otlp_config_receiver_protocols_grpc_endpoint() -> String {
         "localhost:4317".to_string()

--- a/lib/datadog-agent/config/src/generated/env_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_keys.rs
@@ -751,6 +751,11 @@ pub static DATADOG_ENV_KEYS: &[EnvKey] = &[
         decode: EnvDecode::Bool,
     },
     EnvKey {
+        env_vars: &["DD_OTLP_CONFIG_METRICS_HISTOGRAMS_MODE"],
+        path: &["otlp_config", "metrics", "histograms", "mode"],
+        decode: EnvDecode::RawString,
+    },
+    EnvKey {
         env_vars: &["DD_OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS"],
         path: &["otlp_config", "metrics", "resource_attributes_as_tags"],
         decode: EnvDecode::Bool,

--- a/lib/datadog-agent/config/src/generated/env_overlay_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_overlay_keys.rs
@@ -279,6 +279,10 @@ pub static ENV_OVERLAY_KEYS: &[EnvOverlayKey] = &[
         path: &["otlp_config", "metrics", "enabled"],
     },
     EnvOverlayKey {
+        flats: &["otlp_config_metrics_histograms_mode"],
+        path: &["otlp_config", "metrics", "histograms", "mode"],
+    },
+    EnvOverlayKey {
         flats: &["otlp_config_metrics_resource_attributes_as_tags"],
         path: &["otlp_config", "metrics", "resource_attributes_as_tags"],
     },

--- a/lib/datadog-agent/config/src/generated/witness.rs
+++ b/lib/datadog-agent/config/src/generated/witness.rs
@@ -160,6 +160,7 @@ pub trait DatadogConfigWitness {
     fn consume_origin_detection_unified(&mut self, value: bool);
     fn consume_otlp_config_logs_enabled(&mut self, value: bool);
     fn consume_otlp_config_metrics_enabled(&mut self, value: bool);
+    fn consume_otlp_config_metrics_histograms_mode(&mut self, value: String);
     fn consume_otlp_config_metrics_resource_attributes_as_tags(&mut self, value: bool);
     fn consume_otlp_config_metrics_tags(&mut self, value: String);
     fn consume_otlp_config_receiver_protocols_grpc_endpoint(&mut self, value: String);
@@ -415,6 +416,7 @@ pub fn drive(config: &DatadogConfiguration, consumer: &mut impl DatadogConfigWit
     consumer.consume_origin_detection_unified(config.origin_detection_unified.clone());
     consumer.consume_otlp_config_logs_enabled(config.otlp_config.logs.enabled.clone());
     consumer.consume_otlp_config_metrics_enabled(config.otlp_config.metrics.enabled.clone());
+    consumer.consume_otlp_config_metrics_histograms_mode(config.otlp_config.metrics.histograms.mode.clone());
     consumer.consume_otlp_config_metrics_resource_attributes_as_tags(
         config.otlp_config.metrics.resource_attributes_as_tags.clone(),
     );

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -13,6 +13,7 @@ default = []
 fips = ["saluki-io/fips"]
 
 [dependencies]
+agent-data-plane-config = { workspace = true }
 arc-swap = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -157,6 +157,7 @@ impl Default for LogsConfig {
     }
 }
 
+// TODO: delete when this component uses typed config
 fn deserialize_histogram_mode<'de, D>(deserializer: D) -> Result<HistogramMode, D::Error>
 where
     D: Deserializer<'de>,

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -1,10 +1,11 @@
 //! Shared OTLP receiver configuration.
 
+use agent_data_plane_config::domains::otlp::HistogramMode;
 use bytesize::ByteSize;
 use facet::Facet;
 use saluki_config::GenericConfiguration;
 use saluki_error::GenericError;
-use serde::Deserialize;
+use serde::{de::Error as _, Deserialize, Deserializer};
 
 fn default_grpc_endpoint() -> String {
     "0.0.0.0:4317".to_string()
@@ -156,6 +157,28 @@ impl Default for LogsConfig {
     }
 }
 
+fn deserialize_histogram_mode<'de, D>(deserializer: D) -> Result<HistogramMode, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer)?.parse().map_err(D::Error::custom)
+}
+
+/// Configuration for OTLP histogram processing.
+#[derive(Debug, Default, Deserialize)]
+#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
+pub struct HistogramsConfig {
+    /// Controls how histogram buckets are reported.
+    ///
+    /// Use `distributions` for distribution metrics, `counters` for one metric per bucket, or
+    /// `nobuckets` to omit bucket metrics. The `nobuckets` mode requires histogram aggregation
+    /// metrics to be enabled separately.
+    ///
+    /// Defaults to `distributions`.
+    #[serde(default, deserialize_with = "deserialize_histogram_mode")]
+    pub mode: HistogramMode,
+}
+
 /// Configuration for OTLP metrics processing.
 #[derive(Deserialize, Debug)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
@@ -165,6 +188,10 @@ pub struct MetricsConfig {
     /// Defaults to `true`.
     #[serde(default = "default_metrics_enabled")]
     pub enabled: bool,
+
+    /// Histogram processing configuration.
+    #[serde(default)]
+    pub histograms: HistogramsConfig,
 
     /// Whether to add scalar resource attributes as raw tags on emitted metrics.
     ///
@@ -193,6 +220,7 @@ impl Default for MetricsConfig {
     fn default() -> Self {
         Self {
             enabled: default_metrics_enabled(),
+            histograms: HistogramsConfig::default(),
             resource_attributes_as_tags: false,
             tags: String::new(),
         }

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -1,20 +1,10 @@
 use std::time::Duration;
 
+use agent_data_plane_config::domains::otlp::HistogramMode;
 use saluki_error::{generic_error, GenericError};
 
 const DEFAULT_DELTA_TTL: Duration = Duration::from_secs(3600);
 const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(1800);
-
-// https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/config.go#L131-L140
-#[derive(Debug, Clone, Copy, PartialEq)]
-#[allow(dead_code)]
-#[derive(Default)]
-pub enum HistogramMode {
-    NoBuckets,
-    Counters,
-    #[default]
-    Distributions,
-}
 
 // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/config.go#L178-L190
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/lib/saluki-components/src/sources/otlp/metrics/dimensions.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/dimensions.rs
@@ -1,7 +1,7 @@
 //! OTLP metric dimensions.
 
 use otlp_protos::opentelemetry::proto::common::v1 as otlp_common;
-use saluki_context::tags::{SharedTagSet, TagSet};
+use saluki_context::tags::{SharedTagSet, Tag, TagSet};
 use stringtheory::MetaString;
 
 use super::internal::utils::format_key_value_tag;
@@ -27,20 +27,23 @@ impl Dimensions {
         }
     }
 
-    /// Creates a new `Dimensions` with additional tags.
-    #[allow(dead_code)]
-    pub fn add_tags(&self, tags_to_add: &[String]) -> Self {
-        let mut new_tags = TagSet::default();
-        for tag in &self.tags {
-            new_tags.insert_tag(tag.clone());
-        }
-        for tag in tags_to_add {
-            new_tags.insert_tag(tag.clone());
-        }
+    /// Creates a new `Dimensions` with additional tags, structurally sharing the existing tags.
+    pub fn add_tags<I>(&self, tags_to_add: I) -> Self
+    where
+        I: IntoIterator<Item = String>,
+    {
+        let additions: SharedTagSet = tags_to_add
+            .into_iter()
+            .filter(|tag| !self.tags.has_tag(tag))
+            .map(Tag::from)
+            .collect();
+
+        let mut tags = self.tags.clone();
+        tags.extend_from_shared(&additions);
 
         Self {
             name: self.name.clone(),
-            tags: new_tags.into_shared(),
+            tags,
             host: self.host.clone(),
             origin_id: self.origin_id.clone(),
         }
@@ -109,5 +112,53 @@ impl Dimensions {
 
         // Join with a null character separator.
         dimensions.join("\0")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use saluki_context::tags::{Tag, TagSet};
+
+    use super::*;
+
+    fn dims_with_tags(name: &str, tags: &[&str]) -> Dimensions {
+        let tag_set: TagSet = tags.iter().map(|t| Tag::from(*t)).collect();
+        Dimensions {
+            name: name.to_string(),
+            tags: tag_set.into_shared(),
+            host: None,
+            origin_id: None,
+        }
+    }
+
+    #[test]
+    fn add_tags_preserves_order_deduplication_and_base() {
+        let base = dims_with_tags("http.request.duration", &["env:prod", "service:web", "lower_bound:1.0"]);
+        let extended = base.add_tags(["lower_bound:1.0".to_string(), "upper_bound:2.0".to_string()]);
+
+        let extended_tags: Vec<&str> = extended.tags.into_iter().map(|t| t.as_str()).collect();
+        assert_eq!(
+            extended_tags,
+            vec!["env:prod", "service:web", "lower_bound:1.0", "upper_bound:2.0"]
+        );
+
+        let base_tags: Vec<&str> = base.tags.into_iter().map(|t| t.as_str()).collect();
+        assert_eq!(base_tags, vec!["env:prod", "service:web", "lower_bound:1.0"]);
+    }
+
+    #[test]
+    fn add_tags_preserves_canonical_cache_key() {
+        let base = dims_with_tags("http.request.duration", &["service:web", "env:prod"]);
+        let extended = base.add_tags(["lower_bound:1.0".to_string(), "upper_bound:2.0".to_string()]);
+
+        let expected = [
+            "env:prod",
+            "lower_bound:1.0",
+            "name:http.request.duration",
+            "service:web",
+            "upper_bound:2.0",
+        ]
+        .join("\0");
+        assert_eq!(extended.get_cache_key(), expected);
     }
 }

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -1176,7 +1176,6 @@ impl OtlpMetricsTranslator {
                 }
             }
 
-            // TODO: Implement bucket-to-sketch conversion.
             match self.config.hist_mode {
                 HistogramMode::NoBuckets => {
                     continue;

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -112,6 +112,13 @@ fn get_bounds(explicit_bounds: &[f64], idx: usize) -> (f64, f64) {
 fn validate_histogram_buckets(point_dims: &Dimensions, p: &OtlpHistogramDataPoint) -> Result<(), GenericError> {
     let bucket_count = p.bucket_counts.len();
     let bound_count = p.explicit_bounds.len();
+    if bucket_count == 0 && bound_count != 0 {
+        return Err(generic_error!(
+            "Histogram '{}' has no bucket counts but {} explicit bounds; explicit bounds must be empty when bucket counts are empty.",
+            point_dims.name,
+            bound_count
+        ));
+    }
     if bucket_count > 0 && bucket_count != bound_count + 1 {
         return Err(generic_error!(
             "Histogram '{}' has {} bucket counts but {} explicit bounds; bucket count must equal bound count plus one.",
@@ -1487,7 +1494,7 @@ mod tests {
 
     // Matches the Agent's rejection of malformed explicit histograms:
     // https://github.com/DataDog/datadog-agent/blob/087bbbe6d66864dbc8374ed2c66f71f3c1259c36/pkg/opentelemetry-mapping-go/otlp/metrics/default_mapper.go#L348-L352
-    fn map_malformed_histogram(mode: HistogramMode) -> Vec<Event> {
+    fn map_malformed_histogram(mode: HistogramMode, bucket_counts: Vec<u64>, explicit_bounds: Vec<f64>) -> Vec<Event> {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
         translator.config.hist_mode = mode;
@@ -1502,8 +1509,8 @@ mod tests {
         let point = OtlpHistogramDataPoint {
             count: 1,
             sum: Some(0.5),
-            bucket_counts: vec![1],
-            explicit_bounds: vec![1.0, 2.0],
+            bucket_counts,
+            explicit_bounds,
             time_unix_nano: nanos_from_seconds(1),
             ..Default::default()
         };
@@ -1513,12 +1520,17 @@ mod tests {
 
     #[test]
     fn mismatched_bucket_and_bound_lengths_emit_no_distribution() {
-        assert!(map_malformed_histogram(HistogramMode::Distributions).is_empty());
+        assert!(map_malformed_histogram(HistogramMode::Distributions, vec![1], vec![1.0, 2.0]).is_empty());
     }
 
     #[test]
     fn mismatched_bucket_and_bound_lengths_emit_no_bucket_counters() {
-        assert!(map_malformed_histogram(HistogramMode::Counters).is_empty());
+        assert!(map_malformed_histogram(HistogramMode::Counters, vec![1], vec![1.0, 2.0]).is_empty());
+    }
+
+    #[test]
+    fn empty_bucket_counts_with_bounds_emit_no_distribution() {
+        assert!(map_malformed_histogram(HistogramMode::Distributions, vec![], vec![1.0]).is_empty());
     }
 
     #[track_caller]

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -898,8 +898,6 @@ impl OtlpMetricsTranslator {
         &mut self, context: &TranslationContext, point_dims: Dimensions, p: &OtlpHistogramDataPoint, delta: bool,
         events: &mut Vec<Event>, hist_info: HistogramInfo,
     ) -> Result<(), GenericError> {
-        validate_histogram_buckets(&point_dims, p)?;
-
         let start_ts = p.start_time_unix_nano;
         let ts = p.time_unix_nano;
 
@@ -1047,8 +1045,6 @@ impl OtlpMetricsTranslator {
         &mut self, context: &TranslationContext, point_dims: Dimensions, p: OtlpHistogramDataPoint, delta: bool,
         events: &mut Vec<Event>,
     ) -> Result<(), GenericError> {
-        validate_histogram_buckets(&point_dims, &p)?;
-
         let start_ts = p.start_time_unix_nano;
         let ts = p.time_unix_nano;
 
@@ -1087,6 +1083,13 @@ impl OtlpMetricsTranslator {
                 .resource_attributes_as_tags
                 .then_some(context.resource_attributes);
             let point_dims = base_dims.with_attribute_map(&dp.attributes, shadowing_resource_attributes);
+
+            // Validate before updating cumulative state.
+            if let Err(e) = validate_histogram_buckets(&point_dims, &dp) {
+                warn!(error = %e, "Failed to validate histogram buckets, dropping data point.");
+                continue;
+            }
+
             let mut hist_info = HistogramInfo {
                 ok: true,
                 ..Default::default()
@@ -1531,6 +1534,44 @@ mod tests {
     #[test]
     fn empty_bucket_counts_with_bounds_emit_no_distribution() {
         assert!(map_malformed_histogram(HistogramMode::Distributions, vec![], vec![1.0]).is_empty());
+    }
+
+    #[test]
+    fn malformed_cumulative_histogram_does_not_update_aggregation_caches() {
+        let metrics = Metrics::for_tests();
+        let context = TranslationContext {
+            resource_attributes: &[],
+            metrics: &metrics,
+        };
+        let dims = Dimensions {
+            name: "malformed.histogram".to_string(),
+            ..Default::default()
+        };
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        translator.config.hist_mode = HistogramMode::Counters;
+        translator.config.send_histogram_aggregations = true;
+
+        let malformed = OtlpHistogramDataPoint {
+            count: 5,
+            sum: Some(8.0),
+            bucket_counts: vec![1],
+            explicit_bounds: vec![1.0, 2.0],
+            start_time_unix_nano: nanos_from_seconds(1),
+            time_unix_nano: nanos_from_seconds(2),
+            ..Default::default()
+        };
+        let valid = OtlpHistogramDataPoint {
+            count: 12,
+            sum: Some(20.0),
+            bucket_counts: vec![5, 7],
+            explicit_bounds: vec![1.0],
+            start_time_unix_nano: nanos_from_seconds(1),
+            time_unix_nano: nanos_from_seconds(3),
+            ..Default::default()
+        };
+
+        let events = translator.map_histogram_metrics(dims, vec![malformed, valid], false, &context);
+        assert!(events.is_empty());
     }
 
     #[track_caller]

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -2,11 +2,13 @@
 
 use std::collections::BTreeMap;
 use std::collections::HashSet;
+use std::fmt;
 use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::vec::IntoIter;
 
 use ::ddsketch::canonical::mapping::IndexMapping;
+use agent_data_plane_config::domains::otlp::HistogramMode;
 use datadog_protos::metrics::Dogsketch;
 use ddsketch::canonical::mapping::LogarithmicMapping;
 use ddsketch::canonical::store::DenseStore;
@@ -29,7 +31,7 @@ use stringtheory::MetaString;
 use tracing::{debug, trace, warn};
 
 use super::cache::PointsCache;
-use super::config::{HistogramMode, NumberMode, OtlpMetricsTranslatorConfig};
+use super::config::{NumberMode, OtlpMetricsTranslatorConfig};
 use super::dimensions::Dimensions;
 use super::internal::{instrumentationlibrary, instrumentationscope};
 use super::remap;
@@ -107,6 +109,20 @@ fn get_bounds(explicit_bounds: &[f64], idx: usize) -> (f64, f64) {
     (lower, upper)
 }
 
+fn validate_histogram_buckets(point_dims: &Dimensions, p: &OtlpHistogramDataPoint) -> Result<(), GenericError> {
+    let bucket_count = p.bucket_counts.len();
+    let bound_count = p.explicit_bounds.len();
+    if bucket_count > 0 && bucket_count != bound_count + 1 {
+        return Err(generic_error!(
+            "Histogram '{}' has {} bucket counts but {} explicit bounds; bucket count must equal bound count plus one.",
+            point_dims.name,
+            bucket_count,
+            bound_count
+        ));
+    }
+    Ok(())
+}
+
 fn infer_delta_interval(start_ts: u64, ts: u64) -> i64 {
     if start_ts == 0 || start_ts > ts {
         return 0;
@@ -121,46 +137,54 @@ fn infer_delta_interval(start_ts: u64, ts: u64) -> i64 {
     0
 }
 
-fn format_float(f: f64) -> String {
-    if f == f64::INFINITY {
-        return "inf".to_string();
-    } else if f == f64::NEG_INFINITY {
-        return "-inf".to_string();
-    } else if f.is_nan() {
-        return "nan".to_string();
-    } else if f == 0.0 {
-        return "0".to_string();
-    }
+/// Formats a float using Go semantics directly into the caller's output buffer.
+struct GoFloat(f64);
 
-    // Mirror Go's strconv.FormatFloat(f, 'g', -1, 64): switch to scientific
-    // notation below 1e-4 and at/above 1e6, with a zero-padded two-digit
-    // signed exponent.
-    if f.abs() < 1e-4 || f.abs() >= 1e6 {
-        let s = format!("{f:e}");
-        let (mantissa, exp_part) = s.split_once('e').expect("{:e} always contains 'e'");
-        let (sign, digits) = if let Some(d) = exp_part.strip_prefix('-') {
-            ("-", d)
-        } else {
-            ("+", exp_part.strip_prefix('+').unwrap_or(exp_part))
-        };
-        let s = if digits.len() < 2 {
-            format!("{mantissa}e{sign}0{digits}")
-        } else {
-            format!("{mantissa}e{sign}{digits}")
-        };
-        return if f == f.floor() { format!("{s}.0") } else { s };
-    }
+impl fmt::Display for GoFloat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let v = self.0;
+        if v == f64::INFINITY {
+            return f.write_str("inf");
+        } else if v == f64::NEG_INFINITY {
+            return f.write_str("-inf");
+        } else if v.is_nan() {
+            return f.write_str("nan");
+        } else if v == 0.0 {
+            return f.write_str("0");
+        }
 
-    let s = format!("{f}");
-    if f == f.floor() {
-        format!("{s}.0")
-    } else {
-        s
+        // Mirror Go's strconv.FormatFloat(f, 'g', -1, 64): switch to scientific
+        // notation below 1e-4 and at/above 1e6, with a zero-padded two-digit
+        // signed exponent.
+        if v.abs() < 1e-4 || v.abs() >= 1e6 {
+            let s = format!("{v:e}");
+            let (mantissa, exp_part) = s.split_once('e').expect("{:e} always contains 'e'");
+            let (sign, digits) = if let Some(d) = exp_part.strip_prefix('-') {
+                ("-", d)
+            } else {
+                ("+", exp_part.strip_prefix('+').unwrap_or(exp_part))
+            };
+            if digits.len() < 2 {
+                write!(f, "{mantissa}e{sign}0{digits}")?;
+            } else {
+                write!(f, "{mantissa}e{sign}{digits}")?;
+            }
+            if v == v.floor() {
+                f.write_str(".0")?;
+            }
+            return Ok(());
+        }
+
+        write!(f, "{v}")?;
+        if v == v.floor() {
+            f.write_str(".0")?;
+        }
+        Ok(())
     }
 }
 
 fn format_quantile_tag(quantile: f64) -> String {
-    "quantile:".to_string() + format_float(quantile).as_str()
+    format!("quantile:{}", GoFloat(quantile))
 }
 
 fn to_store(b: Option<&OtlpExponentialHistogramBuckets>) -> DenseStore {
@@ -728,7 +752,7 @@ impl OtlpMetricsTranslator {
                     if is_skippable(quantile.value) {
                         continue;
                     }
-                    let quantile_dims = base_quantile_dims.add_tags(&[format_quantile_tag(quantile.quantile)]);
+                    let quantile_dims = base_quantile_dims.add_tags([format_quantile_tag(quantile.quantile)]);
                     self.record_metric_event(
                         &quantile_dims,
                         quantile.value,
@@ -867,6 +891,8 @@ impl OtlpMetricsTranslator {
         &mut self, context: &TranslationContext, point_dims: Dimensions, p: &OtlpHistogramDataPoint, delta: bool,
         events: &mut Vec<Event>, hist_info: HistogramInfo,
     ) -> Result<(), GenericError> {
+        validate_histogram_buckets(&point_dims, p)?;
+
         let start_ts = p.start_time_unix_nano;
         let ts = p.time_unix_nano;
 
@@ -875,6 +901,8 @@ impl OtlpMetricsTranslator {
         let mut explicit_bounds = p.explicit_bounds.clone();
 
         if bucket_counts.is_empty() && hist_info.ok {
+            explicit_bounds.clear();
+
             if hist_info.has_min_from_last_time_window {
                 bucket_counts.push(0);
                 explicit_bounds.push(p.min.unwrap_or(0.0));
@@ -895,9 +923,9 @@ impl OtlpMetricsTranslator {
             let (lower_bound, upper_bound) = get_bounds(&explicit_bounds, j);
             let (original_lower_bound, original_upper_bound) = (lower_bound, upper_bound);
 
-            let bucket_dims = point_dims.add_tags(&[
-                "lower_bound:".to_string() + format_float(lower_bound).as_str(),
-                "upper_bound:".to_string() + format_float(upper_bound).as_str(),
+            let bucket_dims = point_dims.add_tags([
+                format!("lower_bound:{}", GoFloat(lower_bound)),
+                format!("upper_bound:{}", GoFloat(upper_bound)),
             ]);
 
             let (dx, ok) = self.prev_pts.diff(&bucket_dims, start_ts, ts, count as f64);
@@ -1011,7 +1039,9 @@ impl OtlpMetricsTranslator {
     fn get_legacy_buckets(
         &mut self, context: &TranslationContext, point_dims: Dimensions, p: OtlpHistogramDataPoint, delta: bool,
         events: &mut Vec<Event>,
-    ) {
+    ) -> Result<(), GenericError> {
+        validate_histogram_buckets(&point_dims, &p)?;
+
         let start_ts = p.start_time_unix_nano;
         let ts = p.time_unix_nano;
 
@@ -1019,9 +1049,9 @@ impl OtlpMetricsTranslator {
         for idx in 0..p.bucket_counts.len() {
             let (lower_bound, upper_bound) = get_bounds(&p.explicit_bounds, idx);
 
-            let bucket_dims = base_bucket_dims.add_tags(&[
-                "lower_bound:".to_string() + format_float(lower_bound).as_str(),
-                "upper_bound:".to_string() + format_float(upper_bound).as_str(),
+            let bucket_dims = base_bucket_dims.add_tags([
+                format!("lower_bound:{}", GoFloat(lower_bound)),
+                format!("upper_bound:{}", GoFloat(upper_bound)),
             ]);
             let count = p.bucket_counts[idx];
             let (dx, ok) = self.prev_pts.diff(&bucket_dims, start_ts, ts, count as f64);
@@ -1031,6 +1061,7 @@ impl OtlpMetricsTranslator {
                 self.record_metric_event(&bucket_dims, dx, ts, DataType::Count, events, context);
             }
         }
+        Ok(())
     }
 
     fn map_histogram_metrics(
@@ -1141,7 +1172,9 @@ impl OtlpMetricsTranslator {
                     continue;
                 }
                 HistogramMode::Counters => {
-                    self.get_legacy_buckets(context, point_dims, dp, delta, &mut events);
+                    if let Err(e) = self.get_legacy_buckets(context, point_dims, dp, delta, &mut events) {
+                        warn!(error = %e, "Failed to convert histogram buckets to counters, dropping data point.");
+                    }
                 }
                 HistogramMode::Distributions => {
                     if let Err(e) = self.get_sketch_buckets(context, point_dims, &dp, delta, &mut events, hist_info) {
@@ -1452,9 +1485,117 @@ mod tests {
         s * 1_000_000_000
     }
 
+    // Matches the Agent's rejection of malformed explicit histograms:
+    // https://github.com/DataDog/datadog-agent/blob/087bbbe6d66864dbc8374ed2c66f71f3c1259c36/pkg/opentelemetry-mapping-go/otlp/metrics/default_mapper.go#L348-L352
+    fn map_malformed_histogram(mode: HistogramMode) -> Vec<Event> {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        translator.config.hist_mode = mode;
+        let context = TranslationContext {
+            resource_attributes: &[],
+            metrics: &metrics,
+        };
+        let dims = Dimensions {
+            name: "malformed.histogram".to_string(),
+            ..Default::default()
+        };
+        let point = OtlpHistogramDataPoint {
+            count: 1,
+            sum: Some(0.5),
+            bucket_counts: vec![1],
+            explicit_bounds: vec![1.0, 2.0],
+            time_unix_nano: nanos_from_seconds(1),
+            ..Default::default()
+        };
+
+        translator.map_histogram_metrics(dims, vec![point], true, &context)
+    }
+
+    #[test]
+    fn mismatched_bucket_and_bound_lengths_emit_no_distribution() {
+        assert!(map_malformed_histogram(HistogramMode::Distributions).is_empty());
+    }
+
+    #[test]
+    fn mismatched_bucket_and_bound_lengths_emit_no_bucket_counters() {
+        assert!(map_malformed_histogram(HistogramMode::Counters).is_empty());
+    }
+
+    #[track_caller]
+    fn assert_bucket_events(events: &[Event], values: &[f64], timestamp: u64) {
+        let bounds = [("-inf", "1.0"), ("1.0", "inf")];
+        assert_eq!(events.len(), values.len());
+        for ((event, value), (lower, upper)) in events.iter().zip(values).zip(bounds) {
+            let metric = event.try_as_metric().expect("event should be a metric");
+            assert_eq!(metric.context().name(), "valid.histogram.bucket");
+            assert_eq!(metric.values(), &MetricValues::counter((timestamp, *value)));
+            assert_eq!(
+                metric.context().tags().get_single_tag("lower_bound").unwrap().value(),
+                Some(lower)
+            );
+            assert_eq!(
+                metric.context().tags().get_single_tag("upper_bound").unwrap().value(),
+                Some(upper)
+            );
+        }
+    }
+
+    #[test]
+    fn valid_bucket_counters_preserve_bounds_and_cumulative_diffs() {
+        let metrics = Metrics::for_tests();
+        let context = TranslationContext {
+            resource_attributes: &[],
+            metrics: &metrics,
+        };
+        let dims = Dimensions {
+            name: "valid.histogram".to_string(),
+            ..Default::default()
+        };
+
+        let mut delta_translator = OtlpMetricsTranslator::for_tests();
+        delta_translator.config.hist_mode = HistogramMode::Counters;
+        let delta_point = OtlpHistogramDataPoint {
+            count: 5,
+            sum: Some(8.0),
+            bucket_counts: vec![2, 3],
+            explicit_bounds: vec![1.0],
+            time_unix_nano: nanos_from_seconds(1),
+            ..Default::default()
+        };
+        let delta_events = delta_translator.map_histogram_metrics(dims.clone(), vec![delta_point], true, &context);
+        assert_bucket_events(&delta_events, &[2.0, 3.0], 1);
+
+        let mut cumulative_translator = OtlpMetricsTranslator::for_tests();
+        cumulative_translator.config.hist_mode = HistogramMode::Counters;
+        let initial_point = OtlpHistogramDataPoint {
+            count: 5,
+            sum: Some(8.0),
+            bucket_counts: vec![2, 3],
+            explicit_bounds: vec![1.0],
+            start_time_unix_nano: nanos_from_seconds(1),
+            time_unix_nano: nanos_from_seconds(2),
+            ..Default::default()
+        };
+        let next_point = OtlpHistogramDataPoint {
+            count: 12,
+            sum: Some(20.0),
+            bucket_counts: vec![5, 7],
+            explicit_bounds: vec![1.0],
+            start_time_unix_nano: nanos_from_seconds(1),
+            time_unix_nano: nanos_from_seconds(3),
+            ..Default::default()
+        };
+        let initial_events =
+            cumulative_translator.map_histogram_metrics(dims.clone(), vec![initial_point], false, &context);
+        assert!(initial_events.is_empty());
+        let cumulative_events = cumulative_translator.map_histogram_metrics(dims, vec![next_point], false, &context);
+        assert_bucket_events(&cumulative_events, &[3.0, 4.0], 3);
+    }
+
+    // Ported from the Go OTLP mapping tests:
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L2225
     #[test]
-    fn test_format_float_go_parity() {
+    fn go_float_matches_go_format_float() {
         let tests = [
             (0.0, "0"),
             (0.001, "0.001"),
@@ -1479,8 +1620,21 @@ mod tests {
         ];
 
         for (input, expected) in tests {
-            assert_eq!(format_float(input), expected);
+            assert_eq!(GoFloat(input).to_string(), expected);
         }
+    }
+
+    #[test]
+    fn bucket_bound_tags_use_go_float_format() {
+        assert_eq!(
+            format!("lower_bound:{}", GoFloat(f64::NEG_INFINITY)),
+            "lower_bound:-inf"
+        );
+        assert_eq!(format!("upper_bound:{}", GoFloat(f64::INFINITY)), "upper_bound:inf");
+        assert_eq!(format!("lower_bound:{}", GoFloat(0.0)), "lower_bound:0");
+        assert_eq!(format!("lower_bound:{}", GoFloat(1.0)), "lower_bound:1.0");
+        assert_eq!(format!("lower_bound:{}", GoFloat(0.001)), "lower_bound:0.001");
+        assert_eq!(format!("upper_bound:{}", GoFloat(1e6)), "upper_bound:1e+06.0");
     }
 
     /// A helper function to build a series of cumulative monotonic integer data points from deltas.

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -152,6 +152,14 @@ impl OtlpConfiguration {
         Ok(cfg)
     }
 
+    fn metrics_translator_config(&self) -> metrics::config::OtlpMetricsTranslatorConfig {
+        metrics::config::OtlpMetricsTranslatorConfig::default()
+            .with_remapping(true)
+            .with_quantiles(true)
+            .with_histogram_mode(self.otlp_config.metrics.histograms.mode)
+            .with_resource_attributes_as_tags(self.otlp_config.metrics.resource_attributes_as_tags)
+    }
+
     /// Sets the default hostname used when OTLP metrics do not carry a resource hostname.
     pub fn with_default_hostname(mut self, hostname: impl Into<MetaString>) -> Self {
         self.default_hostname = hostname.into();
@@ -227,10 +235,7 @@ impl SourceBuilder for OtlpConfiguration {
         let maybe_origin_tags_resolver = self.workload_provider.clone().map(OtlpOriginTagResolver::new);
 
         let context_resolver = build_context_resolver(self, &context, maybe_origin_tags_resolver.clone())?;
-        let metrics_translator_config = metrics::config::OtlpMetricsTranslatorConfig::default()
-            .with_remapping(true)
-            .with_quantiles(true)
-            .with_resource_attributes_as_tags(self.otlp_config.metrics.resource_attributes_as_tags);
+        let metrics_translator_config = self.metrics_translator_config();
 
         let metric_tags = parse_configured_metric_tags(&self.otlp_config.metrics.tags);
         let traces_interner_size =
@@ -565,13 +570,42 @@ mod config_smoke {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_configured_metric_tags;
+    use agent_data_plane_config::domains::otlp::HistogramMode;
+    use saluki_config::config_from;
+    use serde_json::json;
+
+    use super::{parse_configured_metric_tags, OtlpConfiguration};
 
     fn tags(raw: &str) -> Vec<String> {
         parse_configured_metric_tags(raw)
             .into_iter()
             .map(|t| t.to_string())
             .collect()
+    }
+
+    #[tokio::test]
+    async fn histogram_modes_flow_to_metrics_translator() {
+        let cases = [
+            ("nobuckets", HistogramMode::NoBuckets),
+            ("counters", HistogramMode::Counters),
+            ("distributions", HistogramMode::Distributions),
+        ];
+
+        for (configured_mode, expected_mode) in cases {
+            let config = config_from(json!({
+                "otlp_config": {
+                    "metrics": {
+                        "histograms": {
+                            "mode": configured_mode
+                        }
+                    }
+                }
+            }))
+            .await;
+            let otlp_config = OtlpConfiguration::from_configuration(&config).expect("OTLP configuration should parse");
+
+            assert_eq!(otlp_config.metrics_translator_config().hist_mode, expected_mode);
+        }
     }
 
     #[test]

--- a/test/correctness/cases/otlp-metrics-histogram-counters/config.yaml
+++ b/test/correctness/cases/otlp-metrics-histogram-counters/config.yaml
@@ -1,0 +1,19 @@
+type: correctness
+runtime: docker
+analysis_mode: metrics
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=true
+    - DD_DATA_PLANE_OTLP_ENABLED=true
+    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/cases/otlp-metrics-histogram-counters/datadog.yaml
+++ b/test/correctness/cases/otlp-metrics-histogram-counters/datadog.yaml
@@ -1,0 +1,13 @@
+hostname: "correctness-testing"
+api_key: dummy-api-key-correctness-testing
+health_port: 5555
+dd_url: "http://datadog-intake:2049"
+
+otlp_config:
+  metrics:
+    histograms:
+      mode: counters
+  receiver:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"

--- a/test/correctness/cases/otlp-metrics-histogram-counters/millstone.yaml
+++ b/test/correctness/cases/otlp-metrics-histogram-counters/millstone.yaml
@@ -1,0 +1,9 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "grpc://$GROUP:4317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export"
+aggregation_bucket_width_secs: 10
+volume: 1
+corpus:
+  size: 1
+  payload:
+    # One valid delta histogram with two explicit bounds and three bucket counts.
+    static_base64: "CmoSaBJmCg5vdGxwLmhpc3RvZ3JhbUpUClARAMqaOwAAAAAZAJQ1dwAAAAAhBgAAAAAAAAApAAAAAACAN0AyGAEAAAAAAAAAAgAAAAAAAAADAAAAAAAAADoQAAAAAAAA8D8AAAAAAAAkQBAB"


### PR DESCRIPTION
## Summary

The three histogram mode implementations were already there. This PR makes the Agent configuration select them correctly, then fixes validation and cache-state bugs exposed by making that behavior configurable.

- Wire `otlp_config.metrics.histograms.mode` through the Datadog and Saluki configuration models into the OTLP metrics translator.
- Centralize `HistogramMode` parsing and reject malformed histogram bucket/bound cardinalities in distribution and counter paths.
- Preserve valid delta and cumulative counter buckets, with structural tag sharing and correctness coverage.

## Change Type
- [x] Bug fix
- [x] New feature
- [x] Performance

## How did you test this PR?

- `make fmt`
- `cargo build -p datadog-agent-config-testing`
- `cargo check --workspace`
- `cargo check --workspace --tests`
- `cargo nextest run -p saluki-components` — 767 passed
- `cargo nextest run -p agent-data-plane-config-system` — 34 passed
- `cargo clippy -p agent-data-plane-config -p agent-data-plane-config-system -p saluki-components --tests -- -D warnings`
- `make check-all`
- `make test-all`
- `make test-correctness-case CASE=otlp-metrics-histogram-counters` — passed

The correctness test was demonstrated red against the base implementation and green with this change.

## References

- Closes: #2020
- Related: #2021
