### PR TITLE
feat(otlp): support cumulative_monotonic_mode config option

### DIFF
--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -703,6 +703,7 @@ compressed wire payload bytes.
 | `otlp_config.logs.enabled`                                     | otlp_config.logs.enabled                           |
 | `otlp_config.metrics.enabled`                                  | otlp_config.metrics.enabled                        |
 | `otlp_config.metrics.resource_attributes_as_tags`              | Add scalar resource attributes as raw tags.        |
+| `otlp_config.metrics.sums.cumulative_monotonic_mode`           | Cumulative monotonic sum reporting mode.           |
 | `otlp_config.metrics.tags`                                     | Comma-separated tags for all OTLP metrics.         |
 | `otlp_config.receiver.protocols.grpc.endpoint`                 | otlp_config.receiver.protocols.grpc.endpoint       |
 | `otlp_config.receiver.protocols.grpc.max_recv_msg_size_mib`    | Max OTLP inbound gRPC message size (MiB)           |

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -23,7 +23,7 @@ use agent_data_plane_config::control::ListenAddress;
 use agent_data_plane_config::domains::dogstatsd::{
     FilterAction, MapperProfile, MetricMapping, MetricTagFilterEntry, OriginTagCardinality,
 };
-use agent_data_plane_config::domains::otlp::HistogramMode;
+use agent_data_plane_config::domains::otlp::{CumulativeMonotonicMode, HistogramMode};
 use agent_data_plane_config::shared::ForwarderHttpProtocol;
 use agent_data_plane_config::SalukiConfiguration;
 use bytesize::ByteSize;
@@ -888,7 +888,13 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_otlp_config_metrics_sums_cumulative_monotonic_mode(&mut self, value: String) {
-        self.config.domains.otlp.metrics.sums.mode = value;
+        match value.parse::<CumulativeMonotonicMode>() {
+            Ok(mode) => self.config.domains.otlp.metrics.sums.cumulative_monotonic_mode = mode,
+            Err(error) => self.record_error(TranslateError::new(
+                "otlp_config.metrics.sums.cumulative_monotonic_mode",
+                error,
+            )),
+        }
     }
 
     fn consume_otlp_config_metrics_tags(&mut self, value: String) {
@@ -1107,7 +1113,7 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
 mod tests {
     use std::time::Duration;
 
-    use agent_data_plane_config::domains::dogstatsd::OriginTagCardinality;
+    use agent_data_plane_config::domains::{dogstatsd::OriginTagCardinality, otlp::CumulativeMonotonicMode};
     use datadog_agent_config::DatadogConfiguration;
     use serde_json::json;
 
@@ -1257,5 +1263,55 @@ mod tests {
 
         // The error is still surfaced, so startup's strict gate rejects the config.
         assert!(errors.is_some(), "an unknown action must record a translation error");
+    }
+
+    #[test]
+    fn cumulative_monotonic_sum_mode_translates_known_values() {
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "otlp_config": {
+                "metrics": {
+                    "sums": {
+                        "cumulative_monotonic_mode": "raw_value"
+                    }
+                }
+            }
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, errors) = DatadogTranslator::new(&datadog).translate();
+
+        assert!(errors.is_none());
+        assert_eq!(
+            config.domains.otlp.metrics.sums.cumulative_monotonic_mode,
+            CumulativeMonotonicMode::RawValue
+        );
+    }
+
+    #[test]
+    fn invalid_cumulative_monotonic_sum_mode_records_error_and_keeps_default() {
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "otlp_config": {
+                "metrics": {
+                    "sums": {
+                        "cumulative_monotonic_mode": "unsupported"
+                    }
+                }
+            }
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, errors) = DatadogTranslator::new(&datadog).translate();
+
+        assert_eq!(
+            config.domains.otlp.metrics.sums.cumulative_monotonic_mode,
+            CumulativeMonotonicMode::ToDelta
+        );
+        let errors = errors.expect("invalid mode should record a translation error");
+        assert!(errors
+            .to_string()
+            .contains("otlp_config.metrics.sums.cumulative_monotonic_mode"));
+        assert!(errors
+            .to_string()
+            .contains("unknown cumulative monotonic sum mode `unsupported`"));
     }
 }

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -888,7 +888,7 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_otlp_config_metrics_sums_cumulative_monotonic_mode(&mut self, value: String) {
-        self.config.domains.otlp.metrics.cumulative_monotonic_mode = value;
+        self.config.domains.otlp.metrics.sums.mode = value;
     }
 
     fn consume_otlp_config_metrics_tags(&mut self, value: String) {

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -887,6 +887,10 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
         self.config.domains.otlp.metrics.resource_attributes_as_tags = value;
     }
 
+    fn consume_otlp_config_metrics_sums_cumulative_monotonic_mode(&mut self, value: String) {
+        self.config.domains.otlp.metrics.cumulative_monotonic_mode = value;
+    }
+
     fn consume_otlp_config_metrics_tags(&mut self, value: String) {
         self.config.domains.otlp.metrics.tags = value;
     }

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -24,7 +24,7 @@ pub struct Domain {
 }
 
 /// OTLP metrics translation settings.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Metrics {
     /// How explicit histogram buckets are reported.
     pub histogram_mode: HistogramMode,
@@ -32,6 +32,12 @@ pub struct Metrics {
     /// Whether every resource attribute is added as a raw metric tag, in addition to the
     /// semantic-convention mappings that are always applied.
     pub resource_attributes_as_tags: bool,
+
+    /// Cumulative monotonic sum reporting mode.
+    ///
+    /// Defaults to `to_delta`, which converts cumulative values to delta counts. Set to `raw_value` to emit
+    /// cumulative values as gauges.
+    pub cumulative_monotonic_mode: String,
 
     /// Comma-separated list of tags to add to every emitted metric.
     pub tags: String,
@@ -62,6 +68,17 @@ impl FromStr for HistogramMode {
             other => Err(Error::new_without_source(format!(
                 "unknown histogram mode `{other}`; expected `nobuckets`, `counters`, or `distributions`"
             ))),
+        }
+    }
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        Self {
+            histogram_mode: HistogramMode::default(),
+            resource_attributes_as_tags: false,
+            cumulative_monotonic_mode: "to_delta".to_string(),
+            tags: String::new(),
         }
     }
 }

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -24,7 +24,7 @@ pub struct Domain {
 }
 
 /// OTLP metrics translation settings.
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct Metrics {
     /// How explicit histogram buckets are reported.
     pub histogram_mode: HistogramMode,
@@ -33,11 +33,8 @@ pub struct Metrics {
     /// semantic-convention mappings that are always applied.
     pub resource_attributes_as_tags: bool,
 
-    /// Cumulative monotonic sum reporting mode.
-    ///
-    /// Defaults to `to_delta`, which converts cumulative values to delta counts. Set to `raw_value` to emit
-    /// cumulative values as gauges.
-    pub cumulative_monotonic_mode: String,
+    /// OTLP sum translation settings.
+    pub sums: Sums,
 
     /// Comma-separated list of tags to add to every emitted metric.
     pub tags: String,
@@ -72,13 +69,20 @@ impl FromStr for HistogramMode {
     }
 }
 
-impl Default for Metrics {
+/// OTLP sum translation settings.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct Sums {
+    /// Cumulative monotonic sum reporting mode.
+    ///
+    /// Defaults to `to_delta`, which converts cumulative values to delta counts. Set to `raw_value` to emit
+    /// cumulative values as gauges.
+    pub mode: String,
+}
+
+impl Default for Sums {
     fn default() -> Self {
         Self {
-            histogram_mode: HistogramMode::default(),
-            resource_attributes_as_tags: false,
-            cumulative_monotonic_mode: "to_delta".to_string(),
-            tags: String::new(),
+            mode: "to_delta".to_string(),
         }
     }
 }

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -69,22 +69,39 @@ impl FromStr for HistogramMode {
     }
 }
 
+/// How cumulative monotonic sums are reported.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub enum CumulativeMonotonicMode {
+    /// Converts cumulative values to deltas and reports them as counts.
+    #[default]
+    ToDelta,
+
+    /// Reports cumulative values as gauges without converting them to deltas.
+    RawValue,
+}
+
+impl FromStr for CumulativeMonotonicMode {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "to_delta" => Ok(Self::ToDelta),
+            "raw_value" => Ok(Self::RawValue),
+            other => Err(Error::new_without_source(format!(
+                "unknown cumulative monotonic sum mode `{other}`; expected `to_delta` or `raw_value`"
+            ))),
+        }
+    }
+}
+
 /// OTLP sum translation settings.
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct Sums {
     /// Cumulative monotonic sum reporting mode.
     ///
     /// Defaults to `to_delta`, which converts cumulative values to delta counts. Set to `raw_value` to emit
     /// cumulative values as gauges.
-    pub mode: String,
-}
-
-impl Default for Sums {
-    fn default() -> Self {
-        Self {
-            mode: "to_delta".to_string(),
-        }
-    }
+    pub cumulative_monotonic_mode: CumulativeMonotonicMode,
 }
 
 /// OTLP receiver transports and per-signal activation.
@@ -161,4 +178,37 @@ pub struct Contexts {
 
     /// Number of entries the context string interner holds. (not in Datadog Agent config schema)
     pub string_interner_size: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CumulativeMonotonicMode;
+
+    #[test]
+    fn cumulative_monotonic_mode_parses_known_values() {
+        assert_eq!(
+            "to_delta"
+                .parse::<CumulativeMonotonicMode>()
+                .expect("to_delta should parse"),
+            CumulativeMonotonicMode::ToDelta
+        );
+        assert_eq!(
+            "raw_value"
+                .parse::<CumulativeMonotonicMode>()
+                .expect("raw_value should parse"),
+            CumulativeMonotonicMode::RawValue
+        );
+    }
+
+    #[test]
+    fn cumulative_monotonic_mode_rejects_unknown_values() {
+        let error = "unsupported"
+            .parse::<CumulativeMonotonicMode>()
+            .expect_err("unsupported mode should be rejected");
+
+        assert_eq!(
+            error.to_string(),
+            "unknown cumulative monotonic sum mode `unsupported`; expected `to_delta` or `raw_value`"
+        );
+    }
 }

--- a/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
@@ -278,6 +278,17 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
     };
+    /// `otlp_config.metrics.sums.cumulative_monotonic_mode`-Cumulative monotonic sum reporting mode.
+    OTLP_CONFIG_METRICS_SUMS_CUMULATIVE_MONOTONIC_MODE = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_METRICS_SUMS_CUMULATIVE_MONOTONIC_MODE,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::OTLP_CONFIGURATION],
+        value_type_override: None,
+        test_json: Some(r#""raw_value""#),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
     /// `otlp_config.metrics.tags`-Comma-separated tags for all OTLP metrics.
     OTLP_CONFIG_METRICS_TAGS = SalukiAnnotation {
         schema: &schema::OTLP_CONFIG_METRICS_TAGS,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -2025,6 +2025,19 @@ inventory:
       additional_attributes:
         config_registry_filename: otlp.rs
 
+  otlp_config.metrics.sums.cumulative_monotonic_mode:
+    support: full
+    pipelines: [otlp]
+    description: "Cumulative monotonic sum reporting mode."
+    documentation: |-
+      Controls how cumulative monotonic sums are reported. The default `to_delta` converts cumulative values to
+      deltas and reports them as counts. Set this to `raw_value` to report cumulative values as gauges.
+    test_support:
+      used_by: [OtlpConfiguration]
+      test_json: '"raw_value"'
+      additional_attributes:
+        config_registry_filename: otlp.rs
+
   otlp_config.metrics.tags:
     support: full
     pipelines: [otlp]
@@ -3914,7 +3927,6 @@ excluded:
   otlp_config.metrics.histograms.send_count_sum_metrics: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.instrumentation_scope_metadata_as_tags: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.summaries.mode: "ignored in initial audit 2026-04-23"
-  otlp_config.metrics.sums.cumulative_monotonic_mode: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.sums.initial_cumulative_monotonic_value: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.tag_cardinality: "ignored in initial audit 2026-04-23"
   otlp_config.receiver.protocols.grpc.include_metadata: "ignored in initial audit 2026-04-23"

--- a/lib/datadog-agent/config/src/generated/datadog_configuration.rs
+++ b/lib/datadog-agent/config/src/generated/datadog_configuration.rs
@@ -1283,6 +1283,9 @@ pub struct OtlpConfigMetrics {
     pub resource_attributes_as_tags: bool,
 
     #[serde(default)]
+    pub sums: OtlpConfigMetricsSums,
+
+    #[serde(default)]
     pub tags: String,
 }
 
@@ -1292,6 +1295,7 @@ impl Default for OtlpConfigMetrics {
             enabled: defaults::default_bool::<true>(),
             histograms: Default::default(),
             resource_attributes_as_tags: Default::default(),
+            sums: Default::default(),
             tags: Default::default(),
         }
     }
@@ -1309,6 +1313,22 @@ impl Default for OtlpConfigMetricsHistograms {
     fn default() -> Self {
         Self {
             mode: defaults::datadog_configuration_otlp_config_metrics_histograms_mode(),
+        }
+    }
+}
+
+#[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+pub struct OtlpConfigMetricsSums {
+    #[serde(
+        default = "defaults::datadog_configuration_otlp_config_metrics_sums_cumulative_monotonic_mode"
+    )]
+    pub cumulative_monotonic_mode: String,
+}
+
+impl Default for OtlpConfigMetricsSums {
+    fn default() -> Self {
+        Self {
+            cumulative_monotonic_mode: defaults::datadog_configuration_otlp_config_metrics_sums_cumulative_monotonic_mode(),
         }
     }
 }
@@ -1759,6 +1779,9 @@ pub mod defaults {
     }
     pub(super) fn datadog_configuration_otlp_config_metrics_histograms_mode() -> String {
         "distributions".to_string()
+    }
+    pub(super) fn datadog_configuration_otlp_config_metrics_sums_cumulative_monotonic_mode() -> String {
+        "to_delta".to_string()
     }
     pub(super) fn datadog_configuration_otlp_config_receiver_protocols_grpc_endpoint() -> String {
         "localhost:4317".to_string()

--- a/lib/datadog-agent/config/src/generated/env_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_keys.rs
@@ -761,6 +761,11 @@ pub static DATADOG_ENV_KEYS: &[EnvKey] = &[
         decode: EnvDecode::Bool,
     },
     EnvKey {
+        env_vars: &["DD_OTLP_CONFIG_METRICS_SUMS_CUMULATIVE_MONOTONIC_MODE"],
+        path: &["otlp_config", "metrics", "sums", "cumulative_monotonic_mode"],
+        decode: EnvDecode::RawString,
+    },
+    EnvKey {
         env_vars: &["DD_OTLP_CONFIG_METRICS_TAGS"],
         path: &["otlp_config", "metrics", "tags"],
         decode: EnvDecode::RawString,

--- a/lib/datadog-agent/config/src/generated/env_overlay_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_overlay_keys.rs
@@ -287,6 +287,10 @@ pub static ENV_OVERLAY_KEYS: &[EnvOverlayKey] = &[
         path: &["otlp_config", "metrics", "resource_attributes_as_tags"],
     },
     EnvOverlayKey {
+        flats: &["otlp_config_metrics_sums_cumulative_monotonic_mode"],
+        path: &["otlp_config", "metrics", "sums", "cumulative_monotonic_mode"],
+    },
+    EnvOverlayKey {
         flats: &["otlp_config_metrics_tags"],
         path: &["otlp_config", "metrics", "tags"],
     },

--- a/lib/datadog-agent/config/src/generated/witness.rs
+++ b/lib/datadog-agent/config/src/generated/witness.rs
@@ -162,6 +162,7 @@ pub trait DatadogConfigWitness {
     fn consume_otlp_config_metrics_enabled(&mut self, value: bool);
     fn consume_otlp_config_metrics_histograms_mode(&mut self, value: String);
     fn consume_otlp_config_metrics_resource_attributes_as_tags(&mut self, value: bool);
+    fn consume_otlp_config_metrics_sums_cumulative_monotonic_mode(&mut self, value: String);
     fn consume_otlp_config_metrics_tags(&mut self, value: String);
     fn consume_otlp_config_receiver_protocols_grpc_endpoint(&mut self, value: String);
     fn consume_otlp_config_receiver_protocols_grpc_max_recv_msg_size_mib(&mut self, value: i64);
@@ -419,6 +420,9 @@ pub fn drive(config: &DatadogConfiguration, consumer: &mut impl DatadogConfigWit
     consumer.consume_otlp_config_metrics_histograms_mode(config.otlp_config.metrics.histograms.mode.clone());
     consumer.consume_otlp_config_metrics_resource_attributes_as_tags(
         config.otlp_config.metrics.resource_attributes_as_tags.clone(),
+    );
+    consumer.consume_otlp_config_metrics_sums_cumulative_monotonic_mode(
+        config.otlp_config.metrics.sums.cumulative_monotonic_mode.clone(),
     );
     consumer.consume_otlp_config_metrics_tags(config.otlp_config.metrics.tags.clone());
     consumer.consume_otlp_config_receiver_protocols_grpc_endpoint(

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -180,6 +180,20 @@ pub struct HistogramsConfig {
     pub mode: HistogramMode,
 }
 
+/// Controls how cumulative monotonic sums are emitted.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq)]
+#[cfg_attr(test, derive(serde::Serialize))]
+pub enum CumulativeMonotonicMode {
+    /// Converts cumulative values to deltas and emits them as counts.
+    #[default]
+    #[serde(rename = "to_delta")]
+    ToDelta,
+
+    /// Emits cumulative values as gauges without converting them to deltas.
+    #[serde(rename = "raw_value")]
+    RawValue,
+}
+
 /// Configuration for OTLP metrics processing.
 #[derive(Deserialize, Debug)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
@@ -211,6 +225,26 @@ pub struct MetricsConfig {
     /// Defaults to empty.
     #[serde(default)]
     pub tags: String,
+
+    /// Configuration for OTLP sums.
+    #[serde(default)]
+    pub sums: SumsConfig,
+}
+
+/// Configuration for OTLP sums.
+#[derive(Deserialize, Debug, Default)]
+#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
+pub struct SumsConfig {
+    /// Controls how cumulative monotonic sums are emitted.
+    ///
+    /// The default `to_delta` converts each cumulative value to a delta and emits it as a count. Set this to
+    /// `raw_value` to emit the cumulative value as a gauge instead. This affects only cumulative monotonic sums;
+    /// delta sums and non-monotonic sums retain their existing behavior. Use `raw_value` when the receiver of the
+    /// translated metrics needs the original cumulative value.
+    ///
+    /// Corresponds to `otlp_config.metrics.sums.cumulative_monotonic_mode`.
+    #[serde(default, rename = "cumulative_monotonic_mode")]
+    pub mode: CumulativeMonotonicMode,
 }
 
 fn default_metrics_enabled() -> bool {
@@ -224,6 +258,7 @@ impl Default for MetricsConfig {
             histograms: HistogramsConfig::default(),
             resource_attributes_as_tags: false,
             tags: String::new(),
+            sums: SumsConfig::default(),
         }
     }
 }

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -263,6 +263,18 @@ impl Default for MetricsConfig {
     }
 }
 
+impl MetricsConfig {
+    /// Applies environment-variable overrides for sum settings that normal nested deserialization cannot read.
+    pub(crate) fn apply_env_overrides(&mut self, config: &GenericConfiguration) -> Result<(), GenericError> {
+        if let Some(mode) =
+            config.try_get_typed::<CumulativeMonotonicMode>("otlp_config_metrics_sums_cumulative_monotonic_mode")?
+        {
+            self.sums.mode = mode;
+        }
+        Ok(())
+    }
+}
+
 /// Configuration for OTLP traces processing.
 ///
 /// Mirrors the Agent's `otlp_config.traces` configuration.

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -1,10 +1,10 @@
 //! Shared OTLP receiver configuration.
 
-use agent_data_plane_config::domains::otlp::HistogramMode;
+use agent_data_plane_config::domains::otlp::{CumulativeMonotonicMode, HistogramMode};
 use bytesize::ByteSize;
 use facet::Facet;
 use saluki_config::GenericConfiguration;
-use saluki_error::GenericError;
+use saluki_error::{generic_error, GenericError};
 use serde::{de::Error as _, Deserialize, Deserializer};
 
 fn default_grpc_endpoint() -> String {
@@ -180,18 +180,12 @@ pub struct HistogramsConfig {
     pub mode: HistogramMode,
 }
 
-/// Controls how cumulative monotonic sums are emitted.
-#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq)]
-#[cfg_attr(test, derive(serde::Serialize))]
-pub enum CumulativeMonotonicMode {
-    /// Converts cumulative values to deltas and emits them as counts.
-    #[default]
-    #[serde(rename = "to_delta")]
-    ToDelta,
-
-    /// Emits cumulative values as gauges without converting them to deltas.
-    #[serde(rename = "raw_value")]
-    RawValue,
+// TODO: delete when this component uses typed config
+fn deserialize_cumulative_monotonic_mode<'de, D>(deserializer: D) -> Result<CumulativeMonotonicMode, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer)?.parse().map_err(D::Error::custom)
 }
 
 /// Configuration for OTLP metrics processing.
@@ -243,8 +237,8 @@ pub struct SumsConfig {
     /// translated metrics needs the original cumulative value.
     ///
     /// Corresponds to `otlp_config.metrics.sums.cumulative_monotonic_mode`.
-    #[serde(default, rename = "cumulative_monotonic_mode")]
-    pub mode: CumulativeMonotonicMode,
+    #[serde(default, deserialize_with = "deserialize_cumulative_monotonic_mode")]
+    pub cumulative_monotonic_mode: CumulativeMonotonicMode,
 }
 
 fn default_metrics_enabled() -> bool {
@@ -266,10 +260,12 @@ impl Default for MetricsConfig {
 impl MetricsConfig {
     /// Applies environment-variable overrides for sum settings that normal nested deserialization cannot read.
     pub(crate) fn apply_env_overrides(&mut self, config: &GenericConfiguration) -> Result<(), GenericError> {
-        if let Some(mode) =
-            config.try_get_typed::<CumulativeMonotonicMode>("otlp_config_metrics_sums_cumulative_monotonic_mode")?
-        {
-            self.sums.mode = mode;
+        if let Some(raw_mode) = config.try_get_typed::<String>("otlp_config_metrics_sums_cumulative_monotonic_mode")? {
+            self.sums.cumulative_monotonic_mode = raw_mode.parse().map_err(|error| {
+                generic_error!(
+                    "invalid `otlp_config.metrics.sums.cumulative_monotonic_mode` environment override: {error}"
+                )
+            })?;
         }
         Ok(())
     }

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -1,9 +1,7 @@
 use std::time::Duration;
 
-use agent_data_plane_config::domains::otlp::HistogramMode;
+use agent_data_plane_config::domains::otlp::{CumulativeMonotonicMode, HistogramMode};
 use saluki_error::{generic_error, GenericError};
-
-use crate::common::otlp::config::CumulativeMonotonicMode;
 
 const DEFAULT_DELTA_TTL: Duration = Duration::from_secs(3600);
 const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(1800);

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -3,17 +3,27 @@ use std::time::Duration;
 use agent_data_plane_config::domains::otlp::HistogramMode;
 use saluki_error::{generic_error, GenericError};
 
+use crate::common::otlp::config::CumulativeMonotonicMode;
+
 const DEFAULT_DELTA_TTL: Duration = Duration::from_secs(3600);
 const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(1800);
 
 // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/config.go#L178-L190
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 #[allow(dead_code)]
-#[derive(Default)]
 pub enum NumberMode {
     #[default]
     CumulativeToDelta,
     RawValue,
+}
+
+impl From<CumulativeMonotonicMode> for NumberMode {
+    fn from(mode: CumulativeMonotonicMode) -> Self {
+        match mode {
+            CumulativeMonotonicMode::ToDelta => Self::CumulativeToDelta,
+            CumulativeMonotonicMode::RawValue => Self::RawValue,
+        }
+    }
 }
 
 // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/config.go#L209-L224

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -1773,6 +1773,43 @@ mod tests {
         assert_eq!(metric.context().host(), Some("resource-host"));
     }
 
+    #[test]
+    fn raw_value_mode_emits_cumulative_monotonic_sums_as_gauges() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        translator.config.number_mode = NumberMode::RawValue;
+
+        let events = translator.map_to_dd_format(
+            OtlpMetric {
+                name: "cumulative.sum".to_string(),
+                data: Some(OtlpMetricData::Sum(
+                    otlp_protos::opentelemetry::proto::metrics::v1::Sum {
+                        aggregation_temporality: AggregationTemporality::Cumulative as i32,
+                        is_monotonic: true,
+                        data_points: vec![OtlpNumberDataPoint {
+                            value: Some(OtlpNumberDataPointValue::AsInt(42)),
+                            start_time_unix_nano: nanos_from_seconds(1),
+                            time_unix_nano: nanos_from_seconds(2),
+                            ..Default::default()
+                        }],
+                        ..Default::default()
+                    },
+                )),
+                ..Default::default()
+            },
+            &SharedTagSet::default(),
+            None,
+            &[],
+            &metrics,
+        );
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].try_as_metric().expect("metric event").values(),
+            &MetricValues::gauge((2, 42.0))
+        );
+    }
+
     fn string_attribute(key: &str, value: &str) -> OtlpKeyValue {
         OtlpKeyValue {
             key: key.to_string(),

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -1792,7 +1792,6 @@ mod tests {
                             time_unix_nano: nanos_from_seconds(2),
                             ..Default::default()
                         }],
-                        ..Default::default()
                     },
                 )),
                 ..Default::default()

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -148,6 +148,7 @@ impl OtlpConfiguration {
     /// Creates a new `OTLPConfiguration` from the given configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         let mut cfg: Self = config.as_typed()?;
+        cfg.otlp_config.metrics.apply_env_overrides(config)?;
         cfg.otlp_config.traces.apply_env_overrides(config)?;
         Ok(cfg)
     }
@@ -640,6 +641,27 @@ mod tests {
             OtlpConfiguration::from_configuration(&generic_config).expect("OTLP configuration should deserialize");
 
         assert_eq!(config.metrics_translator_config().number_mode, NumberMode::RawValue);
+    }
+
+    #[tokio::test]
+    async fn cumulative_monotonic_mode_environment_variable_configures_metrics_translator() {
+        let env_vars = [(
+            "OTLP_CONFIG_METRICS_SUMS_CUMULATIVE_MONOTONIC_MODE".to_string(),
+            "raw_value".to_string(),
+        )];
+        let (generic_config, _) = ConfigurationLoader::for_tests_with_provider_factory(
+            Some(json!({ "otlp_config": {} })),
+            Some(&env_vars),
+            false,
+            KEY_ALIASES,
+            DatadogRemapper::new,
+        )
+        .await;
+        let config =
+            OtlpConfiguration::from_configuration(&generic_config).expect("OTLP configuration should deserialize");
+        let translator_config = config.metrics_translator_config();
+
+        assert_eq!(translator_config.number_mode, NumberMode::RawValue);
     }
 
     #[test]

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -158,7 +158,7 @@ impl OtlpConfiguration {
             .with_remapping(true)
             .with_quantiles(true)
             .with_histogram_mode(self.otlp_config.metrics.histograms.mode)
-            .with_number_mode(self.otlp_config.metrics.sums.mode.into())
+            .with_number_mode(self.otlp_config.metrics.sums.cumulative_monotonic_mode.into())
             .with_resource_attributes_as_tags(self.otlp_config.metrics.resource_attributes_as_tags)
     }
 

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -157,6 +157,7 @@ impl OtlpConfiguration {
             .with_remapping(true)
             .with_quantiles(true)
             .with_histogram_mode(self.otlp_config.metrics.histograms.mode)
+            .with_number_mode(self.otlp_config.metrics.sums.mode.into())
             .with_resource_attributes_as_tags(self.otlp_config.metrics.resource_attributes_as_tags)
     }
 
@@ -571,10 +572,11 @@ mod config_smoke {
 #[cfg(test)]
 mod tests {
     use agent_data_plane_config::domains::otlp::HistogramMode;
-    use saluki_config::config_from;
+    use saluki_config::{config_from, ConfigurationLoader};
     use serde_json::json;
 
-    use super::{parse_configured_metric_tags, OtlpConfiguration};
+    use super::{metrics::config::NumberMode, parse_configured_metric_tags, OtlpConfiguration};
+    use crate::config::{DatadogRemapper, KEY_ALIASES};
 
     fn tags(raw: &str) -> Vec<String> {
         parse_configured_metric_tags(raw)
@@ -606,6 +608,38 @@ mod tests {
 
             assert_eq!(otlp_config.metrics_translator_config().hist_mode, expected_mode);
         }
+    }
+
+    #[test]
+    fn cumulative_monotonic_sum_mode_defaults_to_delta_conversion() {
+        assert_eq!(
+            OtlpConfiguration::default().metrics_translator_config().number_mode,
+            NumberMode::CumulativeToDelta
+        );
+    }
+
+    #[tokio::test]
+    async fn cumulative_monotonic_sum_mode_configures_metrics_translator() {
+        let (generic_config, _) = ConfigurationLoader::for_tests_with_provider_factory(
+            Some(json!({
+                "otlp_config": {
+                    "metrics": {
+                        "sums": {
+                            "cumulative_monotonic_mode": "raw_value"
+                        }
+                    }
+                }
+            })),
+            None,
+            false,
+            KEY_ALIASES,
+            DatadogRemapper::new,
+        )
+        .await;
+        let config =
+            OtlpConfiguration::from_configuration(&generic_config).expect("OTLP configuration should deserialize");
+
+        assert_eq!(config.metrics_translator_config().number_mode, NumberMode::RawValue);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Wires up `cumulative_monotonic_mode` config key for OTLP sum metric, allowing for operators to configure whether they would prefer a `raw_value` or `to_delta` report per metric emission. 

Example: 
Time: `1` | Reported Value: `100`
Time: `2` | Reported Value: `125`

`to_delta` emits `25`
`raw_value` emits `125`

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

Unit tests. 

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

- Closes: https://github.com/DataDog/saluki/issues/2023

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
