### PR TITLE
feat(otlp): support initial_cumulative_monotonic_value and cumulative_montonic_mode

### DIFF
--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -704,6 +704,7 @@ compressed wire payload bytes.
 | `otlp_config.metrics.enabled`                                  | otlp_config.metrics.enabled                        |
 | `otlp_config.metrics.resource_attributes_as_tags`              | Add scalar resource attributes as raw tags.        |
 | `otlp_config.metrics.sums.cumulative_monotonic_mode`           | Cumulative monotonic sum reporting mode.           |
+| `otlp_config.metrics.sums.initial_cumulative_monotonic_value`  | Initial cumulative sum reporting behavior.         |
 | `otlp_config.metrics.tags`                                     | Comma-separated tags for all OTLP metrics.         |
 | `otlp_config.receiver.protocols.grpc.endpoint`                 | otlp_config.receiver.protocols.grpc.endpoint       |
 | `otlp_config.receiver.protocols.grpc.max_recv_msg_size_mib`    | Max OTLP inbound gRPC message size (MiB)           |

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -703,6 +703,7 @@ compressed wire payload bytes.
 | `otlp_config.logs.enabled`                                     | otlp_config.logs.enabled                           |
 | `otlp_config.metrics.enabled`                                  | otlp_config.metrics.enabled                        |
 | `otlp_config.metrics.resource_attributes_as_tags`              | Add scalar resource attributes as raw tags.        |
+| `otlp_config.metrics.sums.cumulative_monotonic_mode`           | Cumulative monotonic sum reporting mode.           |
 | `otlp_config.metrics.tags`                                     | Comma-separated tags for all OTLP metrics.         |
 | `otlp_config.receiver.protocols.grpc.endpoint`                 | otlp_config.receiver.protocols.grpc.endpoint       |
 | `otlp_config.receiver.protocols.grpc.max_recv_msg_size_mib`    | Max OTLP inbound gRPC message size (MiB)           |

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -23,7 +23,7 @@ use agent_data_plane_config::control::ListenAddress;
 use agent_data_plane_config::domains::dogstatsd::{
     FilterAction, MapperProfile, MetricMapping, MetricTagFilterEntry, OriginTagCardinality,
 };
-use agent_data_plane_config::domains::otlp::HistogramMode;
+use agent_data_plane_config::domains::otlp::{CumulativeMonotonicMode, HistogramMode, InitialCumulativeMonotonicValue};
 use agent_data_plane_config::shared::ForwarderHttpProtocol;
 use agent_data_plane_config::SalukiConfiguration;
 use bytesize::ByteSize;
@@ -888,11 +888,23 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_otlp_config_metrics_sums_cumulative_monotonic_mode(&mut self, value: String) {
-        self.config.domains.otlp.metrics.sums.cumulative_monotonic_mode = value;
+        match value.parse::<CumulativeMonotonicMode>() {
+            Ok(mode) => self.config.domains.otlp.metrics.sums.cumulative_monotonic_mode = mode,
+            Err(error) => self.record_error(TranslateError::new(
+                "otlp_config.metrics.sums.cumulative_monotonic_mode",
+                error,
+            )),
+        }
     }
 
     fn consume_otlp_config_metrics_sums_initial_cumulative_monotonic_value(&mut self, value: String) {
-        self.config.domains.otlp.metrics.sums.initial_cumulative_monotonic_value = value;
+        match value.parse::<InitialCumulativeMonotonicValue>() {
+            Ok(mode) => self.config.domains.otlp.metrics.sums.initial_cumulative_monotonic_value = mode,
+            Err(error) => self.record_error(TranslateError::new(
+                "otlp_config.metrics.sums.initial_cumulative_monotonic_value",
+                error,
+            )),
+        }
     }
 
     fn consume_otlp_config_metrics_tags(&mut self, value: String) {
@@ -1111,7 +1123,10 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
 mod tests {
     use std::time::Duration;
 
-    use agent_data_plane_config::domains::dogstatsd::OriginTagCardinality;
+    use agent_data_plane_config::domains::{
+        dogstatsd::OriginTagCardinality,
+        otlp::{CumulativeMonotonicMode, InitialCumulativeMonotonicValue},
+    };
     use datadog_agent_config::DatadogConfiguration;
     use serde_json::json;
 
@@ -1261,5 +1276,111 @@ mod tests {
 
         // The error is still surfaced, so startup's strict gate rejects the config.
         assert!(errors.is_some(), "an unknown action must record a translation error");
+    }
+
+    #[test]
+    fn cumulative_monotonic_sum_mode_translates_known_values() {
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "otlp_config": {
+                "metrics": {
+                    "sums": {
+                        "cumulative_monotonic_mode": "raw_value"
+                    }
+                }
+            }
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, errors) = DatadogTranslator::new(&datadog).translate();
+
+        assert!(errors.is_none());
+        assert_eq!(
+            config.domains.otlp.metrics.sums.cumulative_monotonic_mode,
+            CumulativeMonotonicMode::RawValue
+        );
+    }
+
+    #[test]
+    fn invalid_cumulative_monotonic_sum_mode_records_error_and_keeps_default() {
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "otlp_config": {
+                "metrics": {
+                    "sums": {
+                        "cumulative_monotonic_mode": "unsupported"
+                    }
+                }
+            }
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, errors) = DatadogTranslator::new(&datadog).translate();
+
+        assert_eq!(
+            config.domains.otlp.metrics.sums.cumulative_monotonic_mode,
+            CumulativeMonotonicMode::ToDelta
+        );
+        let errors = errors.expect("invalid mode should record a translation error");
+        assert!(errors
+            .to_string()
+            .contains("otlp_config.metrics.sums.cumulative_monotonic_mode"));
+        assert!(errors
+            .to_string()
+            .contains("unknown cumulative monotonic sum mode `unsupported`"));
+    }
+
+    #[test]
+    fn initial_cumulative_monotonic_value_translates_known_values() {
+        for (value, expected) in [
+            ("auto", InitialCumulativeMonotonicValue::Auto),
+            ("drop", InitialCumulativeMonotonicValue::Drop),
+            ("keep", InitialCumulativeMonotonicValue::Keep),
+        ] {
+            let datadog: DatadogConfiguration = serde_json::from_value(json!({
+                "otlp_config": {
+                    "metrics": {
+                        "sums": {
+                            "initial_cumulative_monotonic_value": value
+                        }
+                    }
+                }
+            }))
+            .expect("datadog source deserializes");
+
+            let (config, errors) = DatadogTranslator::new(&datadog).translate();
+
+            assert!(errors.is_none());
+            assert_eq!(
+                config.domains.otlp.metrics.sums.initial_cumulative_monotonic_value,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_initial_cumulative_monotonic_value_records_error_and_keeps_default() {
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "otlp_config": {
+                "metrics": {
+                    "sums": {
+                        "initial_cumulative_monotonic_value": "unsupported"
+                    }
+                }
+            }
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, errors) = DatadogTranslator::new(&datadog).translate();
+
+        assert_eq!(
+            config.domains.otlp.metrics.sums.initial_cumulative_monotonic_value,
+            InitialCumulativeMonotonicValue::Auto
+        );
+        let errors = errors.expect("invalid value should record a translation error");
+        assert!(errors
+            .to_string()
+            .contains("otlp_config.metrics.sums.initial_cumulative_monotonic_value"));
+        assert!(errors
+            .to_string()
+            .contains("unknown initial cumulative monotonic value `unsupported`"));
     }
 }

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -888,7 +888,7 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_otlp_config_metrics_sums_cumulative_monotonic_mode(&mut self, value: String) {
-        self.config.domains.otlp.metrics.cumulative_monotonic_mode = value;
+        self.config.domains.otlp.metrics.sums.cumulative_monotonic_mode = value;
     }
 
     fn consume_otlp_config_metrics_tags(&mut self, value: String) {

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -887,6 +887,10 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
         self.config.domains.otlp.metrics.resource_attributes_as_tags = value;
     }
 
+    fn consume_otlp_config_metrics_sums_cumulative_monotonic_mode(&mut self, value: String) {
+        self.config.domains.otlp.metrics.cumulative_monotonic_mode = value;
+    }
+
     fn consume_otlp_config_metrics_tags(&mut self, value: String) {
         self.config.domains.otlp.metrics.tags = value;
     }

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -891,6 +891,10 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
         self.config.domains.otlp.metrics.sums.cumulative_monotonic_mode = value;
     }
 
+    fn consume_otlp_config_metrics_sums_initial_cumulative_monotonic_value(&mut self, value: String) {
+        self.config.domains.otlp.metrics.sums.initial_cumulative_monotonic_value = value;
+    }
+
     fn consume_otlp_config_metrics_tags(&mut self, value: String) {
         self.config.domains.otlp.metrics.tags = value;
     }

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -77,12 +77,19 @@ pub struct Sums {
     /// Defaults to `to_delta`, which converts cumulative values to delta counts. Set to `raw_value` to emit
     /// cumulative values as gauges.
     pub cumulative_monotonic_mode: String,
+
+    /// Initial cumulative monotonic sum reporting behavior.
+    ///
+    /// Defaults to `auto`, which reports the value only when its series started after the translator process.
+    /// Set this to `drop` to always discard the first value or `keep` to always report it.
+    pub initial_cumulative_monotonic_value: String,
 }
 
 impl Default for Sums {
     fn default() -> Self {
         Self {
             cumulative_monotonic_mode: "to_delta".to_string(),
+            initial_cumulative_monotonic_value: "auto".to_string(),
         }
     }
 }

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -1,12 +1,11 @@
 //! OTLP domain: the OTLP receiver (gRPC/HTTP transports, logs/metrics activation), the OTLP proxy
 //! gating, and OTLP context sizing. OTLP trace handling lives in the `traces` domain.
 
-use std::{
-    io::{Error, ErrorKind},
-    str::FromStr,
-};
+use std::str::FromStr;
 
 use serde::Serialize;
+
+use crate::Error;
 
 /// Resolved OTLP configuration.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
@@ -63,10 +62,9 @@ impl FromStr for HistogramMode {
             "nobuckets" => Ok(Self::NoBuckets),
             "counters" => Ok(Self::Counters),
             "distributions" => Ok(Self::Distributions),
-            other => Err(Error::new(
-                ErrorKind::InvalidInput,
-                format!("unknown histogram mode `{other}`; expected `nobuckets`, `counters`, or `distributions`"),
-            )),
+            other => Err(Error::new_without_source(format!(
+                "unknown histogram mode `{other}`; expected `nobuckets`, `counters`, or `distributions`"
+            ))),
         }
     }
 }
@@ -89,10 +87,9 @@ impl FromStr for CumulativeMonotonicMode {
         match value {
             "to_delta" => Ok(Self::ToDelta),
             "raw_value" => Ok(Self::RawValue),
-            other => Err(Error::new(
-                ErrorKind::InvalidInput,
-                format!("unknown cumulative monotonic sum mode `{other}`; expected `to_delta` or `raw_value`"),
-            )),
+            other => Err(Error::new_without_source(format!(
+                "unknown cumulative monotonic sum mode `{other}`; expected `to_delta` or `raw_value`"
+            ))),
         }
     }
 }
@@ -119,10 +116,9 @@ impl FromStr for InitialCumulativeMonotonicValue {
             "auto" => Ok(Self::Auto),
             "drop" => Ok(Self::Drop),
             "keep" => Ok(Self::Keep),
-            other => Err(Error::new(
-                ErrorKind::InvalidInput,
-                format!("unknown initial cumulative monotonic value `{other}`; expected `auto`, `drop`, or `keep`"),
-            )),
+            other => Err(Error::new_without_source(format!(
+                "unknown initial cumulative monotonic value `{other}`; expected `auto`, `drop`, or `keep`"
+            ))),
         }
     }
 }

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -24,7 +24,7 @@ pub struct Domain {
 }
 
 /// OTLP metrics translation settings.
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct Metrics {
     /// How explicit histogram buckets are reported.
     pub histogram_mode: HistogramMode,
@@ -33,11 +33,8 @@ pub struct Metrics {
     /// semantic-convention mappings that are always applied.
     pub resource_attributes_as_tags: bool,
 
-    /// Cumulative monotonic sum reporting mode.
-    ///
-    /// Defaults to `to_delta`, which converts cumulative values to delta counts. Set to `raw_value` to emit
-    /// cumulative values as gauges.
-    pub cumulative_monotonic_mode: String,
+    /// OTLP sum translation settings.
+    pub sums: Sums,
 
     /// Comma-separated list of tags to add to every emitted metric.
     pub tags: String,
@@ -72,13 +69,20 @@ impl FromStr for HistogramMode {
     }
 }
 
-impl Default for Metrics {
+/// OTLP sum translation settings.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct Sums {
+    /// Cumulative monotonic sum reporting mode.
+    ///
+    /// Defaults to `to_delta`, which converts cumulative values to delta counts. Set to `raw_value` to emit
+    /// cumulative values as gauges.
+    pub cumulative_monotonic_mode: String,
+}
+
+impl Default for Sums {
     fn default() -> Self {
         Self {
-            histogram_mode: HistogramMode::default(),
-            resource_attributes_as_tags: false,
             cumulative_monotonic_mode: "to_delta".to_string(),
-            tags: String::new(),
         }
     }
 }

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -24,7 +24,7 @@ pub struct Domain {
 }
 
 /// OTLP metrics translation settings.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Metrics {
     /// How explicit histogram buckets are reported.
     pub histogram_mode: HistogramMode,
@@ -32,6 +32,12 @@ pub struct Metrics {
     /// Whether every resource attribute is added as a raw metric tag, in addition to the
     /// semantic-convention mappings that are always applied.
     pub resource_attributes_as_tags: bool,
+
+    /// Cumulative monotonic sum reporting mode.
+    ///
+    /// Defaults to `to_delta`, which converts cumulative values to delta counts. Set to `raw_value` to emit
+    /// cumulative values as gauges.
+    pub cumulative_monotonic_mode: String,
 
     /// Comma-separated list of tags to add to every emitted metric.
     pub tags: String,
@@ -62,6 +68,17 @@ impl FromStr for HistogramMode {
             other => Err(Error::new_without_source(format!(
                 "unknown histogram mode `{other}`; expected `nobuckets`, `counters`, or `distributions`"
             ))),
+        }
+    }
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        Self {
+            histogram_mode: HistogramMode::default(),
+            resource_attributes_as_tags: false,
+            cumulative_monotonic_mode: "to_delta".to_string(),
+            tags: String::new(),
         }
     }
 }

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -1,11 +1,12 @@
 //! OTLP domain: the OTLP receiver (gRPC/HTTP transports, logs/metrics activation), the OTLP proxy
 //! gating, and OTLP context sizing. OTLP trace handling lives in the `traces` domain.
 
-use std::str::FromStr;
+use std::{
+    io::{Error, ErrorKind},
+    str::FromStr,
+};
 
 use serde::Serialize;
-
-use crate::Error;
 
 /// Resolved OTLP configuration.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
@@ -62,36 +63,84 @@ impl FromStr for HistogramMode {
             "nobuckets" => Ok(Self::NoBuckets),
             "counters" => Ok(Self::Counters),
             "distributions" => Ok(Self::Distributions),
-            other => Err(Error::new_without_source(format!(
-                "unknown histogram mode `{other}`; expected `nobuckets`, `counters`, or `distributions`"
-            ))),
+            other => Err(Error::new(
+                ErrorKind::InvalidInput,
+                format!("unknown histogram mode `{other}`; expected `nobuckets`, `counters`, or `distributions`"),
+            )),
+        }
+    }
+}
+
+/// How cumulative monotonic sums are reported.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub enum CumulativeMonotonicMode {
+    /// Converts cumulative values to deltas and reports them as counts.
+    #[default]
+    ToDelta,
+
+    /// Reports cumulative values as gauges without converting them to deltas.
+    RawValue,
+}
+
+impl FromStr for CumulativeMonotonicMode {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "to_delta" => Ok(Self::ToDelta),
+            "raw_value" => Ok(Self::RawValue),
+            other => Err(Error::new(
+                ErrorKind::InvalidInput,
+                format!("unknown cumulative monotonic sum mode `{other}`; expected `to_delta` or `raw_value`"),
+            )),
+        }
+    }
+}
+
+/// Controls how the first value of a cumulative monotonic sum is reported.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub enum InitialCumulativeMonotonicValue {
+    /// Reports the first value when its series started after the translator process.
+    #[default]
+    Auto,
+
+    /// Always drops the first value.
+    Drop,
+
+    /// Always reports the first value.
+    Keep,
+}
+
+impl FromStr for InitialCumulativeMonotonicValue {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "auto" => Ok(Self::Auto),
+            "drop" => Ok(Self::Drop),
+            "keep" => Ok(Self::Keep),
+            other => Err(Error::new(
+                ErrorKind::InvalidInput,
+                format!("unknown initial cumulative monotonic value `{other}`; expected `auto`, `drop`, or `keep`"),
+            )),
         }
     }
 }
 
 /// OTLP sum translation settings.
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct Sums {
     /// Cumulative monotonic sum reporting mode.
     ///
     /// Defaults to `to_delta`, which converts cumulative values to delta counts. Set to `raw_value` to emit
     /// cumulative values as gauges.
-    pub cumulative_monotonic_mode: String,
+    pub cumulative_monotonic_mode: CumulativeMonotonicMode,
 
     /// Initial cumulative monotonic sum reporting behavior.
     ///
     /// Defaults to `auto`, which reports the value only when its series started after the translator process.
     /// Set this to `drop` to always discard the first value or `keep` to always report it.
-    pub initial_cumulative_monotonic_value: String,
-}
-
-impl Default for Sums {
-    fn default() -> Self {
-        Self {
-            cumulative_monotonic_mode: "to_delta".to_string(),
-            initial_cumulative_monotonic_value: "auto".to_string(),
-        }
-    }
+    pub initial_cumulative_monotonic_value: InitialCumulativeMonotonicValue,
 }
 
 /// OTLP receiver transports and per-signal activation.
@@ -168,4 +217,65 @@ pub struct Contexts {
 
     /// Number of entries the context string interner holds. (not in Datadog Agent config schema)
     pub string_interner_size: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CumulativeMonotonicMode, InitialCumulativeMonotonicValue};
+
+    #[test]
+    fn cumulative_monotonic_mode_parses_known_values() {
+        assert_eq!(
+            "to_delta"
+                .parse::<CumulativeMonotonicMode>()
+                .expect("to_delta should parse"),
+            CumulativeMonotonicMode::ToDelta
+        );
+        assert_eq!(
+            "raw_value"
+                .parse::<CumulativeMonotonicMode>()
+                .expect("raw_value should parse"),
+            CumulativeMonotonicMode::RawValue
+        );
+    }
+
+    #[test]
+    fn cumulative_monotonic_mode_rejects_unknown_values() {
+        let error = "unsupported"
+            .parse::<CumulativeMonotonicMode>()
+            .expect_err("unsupported mode should be rejected");
+
+        assert_eq!(
+            error.to_string(),
+            "unknown cumulative monotonic sum mode `unsupported`; expected `to_delta` or `raw_value`"
+        );
+    }
+
+    #[test]
+    fn initial_cumulative_monotonic_value_parses_known_values() {
+        for (value, expected) in [
+            ("auto", InitialCumulativeMonotonicValue::Auto),
+            ("drop", InitialCumulativeMonotonicValue::Drop),
+            ("keep", InitialCumulativeMonotonicValue::Keep),
+        ] {
+            assert_eq!(
+                value
+                    .parse::<InitialCumulativeMonotonicValue>()
+                    .expect("known value should parse"),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn initial_cumulative_monotonic_value_rejects_unknown_values() {
+        let error = "unsupported"
+            .parse::<InitialCumulativeMonotonicValue>()
+            .expect_err("unsupported value should be rejected");
+
+        assert_eq!(
+            error.to_string(),
+            "unknown initial cumulative monotonic value `unsupported`; expected `auto`, `drop`, or `keep`"
+        );
+    }
 }

--- a/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
@@ -289,6 +289,17 @@ crate::declare_annotations! {
         test_json: Some(r#""raw_value""#),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
     };
+    /// `otlp_config.metrics.sums.initial_cumulative_monotonic_value`-Initial cumulative sum reporting behavior.
+    OTLP_CONFIG_METRICS_SUMS_INITIAL_CUMULATIVE_MONOTONIC_VALUE = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_METRICS_SUMS_INITIAL_CUMULATIVE_MONOTONIC_VALUE,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::OTLP_CONFIGURATION],
+        value_type_override: None,
+        test_json: Some(r#""drop""#),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
     /// `otlp_config.metrics.tags`-Comma-separated tags for all OTLP metrics.
     OTLP_CONFIG_METRICS_TAGS = SalukiAnnotation {
         schema: &schema::OTLP_CONFIG_METRICS_TAGS,

--- a/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
@@ -278,6 +278,17 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
     };
+    /// `otlp_config.metrics.sums.cumulative_monotonic_mode`-Cumulative monotonic sum reporting mode.
+    OTLP_CONFIG_METRICS_SUMS_CUMULATIVE_MONOTONIC_MODE = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_METRICS_SUMS_CUMULATIVE_MONOTONIC_MODE,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::OTLP_CONFIGURATION],
+        value_type_override: None,
+        test_json: Some(r#""raw_value""#),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
     /// `otlp_config.metrics.tags`-Comma-separated tags for all OTLP metrics.
     OTLP_CONFIG_METRICS_TAGS = SalukiAnnotation {
         schema: &schema::OTLP_CONFIG_METRICS_TAGS,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -2038,6 +2038,20 @@ inventory:
       additional_attributes:
         config_registry_filename: otlp.rs
 
+  otlp_config.metrics.sums.initial_cumulative_monotonic_value:
+    support: full
+    pipelines: [otlp]
+    description: "Initial cumulative sum reporting behavior."
+    documentation: |-
+      Controls how the first cumulative monotonic sum value is reported. The default `auto` reports the value only
+      when the series started after the Agent Data Plane process. Set this to `drop` to always discard the first value
+      or `keep` to always report it.
+    test_support:
+      used_by: [OtlpConfiguration]
+      test_json: '"drop"'
+      additional_attributes:
+        config_registry_filename: otlp.rs
+
   otlp_config.metrics.tags:
     support: full
     pipelines: [otlp]
@@ -3927,7 +3941,6 @@ excluded:
   otlp_config.metrics.histograms.send_count_sum_metrics: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.instrumentation_scope_metadata_as_tags: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.summaries.mode: "ignored in initial audit 2026-04-23"
-  otlp_config.metrics.sums.initial_cumulative_monotonic_value: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.tag_cardinality: "ignored in initial audit 2026-04-23"
   otlp_config.receiver.protocols.grpc.include_metadata: "ignored in initial audit 2026-04-23"
   otlp_config.receiver.protocols.grpc.keepalive.enforcement_policy.min_time: "ignored in initial audit 2026-04-23"

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -2025,6 +2025,19 @@ inventory:
       additional_attributes:
         config_registry_filename: otlp.rs
 
+  otlp_config.metrics.sums.cumulative_monotonic_mode:
+    support: full
+    pipelines: [otlp]
+    description: "Cumulative monotonic sum reporting mode."
+    documentation: |-
+      Controls how cumulative monotonic sums are reported. The default `to_delta` converts cumulative values to
+      deltas and reports them as counts. Set this to `raw_value` to report cumulative values as gauges.
+    test_support:
+      used_by: [OtlpConfiguration]
+      test_json: '"raw_value"'
+      additional_attributes:
+        config_registry_filename: otlp.rs
+
   otlp_config.metrics.tags:
     support: full
     pipelines: [otlp]
@@ -3914,7 +3927,6 @@ excluded:
   otlp_config.metrics.histograms.send_count_sum_metrics: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.instrumentation_scope_metadata_as_tags: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.summaries.mode: "ignored in initial audit 2026-04-23"
-  otlp_config.metrics.sums.cumulative_monotonic_mode: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.sums.initial_cumulative_monotonic_value: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.tag_cardinality: "ignored in initial audit 2026-04-23"
   otlp_config.receiver.protocols.grpc.include_metadata: "ignored in initial audit 2026-04-23"

--- a/lib/datadog-agent/config/src/generated/datadog_configuration.rs
+++ b/lib/datadog-agent/config/src/generated/datadog_configuration.rs
@@ -1283,6 +1283,9 @@ pub struct OtlpConfigMetrics {
     pub resource_attributes_as_tags: bool,
 
     #[serde(default)]
+    pub sums: OtlpConfigMetricsSums,
+
+    #[serde(default)]
     pub tags: String,
 }
 
@@ -1292,6 +1295,7 @@ impl Default for OtlpConfigMetrics {
             enabled: defaults::default_bool::<true>(),
             histograms: Default::default(),
             resource_attributes_as_tags: Default::default(),
+            sums: Default::default(),
             tags: Default::default(),
         }
     }
@@ -1309,6 +1313,22 @@ impl Default for OtlpConfigMetricsHistograms {
     fn default() -> Self {
         Self {
             mode: defaults::datadog_configuration_otlp_config_metrics_histograms_mode(),
+        }
+    }
+}
+
+#[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+pub struct OtlpConfigMetricsSums {
+    #[serde(
+        default = "defaults::datadog_configuration_otlp_config_metrics_sums_cumulative_monotonic_mode"
+    )]
+    pub cumulative_monotonic_mode: String,
+}
+
+impl Default for OtlpConfigMetricsSums {
+    fn default() -> Self {
+        Self {
+            cumulative_monotonic_mode: defaults::datadog_configuration_otlp_config_metrics_sums_cumulative_monotonic_mode(),
         }
     }
 }
@@ -1759,6 +1779,9 @@ pub mod defaults {
     }
     pub(super) fn datadog_configuration_otlp_config_metrics_histograms_mode() -> String {
         "distributions".to_string()
+    }
+    pub(super) fn datadog_configuration_otlp_config_metrics_sums_cumulative_monotonic_mode() -> String {
+        "to_delta".to_string()
     }
     pub(super) fn datadog_configuration_otlp_config_receiver_protocols_grpc_endpoint() -> String {
         "localhost:4317".to_string()

--- a/lib/datadog-agent/config/src/generated/datadog_configuration.rs
+++ b/lib/datadog-agent/config/src/generated/datadog_configuration.rs
@@ -1323,12 +1323,18 @@ pub struct OtlpConfigMetricsSums {
         default = "defaults::datadog_configuration_otlp_config_metrics_sums_cumulative_monotonic_mode"
     )]
     pub cumulative_monotonic_mode: String,
+
+    #[serde(
+        default = "defaults::datadog_configuration_otlp_config_metrics_sums_initial_cumulative_monotonic_value"
+    )]
+    pub initial_cumulative_monotonic_value: String,
 }
 
 impl Default for OtlpConfigMetricsSums {
     fn default() -> Self {
         Self {
             cumulative_monotonic_mode: defaults::datadog_configuration_otlp_config_metrics_sums_cumulative_monotonic_mode(),
+            initial_cumulative_monotonic_value: defaults::datadog_configuration_otlp_config_metrics_sums_initial_cumulative_monotonic_value(),
         }
     }
 }
@@ -1782,6 +1788,9 @@ pub mod defaults {
     }
     pub(super) fn datadog_configuration_otlp_config_metrics_sums_cumulative_monotonic_mode() -> String {
         "to_delta".to_string()
+    }
+    pub(super) fn datadog_configuration_otlp_config_metrics_sums_initial_cumulative_monotonic_value() -> String {
+        "auto".to_string()
     }
     pub(super) fn datadog_configuration_otlp_config_receiver_protocols_grpc_endpoint() -> String {
         "localhost:4317".to_string()

--- a/lib/datadog-agent/config/src/generated/env_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_keys.rs
@@ -761,6 +761,11 @@ pub static DATADOG_ENV_KEYS: &[EnvKey] = &[
         decode: EnvDecode::Bool,
     },
     EnvKey {
+        env_vars: &["DD_OTLP_CONFIG_METRICS_SUMS_CUMULATIVE_MONOTONIC_MODE"],
+        path: &["otlp_config", "metrics", "sums", "cumulative_monotonic_mode"],
+        decode: EnvDecode::RawString,
+    },
+    EnvKey {
         env_vars: &["DD_OTLP_CONFIG_METRICS_TAGS"],
         path: &["otlp_config", "metrics", "tags"],
         decode: EnvDecode::RawString,

--- a/lib/datadog-agent/config/src/generated/env_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_keys.rs
@@ -766,6 +766,11 @@ pub static DATADOG_ENV_KEYS: &[EnvKey] = &[
         decode: EnvDecode::RawString,
     },
     EnvKey {
+        env_vars: &["DD_OTLP_CONFIG_METRICS_SUMS_INITIAL_CUMULATIVE_MONOTONIC_VALUE"],
+        path: &["otlp_config", "metrics", "sums", "initial_cumulative_monotonic_value"],
+        decode: EnvDecode::RawString,
+    },
+    EnvKey {
         env_vars: &["DD_OTLP_CONFIG_METRICS_TAGS"],
         path: &["otlp_config", "metrics", "tags"],
         decode: EnvDecode::RawString,

--- a/lib/datadog-agent/config/src/generated/env_overlay_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_overlay_keys.rs
@@ -287,6 +287,10 @@ pub static ENV_OVERLAY_KEYS: &[EnvOverlayKey] = &[
         path: &["otlp_config", "metrics", "resource_attributes_as_tags"],
     },
     EnvOverlayKey {
+        flats: &["otlp_config_metrics_sums_cumulative_monotonic_mode"],
+        path: &["otlp_config", "metrics", "sums", "cumulative_monotonic_mode"],
+    },
+    EnvOverlayKey {
         flats: &["otlp_config_metrics_tags"],
         path: &["otlp_config", "metrics", "tags"],
     },

--- a/lib/datadog-agent/config/src/generated/env_overlay_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_overlay_keys.rs
@@ -291,6 +291,10 @@ pub static ENV_OVERLAY_KEYS: &[EnvOverlayKey] = &[
         path: &["otlp_config", "metrics", "sums", "cumulative_monotonic_mode"],
     },
     EnvOverlayKey {
+        flats: &["otlp_config_metrics_sums_initial_cumulative_monotonic_value"],
+        path: &["otlp_config", "metrics", "sums", "initial_cumulative_monotonic_value"],
+    },
+    EnvOverlayKey {
         flats: &["otlp_config_metrics_tags"],
         path: &["otlp_config", "metrics", "tags"],
     },

--- a/lib/datadog-agent/config/src/generated/witness.rs
+++ b/lib/datadog-agent/config/src/generated/witness.rs
@@ -163,6 +163,7 @@ pub trait DatadogConfigWitness {
     fn consume_otlp_config_metrics_histograms_mode(&mut self, value: String);
     fn consume_otlp_config_metrics_resource_attributes_as_tags(&mut self, value: bool);
     fn consume_otlp_config_metrics_sums_cumulative_monotonic_mode(&mut self, value: String);
+    fn consume_otlp_config_metrics_sums_initial_cumulative_monotonic_value(&mut self, value: String);
     fn consume_otlp_config_metrics_tags(&mut self, value: String);
     fn consume_otlp_config_receiver_protocols_grpc_endpoint(&mut self, value: String);
     fn consume_otlp_config_receiver_protocols_grpc_max_recv_msg_size_mib(&mut self, value: i64);
@@ -423,6 +424,14 @@ pub fn drive(config: &DatadogConfiguration, consumer: &mut impl DatadogConfigWit
     );
     consumer.consume_otlp_config_metrics_sums_cumulative_monotonic_mode(
         config.otlp_config.metrics.sums.cumulative_monotonic_mode.clone(),
+    );
+    consumer.consume_otlp_config_metrics_sums_initial_cumulative_monotonic_value(
+        config
+            .otlp_config
+            .metrics
+            .sums
+            .initial_cumulative_monotonic_value
+            .clone(),
     );
     consumer.consume_otlp_config_metrics_tags(config.otlp_config.metrics.tags.clone());
     consumer.consume_otlp_config_receiver_protocols_grpc_endpoint(

--- a/lib/datadog-agent/config/src/generated/witness.rs
+++ b/lib/datadog-agent/config/src/generated/witness.rs
@@ -162,6 +162,7 @@ pub trait DatadogConfigWitness {
     fn consume_otlp_config_metrics_enabled(&mut self, value: bool);
     fn consume_otlp_config_metrics_histograms_mode(&mut self, value: String);
     fn consume_otlp_config_metrics_resource_attributes_as_tags(&mut self, value: bool);
+    fn consume_otlp_config_metrics_sums_cumulative_monotonic_mode(&mut self, value: String);
     fn consume_otlp_config_metrics_tags(&mut self, value: String);
     fn consume_otlp_config_receiver_protocols_grpc_endpoint(&mut self, value: String);
     fn consume_otlp_config_receiver_protocols_grpc_max_recv_msg_size_mib(&mut self, value: i64);
@@ -419,6 +420,9 @@ pub fn drive(config: &DatadogConfiguration, consumer: &mut impl DatadogConfigWit
     consumer.consume_otlp_config_metrics_histograms_mode(config.otlp_config.metrics.histograms.mode.clone());
     consumer.consume_otlp_config_metrics_resource_attributes_as_tags(
         config.otlp_config.metrics.resource_attributes_as_tags.clone(),
+    );
+    consumer.consume_otlp_config_metrics_sums_cumulative_monotonic_mode(
+        config.otlp_config.metrics.sums.cumulative_monotonic_mode.clone(),
     );
     consumer.consume_otlp_config_metrics_tags(config.otlp_config.metrics.tags.clone());
     consumer.consume_otlp_config_receiver_protocols_grpc_endpoint(

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -1,10 +1,10 @@
 //! Shared OTLP receiver configuration.
 
-use agent_data_plane_config::domains::otlp::HistogramMode;
+use agent_data_plane_config::domains::otlp::{CumulativeMonotonicMode, HistogramMode, InitialCumulativeMonotonicValue};
 use bytesize::ByteSize;
 use facet::Facet;
 use saluki_config::GenericConfiguration;
-use saluki_error::GenericError;
+use saluki_error::{generic_error, GenericError};
 use serde::{de::Error as _, Deserialize, Deserializer};
 
 fn default_grpc_endpoint() -> String {
@@ -180,36 +180,22 @@ pub struct HistogramsConfig {
     pub mode: HistogramMode,
 }
 
-/// Controls how cumulative monotonic sums are emitted.
-#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq)]
-#[cfg_attr(test, derive(serde::Serialize))]
-pub enum CumulativeMonotonicMode {
-    /// Converts cumulative values to deltas and emits them as counts.
-    #[default]
-    #[serde(rename = "to_delta")]
-    ToDelta,
-
-    /// Emits cumulative values as gauges without converting them to deltas.
-    #[serde(rename = "raw_value")]
-    RawValue,
+// TODO: delete when this component uses typed config
+fn deserialize_cumulative_monotonic_mode<'de, D>(deserializer: D) -> Result<CumulativeMonotonicMode, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer)?.parse().map_err(D::Error::custom)
 }
 
-/// Controls how the translator handles the first value of a cumulative monotonic sum.
-#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq)]
-#[cfg_attr(test, derive(serde::Serialize))]
-pub enum InitialCumulativeMonotonicValue {
-    /// Reports the initial value when its series started after the translator process.
-    #[default]
-    #[serde(rename = "auto")]
-    Auto,
-
-    /// Always drops the initial value.
-    #[serde(rename = "drop")]
-    Drop,
-
-    /// Always reports the initial value.
-    #[serde(rename = "keep")]
-    Keep,
+// TODO: delete when this component uses typed config
+fn deserialize_initial_cumulative_monotonic_value<'de, D>(
+    deserializer: D,
+) -> Result<InitialCumulativeMonotonicValue, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer)?.parse().map_err(D::Error::custom)
 }
 
 /// Configuration for OTLP metrics processing.
@@ -261,17 +247,17 @@ pub struct SumsConfig {
     /// translated metrics needs the original cumulative value.
     ///
     /// Corresponds to `otlp_config.metrics.sums.cumulative_monotonic_mode`.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_cumulative_monotonic_mode")]
     pub cumulative_monotonic_mode: CumulativeMonotonicMode,
 
     /// Controls how the first value of a cumulative monotonic sum is emitted.
     ///
-    /// Defaults to `auto`, which reports the value only when its series started after the translator process.
-    /// Set this to `drop` to always discard the first value or `keep` to always report it. This setting affects
-    /// only cumulative monotonic sums in `to_delta` mode; `raw_value` emits every value as a gauge.
+    /// The default `auto` reports the first value only when its series started after the translator process. Set this
+    /// to `drop` to always discard the first value or `keep` to always report it. This affects only cumulative
+    /// monotonic sums in `to_delta` mode; `raw_value` emits every value as a gauge.
     ///
     /// Corresponds to `otlp_config.metrics.sums.initial_cumulative_monotonic_value`.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_initial_cumulative_monotonic_value")]
     pub initial_cumulative_monotonic_value: InitialCumulativeMonotonicValue,
 }
 
@@ -291,13 +277,24 @@ impl Default for MetricsConfig {
     }
 }
 
-impl SumsConfig {
-    /// Applies the initial-value environment-variable override that normal nested deserialization cannot read.
+impl MetricsConfig {
+    /// Applies environment-variable overrides for sum settings that normal nested deserialization cannot read.
     pub(crate) fn apply_env_overrides(&mut self, config: &GenericConfiguration) -> Result<(), GenericError> {
-        if let Some(mode) = config.try_get_typed::<InitialCumulativeMonotonicValue>(
-            "otlp_config_metrics_sums_initial_cumulative_monotonic_value",
-        )? {
-            self.initial_cumulative_monotonic_value = mode;
+        if let Some(raw_mode) = config.try_get_typed::<String>("otlp_config_metrics_sums_cumulative_monotonic_mode")? {
+            self.sums.cumulative_monotonic_mode = raw_mode.parse().map_err(|error| {
+                generic_error!(
+                    "invalid `otlp_config.metrics.sums.cumulative_monotonic_mode` environment override: {error}"
+                )
+            })?;
+        }
+        if let Some(raw_value) =
+            config.try_get_typed::<String>("otlp_config_metrics_sums_initial_cumulative_monotonic_value")?
+        {
+            self.sums.initial_cumulative_monotonic_value = raw_value.parse().map_err(|error| {
+                generic_error!(
+                    "invalid `otlp_config.metrics.sums.initial_cumulative_monotonic_value` environment override: {error}"
+                )
+            })?;
         }
         Ok(())
     }

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -277,6 +277,7 @@ impl Default for MetricsConfig {
     }
 }
 
+//TODO: remove env handling with typed config, unblocked by #2094
 impl MetricsConfig {
     /// Applies environment-variable overrides for sum settings that normal nested deserialization cannot read.
     pub(crate) fn apply_env_overrides(&mut self, config: &GenericConfiguration) -> Result<(), GenericError> {

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -291,6 +291,18 @@ impl Default for MetricsConfig {
     }
 }
 
+impl SumsConfig {
+    /// Applies the initial-value environment-variable override that normal nested deserialization cannot read.
+    pub(crate) fn apply_env_overrides(&mut self, config: &GenericConfiguration) -> Result<(), GenericError> {
+        if let Some(mode) = config.try_get_typed::<InitialCumulativeMonotonicValue>(
+            "otlp_config_metrics_sums_initial_cumulative_monotonic_value",
+        )? {
+            self.initial_cumulative_monotonic_value = mode;
+        }
+        Ok(())
+    }
+}
+
 /// Configuration for OTLP traces processing.
 ///
 /// Mirrors the Agent's `otlp_config.traces` configuration.

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -194,6 +194,24 @@ pub enum CumulativeMonotonicMode {
     RawValue,
 }
 
+/// Controls how the translator handles the first value of a cumulative monotonic sum.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq)]
+#[cfg_attr(test, derive(serde::Serialize))]
+pub enum InitialCumulativeMonotonicValue {
+    /// Reports the initial value when its series started after the translator process.
+    #[default]
+    #[serde(rename = "auto")]
+    Auto,
+
+    /// Always drops the initial value.
+    #[serde(rename = "drop")]
+    Drop,
+
+    /// Always reports the initial value.
+    #[serde(rename = "keep")]
+    Keep,
+}
+
 /// Configuration for OTLP metrics processing.
 #[derive(Deserialize, Debug)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
@@ -245,6 +263,16 @@ pub struct SumsConfig {
     /// Corresponds to `otlp_config.metrics.sums.cumulative_monotonic_mode`.
     #[serde(default)]
     pub cumulative_monotonic_mode: CumulativeMonotonicMode,
+
+    /// Controls how the first value of a cumulative monotonic sum is emitted.
+    ///
+    /// Defaults to `auto`, which reports the value only when its series started after the translator process.
+    /// Set this to `drop` to always discard the first value or `keep` to always report it. This setting affects
+    /// only cumulative monotonic sums in `to_delta` mode; `raw_value` emits every value as a gauge.
+    ///
+    /// Corresponds to `otlp_config.metrics.sums.initial_cumulative_monotonic_value`.
+    #[serde(default)]
+    pub initial_cumulative_monotonic_value: InitialCumulativeMonotonicValue,
 }
 
 fn default_metrics_enabled() -> bool {

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -180,6 +180,20 @@ pub struct HistogramsConfig {
     pub mode: HistogramMode,
 }
 
+/// Controls how cumulative monotonic sums are emitted.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq)]
+#[cfg_attr(test, derive(serde::Serialize))]
+pub enum CumulativeMonotonicMode {
+    /// Converts cumulative values to deltas and emits them as counts.
+    #[default]
+    #[serde(rename = "to_delta")]
+    ToDelta,
+
+    /// Emits cumulative values as gauges without converting them to deltas.
+    #[serde(rename = "raw_value")]
+    RawValue,
+}
+
 /// Configuration for OTLP metrics processing.
 #[derive(Deserialize, Debug)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
@@ -211,6 +225,26 @@ pub struct MetricsConfig {
     /// Defaults to empty.
     #[serde(default)]
     pub tags: String,
+
+    /// Configuration for OTLP sums.
+    #[serde(default)]
+    pub sums: SumsConfig,
+}
+
+/// Configuration for OTLP sums.
+#[derive(Deserialize, Debug, Default)]
+#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
+pub struct SumsConfig {
+    /// Controls how cumulative monotonic sums are emitted.
+    ///
+    /// The default `to_delta` converts each cumulative value to a delta and emits it as a count. Set this to
+    /// `raw_value` to emit the cumulative value as a gauge instead. This affects only cumulative monotonic sums;
+    /// delta sums and non-monotonic sums retain their existing behavior. Use `raw_value` when the receiver of the
+    /// translated metrics needs the original cumulative value.
+    ///
+    /// Corresponds to `otlp_config.metrics.sums.cumulative_monotonic_mode`.
+    #[serde(default)]
+    pub cumulative_monotonic_mode: CumulativeMonotonicMode,
 }
 
 fn default_metrics_enabled() -> bool {
@@ -224,6 +258,7 @@ impl Default for MetricsConfig {
             histograms: HistogramsConfig::default(),
             resource_attributes_as_tags: false,
             tags: String::new(),
+            sums: SumsConfig::default(),
         }
     }
 }

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use agent_data_plane_config::domains::otlp::HistogramMode;
 use saluki_error::{generic_error, GenericError};
 
-use crate::common::otlp::config::CumulativeMonotonicMode;
+use crate::common::otlp::config::{CumulativeMonotonicMode, InitialCumulativeMonotonicValue};
 
 const DEFAULT_DELTA_TTL: Duration = Duration::from_secs(3600);
 const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(1800);
@@ -26,7 +26,6 @@ impl From<CumulativeMonotonicMode> for NumberMode {
     }
 }
 
-// https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/config.go#L209-L224
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[allow(dead_code)]
 #[derive(Default)]
@@ -35,6 +34,16 @@ pub enum InitialCumulMonoValueMode {
     Auto,
     Drop,
     Keep,
+}
+
+impl From<InitialCumulativeMonotonicValue> for InitialCumulMonoValueMode {
+    fn from(mode: InitialCumulativeMonotonicValue) -> Self {
+        match mode {
+            InitialCumulativeMonotonicValue::Auto => Self::Auto,
+            InitialCumulativeMonotonicValue::Drop => Self::Drop,
+            InitialCumulativeMonotonicValue::Keep => Self::Keep,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -3,17 +3,27 @@ use std::time::Duration;
 use agent_data_plane_config::domains::otlp::HistogramMode;
 use saluki_error::{generic_error, GenericError};
 
+use crate::common::otlp::config::CumulativeMonotonicMode;
+
 const DEFAULT_DELTA_TTL: Duration = Duration::from_secs(3600);
 const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(1800);
 
 // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/config.go#L178-L190
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 #[allow(dead_code)]
-#[derive(Default)]
 pub enum NumberMode {
     #[default]
     CumulativeToDelta,
     RawValue,
+}
+
+impl From<CumulativeMonotonicMode> for NumberMode {
+    fn from(mode: CumulativeMonotonicMode) -> Self {
+        match mode {
+            CumulativeMonotonicMode::ToDelta => Self::CumulativeToDelta,
+            CumulativeMonotonicMode::RawValue => Self::RawValue,
+        }
+    }
 }
 
 // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/config.go#L209-L224

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -6,52 +6,13 @@ use saluki_error::{generic_error, GenericError};
 const DEFAULT_DELTA_TTL: Duration = Duration::from_secs(3600);
 const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(1800);
 
-// https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/config.go#L178-L190
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
-#[allow(dead_code)]
-pub enum NumberMode {
-    #[default]
-    CumulativeToDelta,
-    RawValue,
-}
-
-impl From<CumulativeMonotonicMode> for NumberMode {
-    fn from(mode: CumulativeMonotonicMode) -> Self {
-        match mode {
-            CumulativeMonotonicMode::ToDelta => Self::CumulativeToDelta,
-            CumulativeMonotonicMode::RawValue => Self::RawValue,
-        }
-    }
-}
-
-// https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/config.go#L209-L224
-#[derive(Debug, Clone, Copy, PartialEq)]
-#[allow(dead_code)]
-#[derive(Default)]
-pub enum InitialCumulMonoValueMode {
-    #[default]
-    Auto,
-    Drop,
-    Keep,
-}
-
-impl From<InitialCumulativeMonotonicValue> for InitialCumulMonoValueMode {
-    fn from(mode: InitialCumulativeMonotonicValue) -> Self {
-        match mode {
-            InitialCumulativeMonotonicValue::Auto => Self::Auto,
-            InitialCumulativeMonotonicValue::Drop => Self::Drop,
-            InitialCumulativeMonotonicValue::Keep => Self::Keep,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy)]
 #[allow(dead_code)]
 pub struct OtlpMetricsTranslatorConfig {
     pub hist_mode: HistogramMode,
     pub send_histogram_aggregations: bool,
-    pub number_mode: NumberMode,
-    pub initial_cumul_mono_value_mode: InitialCumulMonoValueMode,
+    pub cumulative_monotonic_mode: CumulativeMonotonicMode,
+    pub initial_cumulative_monotonic_value: InitialCumulativeMonotonicValue,
     pub instrumentation_scope_metadata_as_tags: bool,
     pub instrumentation_library_metadata_as_tags: bool,
     // Whether scalar resource attributes should be added as raw tags on emitted metrics, in
@@ -94,10 +55,10 @@ impl OtlpMetricsTranslatorConfig {
         self
     }
 
-    pub fn with_initial_cumul_mono_value_mode(
-        mut self, initial_cumul_mono_value_mode: InitialCumulMonoValueMode,
+    pub fn with_initial_cumulative_monotonic_value(
+        mut self, initial_cumulative_monotonic_value: InitialCumulativeMonotonicValue,
     ) -> Self {
-        self.initial_cumul_mono_value_mode = initial_cumul_mono_value_mode;
+        self.initial_cumulative_monotonic_value = initial_cumulative_monotonic_value;
         self
     }
 
@@ -106,8 +67,8 @@ impl OtlpMetricsTranslatorConfig {
         self
     }
 
-    pub fn with_number_mode(mut self, number_mode: NumberMode) -> Self {
-        self.number_mode = number_mode;
+    pub fn with_cumulative_monotonic_mode(mut self, cumulative_monotonic_mode: CumulativeMonotonicMode) -> Self {
+        self.cumulative_monotonic_mode = cumulative_monotonic_mode;
         self
     }
 
@@ -159,8 +120,8 @@ impl Default for OtlpMetricsTranslatorConfig {
         Self {
             hist_mode: HistogramMode::default(),
             send_histogram_aggregations: false,
-            number_mode: NumberMode::default(),
-            initial_cumul_mono_value_mode: InitialCumulMonoValueMode::default(),
+            cumulative_monotonic_mode: CumulativeMonotonicMode::default(),
+            initial_cumulative_monotonic_value: InitialCumulativeMonotonicValue::default(),
             instrumentation_scope_metadata_as_tags: true,
             instrumentation_library_metadata_as_tags: false,
             resource_attributes_as_tags: false,

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -1,9 +1,7 @@
 use std::time::Duration;
 
-use agent_data_plane_config::domains::otlp::HistogramMode;
+use agent_data_plane_config::domains::otlp::{CumulativeMonotonicMode, HistogramMode, InitialCumulativeMonotonicValue};
 use saluki_error::{generic_error, GenericError};
-
-use crate::common::otlp::config::{CumulativeMonotonicMode, InitialCumulativeMonotonicValue};
 
 const DEFAULT_DELTA_TTL: Duration = Duration::from_secs(3600);
 const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(1800);
@@ -26,6 +24,7 @@ impl From<CumulativeMonotonicMode> for NumberMode {
     }
 }
 
+// https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/config.go#L209-L224
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[allow(dead_code)]
 #[derive(Default)]

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -759,7 +759,7 @@ impl OtlpMetricsTranslator {
                     if is_skippable(quantile.value) {
                         continue;
                     }
-                    let quantile_dims = base_quantile_dims.add_tags([format_quantile_tag(quantile.quantile)]);
+                    let quantile_dims = base_quantile_dims.add_tags(&[format_quantile_tag(quantile.quantile)]);
                     self.record_metric_event(
                         &quantile_dims,
                         quantile.value,
@@ -928,7 +928,7 @@ impl OtlpMetricsTranslator {
             let (lower_bound, upper_bound) = get_bounds(&explicit_bounds, j);
             let (original_lower_bound, original_upper_bound) = (lower_bound, upper_bound);
 
-            let bucket_dims = point_dims.add_tags([
+            let bucket_dims = point_dims.add_tags(&[
                 format!("lower_bound:{}", GoFloat(lower_bound)),
                 format!("upper_bound:{}", GoFloat(upper_bound)),
             ]);
@@ -1052,7 +1052,7 @@ impl OtlpMetricsTranslator {
         for idx in 0..p.bucket_counts.len() {
             let (lower_bound, upper_bound) = get_bounds(&p.explicit_bounds, idx);
 
-            let bucket_dims = base_bucket_dims.add_tags([
+            let bucket_dims = base_bucket_dims.add_tags(&[
                 format!("lower_bound:{}", GoFloat(lower_bound)),
                 format!("upper_bound:{}", GoFloat(upper_bound)),
             ]);

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -1809,6 +1809,83 @@ mod tests {
         );
     }
 
+    fn initial_cumulative_monotonic_sum(value: i64, start_time_unix_nano: u64, time_unix_nano: u64) -> OtlpMetric {
+        OtlpMetric {
+            name: "cumulative.sum".to_string(),
+            data: Some(OtlpMetricData::Sum(
+                otlp_protos::opentelemetry::proto::metrics::v1::Sum {
+                    aggregation_temporality: AggregationTemporality::Cumulative as i32,
+                    is_monotonic: true,
+                    data_points: vec![OtlpNumberDataPoint {
+                        value: Some(OtlpNumberDataPointValue::AsInt(value)),
+                        start_time_unix_nano,
+                        time_unix_nano,
+                        ..Default::default()
+                    }],
+                },
+            )),
+            ..Default::default()
+        }
+    }
+
+    fn translate_initial_cumulative_monotonic_sum(
+        translator: &mut OtlpMetricsTranslator, metrics: &Metrics, value: i64, start_time_unix_nano: u64,
+        time_unix_nano: u64,
+    ) -> Vec<Event> {
+        translator.map_to_dd_format(
+            initial_cumulative_monotonic_sum(value, start_time_unix_nano, time_unix_nano),
+            &SharedTagSet::default(),
+            None,
+            &[],
+            metrics,
+        )
+    }
+
+    #[test]
+    fn auto_initial_cumulative_monotonic_value_mode_reports_new_series() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        let start_time = translator.process_start_time_ns + 1;
+        let timestamp = start_time + nanos_from_seconds(1);
+
+        let events = translate_initial_cumulative_monotonic_sum(&mut translator, &metrics, 42, start_time, timestamp);
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].try_as_metric().expect("metric event").values(),
+            &MetricValues::counter((timestamp / 1_000_000_000, 42.0))
+        );
+    }
+
+    #[test]
+    fn keep_initial_cumulative_monotonic_value_mode_reports_first_value() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        translator.config.initial_cumul_mono_value_mode = InitialCumulMonoValueMode::Keep;
+        let timestamp = translator.process_start_time_ns;
+
+        let events = translate_initial_cumulative_monotonic_sum(&mut translator, &metrics, 42, timestamp, timestamp);
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].try_as_metric().expect("metric event").values(),
+            &MetricValues::counter((timestamp / 1_000_000_000, 42.0))
+        );
+    }
+
+    #[test]
+    fn drop_initial_cumulative_monotonic_value_mode_drops_new_series() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        translator.config.initial_cumul_mono_value_mode = InitialCumulMonoValueMode::Drop;
+        let start_time = translator.process_start_time_ns + 1;
+        let timestamp = start_time + nanos_from_seconds(1);
+
+        let events = translate_initial_cumulative_monotonic_sum(&mut translator, &metrics, 42, start_time, timestamp);
+
+        assert!(events.is_empty());
+    }
+
     fn string_attribute(key: &str, value: &str) -> OtlpKeyValue {
         OtlpKeyValue {
             key: key.to_string(),

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -8,7 +8,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use std::vec::IntoIter;
 
 use ::ddsketch::canonical::mapping::IndexMapping;
-use agent_data_plane_config::domains::otlp::HistogramMode;
+use agent_data_plane_config::domains::otlp::{CumulativeMonotonicMode, HistogramMode, InitialCumulativeMonotonicValue};
 use datadog_protos::metrics::Dogsketch;
 use ddsketch::canonical::mapping::LogarithmicMapping;
 use ddsketch::canonical::store::DenseStore;
@@ -31,7 +31,7 @@ use stringtheory::MetaString;
 use tracing::{debug, trace, warn};
 
 use super::cache::PointsCache;
-use super::config::{NumberMode, OtlpMetricsTranslatorConfig};
+use super::config::OtlpMetricsTranslatorConfig;
 use super::dimensions::Dimensions;
 use super::internal::{instrumentationlibrary, instrumentationscope};
 use super::remap;
@@ -39,7 +39,6 @@ use super::runtime_metrics::{RuntimeMetricMapping, RUNTIME_METRICS_MAPPINGS};
 use crate::common::otlp::attributes::translator::AttributeTranslator;
 use crate::common::otlp::attributes::{raw_origin_from_attributes, ResourceAttributeTagMode};
 use crate::common::otlp::util::{Source, SourceKind};
-use crate::sources::otlp::metrics::config::InitialCumulMonoValueMode;
 use crate::sources::otlp::Metrics;
 
 // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator.go#L48-L63
@@ -610,11 +609,11 @@ impl OtlpMetricsTranslator {
                 OtlpMetricData::Sum(sum) => match AggregationTemporality::try_from(sum.aggregation_temporality) {
                     Ok(AggregationTemporality::Cumulative) => {
                         if sum.is_monotonic {
-                            match self.config.number_mode {
-                                NumberMode::CumulativeToDelta => {
+                            match self.config.cumulative_monotonic_mode {
+                                CumulativeMonotonicMode::ToDelta => {
                                     self.map_number_monotonic_metrics(base_dims, sum.data_points, &context)
                                 }
-                                NumberMode::RawValue => {
+                                CumulativeMonotonicMode::RawValue => {
                                     self.map_number_metrics(base_dims, sum.data_points, DataType::Gauge, &context)
                                 }
                             }
@@ -1338,13 +1337,13 @@ impl OtlpMetricsTranslator {
 
     /// Determines if the initial value of a cumulative monotonic metric should be consumed.
     fn should_consume_initial_value(&self, start_ts: u64, ts: u64) -> bool {
-        match self.config.initial_cumul_mono_value_mode {
-            InitialCumulMonoValueMode::Auto => {
+        match self.config.initial_cumulative_monotonic_value {
+            InitialCumulativeMonotonicValue::Auto => {
                 // We report the first value if the timeseries started after the translator process started.
                 self.process_start_time_ns < start_ts && start_ts != ts
             }
-            InitialCumulMonoValueMode::Keep => true,
-            InitialCumulMonoValueMode::Drop => false,
+            InitialCumulativeMonotonicValue::Keep => true,
+            InitialCumulativeMonotonicValue::Drop => false,
         }
     }
 }
@@ -1777,7 +1776,7 @@ mod tests {
     fn raw_value_mode_emits_cumulative_monotonic_sums_as_gauges() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
-        translator.config.number_mode = NumberMode::RawValue;
+        translator.config.cumulative_monotonic_mode = CumulativeMonotonicMode::RawValue;
 
         let events = translator.map_to_dd_format(
             OtlpMetric {
@@ -1861,7 +1860,7 @@ mod tests {
     fn keep_initial_cumulative_monotonic_value_mode_reports_first_value() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
-        translator.config.initial_cumul_mono_value_mode = InitialCumulMonoValueMode::Keep;
+        translator.config.initial_cumulative_monotonic_value = InitialCumulativeMonotonicValue::Keep;
         let timestamp = translator.process_start_time_ns;
 
         let events = translate_initial_cumulative_monotonic_sum(&mut translator, &metrics, 42, timestamp, timestamp);
@@ -1877,7 +1876,7 @@ mod tests {
     fn drop_initial_cumulative_monotonic_value_mode_drops_new_series() {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
-        translator.config.initial_cumul_mono_value_mode = InitialCumulMonoValueMode::Drop;
+        translator.config.initial_cumulative_monotonic_value = InitialCumulativeMonotonicValue::Drop;
         let start_time = translator.process_start_time_ns + 1;
         let timestamp = start_time + nanos_from_seconds(1);
 

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -1773,6 +1773,43 @@ mod tests {
         assert_eq!(metric.context().host(), Some("resource-host"));
     }
 
+    #[test]
+    fn raw_value_mode_emits_cumulative_monotonic_sums_as_gauges() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        translator.config.number_mode = NumberMode::RawValue;
+
+        let events = translator.map_to_dd_format(
+            OtlpMetric {
+                name: "cumulative.sum".to_string(),
+                data: Some(OtlpMetricData::Sum(
+                    otlp_protos::opentelemetry::proto::metrics::v1::Sum {
+                        aggregation_temporality: AggregationTemporality::Cumulative as i32,
+                        is_monotonic: true,
+                        data_points: vec![OtlpNumberDataPoint {
+                            value: Some(OtlpNumberDataPointValue::AsInt(42)),
+                            start_time_unix_nano: nanos_from_seconds(1),
+                            time_unix_nano: nanos_from_seconds(2),
+                            ..Default::default()
+                        }],
+                        ..Default::default()
+                    },
+                )),
+                ..Default::default()
+            },
+            &SharedTagSet::default(),
+            None,
+            &[],
+            &metrics,
+        );
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].try_as_metric().expect("metric event").values(),
+            &MetricValues::gauge((2, 42.0))
+        );
+    }
+
     fn string_attribute(key: &str, value: &str) -> OtlpKeyValue {
         OtlpKeyValue {
             key: key.to_string(),

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -1792,7 +1792,6 @@ mod tests {
                             time_unix_nano: nanos_from_seconds(2),
                             ..Default::default()
                         }],
-                        ..Default::default()
                     },
                 )),
                 ..Default::default()

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -759,7 +759,7 @@ impl OtlpMetricsTranslator {
                     if is_skippable(quantile.value) {
                         continue;
                     }
-                    let quantile_dims = base_quantile_dims.add_tags(&[format_quantile_tag(quantile.quantile)]);
+                    let quantile_dims = base_quantile_dims.add_tags([format_quantile_tag(quantile.quantile)]);
                     self.record_metric_event(
                         &quantile_dims,
                         quantile.value,
@@ -928,7 +928,7 @@ impl OtlpMetricsTranslator {
             let (lower_bound, upper_bound) = get_bounds(&explicit_bounds, j);
             let (original_lower_bound, original_upper_bound) = (lower_bound, upper_bound);
 
-            let bucket_dims = point_dims.add_tags(&[
+            let bucket_dims = point_dims.add_tags([
                 format!("lower_bound:{}", GoFloat(lower_bound)),
                 format!("upper_bound:{}", GoFloat(upper_bound)),
             ]);
@@ -1052,7 +1052,7 @@ impl OtlpMetricsTranslator {
         for idx in 0..p.bucket_counts.len() {
             let (lower_bound, upper_bound) = get_bounds(&p.explicit_bounds, idx);
 
-            let bucket_dims = base_bucket_dims.add_tags(&[
+            let bucket_dims = base_bucket_dims.add_tags([
                 format!("lower_bound:{}", GoFloat(lower_bound)),
                 format!("upper_bound:{}", GoFloat(upper_bound)),
             ]);

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -159,6 +159,7 @@ impl OtlpConfiguration {
             .with_histogram_mode(self.otlp_config.metrics.histograms.mode)
             .with_number_mode(self.otlp_config.metrics.sums.cumulative_monotonic_mode.into())
             .with_resource_attributes_as_tags(self.otlp_config.metrics.resource_attributes_as_tags)
+            .with_initial_cumul_mono_value_mode(self.otlp_config.metrics.sums.initial_cumulative_monotonic_value.into())
     }
 
     /// Sets the default hostname used when OTLP metrics do not carry a resource hostname.
@@ -575,7 +576,10 @@ mod tests {
     use saluki_config::{config_from, ConfigurationLoader};
     use serde_json::json;
 
-    use super::{metrics::config::NumberMode, parse_configured_metric_tags, OtlpConfiguration};
+    use super::{
+        metrics::config::{InitialCumulMonoValueMode, NumberMode},
+        parse_configured_metric_tags, OtlpConfiguration,
+    };
     use crate::config::{DatadogRemapper, KEY_ALIASES};
 
     fn tags(raw: &str) -> Vec<String> {
@@ -640,6 +644,39 @@ mod tests {
             OtlpConfiguration::from_configuration(&generic_config).expect("OTLP configuration should deserialize");
 
         assert_eq!(config.metrics_translator_config().number_mode, NumberMode::RawValue);
+    }
+
+    #[tokio::test]
+    async fn initial_cumulative_monotonic_value_configures_metrics_translator() {
+        for (configured_value, expected_mode) in [
+            ("auto", InitialCumulMonoValueMode::Auto),
+            ("drop", InitialCumulMonoValueMode::Drop),
+            ("keep", InitialCumulMonoValueMode::Keep),
+        ] {
+            let (generic_config, _) = ConfigurationLoader::for_tests_with_provider_factory(
+                Some(json!({
+                    "otlp_config": {
+                        "metrics": {
+                            "sums": {
+                                "initial_cumulative_monotonic_value": configured_value
+                            }
+                        }
+                    }
+                })),
+                None,
+                false,
+                KEY_ALIASES,
+                DatadogRemapper::new,
+            )
+            .await;
+            let config =
+                OtlpConfiguration::from_configuration(&generic_config).expect("OTLP configuration should deserialize");
+
+            assert_eq!(
+                config.metrics_translator_config().initial_cumul_mono_value_mode,
+                expected_mode
+            );
+        }
     }
 
     #[test]

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -148,6 +148,7 @@ impl OtlpConfiguration {
     /// Creates a new `OTLPConfiguration` from the given configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         let mut cfg: Self = config.as_typed()?;
+        cfg.otlp_config.metrics.sums.apply_env_overrides(config)?;
         cfg.otlp_config.traces.apply_env_overrides(config)?;
         Ok(cfg)
     }
@@ -644,6 +645,35 @@ mod tests {
             OtlpConfiguration::from_configuration(&generic_config).expect("OTLP configuration should deserialize");
 
         assert_eq!(config.metrics_translator_config().number_mode, NumberMode::RawValue);
+    }
+
+    #[tokio::test]
+    async fn initial_cumulative_monotonic_value_environment_variable_configures_metrics_translator() {
+        for (configured_value, expected_mode) in [
+            ("auto", InitialCumulMonoValueMode::Auto),
+            ("drop", InitialCumulMonoValueMode::Drop),
+            ("keep", InitialCumulMonoValueMode::Keep),
+        ] {
+            let env_vars = [(
+                "OTLP_CONFIG_METRICS_SUMS_INITIAL_CUMULATIVE_MONOTONIC_VALUE".to_string(),
+                configured_value.to_string(),
+            )];
+            let (generic_config, _) = ConfigurationLoader::for_tests_with_provider_factory(
+                Some(json!({ "otlp_config": {} })),
+                Some(&env_vars),
+                false,
+                KEY_ALIASES,
+                DatadogRemapper::new,
+            )
+            .await;
+            let config =
+                OtlpConfiguration::from_configuration(&generic_config).expect("OTLP configuration should deserialize");
+
+            assert_eq!(
+                config.metrics_translator_config().initial_cumul_mono_value_mode,
+                expected_mode
+            );
+        }
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -158,8 +158,8 @@ impl OtlpConfiguration {
             .with_remapping(true)
             .with_quantiles(true)
             .with_histogram_mode(self.otlp_config.metrics.histograms.mode)
-            .with_number_mode(self.otlp_config.metrics.sums.cumulative_monotonic_mode.into())
-            .with_initial_cumul_mono_value_mode(self.otlp_config.metrics.sums.initial_cumulative_monotonic_value.into())
+            .with_cumulative_monotonic_mode(self.otlp_config.metrics.sums.cumulative_monotonic_mode)
+            .with_initial_cumulative_monotonic_value(self.otlp_config.metrics.sums.initial_cumulative_monotonic_value)
             .with_resource_attributes_as_tags(self.otlp_config.metrics.resource_attributes_as_tags)
     }
 
@@ -573,14 +573,13 @@ mod config_smoke {
 
 #[cfg(test)]
 mod tests {
-    use agent_data_plane_config::domains::otlp::HistogramMode;
+    use agent_data_plane_config::domains::otlp::{
+        CumulativeMonotonicMode, HistogramMode, InitialCumulativeMonotonicValue,
+    };
     use saluki_config::{config_from, ConfigurationLoader};
     use serde_json::json;
 
-    use super::{
-        metrics::config::{InitialCumulMonoValueMode, NumberMode},
-        parse_configured_metric_tags, OtlpConfiguration,
-    };
+    use super::{parse_configured_metric_tags, OtlpConfiguration};
     use crate::config::{DatadogRemapper, KEY_ALIASES};
 
     fn tags(raw: &str) -> Vec<String> {
@@ -618,8 +617,10 @@ mod tests {
     #[test]
     fn cumulative_monotonic_sum_mode_defaults_to_delta_conversion() {
         assert_eq!(
-            OtlpConfiguration::default().metrics_translator_config().number_mode,
-            NumberMode::CumulativeToDelta
+            OtlpConfiguration::default()
+                .metrics_translator_config()
+                .cumulative_monotonic_mode,
+            CumulativeMonotonicMode::ToDelta
         );
     }
 
@@ -644,7 +645,10 @@ mod tests {
         let config =
             OtlpConfiguration::from_configuration(&generic_config).expect("OTLP configuration should deserialize");
 
-        assert_eq!(config.metrics_translator_config().number_mode, NumberMode::RawValue);
+        assert_eq!(
+            config.metrics_translator_config().cumulative_monotonic_mode,
+            CumulativeMonotonicMode::RawValue
+        );
     }
 
     #[tokio::test]
@@ -665,15 +669,18 @@ mod tests {
             OtlpConfiguration::from_configuration(&generic_config).expect("OTLP configuration should deserialize");
         let translator_config = config.metrics_translator_config();
 
-        assert_eq!(translator_config.number_mode, NumberMode::RawValue);
+        assert_eq!(
+            translator_config.cumulative_monotonic_mode,
+            CumulativeMonotonicMode::RawValue
+        );
     }
 
     #[tokio::test]
     async fn initial_cumulative_monotonic_value_configures_metrics_translator() {
         for (configured_value, expected_mode) in [
-            ("auto", InitialCumulMonoValueMode::Auto),
-            ("drop", InitialCumulMonoValueMode::Drop),
-            ("keep", InitialCumulMonoValueMode::Keep),
+            ("auto", InitialCumulativeMonotonicValue::Auto),
+            ("drop", InitialCumulativeMonotonicValue::Drop),
+            ("keep", InitialCumulativeMonotonicValue::Keep),
         ] {
             let (generic_config, _) = ConfigurationLoader::for_tests_with_provider_factory(
                 Some(json!({
@@ -695,7 +702,7 @@ mod tests {
                 OtlpConfiguration::from_configuration(&generic_config).expect("OTLP configuration should deserialize");
 
             assert_eq!(
-                config.metrics_translator_config().initial_cumul_mono_value_mode,
+                config.metrics_translator_config().initial_cumulative_monotonic_value,
                 expected_mode
             );
         }
@@ -704,9 +711,9 @@ mod tests {
     #[tokio::test]
     async fn initial_cumulative_monotonic_value_environment_variable_configures_metrics_translator() {
         for (configured_value, expected_mode) in [
-            ("auto", InitialCumulMonoValueMode::Auto),
-            ("drop", InitialCumulMonoValueMode::Drop),
-            ("keep", InitialCumulMonoValueMode::Keep),
+            ("auto", InitialCumulativeMonotonicValue::Auto),
+            ("drop", InitialCumulativeMonotonicValue::Drop),
+            ("keep", InitialCumulativeMonotonicValue::Keep),
         ] {
             let env_vars = [(
                 "OTLP_CONFIG_METRICS_SUMS_INITIAL_CUMULATIVE_MONOTONIC_VALUE".to_string(),
@@ -724,7 +731,7 @@ mod tests {
                 OtlpConfiguration::from_configuration(&generic_config).expect("OTLP configuration should deserialize");
 
             assert_eq!(
-                config.metrics_translator_config().initial_cumul_mono_value_mode,
+                config.metrics_translator_config().initial_cumulative_monotonic_value,
                 expected_mode
             );
         }

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -157,6 +157,7 @@ impl OtlpConfiguration {
             .with_remapping(true)
             .with_quantiles(true)
             .with_histogram_mode(self.otlp_config.metrics.histograms.mode)
+            .with_number_mode(self.otlp_config.metrics.sums.cumulative_monotonic_mode.into())
             .with_resource_attributes_as_tags(self.otlp_config.metrics.resource_attributes_as_tags)
     }
 
@@ -571,10 +572,11 @@ mod config_smoke {
 #[cfg(test)]
 mod tests {
     use agent_data_plane_config::domains::otlp::HistogramMode;
-    use saluki_config::config_from;
+    use saluki_config::{config_from, ConfigurationLoader};
     use serde_json::json;
 
-    use super::{parse_configured_metric_tags, OtlpConfiguration};
+    use super::{metrics::config::NumberMode, parse_configured_metric_tags, OtlpConfiguration};
+    use crate::config::{DatadogRemapper, KEY_ALIASES};
 
     fn tags(raw: &str) -> Vec<String> {
         parse_configured_metric_tags(raw)
@@ -606,6 +608,38 @@ mod tests {
 
             assert_eq!(otlp_config.metrics_translator_config().hist_mode, expected_mode);
         }
+    }
+
+    #[test]
+    fn cumulative_monotonic_sum_mode_defaults_to_delta_conversion() {
+        assert_eq!(
+            OtlpConfiguration::default().metrics_translator_config().number_mode,
+            NumberMode::CumulativeToDelta
+        );
+    }
+
+    #[tokio::test]
+    async fn cumulative_monotonic_sum_mode_configures_metrics_translator() {
+        let (generic_config, _) = ConfigurationLoader::for_tests_with_provider_factory(
+            Some(json!({
+                "otlp_config": {
+                    "metrics": {
+                        "sums": {
+                            "cumulative_monotonic_mode": "raw_value"
+                        }
+                    }
+                }
+            })),
+            None,
+            false,
+            KEY_ALIASES,
+            DatadogRemapper::new,
+        )
+        .await;
+        let config =
+            OtlpConfiguration::from_configuration(&generic_config).expect("OTLP configuration should deserialize");
+
+        assert_eq!(config.metrics_translator_config().number_mode, NumberMode::RawValue);
     }
 
     #[test]

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -148,7 +148,7 @@ impl OtlpConfiguration {
     /// Creates a new `OTLPConfiguration` from the given configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         let mut cfg: Self = config.as_typed()?;
-        cfg.otlp_config.metrics.sums.apply_env_overrides(config)?;
+        cfg.otlp_config.metrics.apply_env_overrides(config)?;
         cfg.otlp_config.traces.apply_env_overrides(config)?;
         Ok(cfg)
     }
@@ -159,8 +159,8 @@ impl OtlpConfiguration {
             .with_quantiles(true)
             .with_histogram_mode(self.otlp_config.metrics.histograms.mode)
             .with_number_mode(self.otlp_config.metrics.sums.cumulative_monotonic_mode.into())
-            .with_resource_attributes_as_tags(self.otlp_config.metrics.resource_attributes_as_tags)
             .with_initial_cumul_mono_value_mode(self.otlp_config.metrics.sums.initial_cumulative_monotonic_value.into())
+            .with_resource_attributes_as_tags(self.otlp_config.metrics.resource_attributes_as_tags)
     }
 
     /// Sets the default hostname used when OTLP metrics do not carry a resource hostname.
@@ -648,32 +648,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn initial_cumulative_monotonic_value_environment_variable_configures_metrics_translator() {
-        for (configured_value, expected_mode) in [
-            ("auto", InitialCumulMonoValueMode::Auto),
-            ("drop", InitialCumulMonoValueMode::Drop),
-            ("keep", InitialCumulMonoValueMode::Keep),
-        ] {
-            let env_vars = [(
-                "OTLP_CONFIG_METRICS_SUMS_INITIAL_CUMULATIVE_MONOTONIC_VALUE".to_string(),
-                configured_value.to_string(),
-            )];
-            let (generic_config, _) = ConfigurationLoader::for_tests_with_provider_factory(
-                Some(json!({ "otlp_config": {} })),
-                Some(&env_vars),
-                false,
-                KEY_ALIASES,
-                DatadogRemapper::new,
-            )
-            .await;
-            let config =
-                OtlpConfiguration::from_configuration(&generic_config).expect("OTLP configuration should deserialize");
+    async fn cumulative_monotonic_mode_environment_variable_configures_metrics_translator() {
+        let env_vars = [(
+            "OTLP_CONFIG_METRICS_SUMS_CUMULATIVE_MONOTONIC_MODE".to_string(),
+            "raw_value".to_string(),
+        )];
+        let (generic_config, _) = ConfigurationLoader::for_tests_with_provider_factory(
+            Some(json!({ "otlp_config": {} })),
+            Some(&env_vars),
+            false,
+            KEY_ALIASES,
+            DatadogRemapper::new,
+        )
+        .await;
+        let config =
+            OtlpConfiguration::from_configuration(&generic_config).expect("OTLP configuration should deserialize");
+        let translator_config = config.metrics_translator_config();
 
-            assert_eq!(
-                config.metrics_translator_config().initial_cumul_mono_value_mode,
-                expected_mode
-            );
-        }
+        assert_eq!(translator_config.number_mode, NumberMode::RawValue);
     }
 
     #[tokio::test]
@@ -694,6 +686,35 @@ mod tests {
                     }
                 })),
                 None,
+                false,
+                KEY_ALIASES,
+                DatadogRemapper::new,
+            )
+            .await;
+            let config =
+                OtlpConfiguration::from_configuration(&generic_config).expect("OTLP configuration should deserialize");
+
+            assert_eq!(
+                config.metrics_translator_config().initial_cumul_mono_value_mode,
+                expected_mode
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn initial_cumulative_monotonic_value_environment_variable_configures_metrics_translator() {
+        for (configured_value, expected_mode) in [
+            ("auto", InitialCumulMonoValueMode::Auto),
+            ("drop", InitialCumulMonoValueMode::Drop),
+            ("keep", InitialCumulMonoValueMode::Keep),
+        ] {
+            let env_vars = [(
+                "OTLP_CONFIG_METRICS_SUMS_INITIAL_CUMULATIVE_MONOTONIC_VALUE".to_string(),
+                configured_value.to_string(),
+            )];
+            let (generic_config, _) = ConfigurationLoader::for_tests_with_provider_factory(
+                Some(json!({ "otlp_config": {} })),
+                Some(&env_vars),
                 false,
                 KEY_ALIASES,
                 DatadogRemapper::new,


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Wire through and support `initial_cumulative_monotonic_sums` key, giving operators choice between three settings (`auto`, `keep`, `drop`)  to handle reporting of the initial value for cumulative monotonic sums. 

Also, wires up `cumulative_monotonic_mode` config key for OTLP sum metric, allowing for operators to configure whether they would prefer a `raw_value` or `to_delta` report per metric emission. 

Example: 
Time: `1` | Reported Value: `100`
Time: `2` | Reported Value: `125`

`to_delta` emits `25`
`raw_value` emits `125`



## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

Unit tests. 

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

- Closes: https://github.com/DataDog/saluki/issues/2024
- Closes: https://github.com/DataDog/saluki/issues/2023

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->

Dependent on: https://github.com/DataDog/saluki/pull/2151
