### PR TITLE
fix(io): honor skip_ssl_validation in FIPS ADP builds

### DIFF
--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -383,9 +383,7 @@ validation. When enabled, this setting affects the Datadog intake clients used b
 logs, traces, events, and service checks that flow through the shared forwarder.
 
 This setting does not affect ADP IPC, local privileged APIs, ADP control-plane clients,
-OTLP proxying to the core agent, or unrelated HTTP clients. In FIPS builds, ADP rejects
-`skip_ssl_validation: true` because disabling TLS certificate validation is not
-FIPS-compliant.
+OTLP proxying to the core agent, or unrelated HTTP clients.
 
 ### `statsd_forward_host`
 

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -2313,9 +2313,7 @@ inventory:
       logs, traces, events, and service checks that flow through the shared forwarder.
 
       This setting does not affect ADP IPC, local privileged APIs, ADP control-plane clients,
-      OTLP proxying to the core agent, or unrelated HTTP clients. In FIPS builds, ADP rejects
-      `skip_ssl_validation: true` because disabling TLS certificate validation is not
-      FIPS-compliant.
+      OTLP proxying to the core agent, or unrelated HTTP clients.
     test_support:
       used_by: [ForwarderConfiguration]
       env_var_override: [DD_SKIP_SSL_VALIDATION]

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -148,15 +148,16 @@ impl TlsCertificateValidation {
         match self {
             Self::Enabled => client_builder,
             Self::Disabled => {
-                warn!(
-                    config_key = "skip_ssl_validation",
-                    "TLS certificate validation is disabled for Datadog intake forwarding."
-                );
                 #[cfg(feature = "fips")]
                 warn!(
                     config_key = "skip_ssl_validation",
                     "Disabling TLS certificate validation in a FIPS build means server certificates are no longer \
                      verified, even though the underlying TLS cipher suites and key exchange remain FIPS-compliant."
+                );
+                #[cfg(not(feature = "fips"))]
+                warn!(
+                    config_key = "skip_ssl_validation",
+                    "TLS certificate validation is disabled for Datadog intake forwarding."
                 );
                 client_builder.with_tls_config(|builder| builder.danger_accept_invalid_certs())
             }

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -152,6 +152,12 @@ impl TlsCertificateValidation {
                     config_key = "skip_ssl_validation",
                     "TLS certificate validation is disabled for Datadog intake forwarding."
                 );
+                #[cfg(feature = "fips")]
+                warn!(
+                    config_key = "skip_ssl_validation",
+                    "Disabling TLS certificate validation in a FIPS build means server certificates are no longer \
+                     verified, even though the underlying TLS cipher suites and key exchange remain FIPS-compliant."
+                );
                 client_builder.with_tls_config(|builder| builder.danger_accept_invalid_certs())
             }
         }

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -144,10 +144,8 @@ impl TlsCertificateValidation {
         }
     }
 
-    fn apply_to(self, client_builder: HttpClientBuilder) -> Result<HttpClientBuilder, GenericError> {
-        self.ensure_supported()?;
-
-        Ok(match self {
+    fn apply_to(self, client_builder: HttpClientBuilder) -> HttpClientBuilder {
+        match self {
             Self::Enabled => client_builder,
             Self::Disabled => {
                 warn!(
@@ -156,18 +154,7 @@ impl TlsCertificateValidation {
                 );
                 client_builder.with_tls_config(|builder| builder.danger_accept_invalid_certs())
             }
-        })
-    }
-
-    fn ensure_supported(self) -> Result<(), GenericError> {
-        #[cfg(feature = "fips")]
-        if matches!(self, Self::Disabled) {
-            return Err(generic_error!(
-                "`skip_ssl_validation: true` is unsupported in FIPS mode because disabling TLS certificate validation is not FIPS-compliant."
-            ));
         }
-
-        Ok(())
     }
 }
 
@@ -229,7 +216,7 @@ where
             client_builder = client_builder.with_connection_age_limit(config.connection_reset_interval());
         }
 
-        client_builder = TlsCertificateValidation::from_forwarder_config(&config).apply_to(client_builder)?;
+        client_builder = TlsCertificateValidation::from_forwarder_config(&config).apply_to(client_builder);
 
         let client = client_builder.build()?;
 
@@ -1137,7 +1124,6 @@ app.datadoghq.com: [key-a, key-b]
 
         validation
             .apply_to(client_builder)
-            .expect("TLS certificate validation policy should apply")
             .build()
             .expect("HTTP client should build")
     }
@@ -1335,15 +1321,16 @@ app.datadoghq.com: [key-a, key-b]
 
     #[cfg(feature = "fips")]
     #[test]
-    fn skip_ssl_validation_rejected_in_fips_mode() {
-        let error = TlsCertificateValidation::Disabled
-            .ensure_supported()
-            .expect_err("skip_ssl_validation should be rejected in FIPS mode");
-        let message = error.to_string();
+    fn skip_ssl_validation_allowed_in_fips_mode() {
+        init_tls_crypto_provider();
 
-        assert!(message.contains("skip_ssl_validation"));
-        assert!(message.contains("FIPS mode"));
-        assert!(message.contains("disabling TLS certificate validation"));
+        let client_builder =
+            HttpClient::builder().with_tls_config(|builder| builder.with_root_cert_store(RootCertStore::empty()));
+
+        TlsCertificateValidation::Disabled
+            .apply_to(client_builder)
+            .build()
+            .expect("HTTP client should build with skip_ssl_validation enabled in FIPS mode");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

FIPS ADP currently hard-rejects any config where `skip_ssl_validation: true` is present, but the FIPS Datadog Agent accepts this setting. We update ADP to match behavior and enhance the warning message.

## Test plan

- [x] Added `skip_ssl_validation_allowed_in_fips_mode` (behind `#[cfg(feature = "fips")]`) verifying the FIPS-enabled HTTP client builds and accepts invalid certs with `skip_ssl_validation: true`.
- [x] Manually built ADP with the `fips` feature and ran it in standalone mode against a local HTTPS server presenting a self-signed cert, confirming `skip_ssl_validation: true` allowed metrics to forward successfully (`network_http_requests_success_total` incremented, no TLS errors).

Closes #2149.