### PR TITLE
chore(agent-data-plane): update lading version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1538,7 +1538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2608,7 +2608,7 @@ dependencies = [
 [[package]]
 name = "lading-payload"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/lading?rev=65770873b5c5880e11ad15dfefec7972bb3540e0#65770873b5c5880e11ad15dfefec7972bb3540e0"
+source = "git+https://github.com/DataDog/lading?rev=d65960d4e023c65dde5e950151f761ab5cb575b2#d65960d4e023c65dde5e950151f761ab5cb575b2"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -3002,7 +3002,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4087,7 +4087,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4100,7 +4100,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4171,7 +4171,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4691,7 +4691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5220,7 +5220,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6183,7 +6183,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1538,7 +1538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2608,7 +2608,7 @@ dependencies = [
 [[package]]
 name = "lading-payload"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/lading?rev=23ad8e3dcda0e732f7fb87ead04c2d88307e10c2#23ad8e3dcda0e732f7fb87ead04c2d88307e10c2"
+source = "git+https://github.com/DataDog/lading?rev=65770873b5c5880e11ad15dfefec7972bb3540e0#65770873b5c5880e11ad15dfefec7972bb3540e0"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -4100,7 +4100,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4171,7 +4171,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4691,7 +4691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5220,7 +5220,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6183,7 +6183,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1538,7 +1538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2608,7 +2608,7 @@ dependencies = [
 [[package]]
 name = "lading-payload"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/lading?rev=576129489df44ae0e71c4871c51910837c919b90#576129489df44ae0e71c4871c51910837c919b90"
+source = "git+https://github.com/DataDog/lading?rev=23ad8e3dcda0e732f7fb87ead04c2d88307e10c2#23ad8e3dcda0e732f7fb87ead04c2d88307e10c2"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -3002,7 +3002,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4100,7 +4100,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4171,7 +4171,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4691,7 +4691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5220,7 +5220,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6183,7 +6183,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ tower-http = { version = "0.7", default-features = false }
 bollard = { version = "0.21", default-features = false }
 home = { version = "0.5", default-features = false }
 reqwest = { version = "0.13", default-features = false }
-lading-payload = { git = "https://github.com/DataDog/lading", rev = "65770873b5c5880e11ad15dfefec7972bb3540e0" }
+lading-payload = { git = "https://github.com/DataDog/lading", rev = "d65960d4e023c65dde5e950151f761ab5cb575b2" }
 serde_yaml = { version = "0.9", default-features = false }
 serde_with = { version = "3.18.0", default-features = false, features = [
   "macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ tower-http = { version = "0.7", default-features = false }
 bollard = { version = "0.21", default-features = false }
 home = { version = "0.5", default-features = false }
 reqwest = { version = "0.13", default-features = false }
-lading-payload = { git = "https://github.com/DataDog/lading", rev = "23ad8e3dcda0e732f7fb87ead04c2d88307e10c2" }
+lading-payload = { git = "https://github.com/DataDog/lading", rev = "65770873b5c5880e11ad15dfefec7972bb3540e0" }
 serde_yaml = { version = "0.9", default-features = false }
 serde_with = { version = "3.18.0", default-features = false, features = [
   "macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ tower-http = { version = "0.7", default-features = false }
 bollard = { version = "0.21", default-features = false }
 home = { version = "0.5", default-features = false }
 reqwest = { version = "0.13", default-features = false }
-lading-payload = { git = "https://github.com/DataDog/lading", rev = "576129489df44ae0e71c4871c51910837c919b90" }
+lading-payload = { git = "https://github.com/DataDog/lading", rev = "23ad8e3dcda0e732f7fb87ead04c2d88307e10c2" }
 serde_yaml = { version = "0.9", default-features = false }
 serde_with = { version = "3.18.0", default-features = false, features = [
   "macros",

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ export CARGO_TOOL_VERSION_cargo-machete ?= 0.9.1
 export CARGO_TOOL_VERSION_rustfilt ?= 0.2.1
 export CARGO_TOOL_VERSION_cargo-auditable ?= 0.7.4
 export DDPROF_VERSION ?= 0.20.0
-export LADING_VERSION ?= sha-d608ffbce8f8c77b147d6750b3bb6d6948af239a
+export LADING_VERSION ?= sha-23ad8e3dcda0e732f7fb87ead04c2d88307e10c2
 
 # Windows cross-compilation settings. These targets currently assume a local macOS host.
 export WINDOWS_CROSS_TARGET ?= x86_64-pc-windows-msvc

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ export CARGO_TOOL_VERSION_cargo-machete ?= 0.9.1
 export CARGO_TOOL_VERSION_rustfilt ?= 0.2.1
 export CARGO_TOOL_VERSION_cargo-auditable ?= 0.7.4
 export DDPROF_VERSION ?= 0.20.0
-export LADING_VERSION ?= sha-65770873b5c5880e11ad15dfefec7972bb3540e0
+export LADING_VERSION ?= sha-d65960d4e023c65dde5e950151f761ab5cb575b2
 
 # Windows cross-compilation settings. These targets currently assume a local macOS host.
 export WINDOWS_CROSS_TARGET ?= x86_64-pc-windows-msvc

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ export CARGO_TOOL_VERSION_cargo-machete ?= 0.9.1
 export CARGO_TOOL_VERSION_rustfilt ?= 0.2.1
 export CARGO_TOOL_VERSION_cargo-auditable ?= 0.7.4
 export DDPROF_VERSION ?= 0.20.0
-export LADING_VERSION ?= sha-23ad8e3dcda0e732f7fb87ead04c2d88307e10c2
+export LADING_VERSION ?= sha-65770873b5c5880e11ad15dfefec7972bb3540e0
 
 # Windows cross-compilation settings. These targets currently assume a local macOS host.
 export WINDOWS_CROSS_TARGET ?= x86_64-pc-windows-msvc

--- a/bin/correctness/datadog-intake/src/app/metrics/handlers.rs
+++ b/bin/correctness/datadog-intake/src/app/metrics/handlers.rs
@@ -78,12 +78,24 @@ pub async fn handle_sketch_beta(State(state): State<MetricsState>, body: Bytes) 
         }
     };
 
-    match state.merge_sketch_payload(payload) {
+    match state.merge_sketch_payload(payload.clone()) {
         Ok(()) => {
             info!("Processed sketch payload.");
             StatusCode::ACCEPTED
         }
         Err(e) => {
+            for sketch in &payload.sketches {
+                for dogsketch in &sketch.dogsketches {
+                    if dogsketch.cnt < 0 {
+                        error!(
+                            metric = sketch.metric(),
+                            count = dogsketch.cnt,
+                            bin_count = dogsketch.n.len(),
+                            "Rejected sketch has a negative count."
+                        );
+                    }
+                }
+            }
             error!(error = %e, "Failed to merge sketch payload.");
             StatusCode::BAD_REQUEST
         }

--- a/test/correctness/cases/otlp-metrics/millstone.yaml
+++ b/test/correctness/cases/otlp-metrics/millstone.yaml
@@ -5,4 +5,11 @@ volume: 1000
 corpus:
   size: 10000
   payload:
-    opentelemetry_metrics: {}
+    opentelemetry_metrics:
+      histogram_count_limits:
+        # The downstream sketch format stores counts as signed 64-bit integers.
+        # Keep every generated bucket and zero count well below that boundary.
+        bucket: 10000
+        zero: 10000
+        # Exponential histograms have at most 200 buckets: 200 * bucket + zero.
+        total: 2010000


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Following changes made to `lading` to expand the set of OTLP metric types tested during correctness tests, we need to update the lading commit hash that ADP points to reflect this. 

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

N/A

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
- Relevant PR: https://github.com/DataDog/lading/pull/1908