### PR TITLE
feat(agent-data-plane): add per-metric tag value filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,7 @@ dependencies = [
  "process-memory",
  "prost",
  "prost-types",
+ "regex",
  "saluki-antithesis",
  "saluki-api",
  "saluki-app",

--- a/METRIC_TAG_FILTERLIST_README.md
+++ b/METRIC_TAG_FILTERLIST_README.md
@@ -1,0 +1,174 @@
+# Metric tag filter list
+
+`metric_tag_filterlist` changes selected DogStatsD metric tags before aggregation. It can reduce
+metric cardinality by removing tag keys, retaining only selected keys, or aggregating unwanted tag
+values under an untagged or sentinel context.
+
+Rules apply to exact metric names and currently affect counters and sketch-backed metrics, including
+distributions. They apply to both instrumented and origin tags.
+
+## Mental model
+
+Each entry runs in two stages:
+
+1. `action` and `tags` decide which **tag keys** survive.
+2. `tag_value_allowlists` or `tag_value_regexes` optionally constrain the **values** of surviving
+   keys.
+
+The resulting metric context is then aggregated. Metrics only combine when all remaining context
+dimensions match, including the metric name and other tags.
+
+## Filter tag keys
+
+To remove selected tag keys, use `exclude`. This is the default action:
+
+```yaml
+metric_tag_filterlist:
+  - metric_name: requests.count
+    action: exclude
+    tags:
+      - customer_id
+```
+
+To retain only selected tag keys, use `include`:
+
+```yaml
+metric_tag_filterlist:
+  - metric_name: requests.count
+    action: include
+    tags:
+      - env
+      - service
+```
+
+Key filtering compares tag names, not complete `name:value` strings. Metric names must match
+exactly; prefixes and wildcards are not supported. With an empty `tags` list, `exclude` preserves
+all keys and `include` removes all keys.
+
+## Allow selected tag values
+
+Use `tag_value_allowlists` to retain configured values and aggregate everything else:
+
+```yaml
+metric_tag_filterlist:
+  - metric_name: requests.count
+    action: exclude
+    tags: []
+    tag_value_allowlists:
+      customer_id:
+        values:
+          - customer-1
+          - customer-2
+        on_miss: replace
+        replacement: other
+```
+
+Each allowlist supports:
+
+| Field | Default | Behavior |
+| --- | --- | --- |
+| `values` | `[]` | Values retained unchanged. An empty list makes every value a mismatch. |
+| `on_miss` | `remove` | Either remove the tag or replace its value. |
+| `replacement` | `other` | Sentinel used when `on_miss` is `replace`. |
+
+With `on_miss: remove`, rejected values lose the tag and combine with otherwise-identical untagged
+metrics. With `on_miss: replace`, they retain an explicit group such as `customer_id:other`.
+
+## Require tag values to match a regular expression
+
+Use `tag_value_regexes` to retain values matching a pattern and replace non-matches:
+
+```yaml
+metric_tag_filterlist:
+  - metric_name: requests.count
+    action: exclude
+    tags: []
+    tag_value_regexes:
+      customer_id:
+        pattern: "customer-[0-9]+"
+        replacement: invalid
+```
+
+The pattern uses Rust regular expression syntax and must match the complete tag value. The
+`replacement` defaults to `other`. Invalid patterns are configuration errors. Bare tags have no
+value and are replaced.
+
+## Combine key and value filtering
+
+Key filtering always runs first. With `action: include`, add every value-filtered key to `tags` or
+the key is removed before its value rule runs:
+
+```yaml
+metric_tag_filterlist:
+  - metric_name: requests.count
+    action: include
+    tags:
+      - env
+      - customer_id
+    tag_value_allowlists:
+      customer_id:
+        values:
+          - customer-1
+        on_miss: replace
+        replacement: other
+```
+
+A metric/tag pair can have an allowlist or a regular expression, but not both.
+
+## Duplicate rules and updates
+
+Multiple entries for the same metric merge as follows:
+
+- Entries with the same `action` union their tag-key lists.
+- If key-filter actions conflict, `exclude` wins.
+- Compatible allowlists union their allowed values.
+- Conflicting allowlist mismatch behavior or replacement values are errors.
+- Duplicate regular expression rules must have identical patterns and replacements.
+
+Invalid startup configuration prevents the component from starting. Invalid runtime updates are
+rejected, logged, and leave the last valid rules active. Valid runtime updates replace the compiled
+rules and clear the filtered-context cache.
+
+## Operational considerations
+
+- Choose sentinel values that cannot collide with real values.
+- `replace` usually produces clearer grouped dashboards because overflow appears as an explicit
+  value. It adds one bounded tag value.
+- `remove` minimizes contexts and avoids an overflow group, but it cannot distinguish rejected
+  values from metrics that arrived without the tag.
+- Queries for specific allowed values behave normally. Unfiltered totals include both allowed and
+  aggregated contexts.
+- The Core Agent does not interpret the value-rule extensions. When ADP is enabled, keep
+  `metric_tag_filterlist_adp_only: true`.
+- `data_plane.dogstatsd.aggregator_tag_filter_cache_capacity` controls the filtered-context cache
+  and defaults to 100,000. It changes resource usage and cache churn, not filtering semantics.
+
+## Schema coherence notes
+
+The current schema exposes three related concepts in separate fields:
+
+- `action` plus `tags` filters keys.
+- `tag_value_allowlists` matches explicit values and can remove or replace mismatches.
+- `tag_value_regexes` matches patterns and always replaces mismatches.
+
+This is functional, but it creates two asymmetries: value matching is split across two maps, and
+only allowlists expose `on_miss`. Duplicate-entry merging also requires several conflict rules.
+
+A possible future simplification is one value-rule map with a single matcher and mismatch policy:
+
+```yaml
+metric_tag_filterlist:
+  - metric_name: requests.count
+    action: exclude
+    tags: []
+    tag_value_rules:
+      customer_id:
+        match:
+          values: [customer-1, customer-2]
+          # Alternatively: regex: "customer-[0-9]+"
+        on_miss: replace
+        replacement: other
+```
+
+This alternative is not implemented. It is included to make the current schema trade-offs explicit
+while evaluating the experimental feature.

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -35,6 +35,7 @@ ottl = { workspace = true }
 process-memory = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
+regex = { workspace = true, features = ["std", "perf"] }
 saluki-antithesis = { workspace = true }
 saluki-api = { workspace = true }
 saluki-app = { workspace = true }

--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -13,6 +13,7 @@ use std::{collections::HashMap as StdHashMap, num::NonZeroUsize, time::Duration}
 use async_trait::async_trait;
 use foldhash::fast::RandomState as FoldHashState;
 use hashbrown::{HashMap, HashSet};
+use regex::Regex;
 use saluki_common::cache::{Cache, CacheBuilder};
 use saluki_config::GenericConfiguration;
 use saluki_context::{tags::Tag, Context, TagSetMutViewState};
@@ -122,6 +123,18 @@ impl Default for TagValueAllowlist {
     }
 }
 
+/// A regular expression and replacement sentinel for one tag key.
+#[derive(Clone, Debug, Deserialize)]
+pub struct TagValueRegex {
+    /// Regular expression that the complete tag value must match.
+    pub pattern: String,
+    /// Value used when the regular expression does not match.
+    ///
+    /// The default is `other`. Configure a value that cannot collide with a real tag value.
+    #[serde(default = "default_tag_value_replacement")]
+    pub replacement: String,
+}
+
 /// A single metric tag filter entry.
 #[derive(Clone, Debug, Deserialize)]
 pub struct MetricTagFilterEntry {
@@ -140,6 +153,12 @@ pub struct MetricTagFilterEntry {
     /// whose unbounded values would create excessive metric cardinality.
     #[serde(default)]
     pub tag_value_allowlists: StdHashMap<String, TagValueAllowlist>,
+    /// Regular expressions required to match specific tag values.
+    ///
+    /// Values that do not match are replaced with the configured sentinel. The map is empty by
+    /// default, which disables regular expression filtering.
+    #[serde(default)]
+    pub tag_value_regexes: StdHashMap<String, TagValueRegex>,
 }
 
 #[derive(Eq, PartialEq)]
@@ -153,11 +172,18 @@ struct CompiledTagValueAllowlist {
     on_miss: CompiledMismatchAction,
 }
 
+struct CompiledTagValueRegex {
+    pattern: String,
+    regex: Regex,
+    replacement: Tag,
+}
+
 /// A compiled filter rule for one metric name.
 pub struct CompiledFilter {
     is_exclude: bool,
     tag_names: HashSet<String, FoldHashState>,
     tag_value_allowlists: HashMap<String, CompiledTagValueAllowlist, FoldHashState>,
+    tag_value_regexes: HashMap<String, CompiledTagValueRegex, FoldHashState>,
 }
 
 /// Compiled filter table keyed by metric name.
@@ -186,8 +212,9 @@ pub enum FilterMetricTagsOutcome {
 ///
 /// # Errors
 ///
-/// Returns an error when duplicate rules for the same metric and tag key configure different
-/// mismatch actions or replacement values.
+/// Returns an error when a regular expression is invalid, when the same metric and tag key has
+/// both an allowlist and a regular expression, or when duplicate rules configure conflicting
+/// behavior.
 pub fn compile_filters(entries: &[MetricTagFilterEntry]) -> Result<CompiledFilters, GenericError> {
     let mut filters: CompiledFilters = HashMap::with_hasher(FoldHashState::default());
 
@@ -221,12 +248,45 @@ pub fn compile_filters(entries: &[MetricTagFilterEntry]) -> Result<CompiledFilte
             );
         }
 
+        let mut tag_value_regexes =
+            HashMap::with_capacity_and_hasher(entry.tag_value_regexes.len(), FoldHashState::default());
+        for (tag_name, regex) in &entry.tag_value_regexes {
+            if tag_value_allowlists.contains_key(tag_name) {
+                return Err(generic_error!(
+                    "Metric '{}' configures both a tag value allowlist and regular expression for tag '{}'. \
+                     Configure only one value aggregation rule for that metric and tag.",
+                    entry.metric_name,
+                    tag_name
+                ));
+            }
+
+            let anchored_pattern = format!(r"\A(?:{})\z", regex.pattern);
+            let compiled = Regex::new(&anchored_pattern).map_err(|error| {
+                generic_error!(
+                    "Invalid tag value regular expression '{}' for metric '{}' and tag '{}': {}",
+                    regex.pattern,
+                    entry.metric_name,
+                    tag_name,
+                    error
+                )
+            })?;
+            tag_value_regexes.insert(
+                tag_name.clone(),
+                CompiledTagValueRegex {
+                    pattern: regex.pattern.clone(),
+                    regex: compiled,
+                    replacement: Tag::from(format!("{}:{}", tag_name, regex.replacement)),
+                },
+            );
+        }
+
         match filters.entry(entry.metric_name.clone()) {
             hashbrown::hash_map::Entry::Vacant(e) => {
                 e.insert(CompiledFilter {
                     is_exclude,
                     tag_names,
                     tag_value_allowlists,
+                    tag_value_regexes,
                 });
             }
             hashbrown::hash_map::Entry::Occupied(mut e) => {
@@ -239,6 +299,14 @@ pub fn compile_filters(entries: &[MetricTagFilterEntry]) -> Result<CompiledFilte
                 }
 
                 for (tag_name, allowlist) in tag_value_allowlists {
+                    if existing.tag_value_regexes.contains_key(&tag_name) {
+                        return Err(generic_error!(
+                            "Metric '{}' configures both a tag value allowlist and regular expression for tag '{}'. \
+                             Configure only one value aggregation rule for that metric and tag.",
+                            entry.metric_name,
+                            tag_name
+                        ));
+                    }
                     match existing.tag_value_allowlists.entry(tag_name) {
                         hashbrown::hash_map::Entry::Vacant(e) => {
                             e.insert(allowlist);
@@ -253,6 +321,35 @@ pub fn compile_filters(entries: &[MetricTagFilterEntry]) -> Result<CompiledFilte
                                 ));
                             }
                             e.get_mut().allowed_values.extend(allowlist.allowed_values);
+                        }
+                    }
+                }
+
+                for (tag_name, regex) in tag_value_regexes {
+                    if existing.tag_value_allowlists.contains_key(&tag_name) {
+                        return Err(generic_error!(
+                            "Metric '{}' configures both a tag value allowlist and regular expression for tag '{}'. \
+                             Configure only one value aggregation rule for that metric and tag.",
+                            entry.metric_name,
+                            tag_name
+                        ));
+                    }
+                    match existing.tag_value_regexes.entry(tag_name) {
+                        hashbrown::hash_map::Entry::Vacant(e) => {
+                            e.insert(regex);
+                        }
+                        hashbrown::hash_map::Entry::Occupied(e) => {
+                            let existing_regex = e.get();
+                            if existing_regex.pattern != regex.pattern
+                                || existing_regex.replacement != regex.replacement
+                            {
+                                return Err(generic_error!(
+                                    "Conflicting tag value regular expressions for metric '{}' and tag '{}'. \
+                                     Combine the duplicate rules or configure the same `pattern` and `replacement` values.",
+                                    entry.metric_name,
+                                    e.key()
+                                ));
+                            }
                         }
                     }
                 }
@@ -450,21 +547,31 @@ fn filter_tag<'a>(tag: &Tag, filter: &'a CompiledFilter) -> TagFilterAction<'a> 
         return TagFilterAction::Remove;
     }
 
-    let Some(allowlist) = filter.tag_value_allowlists.get(tag.name()) else {
-        return TagFilterAction::Keep;
-    };
-    if tag
-        .value()
-        .is_some_and(|value| allowlist.allowed_values.contains(value))
-    {
-        return TagFilterAction::Keep;
+    if let Some(allowlist) = filter.tag_value_allowlists.get(tag.name()) {
+        if tag
+            .value()
+            .is_some_and(|value| allowlist.allowed_values.contains(value))
+        {
+            return TagFilterAction::Keep;
+        }
+
+        return match &allowlist.on_miss {
+            CompiledMismatchAction::Remove => TagFilterAction::Remove,
+            CompiledMismatchAction::Replace(replacement) if replacement.as_str() == tag.as_ref() => {
+                TagFilterAction::Keep
+            }
+            CompiledMismatchAction::Replace(replacement) => TagFilterAction::Replace(replacement),
+        };
     }
 
-    match &allowlist.on_miss {
-        CompiledMismatchAction::Remove => TagFilterAction::Remove,
-        CompiledMismatchAction::Replace(replacement) if replacement.as_str() == tag.as_ref() => TagFilterAction::Keep,
-        CompiledMismatchAction::Replace(replacement) => TagFilterAction::Replace(replacement),
+    if let Some(regex) = filter.tag_value_regexes.get(tag.name()) {
+        if tag.value().is_some_and(|value| regex.regex.is_match(value)) || regex.replacement.as_str() == tag.as_ref() {
+            return TagFilterAction::Keep;
+        }
+        return TagFilterAction::Replace(&regex.replacement);
     }
+
+    TagFilterAction::Keep
 }
 
 /// Filters the tags of a metric according to the compiled filter table.
@@ -590,6 +697,18 @@ mod tests {
         .collect()
     }
 
+    fn value_regex(tag_name: &str, pattern: &str, replacement: &str) -> StdHashMap<String, TagValueRegex> {
+        [(
+            tag_name.to_string(),
+            TagValueRegex {
+                pattern: pattern.to_string(),
+                replacement: replacement.to_string(),
+            },
+        )]
+        .into_iter()
+        .collect()
+    }
+
     #[test]
     fn exclude_removes_listed_tags() {
         let entries = vec![MetricTagFilterEntry {
@@ -597,6 +716,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec!["env".to_string(), "host".to_string()],
             tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
 
@@ -614,6 +734,7 @@ mod tests {
             action: FilterAction::Include,
             tags: vec!["env".to_string()],
             tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
 
@@ -631,6 +752,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec![],
             tag_value_allowlists: value_allowlist("customer_id", &["top-1", "top-2"]),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
         let mut state = TagSetMutViewState::default();
@@ -653,6 +775,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec![],
             tag_value_allowlists: replacing_value_allowlist("customer_id", &["top-1"], "other"),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
         let mut metric = distribution_metric("my.dist", &["customer_id:unlisted", "service:web"]);
@@ -671,6 +794,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec![],
             tag_value_allowlists: replacing_value_allowlist("customer_id", &[], "other"),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
         let mut metric = distribution_metric("my.dist", &["customer_id:other"]);
@@ -689,6 +813,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec![],
             tag_value_allowlists: replacing_value_allowlist("customer_id", &[], "other"),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
         let mut metric = distribution_metric("my.dist", &["customer_id:a", "customer_id:b"]);
@@ -707,6 +832,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec![],
             tag_value_allowlists: value_allowlist("customer_id", &["top-1"]),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
         let mut metric = distribution_metric("my.dist", &["customer_id", "customer_id:", "service:web"]);
@@ -725,6 +851,7 @@ mod tests {
             action: FilterAction::Include,
             tags: vec!["service".to_string()],
             tag_value_allowlists: value_allowlist("customer_id", &["top-1"]),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
         let mut metric = distribution_metric("my.dist", &["customer_id:top-1", "service:web"]);
@@ -736,12 +863,144 @@ mod tests {
     }
 
     #[test]
+    fn value_regex_keeps_full_matches_and_replaces_non_matches() {
+        let entries = vec![MetricTagFilterEntry {
+            metric_name: "my.dist".to_string(),
+            action: FilterAction::Exclude,
+            tags: vec![],
+            tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: value_regex("customer_id", r"customer-[0-9]+", "invalid"),
+        }];
+        let filters = compile_filters(&entries).unwrap();
+        let mut state = TagSetMutViewState::default();
+
+        let mut matching = distribution_metric("my.dist", &["customer_id:customer-42", "service:web"]);
+        assert_eq!(
+            filter_metric_tags(&mut matching, &mut state, &filters),
+            FilterMetricTagsOutcome::NoChange
+        );
+        assert_eq!(tag_names(&matching), vec!["customer_id:customer-42", "service:web"]);
+
+        let mut non_matching =
+            distribution_metric("my.dist", &["customer_id:prefix-customer-42-suffix", "service:web"]);
+        assert_eq!(
+            filter_metric_tags(&mut non_matching, &mut state, &filters),
+            FilterMetricTagsOutcome::Modified { removed_tags: 1 }
+        );
+        assert_eq!(tag_names(&non_matching), vec!["customer_id:invalid", "service:web"]);
+    }
+
+    #[test]
+    fn value_regex_replaces_bare_tags_and_preserves_the_sentinel() {
+        let entries = vec![MetricTagFilterEntry {
+            metric_name: "my.dist".to_string(),
+            action: FilterAction::Exclude,
+            tags: vec![],
+            tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: value_regex("customer_id", r"customer-[0-9]+", "invalid"),
+        }];
+        let filters = compile_filters(&entries).unwrap();
+        let mut state = TagSetMutViewState::default();
+
+        let mut bare = distribution_metric("my.dist", &["customer_id"]);
+        filter_metric_tags(&mut bare, &mut state, &filters);
+        assert_eq!(tag_names(&bare), vec!["customer_id:invalid"]);
+
+        let mut sentinel = distribution_metric("my.dist", &["customer_id:invalid"]);
+        assert_eq!(
+            filter_metric_tags(&mut sentinel, &mut state, &filters),
+            FilterMetricTagsOutcome::NoChange
+        );
+    }
+
+    #[test]
+    fn value_regex_replaces_non_matching_origin_tags() {
+        let entries = vec![MetricTagFilterEntry {
+            metric_name: "my.dist".to_string(),
+            action: FilterAction::Exclude,
+            tags: vec![],
+            tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: value_regex("region", r"[a-z]+-[0-9]+", "invalid"),
+        }];
+        let filters = compile_filters(&entries).unwrap();
+        let mut metric = distribution_metric_with_origin_tags("my.dist", &[], &["region:bad", "service:web"]);
+        let mut state = TagSetMutViewState::default();
+
+        filter_metric_tags(&mut metric, &mut state, &filters);
+
+        assert_eq!(origin_tag_names(&metric), vec!["region:invalid", "service:web"]);
+    }
+
+    #[test]
+    fn invalid_value_regex_is_rejected() {
+        let entries = vec![MetricTagFilterEntry {
+            metric_name: "my.dist".to_string(),
+            action: FilterAction::Exclude,
+            tags: vec![],
+            tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: value_regex("customer_id", "[", "invalid"),
+        }];
+
+        let error = compile_filters(&entries)
+            .err()
+            .expect("invalid regular expression must fail");
+
+        assert!(error.to_string().contains("metric 'my.dist' and tag 'customer_id'"));
+    }
+
+    #[test]
+    fn allowlist_and_value_regex_for_same_tag_are_rejected() {
+        let entries = vec![MetricTagFilterEntry {
+            metric_name: "my.dist".to_string(),
+            action: FilterAction::Exclude,
+            tags: vec![],
+            tag_value_allowlists: value_allowlist("customer_id", &["top-1"]),
+            tag_value_regexes: value_regex("customer_id", r"customer-[0-9]+", "invalid"),
+        }];
+
+        let error = compile_filters(&entries)
+            .err()
+            .expect("overlapping value aggregation rules must fail");
+
+        assert!(error
+            .to_string()
+            .contains("both a tag value allowlist and regular expression"));
+    }
+
+    #[test]
+    fn conflicting_duplicate_value_regexes_are_rejected() {
+        let entries = vec![
+            MetricTagFilterEntry {
+                metric_name: "my.dist".to_string(),
+                action: FilterAction::Exclude,
+                tags: vec![],
+                tag_value_allowlists: StdHashMap::default(),
+                tag_value_regexes: value_regex("customer_id", r"customer-[0-9]+", "invalid"),
+            },
+            MetricTagFilterEntry {
+                metric_name: "my.dist".to_string(),
+                action: FilterAction::Exclude,
+                tags: vec![],
+                tag_value_allowlists: StdHashMap::default(),
+                tag_value_regexes: value_regex("customer_id", r"customer-[a-z]+", "invalid"),
+            },
+        ];
+
+        let error = compile_filters(&entries)
+            .err()
+            .expect("conflicting regular expressions must fail");
+
+        assert!(error.to_string().contains("metric 'my.dist' and tag 'customer_id'"));
+    }
+
+    #[test]
     fn non_matching_metric_unchanged() {
         let entries = vec![MetricTagFilterEntry {
             metric_name: "other.dist".to_string(),
             action: FilterAction::Exclude,
             tags: vec!["env".to_string()],
             tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
 
@@ -766,6 +1025,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec!["env".to_string(), "host".to_string()],
             tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
 
@@ -784,6 +1044,7 @@ mod tests {
             action: FilterAction::Include,
             tags: vec!["env".to_string()],
             tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
 
@@ -802,6 +1063,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec!["env".to_string()],
             tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
 
@@ -820,6 +1082,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec!["region".to_string()],
             tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
 
@@ -838,6 +1101,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec!["production".to_string()],
             tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
 
@@ -855,6 +1119,7 @@ mod tests {
             action: FilterAction::Include,
             tags: vec![],
             tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
 
@@ -872,6 +1137,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec![],
             tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
 
@@ -890,12 +1156,14 @@ mod tests {
                 action: FilterAction::Exclude,
                 tags: vec!["env".to_string()],
                 tag_value_allowlists: StdHashMap::default(),
+                tag_value_regexes: StdHashMap::default(),
             },
             MetricTagFilterEntry {
                 metric_name: "my.dist".to_string(),
                 action: FilterAction::Exclude,
                 tags: vec!["host".to_string()],
                 tag_value_allowlists: StdHashMap::default(),
+                tag_value_regexes: StdHashMap::default(),
             },
         ];
         let filters = compile_filters(&entries).unwrap();
@@ -915,12 +1183,14 @@ mod tests {
                 action: FilterAction::Exclude,
                 tags: vec![],
                 tag_value_allowlists: value_allowlist("customer_id", &["top-1"]),
+                tag_value_regexes: StdHashMap::default(),
             },
             MetricTagFilterEntry {
                 metric_name: "my.dist".to_string(),
                 action: FilterAction::Exclude,
                 tags: vec![],
                 tag_value_allowlists: value_allowlist("customer_id", &["top-2"]),
+                tag_value_regexes: StdHashMap::default(),
             },
         ];
         let filters = compile_filters(&entries).unwrap();
@@ -943,12 +1213,14 @@ mod tests {
                 action: FilterAction::Exclude,
                 tags: vec![],
                 tag_value_allowlists: replacing_value_allowlist("customer_id", &["top-1"], "other"),
+                tag_value_regexes: StdHashMap::default(),
             },
             MetricTagFilterEntry {
                 metric_name: "my.dist".to_string(),
                 action: FilterAction::Exclude,
                 tags: vec![],
                 tag_value_allowlists: replacing_value_allowlist("customer_id", &["top-2"], "aggregated"),
+                tag_value_regexes: StdHashMap::default(),
             },
         ];
 
@@ -967,12 +1239,14 @@ mod tests {
                 action: FilterAction::Exclude,
                 tags: vec![],
                 tag_value_allowlists: value_allowlist("customer_id", &["top-1"]),
+                tag_value_regexes: StdHashMap::default(),
             },
             MetricTagFilterEntry {
                 metric_name: "my.dist".to_string(),
                 action: FilterAction::Exclude,
                 tags: vec![],
                 tag_value_allowlists: replacing_value_allowlist("customer_id", &["top-2"], "other"),
+                tag_value_regexes: StdHashMap::default(),
             },
         ];
 
@@ -991,12 +1265,14 @@ mod tests {
                 action: FilterAction::Include,
                 tags: vec!["env".to_string()],
                 tag_value_allowlists: StdHashMap::default(),
+                tag_value_regexes: StdHashMap::default(),
             },
             MetricTagFilterEntry {
                 metric_name: "my.dist".to_string(),
                 action: FilterAction::Exclude,
                 tags: vec!["host".to_string()],
                 tag_value_allowlists: StdHashMap::default(),
+                tag_value_regexes: StdHashMap::default(),
             },
         ];
         let filters = compile_filters(&entries).unwrap();
@@ -1016,12 +1292,14 @@ mod tests {
                 action: FilterAction::Exclude,
                 tags: vec!["host".to_string()],
                 tag_value_allowlists: StdHashMap::default(),
+                tag_value_regexes: StdHashMap::default(),
             },
             MetricTagFilterEntry {
                 metric_name: "my.dist".to_string(),
                 action: FilterAction::Include,
                 tags: vec!["env".to_string()],
                 tag_value_allowlists: StdHashMap::default(),
+                tag_value_regexes: StdHashMap::default(),
             },
         ];
         let filters = compile_filters(&entries).unwrap();
@@ -1050,12 +1328,14 @@ mod tests {
                 action: FilterAction::Exclude,
                 tags: vec!["env".to_string()],
                 tag_value_allowlists: StdHashMap::default(),
+                tag_value_regexes: StdHashMap::default(),
             },
             MetricTagFilterEntry {
                 metric_name: "my.dist".to_string(),
                 action: FilterAction::Exclude,
                 tags: vec!["host".to_string()],
                 tag_value_allowlists: StdHashMap::default(),
+                tag_value_regexes: StdHashMap::default(),
             },
         ];
         let filters = compile_filters(&entries).unwrap();
@@ -1089,6 +1369,20 @@ mod tests {
         let allowlist = &entry.tag_value_allowlists["customer_id"];
         assert_eq!(allowlist.on_miss, TagValueMismatchAction::Remove);
         assert_eq!(allowlist.replacement, "other");
+    }
+
+    #[test]
+    fn value_regex_defaults_to_other_replacement() {
+        let entry: MetricTagFilterEntry = serde_json::from_value(json!({
+            "metric_name": "my.dist",
+            "tags": [],
+            "tag_value_regexes": {
+                "customer_id": { "pattern": "customer-[0-9]+" }
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(entry.tag_value_regexes["customer_id"].replacement, "other");
     }
 
     #[test]
@@ -1132,6 +1426,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec!["env".to_string(), "host".to_string()],
             tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
 
@@ -1150,6 +1445,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec![],
             tag_value_allowlists: value_allowlist("customer_id", &["top-1"]),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
         let mut metric = distribution_metric_with_origin_tags(
@@ -1171,6 +1467,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec![],
             tag_value_allowlists: replacing_value_allowlist("customer_id", &["top-1"], "other"),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
         let mut metric = distribution_metric_with_origin_tags("my.dist", &[], &["customer_id:unlisted", "service:web"]);
@@ -1188,6 +1485,7 @@ mod tests {
             action: FilterAction::Include,
             tags: vec!["env".to_string()],
             tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
 
@@ -1206,6 +1504,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec!["env".to_string()],
             tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
 
@@ -1236,6 +1535,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec!["env".to_string(), "host".to_string()],
             tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
 
@@ -1263,6 +1563,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec!["env".to_string(), "host".to_string()],
             tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
 
@@ -1363,6 +1664,12 @@ mod tests {
                             "on_miss": "replace",
                             "replacement": "aggregated"
                         }
+                    },
+                    "tag_value_regexes": {
+                        "region": {
+                            "pattern": "[a-z]+-[0-9]+",
+                            "replacement": "invalid"
+                        }
                     }
                 }]),
             })
@@ -1378,12 +1685,15 @@ mod tests {
 
         let filters = compile_filters(new_entries.as_deref().unwrap_or(&[])).unwrap();
 
-        let mut metric = distribution_metric("my.dist", &["customer_id:other", "env:prod", "host:h1", "service:web"]);
+        let mut metric = distribution_metric(
+            "my.dist",
+            &["customer_id:other", "env:prod", "host:h1", "region:bad", "service:web"],
+        );
         let mut state = TagSetMutViewState::default();
         filter_metric_tags(&mut metric, &mut state, &filters);
         assert_eq!(
             tag_names(&metric),
-            vec!["customer_id:aggregated", "env:prod", "service:web"]
+            vec!["customer_id:aggregated", "env:prod", "region:invalid", "service:web"]
         );
     }
 
@@ -1482,6 +1792,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec!["host".to_string()],
             tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
 
@@ -1502,6 +1813,7 @@ mod tests {
             action: FilterAction::Exclude,
             tags: vec!["region".to_string()],
             tag_value_allowlists: StdHashMap::default(),
+            tag_value_regexes: StdHashMap::default(),
         }];
         let filters = compile_filters(&entries).unwrap();
         let shared_tags = ["env:prod", "host:h1"]

--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -8,7 +8,7 @@
 
 mod telemetry;
 
-use std::{num::NonZeroUsize, time::Duration};
+use std::{collections::HashMap as StdHashMap, num::NonZeroUsize, time::Duration};
 
 use async_trait::async_trait;
 use foldhash::fast::RandomState as FoldHashState;
@@ -29,7 +29,7 @@ use saluki_core::{
     observability::ComponentMetricsExt,
     topology::OutputDefinition,
 };
-use saluki_error::GenericError;
+use saluki_error::{generic_error, GenericError};
 use saluki_metrics::MetricsBuilder;
 use serde::{de::Deserializer, Deserialize};
 use tokio::select;
@@ -77,6 +77,51 @@ impl<'de> Deserialize<'de> for FilterAction {
     }
 }
 
+fn default_tag_value_replacement() -> String {
+    "other".to_string()
+}
+
+/// Action applied when a tag value is absent from its allowlist.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum TagValueMismatchAction {
+    /// Removes the tag.
+    #[default]
+    Remove,
+    /// Replaces the tag value with the configured sentinel.
+    Replace,
+}
+
+/// An allowlist and mismatch behavior for one tag key.
+#[derive(Clone, Debug, Deserialize)]
+pub struct TagValueAllowlist {
+    /// Tag values retained unchanged.
+    ///
+    /// The list is empty by default, so every value is treated as a mismatch.
+    #[serde(default)]
+    pub values: Vec<String>,
+    /// Action applied to values absent from `values`.
+    ///
+    /// The default is [`Remove`][TagValueMismatchAction::Remove].
+    #[serde(default)]
+    pub on_miss: TagValueMismatchAction,
+    /// Value used when `on_miss` is [`Replace`][TagValueMismatchAction::Replace].
+    ///
+    /// The default is `other`. Configure a value that cannot collide with a real tag value.
+    #[serde(default = "default_tag_value_replacement")]
+    pub replacement: String,
+}
+
+impl Default for TagValueAllowlist {
+    fn default() -> Self {
+        Self {
+            values: Vec::new(),
+            on_miss: TagValueMismatchAction::Remove,
+            replacement: default_tag_value_replacement(),
+        }
+    }
+}
+
 /// A single metric tag filter entry.
 #[derive(Clone, Debug, Deserialize)]
 pub struct MetricTagFilterEntry {
@@ -87,10 +132,36 @@ pub struct MetricTagFilterEntry {
     pub action: FilterAction,
     /// Tag key names to include or exclude.
     pub tags: Vec<String>,
+    /// Value allowlists for specific tag keys.
+    ///
+    /// After applying `action` and `tags`, a tag whose key is present in this map is retained only
+    /// when its value is listed. The configured mismatch action removes the tag or replaces its
+    /// value. The map is empty by default, which disables value filtering. Use this for tag keys
+    /// whose unbounded values would create excessive metric cardinality.
+    #[serde(default)]
+    pub tag_value_allowlists: StdHashMap<String, TagValueAllowlist>,
 }
 
-/// Compiled filter table: metric name → (`is_exclude`, set of tag key names).
-pub type CompiledFilters = HashMap<String, (bool, HashSet<String, FoldHashState>), FoldHashState>;
+#[derive(Eq, PartialEq)]
+enum CompiledMismatchAction {
+    Remove,
+    Replace(Tag),
+}
+
+struct CompiledTagValueAllowlist {
+    allowed_values: HashSet<String, FoldHashState>,
+    on_miss: CompiledMismatchAction,
+}
+
+/// A compiled filter rule for one metric name.
+pub struct CompiledFilter {
+    is_exclude: bool,
+    tag_names: HashSet<String, FoldHashState>,
+    tag_value_allowlists: HashMap<String, CompiledTagValueAllowlist, FoldHashState>,
+}
+
+/// Compiled filter table keyed by metric name.
+pub type CompiledFilters = HashMap<String, CompiledFilter, FoldHashState>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 /// Outcome of attempting to apply `metric_tag_filterlist` rules to a metric.
@@ -111,7 +182,13 @@ pub enum FilterMetricTagsOutcome {
 /// Merge rules:
 /// - Same metric name + same action → union of tag key sets.
 /// - Same metric name + conflicting actions → `exclude` wins.
-pub fn compile_filters(entries: &[MetricTagFilterEntry]) -> CompiledFilters {
+/// - Value allowlists for the same metric and tag key → union of allowed values.
+///
+/// # Errors
+///
+/// Returns an error when duplicate rules for the same metric and tag key configure different
+/// mismatch actions or replacement values.
+pub fn compile_filters(entries: &[MetricTagFilterEntry]) -> Result<CompiledFilters, GenericError> {
     let mut filters: CompiledFilters = HashMap::with_hasher(FoldHashState::default());
 
     for entry in entries {
@@ -120,31 +197,75 @@ pub fn compile_filters(entries: &[MetricTagFilterEntry]) -> CompiledFilters {
         }
 
         let is_exclude = entry.action == FilterAction::Exclude;
-        let mut tag_set = HashSet::with_capacity_and_hasher(entry.tags.len(), FoldHashState::default());
-        tag_set.extend(entry.tags.iter().cloned());
+        let mut tag_names = HashSet::with_capacity_and_hasher(entry.tags.len(), FoldHashState::default());
+        tag_names.extend(entry.tags.iter().cloned());
+
+        let mut tag_value_allowlists =
+            HashMap::with_capacity_and_hasher(entry.tag_value_allowlists.len(), FoldHashState::default());
+        for (tag_name, allowlist) in &entry.tag_value_allowlists {
+            let mut allowed_values =
+                HashSet::with_capacity_and_hasher(allowlist.values.len(), FoldHashState::default());
+            allowed_values.extend(allowlist.values.iter().cloned());
+            let on_miss = match allowlist.on_miss {
+                TagValueMismatchAction::Remove => CompiledMismatchAction::Remove,
+                TagValueMismatchAction::Replace => {
+                    CompiledMismatchAction::Replace(Tag::from(format!("{}:{}", tag_name, allowlist.replacement)))
+                }
+            };
+            tag_value_allowlists.insert(
+                tag_name.clone(),
+                CompiledTagValueAllowlist {
+                    allowed_values,
+                    on_miss,
+                },
+            );
+        }
 
         match filters.entry(entry.metric_name.clone()) {
             hashbrown::hash_map::Entry::Vacant(e) => {
-                e.insert((is_exclude, tag_set));
+                e.insert(CompiledFilter {
+                    is_exclude,
+                    tag_names,
+                    tag_value_allowlists,
+                });
             }
             hashbrown::hash_map::Entry::Occupied(mut e) => {
-                let (existing_is_exclude, existing_tags) = e.get_mut();
-                if *existing_is_exclude == is_exclude {
-                    existing_tags.extend(tag_set);
+                let existing = e.get_mut();
+                if existing.is_exclude == is_exclude {
+                    existing.tag_names.extend(tag_names);
                 } else if is_exclude {
-                    *existing_is_exclude = true;
-                    *existing_tags = tag_set;
+                    existing.is_exclude = true;
+                    existing.tag_names = tag_names;
+                }
+
+                for (tag_name, allowlist) in tag_value_allowlists {
+                    match existing.tag_value_allowlists.entry(tag_name) {
+                        hashbrown::hash_map::Entry::Vacant(e) => {
+                            e.insert(allowlist);
+                        }
+                        hashbrown::hash_map::Entry::Occupied(mut e) => {
+                            if e.get().on_miss != allowlist.on_miss {
+                                return Err(generic_error!(
+                                    "Conflicting tag value mismatch behavior for metric '{}' and tag '{}'. \
+                                     Combine the duplicate rules or configure the same `on_miss` and `replacement` values.",
+                                    entry.metric_name,
+                                    e.key()
+                                ));
+                            }
+                            e.get_mut().allowed_values.extend(allowlist.allowed_values);
+                        }
+                    }
                 }
             }
         }
     }
 
-    filters
+    Ok(filters)
 }
 
 /// Metric Tag Filterlist transform.
 ///
-/// Removes or retains specific tags from distribution metrics based on per-metric configuration.
+/// Removes or retains specific tags from counter and sketch-backed metrics based on per-metric configuration.
 /// Configuration is read from `metric_tag_filterlist` and supports runtime updates via Remote Config.
 #[derive(Deserialize)]
 pub struct TagFilterlistConfiguration {
@@ -191,7 +312,7 @@ impl TransformBuilder for TagFilterlistConfiguration {
     async fn build(&self, context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
         let metrics_builder = MetricsBuilder::from_component_context(&context);
         let telemetry = Telemetry::new(&metrics_builder);
-        let filters = compile_filters(&self.entries);
+        let filters = compile_filters(&self.entries)?;
         telemetry.set_size(filters.len());
 
         Ok(Box::new(TagFilterlist {
@@ -294,11 +415,18 @@ impl Transform for TagFilterlist {
                     None => break,
                 },
                 (_, new_entries) = watcher.changed::<Vec<MetricTagFilterEntry>>() => {
-                    self.filters = compile_filters(new_entries.as_deref().unwrap_or(&[]));
-                    self.context_cache = build_context_cache(self.context_cache_capacity);
-                    self.telemetry.set_size(self.filters.len());
-                    self.telemetry.increment_updates();
-                    debug!(rules_loaded = self.filters.len(), "Updated metric tag filterlist.");
+                    match compile_filters(new_entries.as_deref().unwrap_or(&[])) {
+                        Ok(filters) => {
+                            self.filters = filters;
+                            self.context_cache = build_context_cache(self.context_cache_capacity);
+                            self.telemetry.set_size(self.filters.len());
+                            self.telemetry.increment_updates();
+                            debug!(rules_loaded = self.filters.len(), "Updated metric tag filterlist.");
+                        }
+                        Err(error) => {
+                            error!(%error, "Rejected invalid metric tag filterlist update; retaining the previous rules.");
+                        }
+                    }
                 },
             }
         }
@@ -309,28 +437,80 @@ impl Transform for TagFilterlist {
     }
 }
 
-#[inline]
-fn should_keep_tag(tag: &Tag, is_exclude: bool, names: &HashSet<String, FoldHashState>) -> bool {
-    is_exclude != names.contains(tag.as_borrowed().name())
+enum TagFilterAction<'a> {
+    Keep,
+    Remove,
+    Replace(&'a Tag),
 }
 
-/// Filter the tags of a distribution metric according to the compiled filter table.
+#[inline]
+fn filter_tag<'a>(tag: &Tag, filter: &'a CompiledFilter) -> TagFilterAction<'a> {
+    let tag = tag.as_borrowed();
+    if filter.is_exclude == filter.tag_names.contains(tag.name()) {
+        return TagFilterAction::Remove;
+    }
+
+    let Some(allowlist) = filter.tag_value_allowlists.get(tag.name()) else {
+        return TagFilterAction::Keep;
+    };
+    if tag
+        .value()
+        .is_some_and(|value| allowlist.allowed_values.contains(value))
+    {
+        return TagFilterAction::Keep;
+    }
+
+    match &allowlist.on_miss {
+        CompiledMismatchAction::Remove => TagFilterAction::Remove,
+        CompiledMismatchAction::Replace(replacement) if replacement.as_str() == tag.as_ref() => TagFilterAction::Keep,
+        CompiledMismatchAction::Replace(replacement) => TagFilterAction::Replace(replacement),
+    }
+}
+
+/// Filters the tags of a metric according to the compiled filter table.
 ///
-/// Both instrumented tags and origin tags are filtered using the same tag key list.
+/// Both instrumented tags and origin tags are filtered using the same key and value rules.
 /// If the metric name isn't present in `filters`, the metric is left unchanged.
 /// If filtering would not change any tags, the metric context is left untouched (zero allocations).
 #[inline]
 pub fn filter_metric_tags(
     metric: &mut Metric, state: &mut TagSetMutViewState, filters: &CompiledFilters,
 ) -> FilterMetricTagsOutcome {
-    let Some((is_exclude, tag_names)) = filters.get(metric.context().name().as_ref()) else {
+    let Some(filter) = filters.get(metric.context().name().as_ref()) else {
         return FilterMetricTagsOutcome::RuleMiss;
     };
 
+    let mut tag_replacements = Vec::new();
+    let mut origin_tag_replacements = Vec::new();
     let mut tag_set_view = metric.context_mut().tags_mut_view(state);
-    tag_set_view.retain_tags(|tag| should_keep_tag(tag, *is_exclude, tag_names));
-    tag_set_view.retain_origin_tags(|tag| should_keep_tag(tag, *is_exclude, tag_names));
+    tag_set_view.retain_tags(|tag| match filter_tag(tag, filter) {
+        TagFilterAction::Keep => true,
+        TagFilterAction::Remove => false,
+        TagFilterAction::Replace(replacement) => {
+            tag_replacements.push(replacement.clone());
+            false
+        }
+    });
+    tag_set_view.retain_origin_tags(|tag| match filter_tag(tag, filter) {
+        TagFilterAction::Keep => true,
+        TagFilterAction::Remove => false,
+        TagFilterAction::Replace(replacement) => {
+            origin_tag_replacements.push(replacement.clone());
+            false
+        }
+    });
     let total_removed = tag_set_view.finish();
+
+    if !tag_replacements.is_empty() || !origin_tag_replacements.is_empty() {
+        metric.context_mut().with_tag_sets_mut(|tags, origin_tags| {
+            for replacement in tag_replacements {
+                tags.insert_tag(replacement);
+            }
+            for replacement in origin_tag_replacements {
+                origin_tags.insert_tag(replacement);
+            }
+        });
+    }
 
     if total_removed == 0 {
         FilterMetricTagsOutcome::NoChange
@@ -383,14 +563,42 @@ mod tests {
         names
     }
 
+    fn value_allowlist(tag_name: &str, values: &[&str]) -> StdHashMap<String, TagValueAllowlist> {
+        [(
+            tag_name.to_string(),
+            TagValueAllowlist {
+                values: values.iter().map(|value| (*value).to_string()).collect(),
+                ..Default::default()
+            },
+        )]
+        .into_iter()
+        .collect()
+    }
+
+    fn replacing_value_allowlist(
+        tag_name: &str, values: &[&str], replacement: &str,
+    ) -> StdHashMap<String, TagValueAllowlist> {
+        [(
+            tag_name.to_string(),
+            TagValueAllowlist {
+                values: values.iter().map(|value| (*value).to_string()).collect(),
+                on_miss: TagValueMismatchAction::Replace,
+                replacement: replacement.to_string(),
+            },
+        )]
+        .into_iter()
+        .collect()
+    }
+
     #[test]
     fn exclude_removes_listed_tags() {
         let entries = vec![MetricTagFilterEntry {
             metric_name: "my.dist".to_string(),
             action: FilterAction::Exclude,
             tags: vec!["env".to_string(), "host".to_string()],
+            tag_value_allowlists: StdHashMap::default(),
         }];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric = distribution_metric("my.dist", &["env:prod", "service:web", "host:h1"]);
         let mut state = TagSetMutViewState::default();
@@ -405,8 +613,9 @@ mod tests {
             metric_name: "my.dist".to_string(),
             action: FilterAction::Include,
             tags: vec!["env".to_string()],
+            tag_value_allowlists: StdHashMap::default(),
         }];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric = distribution_metric("my.dist", &["env:prod", "service:web", "host:h1"]);
         let mut state = TagSetMutViewState::default();
@@ -416,13 +625,125 @@ mod tests {
     }
 
     #[test]
+    fn value_allowlist_keeps_allowed_values_and_removes_others() {
+        let entries = vec![MetricTagFilterEntry {
+            metric_name: "my.dist".to_string(),
+            action: FilterAction::Exclude,
+            tags: vec![],
+            tag_value_allowlists: value_allowlist("customer_id", &["top-1", "top-2"]),
+        }];
+        let filters = compile_filters(&entries).unwrap();
+        let mut state = TagSetMutViewState::default();
+
+        let mut allowed = distribution_metric("my.dist", &["customer_id:top-1", "service:web"]);
+        let allowed_outcome = filter_metric_tags(&mut allowed, &mut state, &filters);
+        assert_eq!(allowed_outcome, FilterMetricTagsOutcome::NoChange);
+        assert_eq!(tag_names(&allowed), vec!["customer_id:top-1", "service:web"]);
+
+        let mut unlisted = distribution_metric("my.dist", &["customer_id:other", "service:web"]);
+        let unlisted_outcome = filter_metric_tags(&mut unlisted, &mut state, &filters);
+        assert_eq!(unlisted_outcome, FilterMetricTagsOutcome::Modified { removed_tags: 1 });
+        assert_eq!(tag_names(&unlisted), vec!["service:web"]);
+    }
+
+    #[test]
+    fn value_allowlist_replaces_unlisted_values() {
+        let entries = vec![MetricTagFilterEntry {
+            metric_name: "my.dist".to_string(),
+            action: FilterAction::Exclude,
+            tags: vec![],
+            tag_value_allowlists: replacing_value_allowlist("customer_id", &["top-1"], "other"),
+        }];
+        let filters = compile_filters(&entries).unwrap();
+        let mut metric = distribution_metric("my.dist", &["customer_id:unlisted", "service:web"]);
+        let mut state = TagSetMutViewState::default();
+
+        let outcome = filter_metric_tags(&mut metric, &mut state, &filters);
+
+        assert_eq!(outcome, FilterMetricTagsOutcome::Modified { removed_tags: 1 });
+        assert_eq!(tag_names(&metric), vec!["customer_id:other", "service:web"]);
+    }
+
+    #[test]
+    fn value_allowlist_keeps_existing_replacement_value() {
+        let entries = vec![MetricTagFilterEntry {
+            metric_name: "my.dist".to_string(),
+            action: FilterAction::Exclude,
+            tags: vec![],
+            tag_value_allowlists: replacing_value_allowlist("customer_id", &[], "other"),
+        }];
+        let filters = compile_filters(&entries).unwrap();
+        let mut metric = distribution_metric("my.dist", &["customer_id:other"]);
+        let mut state = TagSetMutViewState::default();
+
+        let outcome = filter_metric_tags(&mut metric, &mut state, &filters);
+
+        assert_eq!(outcome, FilterMetricTagsOutcome::NoChange);
+        assert_eq!(tag_names(&metric), vec!["customer_id:other"]);
+    }
+
+    #[test]
+    fn value_allowlist_replacement_deduplicates_multiple_unlisted_values() {
+        let entries = vec![MetricTagFilterEntry {
+            metric_name: "my.dist".to_string(),
+            action: FilterAction::Exclude,
+            tags: vec![],
+            tag_value_allowlists: replacing_value_allowlist("customer_id", &[], "other"),
+        }];
+        let filters = compile_filters(&entries).unwrap();
+        let mut metric = distribution_metric("my.dist", &["customer_id:a", "customer_id:b"]);
+        let mut state = TagSetMutViewState::default();
+
+        let outcome = filter_metric_tags(&mut metric, &mut state, &filters);
+
+        assert_eq!(outcome, FilterMetricTagsOutcome::Modified { removed_tags: 2 });
+        assert_eq!(tag_names(&metric), vec!["customer_id:other"]);
+    }
+
+    #[test]
+    fn value_allowlist_removes_bare_and_empty_unlisted_values() {
+        let entries = vec![MetricTagFilterEntry {
+            metric_name: "my.dist".to_string(),
+            action: FilterAction::Exclude,
+            tags: vec![],
+            tag_value_allowlists: value_allowlist("customer_id", &["top-1"]),
+        }];
+        let filters = compile_filters(&entries).unwrap();
+        let mut metric = distribution_metric("my.dist", &["customer_id", "customer_id:", "service:web"]);
+        let mut state = TagSetMutViewState::default();
+
+        let outcome = filter_metric_tags(&mut metric, &mut state, &filters);
+
+        assert_eq!(outcome, FilterMetricTagsOutcome::Modified { removed_tags: 2 });
+        assert_eq!(tag_names(&metric), vec!["service:web"]);
+    }
+
+    #[test]
+    fn include_filter_must_also_include_value_allowlisted_tag_key() {
+        let entries = vec![MetricTagFilterEntry {
+            metric_name: "my.dist".to_string(),
+            action: FilterAction::Include,
+            tags: vec!["service".to_string()],
+            tag_value_allowlists: value_allowlist("customer_id", &["top-1"]),
+        }];
+        let filters = compile_filters(&entries).unwrap();
+        let mut metric = distribution_metric("my.dist", &["customer_id:top-1", "service:web"]);
+        let mut state = TagSetMutViewState::default();
+
+        filter_metric_tags(&mut metric, &mut state, &filters);
+
+        assert_eq!(tag_names(&metric), vec!["service:web"]);
+    }
+
+    #[test]
     fn non_matching_metric_unchanged() {
         let entries = vec![MetricTagFilterEntry {
             metric_name: "other.dist".to_string(),
             action: FilterAction::Exclude,
             tags: vec!["env".to_string()],
+            tag_value_allowlists: StdHashMap::default(),
         }];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric = distribution_metric("my.dist", &["env:prod", "service:web"]);
         let mut state = TagSetMutViewState::default();
@@ -444,8 +765,9 @@ mod tests {
             metric_name: "my.counter".to_string(),
             action: FilterAction::Exclude,
             tags: vec!["env".to_string(), "host".to_string()],
+            tag_value_allowlists: StdHashMap::default(),
         }];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric = counter_metric("my.counter", &["env:prod", "service:web", "host:h1"]);
         let mut state = TagSetMutViewState::default();
@@ -461,8 +783,9 @@ mod tests {
             metric_name: "my.counter".to_string(),
             action: FilterAction::Include,
             tags: vec!["env".to_string()],
+            tag_value_allowlists: StdHashMap::default(),
         }];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric = counter_metric("my.counter", &["env:prod", "service:web", "host:h1"]);
         let mut state = TagSetMutViewState::default();
@@ -478,8 +801,9 @@ mod tests {
             metric_name: "other.counter".to_string(),
             action: FilterAction::Exclude,
             tags: vec!["env".to_string()],
+            tag_value_allowlists: StdHashMap::default(),
         }];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric = counter_metric("my.counter", &["env:prod", "service:web"]);
         let mut state = TagSetMutViewState::default();
@@ -495,8 +819,9 @@ mod tests {
             metric_name: "my.counter".to_string(),
             action: FilterAction::Exclude,
             tags: vec!["region".to_string()],
+            tag_value_allowlists: StdHashMap::default(),
         }];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric = counter_metric("my.counter", &["env:prod", "service:web"]);
         let mut state = TagSetMutViewState::default();
@@ -512,8 +837,9 @@ mod tests {
             metric_name: "my.dist".to_string(),
             action: FilterAction::Exclude,
             tags: vec!["production".to_string()],
+            tag_value_allowlists: StdHashMap::default(),
         }];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric = distribution_metric("my.dist", &["production", "service:web"]);
         let mut state = TagSetMutViewState::default();
@@ -528,8 +854,9 @@ mod tests {
             metric_name: "my.dist".to_string(),
             action: FilterAction::Include,
             tags: vec![],
+            tag_value_allowlists: StdHashMap::default(),
         }];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric = distribution_metric("my.dist", &["env:prod", "service:web"]);
         let mut state = TagSetMutViewState::default();
@@ -544,8 +871,9 @@ mod tests {
             metric_name: "my.dist".to_string(),
             action: FilterAction::Exclude,
             tags: vec![],
+            tag_value_allowlists: StdHashMap::default(),
         }];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric = distribution_metric("my.dist", &["env:prod", "service:web"]);
         let mut state = TagSetMutViewState::default();
@@ -561,14 +889,16 @@ mod tests {
                 metric_name: "my.dist".to_string(),
                 action: FilterAction::Exclude,
                 tags: vec!["env".to_string()],
+                tag_value_allowlists: StdHashMap::default(),
             },
             MetricTagFilterEntry {
                 metric_name: "my.dist".to_string(),
                 action: FilterAction::Exclude,
                 tags: vec!["host".to_string()],
+                tag_value_allowlists: StdHashMap::default(),
             },
         ];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric = distribution_metric("my.dist", &["env:prod", "host:h1", "service:web"]);
         let mut state = TagSetMutViewState::default();
@@ -578,20 +908,98 @@ mod tests {
     }
 
     #[test]
+    fn merge_same_tag_value_allowlist_unions_values() {
+        let entries = vec![
+            MetricTagFilterEntry {
+                metric_name: "my.dist".to_string(),
+                action: FilterAction::Exclude,
+                tags: vec![],
+                tag_value_allowlists: value_allowlist("customer_id", &["top-1"]),
+            },
+            MetricTagFilterEntry {
+                metric_name: "my.dist".to_string(),
+                action: FilterAction::Exclude,
+                tags: vec![],
+                tag_value_allowlists: value_allowlist("customer_id", &["top-2"]),
+            },
+        ];
+        let filters = compile_filters(&entries).unwrap();
+        let mut state = TagSetMutViewState::default();
+
+        for tag in ["customer_id:top-1", "customer_id:top-2"] {
+            let mut metric = distribution_metric("my.dist", &[tag]);
+            assert_eq!(
+                filter_metric_tags(&mut metric, &mut state, &filters),
+                FilterMetricTagsOutcome::NoChange
+            );
+        }
+    }
+
+    #[test]
+    fn conflicting_value_replacements_are_rejected() {
+        let entries = vec![
+            MetricTagFilterEntry {
+                metric_name: "my.dist".to_string(),
+                action: FilterAction::Exclude,
+                tags: vec![],
+                tag_value_allowlists: replacing_value_allowlist("customer_id", &["top-1"], "other"),
+            },
+            MetricTagFilterEntry {
+                metric_name: "my.dist".to_string(),
+                action: FilterAction::Exclude,
+                tags: vec![],
+                tag_value_allowlists: replacing_value_allowlist("customer_id", &["top-2"], "aggregated"),
+            },
+        ];
+
+        let error = compile_filters(&entries)
+            .err()
+            .expect("conflicting replacements must fail");
+
+        assert!(error.to_string().contains("metric 'my.dist' and tag 'customer_id'"));
+    }
+
+    #[test]
+    fn conflicting_value_mismatch_actions_are_rejected() {
+        let entries = vec![
+            MetricTagFilterEntry {
+                metric_name: "my.dist".to_string(),
+                action: FilterAction::Exclude,
+                tags: vec![],
+                tag_value_allowlists: value_allowlist("customer_id", &["top-1"]),
+            },
+            MetricTagFilterEntry {
+                metric_name: "my.dist".to_string(),
+                action: FilterAction::Exclude,
+                tags: vec![],
+                tag_value_allowlists: replacing_value_allowlist("customer_id", &["top-2"], "other"),
+            },
+        ];
+
+        let error = compile_filters(&entries)
+            .err()
+            .expect("conflicting mismatch actions must fail");
+
+        assert!(error.to_string().contains("metric 'my.dist' and tag 'customer_id'"));
+    }
+
+    #[test]
     fn merge_conflicting_actions_exclude_wins() {
         let entries = vec![
             MetricTagFilterEntry {
                 metric_name: "my.dist".to_string(),
                 action: FilterAction::Include,
                 tags: vec!["env".to_string()],
+                tag_value_allowlists: StdHashMap::default(),
             },
             MetricTagFilterEntry {
                 metric_name: "my.dist".to_string(),
                 action: FilterAction::Exclude,
                 tags: vec!["host".to_string()],
+                tag_value_allowlists: StdHashMap::default(),
             },
         ];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric = distribution_metric("my.dist", &["env:prod", "host:h1", "service:web"]);
         let mut state = TagSetMutViewState::default();
@@ -607,14 +1015,16 @@ mod tests {
                 metric_name: "my.dist".to_string(),
                 action: FilterAction::Exclude,
                 tags: vec!["host".to_string()],
+                tag_value_allowlists: StdHashMap::default(),
             },
             MetricTagFilterEntry {
                 metric_name: "my.dist".to_string(),
                 action: FilterAction::Include,
                 tags: vec!["env".to_string()],
+                tag_value_allowlists: StdHashMap::default(),
             },
         ];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric = distribution_metric("my.dist", &["env:prod", "host:h1", "service:web"]);
         let mut state = TagSetMutViewState::default();
@@ -625,7 +1035,7 @@ mod tests {
 
     #[test]
     fn no_config_is_noop() {
-        let filters = compile_filters(&[]);
+        let filters = compile_filters(&[]).unwrap();
         let mut metric = distribution_metric("my.dist", &["env:prod", "service:web"]);
         let mut state = TagSetMutViewState::default();
         filter_metric_tags(&mut metric, &mut state, &filters);
@@ -639,14 +1049,16 @@ mod tests {
                 metric_name: String::new(),
                 action: FilterAction::Exclude,
                 tags: vec!["env".to_string()],
+                tag_value_allowlists: StdHashMap::default(),
             },
             MetricTagFilterEntry {
                 metric_name: "my.dist".to_string(),
                 action: FilterAction::Exclude,
                 tags: vec!["host".to_string()],
+                tag_value_allowlists: StdHashMap::default(),
             },
         ];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         assert!(!filters.contains_key(""));
         assert!(filters.contains_key("my.dist"));
@@ -661,6 +1073,22 @@ mod tests {
         .unwrap();
 
         assert_eq!(entry.action, FilterAction::Exclude);
+    }
+
+    #[test]
+    fn value_allowlist_defaults_to_remove_with_other_replacement() {
+        let entry: MetricTagFilterEntry = serde_json::from_value(json!({
+            "metric_name": "my.dist",
+            "tags": [],
+            "tag_value_allowlists": {
+                "customer_id": { "values": ["top-1"] }
+            }
+        }))
+        .unwrap();
+
+        let allowlist = &entry.tag_value_allowlists["customer_id"];
+        assert_eq!(allowlist.on_miss, TagValueMismatchAction::Remove);
+        assert_eq!(allowlist.replacement, "other");
     }
 
     #[test]
@@ -703,8 +1131,9 @@ mod tests {
             metric_name: "my.dist".to_string(),
             action: FilterAction::Exclude,
             tags: vec!["env".to_string(), "host".to_string()],
+            tag_value_allowlists: StdHashMap::default(),
         }];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric =
             distribution_metric_with_origin_tags("my.dist", &["env:prod"], &["env:prod", "host:h1", "service:web"]);
@@ -715,13 +1144,52 @@ mod tests {
     }
 
     #[test]
+    fn value_allowlist_filters_origin_tags() {
+        let entries = vec![MetricTagFilterEntry {
+            metric_name: "my.dist".to_string(),
+            action: FilterAction::Exclude,
+            tags: vec![],
+            tag_value_allowlists: value_allowlist("customer_id", &["top-1"]),
+        }];
+        let filters = compile_filters(&entries).unwrap();
+        let mut metric = distribution_metric_with_origin_tags(
+            "my.dist",
+            &[],
+            &["customer_id:top-1", "customer_id:other", "service:web"],
+        );
+        let mut state = TagSetMutViewState::default();
+
+        filter_metric_tags(&mut metric, &mut state, &filters);
+
+        assert_eq!(origin_tag_names(&metric), vec!["customer_id:top-1", "service:web"]);
+    }
+
+    #[test]
+    fn value_allowlist_replaces_origin_tags() {
+        let entries = vec![MetricTagFilterEntry {
+            metric_name: "my.dist".to_string(),
+            action: FilterAction::Exclude,
+            tags: vec![],
+            tag_value_allowlists: replacing_value_allowlist("customer_id", &["top-1"], "other"),
+        }];
+        let filters = compile_filters(&entries).unwrap();
+        let mut metric = distribution_metric_with_origin_tags("my.dist", &[], &["customer_id:unlisted", "service:web"]);
+        let mut state = TagSetMutViewState::default();
+
+        filter_metric_tags(&mut metric, &mut state, &filters);
+
+        assert_eq!(origin_tag_names(&metric), vec!["customer_id:other", "service:web"]);
+    }
+
+    #[test]
     fn include_keeps_only_listed_origin_tags() {
         let entries = vec![MetricTagFilterEntry {
             metric_name: "my.dist".to_string(),
             action: FilterAction::Include,
             tags: vec!["env".to_string()],
+            tag_value_allowlists: StdHashMap::default(),
         }];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric =
             distribution_metric_with_origin_tags("my.dist", &["env:prod"], &["env:prod", "host:h1", "service:web"]);
@@ -737,8 +1205,9 @@ mod tests {
             metric_name: "my.dist".to_string(),
             action: FilterAction::Exclude,
             tags: vec!["env".to_string()],
+            tag_value_allowlists: StdHashMap::default(),
         }];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric = distribution_metric("my.dist", &["env:prod", "service:web"]);
         let mut state = TagSetMutViewState::default();
@@ -766,8 +1235,9 @@ mod tests {
             metric_name: "my.dist".to_string(),
             action: FilterAction::Exclude,
             tags: vec!["env".to_string(), "host".to_string()],
+            tag_value_allowlists: StdHashMap::default(),
         }];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut state = TagSetMutViewState::default();
         filter_metric_tags(&mut metric1, &mut state, &filters);
@@ -792,8 +1262,9 @@ mod tests {
             metric_name: "my.dist".to_string(),
             action: FilterAction::Exclude,
             tags: vec!["env".to_string(), "host".to_string()],
+            tag_value_allowlists: StdHashMap::default(),
         }];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric = distribution_metric_with_origin_tags(
             "my.dist",
@@ -882,9 +1353,18 @@ mod tests {
         sender
             .send(ConfigUpdate::Partial {
                 key: "metric_tag_filterlist".to_string(),
-                value: serde_json::json!([
-                    { "metric_name": "my.dist", "action": "exclude", "tags": ["host"] }
-                ]),
+                value: serde_json::json!([{
+                    "metric_name": "my.dist",
+                    "action": "exclude",
+                    "tags": ["host"],
+                    "tag_value_allowlists": {
+                        "customer_id": {
+                            "values": ["top-1"],
+                            "on_miss": "replace",
+                            "replacement": "aggregated"
+                        }
+                    }
+                }]),
             })
             .await
             .unwrap();
@@ -896,12 +1376,15 @@ mod tests {
         .await
         .expect("timed out waiting for metric_tag_filterlist update");
 
-        let filters = compile_filters(new_entries.as_deref().unwrap_or(&[]));
+        let filters = compile_filters(new_entries.as_deref().unwrap_or(&[])).unwrap();
 
-        let mut metric = distribution_metric("my.dist", &["env:prod", "host:h1", "service:web"]);
+        let mut metric = distribution_metric("my.dist", &["customer_id:other", "env:prod", "host:h1", "service:web"]);
         let mut state = TagSetMutViewState::default();
         filter_metric_tags(&mut metric, &mut state, &filters);
-        assert_eq!(tag_names(&metric), vec!["env:prod", "service:web"]);
+        assert_eq!(
+            tag_names(&metric),
+            vec!["customer_id:aggregated", "env:prod", "service:web"]
+        );
     }
 
     #[tokio::test]
@@ -948,7 +1431,7 @@ mod tests {
         .await
         .expect("timed out waiting for cleared metric_tag_filterlist update");
 
-        let filters = compile_filters(new_entries.as_deref().unwrap_or(&[]));
+        let filters = compile_filters(new_entries.as_deref().unwrap_or(&[])).unwrap();
 
         let mut metric = distribution_metric("my.dist", &["env:prod", "service:web"]);
         let mut state = TagSetMutViewState::default();
@@ -984,7 +1467,7 @@ mod tests {
         .await
         .expect("timed out waiting for metric_tag_filterlist update");
 
-        let filters = compile_filters(new_entries.as_deref().unwrap_or(&[]));
+        let filters = compile_filters(new_entries.as_deref().unwrap_or(&[])).unwrap();
 
         let mut metric = distribution_metric("my.dist", &["env:prod", "service:web", "host:h1"]);
         let mut state = TagSetMutViewState::default();
@@ -998,8 +1481,9 @@ mod tests {
             metric_name: "my.dist".to_string(),
             action: FilterAction::Exclude,
             tags: vec!["host".to_string()],
+            tag_value_allowlists: StdHashMap::default(),
         }];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
 
         let mut metric = distribution_metric("my.dist", &["env:prod", "host:h1"]);
 
@@ -1017,8 +1501,9 @@ mod tests {
             metric_name: "my.dist".to_string(),
             action: FilterAction::Exclude,
             tags: vec!["region".to_string()],
+            tag_value_allowlists: StdHashMap::default(),
         }];
-        let filters = compile_filters(&entries);
+        let filters = compile_filters(&entries).unwrap();
         let shared_tags = ["env:prod", "host:h1"]
             .into_iter()
             .map(Tag::from)

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -476,6 +476,49 @@ ADP uses an explicit process memory limit (`memory_limit`) rather than relying o
 See `memory_limit` above.
 
 
+### `metric_tag_filterlist.*.tag_value_allowlists`
+
+ADP extends each `metric_tag_filterlist` entry with an optional map of tag keys to allowed values.
+For example, to retain a configured set of customer IDs for one metric and aggregate all other
+customer IDs under `customer_id:other`, configure:
+
+```yaml
+metric_tag_filterlist:
+  - metric_name: requests.count
+    action: exclude
+    tags: []
+    tag_value_allowlists:
+      customer_id:
+        values:
+          - customer-1
+          - customer-2
+        on_miss: replace
+        replacement: other
+```
+
+ADP first applies the entry's existing `action` and `tags` filter, then applies the value
+allowlists to tags that remain. With `action: include`, you must also add an allowlisted tag key to
+`tags`; otherwise the include filter removes it before checking its value.
+
+For each allowlist, `on_miss` accepts `remove` or `replace` and defaults to `remove`. When set to
+`replace`, `replacement` controls the sentinel value and defaults to `other`. Configure a sentinel
+that cannot collide with a real tag value. An empty `values` list treats every value as a mismatch.
+Bare tags have no value and are also treated as mismatches.
+
+Duplicate entries for the same metric and tag key may add allowed values only when they configure
+the same mismatch behavior. ADP rejects startup configuration with conflicting `on_miss` or
+`replacement` values. If a runtime update introduces a conflict, ADP retains the previous rules and
+logs the configuration error.
+
+Filtering applies to counters and sketch-backed metrics before aggregation, including both
+instrumented and origin tags. Allowed values retain separate metric contexts. With `remove`,
+unlisted values lose the configured tag and aggregate according to the remaining context
+dimensions. With `replace`, they aggregate under the configured sentinel value.
+
+The core Agent does not interpret `tag_value_allowlists`. Keep `metric_tag_filterlist_adp_only` at
+its default value of `true` when ADP is enabled. If the core Agent applies the same entry directly,
+it only applies `action` and `tags` and ignores value filtering.
+
 ## Transparent Settings
 
 <!-- section:reference -->

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -519,6 +519,34 @@ The core Agent does not interpret `tag_value_allowlists`. Keep `metric_tag_filte
 its default value of `true` when ADP is enabled. If the core Agent applies the same entry directly,
 it only applies `action` and `tags` and ignores value filtering.
 
+### `metric_tag_filterlist.*.tag_value_regexes`
+
+ADP can require the complete value of a tag to match a configured regular expression. Values that
+do not match are replaced with a sentinel before aggregation:
+
+```yaml
+metric_tag_filterlist:
+  - metric_name: requests.count
+    action: exclude
+    tags: []
+    tag_value_regexes:
+      customer_id:
+        pattern: "customer-[0-9]+"
+        replacement: invalid
+```
+
+`pattern` uses Rust regular expression syntax and is matched against the complete tag value. The
+`replacement` defaults to `other`. Bare tags have no value and are replaced. A tag that already has
+the replacement value is retained, preventing repeated replacement work.
+
+ADP rejects invalid regular expressions. It also rejects configurations that apply both an
+allowlist and a regular expression to the same metric and tag key, or duplicate regular expression
+rules with different patterns or replacements. If a runtime update introduces one of these errors,
+ADP retains the previous rules and logs the configuration error.
+
+Regular expression rules have the same metric-type, origin-tag, Core Agent compatibility, and
+pre-aggregation behavior as value allowlists.
+
 ## Transparent Settings
 
 <!-- section:reference -->

--- a/docs/agent-data-plane/configuration/dogstatsd.md.tmpl
+++ b/docs/agent-data-plane/configuration/dogstatsd.md.tmpl
@@ -58,6 +58,49 @@ The following settings are specific to ADP and have no equivalent in the core ag
 
 { adp_only_table }
 { adp_only_docs }
+### `metric_tag_filterlist.*.tag_value_allowlists`
+
+ADP extends each `metric_tag_filterlist` entry with an optional map of tag keys to allowed values.
+For example, to retain a configured set of customer IDs for one metric and aggregate all other
+customer IDs under `customer_id:other`, configure:
+
+```yaml
+metric_tag_filterlist:
+  - metric_name: requests.count
+    action: exclude
+    tags: []
+    tag_value_allowlists:
+      customer_id:
+        values:
+          - customer-1
+          - customer-2
+        on_miss: replace
+        replacement: other
+```
+
+ADP first applies the entry's existing `action` and `tags` filter, then applies the value
+allowlists to tags that remain. With `action: include`, you must also add an allowlisted tag key to
+`tags`; otherwise the include filter removes it before checking its value.
+
+For each allowlist, `on_miss` accepts `remove` or `replace` and defaults to `remove`. When set to
+`replace`, `replacement` controls the sentinel value and defaults to `other`. Configure a sentinel
+that cannot collide with a real tag value. An empty `values` list treats every value as a mismatch.
+Bare tags have no value and are also treated as mismatches.
+
+Duplicate entries for the same metric and tag key may add allowed values only when they configure
+the same mismatch behavior. ADP rejects startup configuration with conflicting `on_miss` or
+`replacement` values. If a runtime update introduces a conflict, ADP retains the previous rules and
+logs the configuration error.
+
+Filtering applies to counters and sketch-backed metrics before aggregation, including both
+instrumented and origin tags. Allowed values retain separate metric contexts. With `remove`,
+unlisted values lose the configured tag and aggregate according to the remaining context
+dimensions. With `replace`, they aggregate under the configured sentinel value.
+
+The core Agent does not interpret `tag_value_allowlists`. Keep `metric_tag_filterlist_adp_only` at
+its default value of `true` when ADP is enabled. If the core Agent applies the same entry directly,
+it only applies `action` and `tags` and ignores value filtering.
+
 ## Transparent Settings
 
 <!-- section:reference -->

--- a/docs/agent-data-plane/configuration/dogstatsd.md.tmpl
+++ b/docs/agent-data-plane/configuration/dogstatsd.md.tmpl
@@ -101,6 +101,34 @@ The core Agent does not interpret `tag_value_allowlists`. Keep `metric_tag_filte
 its default value of `true` when ADP is enabled. If the core Agent applies the same entry directly,
 it only applies `action` and `tags` and ignores value filtering.
 
+### `metric_tag_filterlist.*.tag_value_regexes`
+
+ADP can require the complete value of a tag to match a configured regular expression. Values that
+do not match are replaced with a sentinel before aggregation:
+
+```yaml
+metric_tag_filterlist:
+  - metric_name: requests.count
+    action: exclude
+    tags: []
+    tag_value_regexes:
+      customer_id:
+        pattern: "customer-[0-9]+"
+        replacement: invalid
+```
+
+`pattern` uses Rust regular expression syntax and is matched against the complete tag value. The
+`replacement` defaults to `other`. Bare tags have no value and are replaced. A tag that already has
+the replacement value is retained, preventing repeated replacement work.
+
+ADP rejects invalid regular expressions. It also rejects configurations that apply both an
+allowlist and a regular expression to the same metric and tag key, or duplicate regular expression
+rules with different patterns or replacements. If a runtime update introduces one of these errors,
+ADP retains the previous rules and logs the configuration error.
+
+Regular expression rules have the same metric-type, origin-tag, Core Agent compatibility, and
+pre-aggregation behavior as value allowlists.
+
 ## Transparent Settings
 
 <!-- section:reference -->

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -21,7 +21,8 @@ use std::time::Duration;
 
 use agent_data_plane_config::control::ListenAddress;
 use agent_data_plane_config::domains::dogstatsd::{
-    FilterAction, MapperProfile, MetricMapping, MetricTagFilterEntry, OriginTagCardinality,
+    FilterAction, MapperProfile, MetricMapping, MetricTagFilterEntry, OriginTagCardinality, TagValueAllowlist,
+    TagValueMismatchAction,
 };
 use agent_data_plane_config::shared::ForwarderHttpProtocol;
 use agent_data_plane_config::SalukiConfiguration;
@@ -177,6 +178,28 @@ enum TagFilterEntry {
 /// entry: the schema lets any string through, so the component tolerates typos by defaulting to
 /// `exclude`, and this preserves that behavior while still surfacing the error.
 fn parse_tag_filter_entry(key: &str, raw: serde_json::Value) -> TagFilterEntry {
+    fn default_replacement() -> String {
+        "other".to_string()
+    }
+
+    #[derive(Default, serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    enum RawTagValueMismatchAction {
+        #[default]
+        Remove,
+        Replace,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct RawTagValueAllowlist {
+        #[serde(default)]
+        values: Vec<String>,
+        #[serde(default)]
+        on_miss: RawTagValueMismatchAction,
+        #[serde(default = "default_replacement")]
+        replacement: String,
+    }
+
     #[derive(serde::Deserialize)]
     struct RawEntry {
         metric_name: String,
@@ -184,6 +207,8 @@ fn parse_tag_filter_entry(key: &str, raw: serde_json::Value) -> TagFilterEntry {
         action: String,
         #[serde(default)]
         tags: Vec<String>,
+        #[serde(default)]
+        tag_value_allowlists: HashMap<String, RawTagValueAllowlist>,
     }
 
     let parsed: RawEntry = match serde_json::from_value(raw).map_err(|error| TranslateError::new(key, error)) {
@@ -207,6 +232,24 @@ fn parse_tag_filter_entry(key: &str, raw: serde_json::Value) -> TagFilterEntry {
         metric_name: parsed.metric_name,
         action,
         tags: parsed.tags,
+        tag_value_allowlists: parsed
+            .tag_value_allowlists
+            .into_iter()
+            .map(|(tag_name, allowlist)| {
+                let on_miss = match allowlist.on_miss {
+                    RawTagValueMismatchAction::Remove => TagValueMismatchAction::Remove,
+                    RawTagValueMismatchAction::Replace => TagValueMismatchAction::Replace,
+                };
+                (
+                    tag_name,
+                    TagValueAllowlist {
+                        values: allowlist.values,
+                        on_miss,
+                        replacement: allowlist.replacement,
+                    },
+                )
+            })
+            .collect(),
     };
     match action_error {
         Some(error) => TagFilterEntry::Recovered(entry, error),
@@ -1087,7 +1130,7 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
 mod tests {
     use std::time::Duration;
 
-    use agent_data_plane_config::domains::dogstatsd::OriginTagCardinality;
+    use agent_data_plane_config::domains::dogstatsd::{OriginTagCardinality, TagValueMismatchAction};
     use datadog_agent_config::DatadogConfiguration;
     use serde_json::json;
 
@@ -1203,6 +1246,33 @@ mod tests {
             Some(1024)
         );
         assert_eq!(config.shared.endpoints.forwarder.retry_queue_max_size, None);
+    }
+
+    #[test]
+    fn tag_value_allowlists_are_preserved() {
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "metric_tag_filterlist": [{
+                "metric_name": "a",
+                "action": "exclude",
+                "tags": [],
+                "tag_value_allowlists": {
+                    "customer_id": {
+                        "values": ["top-1", "top-2"],
+                        "on_miss": "replace",
+                        "replacement": "aggregated"
+                    }
+                }
+            }],
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, errors) = DatadogTranslator::new(&datadog).translate();
+
+        assert!(errors.is_none());
+        let allowlist = &config.domains.dogstatsd.tag_filterlist[0].tag_value_allowlists["customer_id"];
+        assert_eq!(allowlist.values, vec!["top-1".to_string(), "top-2".to_string()]);
+        assert_eq!(allowlist.on_miss, TagValueMismatchAction::Replace);
+        assert_eq!(allowlist.replacement, "aggregated");
     }
 
     #[test]

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 use agent_data_plane_config::control::ListenAddress;
 use agent_data_plane_config::domains::dogstatsd::{
     FilterAction, MapperProfile, MetricMapping, MetricTagFilterEntry, OriginTagCardinality, TagValueAllowlist,
-    TagValueMismatchAction,
+    TagValueMismatchAction, TagValueRegex,
 };
 use agent_data_plane_config::shared::ForwarderHttpProtocol;
 use agent_data_plane_config::SalukiConfiguration;
@@ -201,6 +201,13 @@ fn parse_tag_filter_entry(key: &str, raw: serde_json::Value) -> TagFilterEntry {
     }
 
     #[derive(serde::Deserialize)]
+    struct RawTagValueRegex {
+        pattern: String,
+        #[serde(default = "default_replacement")]
+        replacement: String,
+    }
+
+    #[derive(serde::Deserialize)]
     struct RawEntry {
         metric_name: String,
         #[serde(default)]
@@ -209,6 +216,8 @@ fn parse_tag_filter_entry(key: &str, raw: serde_json::Value) -> TagFilterEntry {
         tags: Vec<String>,
         #[serde(default)]
         tag_value_allowlists: HashMap<String, RawTagValueAllowlist>,
+        #[serde(default)]
+        tag_value_regexes: HashMap<String, RawTagValueRegex>,
     }
 
     let parsed: RawEntry = match serde_json::from_value(raw).map_err(|error| TranslateError::new(key, error)) {
@@ -246,6 +255,19 @@ fn parse_tag_filter_entry(key: &str, raw: serde_json::Value) -> TagFilterEntry {
                         values: allowlist.values,
                         on_miss,
                         replacement: allowlist.replacement,
+                    },
+                )
+            })
+            .collect(),
+        tag_value_regexes: parsed
+            .tag_value_regexes
+            .into_iter()
+            .map(|(tag_name, regex)| {
+                (
+                    tag_name,
+                    TagValueRegex {
+                        pattern: regex.pattern,
+                        replacement: regex.replacement,
                     },
                 )
             })
@@ -1249,7 +1271,7 @@ mod tests {
     }
 
     #[test]
-    fn tag_value_allowlists_are_preserved() {
+    fn tag_value_rules_are_preserved() {
         let datadog: DatadogConfiguration = serde_json::from_value(json!({
             "metric_tag_filterlist": [{
                 "metric_name": "a",
@@ -1260,6 +1282,12 @@ mod tests {
                         "values": ["top-1", "top-2"],
                         "on_miss": "replace",
                         "replacement": "aggregated"
+                    }
+                },
+                "tag_value_regexes": {
+                    "region": {
+                        "pattern": "[a-z]+-[0-9]+",
+                        "replacement": "invalid"
                     }
                 }
             }],
@@ -1273,6 +1301,9 @@ mod tests {
         assert_eq!(allowlist.values, vec!["top-1".to_string(), "top-2".to_string()]);
         assert_eq!(allowlist.on_miss, TagValueMismatchAction::Replace);
         assert_eq!(allowlist.replacement, "aggregated");
+        let regex = &config.domains.dogstatsd.tag_filterlist[0].tag_value_regexes["region"];
+        assert_eq!(regex.pattern, "[a-z]+-[0-9]+");
+        assert_eq!(regex.replacement, "invalid");
     }
 
     #[test]

--- a/lib/agent-data-plane-config/src/domains/dogstatsd.rs
+++ b/lib/agent-data-plane-config/src/domains/dogstatsd.rs
@@ -334,6 +334,33 @@ pub struct MetricTagFilterEntry {
     /// The map is empty by default, which disables value filtering. Use this for tag keys whose
     /// unbounded values would create excessive metric cardinality.
     pub tag_value_allowlists: HashMap<String, TagValueAllowlist>,
+
+    /// Regular expressions required to match specific tag values.
+    ///
+    /// Values that do not match are replaced with the configured sentinel. The map is empty by
+    /// default, which disables regular expression filtering.
+    pub tag_value_regexes: HashMap<String, TagValueRegex>,
+}
+
+/// A regular expression and replacement sentinel for one tag key.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct TagValueRegex {
+    /// Regular expression that the complete tag value must match.
+    pub pattern: String,
+
+    /// Value used when the regular expression does not match.
+    ///
+    /// The default is `other`. Configure a value that cannot collide with a real tag value.
+    pub replacement: String,
+}
+
+impl Default for TagValueRegex {
+    fn default() -> Self {
+        Self {
+            pattern: String::new(),
+            replacement: "other".to_string(),
+        }
+    }
 }
 
 /// An allowlist and mismatch behavior for one tag key.

--- a/lib/agent-data-plane-config/src/domains/dogstatsd.rs
+++ b/lib/agent-data-plane-config/src/domains/dogstatsd.rs
@@ -328,6 +328,51 @@ pub struct MetricTagFilterEntry {
 
     /// Tags the action applies to.
     pub tags: Vec<String>,
+
+    /// Value allowlists for specific tag keys.
+    ///
+    /// The map is empty by default, which disables value filtering. Use this for tag keys whose
+    /// unbounded values would create excessive metric cardinality.
+    pub tag_value_allowlists: HashMap<String, TagValueAllowlist>,
+}
+
+/// An allowlist and mismatch behavior for one tag key.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct TagValueAllowlist {
+    /// Tag values retained unchanged.
+    ///
+    /// The list is empty by default, so every value is treated as a mismatch.
+    pub values: Vec<String>,
+
+    /// Action applied to values absent from [`values`][Self::values].
+    ///
+    /// The default is [`Remove`][TagValueMismatchAction::Remove].
+    pub on_miss: TagValueMismatchAction,
+
+    /// Value used when `on_miss` is [`Replace`][TagValueMismatchAction::Replace].
+    ///
+    /// The default is `other`. Configure a value that cannot collide with a real tag value.
+    pub replacement: String,
+}
+
+impl Default for TagValueAllowlist {
+    fn default() -> Self {
+        Self {
+            values: Vec::new(),
+            on_miss: TagValueMismatchAction::Remove,
+            replacement: "other".to_string(),
+        }
+    }
+}
+
+/// Action applied when a tag value is absent from its allowlist.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub enum TagValueMismatchAction {
+    /// Removes the tag.
+    #[default]
+    Remove,
+    /// Replaces the tag value with the configured sentinel.
+    Replace,
 }
 
 /// Whether a tag-filterlist entry includes or excludes the listed tags.


### PR DESCRIPTION
## Summary

> [!NOTE]
> This is an experimental proposal. In addition to implementation feedback, we are looking for
> feedback on whether the configuration schema presents tag-value aggregation coherently.

Add per-metric tag-value filtering to `metric_tag_filterlist` before aggregation.

- Allow configured tag values and remove or replace mismatches with a sentinel.
- Require complete tag values to match a regular expression and replace non-matches.
- Reject invalid or conflicting rules at startup; retain the last valid rules after invalid runtime updates.
- Document current behavior and configuration-schema trade-offs.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- Ran all 51 tag-filterlist unit tests, including new coverage for allowlists, regular expressions, conflicts, origin tags, and dynamic updates.
- Ran all 17 configuration-system tests.
- Ran `cargo check --workspace`.
- Ran `cargo check --workspace --tests`.
- Ran workspace Clippy with warnings denied.
- Ran formatting and `git diff --check`.

## References

N/A
