### PR TITLE
fix(correctness): reduce OTLP metrics burst volume

### DIFF
--- a/test/correctness/cases/otlp-metrics/datadog-baseline.yaml
+++ b/test/correctness/cases/otlp-metrics/datadog-baseline.yaml
@@ -17,6 +17,7 @@ dd_url: "http://datadog-intake:2049"
 otlp_config:
   metrics:
     batch:
+      # TODO: remove after #2160 is fixed
       min_size: 1000000000
       max_size: 0
       flush_timeout: 5s

--- a/test/correctness/cases/otlp-metrics/millstone.yaml
+++ b/test/correctness/cases/otlp-metrics/millstone.yaml
@@ -1,7 +1,8 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
 target: "grpc://$GROUP:54317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export"
 aggregation_bucket_width_secs: 10
-volume: 1000
+# TODO: increase after #2160 is fixed
+volume: 299
 corpus:
   size: 10000
   payload:


### PR DESCRIPTION
## Human Summary

This is intended to be a workaround for our failing nightly pipeline. The issue is that we have different Agent behavior with respect to the batching of OTLP metrics in different Agent versions. @lucastemb worked around this by setting the batch size to infinity, but then on nightly we send too many metrics into a single batch. So my attempted solution is to send fewer metrics and to open #2160 to track getting this actually fixed.

## AI Summary

Reduce the OTLP metrics correctness test burst from 1000 to 299 payloads so the nightly baseline stays below the Core Agent sending-queue capacity while the batching workaround remains necessary.

The existing `min_size: 1000000000` workaround is retained and annotated for removal after #2160 is fixed.

## Change Type
- [x] Bug fix

## How did you test this PR?

- Parsed both modified YAML files successfully with PyYAML.
- Ran `git diff --check`.

## References

- Related: #2160
