### PR TITLE
fix(ci): avoid rewriting agent version fixtures

### DIFF
--- a/.github/workflows/update-agent-version.yml
+++ b/.github/workflows/update-agent-version.yml
@@ -75,22 +75,23 @@ jobs:
 
           echo "Updating all references from $OLD_VERSION to $NEW_VERSION"
 
-          # Find all files containing the old version and update them
-          # Exclude common directories that shouldn't be modified.
+          # Keep source fixtures and documentation examples out of this replacement.
+          VERSION_FILES=(
+            ".gitlab-ci.yml"
+            ".gitlab/windows.yml"
+            "Makefile"
+            "docker/Dockerfile.datadog-agent"
+            "test/antithesis/scenarios/differential/Dockerfile"
+            "test/antithesis/scenarios/general/Dockerfile"
+          )
 
-          find . -type f \
-            -not -path "./.git/*" \
-            -not -path "./node_modules/*" \
-            -not -path "./target/*" \
-            -not -path "./bun.lock" \
-            -not -path "./Cargo.lock" \
-            -not -path "./.github/workflows/update-agent-version.yml" \
-            -exec grep -lF "$OLD_VERSION" {} \; 2>/dev/null | while read -r file; do
+          for file in "${VERSION_FILES[@]}"; do
+            if grep -qF "$OLD_VERSION" "$file"; then
               echo "Updating: $file"
               sed -i "s/$OLD_VERSION_ESCAPED/$NEW_VERSION/g" "$file"
+            fi
           done
 
-          # Update the version tracking file
           echo "$NEW_VERSION" > .datadog-agent-version
 
           echo "Update complete!"


### PR DESCRIPTION
## Human Summary

Attempts to fix what was wrong with #2161

## AI Summary
This fixes the Agent version update workflow so it only replaces versions in build and test configuration files. Source fixtures and documentation examples are left unchanged.

## Change Type
- [x] Bug fix

## How did you test this PR?
- Parsed `.github/workflows/update-agent-version.yml` with PyYAML.
- Simulated the version update and verified that the intended configuration files changed while `lib/datadog-agent/commons/src/agent_version.rs` did not.
- Ran `git diff --check`.

## References

- Related: #2161
