### PR TITLE
feat(otlp): support histogram aggregation metrics

### DIFF
--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -234,7 +234,6 @@ default values.
 | `log_level`                            | Log verbosity directives                  |
 | `min_tls_version`                      | Minimum TLS version for HTTPS connections |
 | `multi_region_failover.enabled`        | Enable multi-region failover mode         |
-| `otlp_config.metrics.histograms.mode`  | OTLP histogram bucket reporting mode      |
 | `serializer_zstd_compressor_level`     | Zstd compression level (Agent)            |
 | `skip_ssl_validation`                  | Skip TLS cert validation                  |
 | `statsd_forward_host`                  | UDP packet forwarding destination host    |
@@ -371,12 +370,6 @@ is enabled.
 | `multi_region_failover.api_key`          | API key for the failover-region endpoint.                                  | unset   |
 | `multi_region_failover.site`             | Datadog site for the failover region, used as `https://app.mrf.<site>`.    | unset   |
 | `multi_region_failover.dd_url`           | Explicit failover intake URL. Takes precedence over `site` when set.       | unset   |
-
-### `otlp_config.metrics.histograms.mode`
-
-ADP supports the `counters` and `distributions` modes. The `nobuckets` mode requires
-`otlp_config.metrics.histograms.send_aggregation_metrics` to be enabled, but ADP does not yet
-read that setting, so selecting `nobuckets` prevents the OTLP source from starting.
 
 ### `serializer_zstd_compressor_level`
 
@@ -700,6 +693,8 @@ compressed wire payload bytes.
 | `origin_detection_unified`                                     | Unified origin detection mode                      |
 | `otlp_config.logs.enabled`                                     | otlp_config.logs.enabled                           |
 | `otlp_config.metrics.enabled`                                  | otlp_config.metrics.enabled                        |
+| `otlp_config.metrics.histograms.mode`                          | OTLP histogram bucket reporting mode               |
+| `otlp_config.metrics.histograms.send_aggregation_metrics`      | Emit OTLP histogram aggregation metrics.           |
 | `otlp_config.metrics.resource_attributes_as_tags`              | Add scalar resource attributes as raw tags.        |
 | `otlp_config.metrics.sums.cumulative_monotonic_mode`           | Cumulative monotonic sum reporting mode.           |
 | `otlp_config.metrics.sums.initial_cumulative_monotonic_value`  | Initial cumulative sum reporting behavior.         |
@@ -768,4 +763,3 @@ compressed wire payload bytes.
 [#1753]: https://github.com/DataDog/saluki/issues/1753
 [#1754]: https://github.com/DataDog/saluki/issues/1754
 [#1755]: https://github.com/DataDog/saluki/issues/1755
-[#2021]: https://github.com/DataDog/saluki/issues/2021

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -883,6 +883,10 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
         }
     }
 
+    fn consume_otlp_config_metrics_histograms_send_aggregation_metrics(&mut self, value: bool) {
+        self.config.domains.otlp.metrics.send_histogram_aggregations = value;
+    }
+
     fn consume_otlp_config_metrics_resource_attributes_as_tags(&mut self, value: bool) {
         self.config.domains.otlp.metrics.resource_attributes_as_tags = value;
     }

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -29,6 +29,11 @@ pub struct Metrics {
     /// How explicit histogram buckets are reported.
     pub histogram_mode: HistogramMode,
 
+    /// Whether histogram count, sum, minimum, and maximum metrics are emitted when available.
+    ///
+    /// The `nobuckets` mode requires this setting. Defaults to `false`.
+    pub send_histogram_aggregations: bool,
+
     /// Whether every resource attribute is added as a raw metric tag, in addition to the
     /// semantic-convention mappings that are always applied.
     pub resource_attributes_as_tags: bool,

--- a/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
@@ -259,12 +259,23 @@ crate::declare_annotations! {
     /// `otlp_config.metrics.histograms.mode`-OTLP histogram bucket reporting mode
     OTLP_CONFIG_METRICS_HISTOGRAMS_MODE = SalukiAnnotation {
         schema: &schema::OTLP_CONFIG_METRICS_HISTOGRAMS_MODE,
-        support_level: SupportLevel::Partial,
+        support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
         used_by: &[structs::OTLP_CONFIGURATION],
         value_type_override: None,
         test_json: Some(r#""counters""#),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
+    /// `otlp_config.metrics.histograms.send_aggregation_metrics`-Emit OTLP histogram aggregation metrics.
+    OTLP_CONFIG_METRICS_HISTOGRAMS_SEND_AGGREGATION_METRICS = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_METRICS_HISTOGRAMS_SEND_AGGREGATION_METRICS,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::OTLP_CONFIGURATION],
+        value_type_override: None,
+        test_json: Some("true"),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
     };
     /// `otlp_config.metrics.resource_attributes_as_tags`-Add scalar resource attributes as raw tags.

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -2002,17 +2002,22 @@ inventory:
         config_registry_filename: otlp.rs
 
   otlp_config.metrics.histograms.mode:
-    support: partial
+    support: full
     pipelines: [otlp]
     description: "OTLP histogram bucket reporting mode"
-    documentation: |-
-      ADP supports the `counters` and `distributions` modes. The `nobuckets` mode requires
-      `otlp_config.metrics.histograms.send_aggregation_metrics` to be enabled, but ADP does not yet
-      read that setting, so selecting `nobuckets` prevents the OTLP source from starting.
-    issue: "#2021"
     test_support:
       used_by: [OtlpConfiguration]
       test_json: '"counters"'
+      additional_attributes:
+        config_registry_filename: otlp.rs
+
+  otlp_config.metrics.histograms.send_aggregation_metrics:
+    support: full
+    pipelines: [otlp]
+    description: "Emit OTLP histogram aggregation metrics."
+    test_support:
+      used_by: [OtlpConfiguration]
+      test_json: "true"
       additional_attributes:
         config_registry_filename: otlp.rs
 
@@ -3935,8 +3940,7 @@ excluded:
   otlp_config.metrics.batch.max_size: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.batch.min_size: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.delta_ttl: "ignored in initial audit 2026-04-23"
-  otlp_config.metrics.histograms.send_aggregation_metrics: "ignored in initial audit 2026-04-23"
-  otlp_config.metrics.histograms.send_count_sum_metrics: "ignored in initial audit 2026-04-23"
+  otlp_config.metrics.histograms.send_count_sum_metrics: "deprecated; ADP supports only send_aggregation_metrics"
   otlp_config.metrics.instrumentation_scope_metadata_as_tags: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.summaries.mode: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.tag_cardinality: "ignored in initial audit 2026-04-23"

--- a/lib/datadog-agent/config/src/generated/datadog_configuration.rs
+++ b/lib/datadog-agent/config/src/generated/datadog_configuration.rs
@@ -1307,12 +1307,16 @@ pub struct OtlpConfigMetricsHistograms {
         default = "defaults::datadog_configuration_otlp_config_metrics_histograms_mode"
     )]
     pub mode: String,
+
+    #[serde(default)]
+    pub send_aggregation_metrics: bool,
 }
 
 impl Default for OtlpConfigMetricsHistograms {
     fn default() -> Self {
         Self {
             mode: defaults::datadog_configuration_otlp_config_metrics_histograms_mode(),
+            send_aggregation_metrics: Default::default(),
         }
     }
 }

--- a/lib/datadog-agent/config/src/generated/env_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_keys.rs
@@ -756,6 +756,11 @@ pub static DATADOG_ENV_KEYS: &[EnvKey] = &[
         decode: EnvDecode::RawString,
     },
     EnvKey {
+        env_vars: &["DD_OTLP_CONFIG_METRICS_HISTOGRAMS_SEND_AGGREGATION_METRICS"],
+        path: &["otlp_config", "metrics", "histograms", "send_aggregation_metrics"],
+        decode: EnvDecode::Bool,
+    },
+    EnvKey {
         env_vars: &["DD_OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS"],
         path: &["otlp_config", "metrics", "resource_attributes_as_tags"],
         decode: EnvDecode::Bool,

--- a/lib/datadog-agent/config/src/generated/env_overlay_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_overlay_keys.rs
@@ -283,6 +283,10 @@ pub static ENV_OVERLAY_KEYS: &[EnvOverlayKey] = &[
         path: &["otlp_config", "metrics", "histograms", "mode"],
     },
     EnvOverlayKey {
+        flats: &["otlp_config_metrics_histograms_send_aggregation_metrics"],
+        path: &["otlp_config", "metrics", "histograms", "send_aggregation_metrics"],
+    },
+    EnvOverlayKey {
         flats: &["otlp_config_metrics_resource_attributes_as_tags"],
         path: &["otlp_config", "metrics", "resource_attributes_as_tags"],
     },

--- a/lib/datadog-agent/config/src/generated/witness.rs
+++ b/lib/datadog-agent/config/src/generated/witness.rs
@@ -161,6 +161,7 @@ pub trait DatadogConfigWitness {
     fn consume_otlp_config_logs_enabled(&mut self, value: bool);
     fn consume_otlp_config_metrics_enabled(&mut self, value: bool);
     fn consume_otlp_config_metrics_histograms_mode(&mut self, value: String);
+    fn consume_otlp_config_metrics_histograms_send_aggregation_metrics(&mut self, value: bool);
     fn consume_otlp_config_metrics_resource_attributes_as_tags(&mut self, value: bool);
     fn consume_otlp_config_metrics_sums_cumulative_monotonic_mode(&mut self, value: String);
     fn consume_otlp_config_metrics_sums_initial_cumulative_monotonic_value(&mut self, value: String);
@@ -419,6 +420,9 @@ pub fn drive(config: &DatadogConfiguration, consumer: &mut impl DatadogConfigWit
     consumer.consume_otlp_config_logs_enabled(config.otlp_config.logs.enabled.clone());
     consumer.consume_otlp_config_metrics_enabled(config.otlp_config.metrics.enabled.clone());
     consumer.consume_otlp_config_metrics_histograms_mode(config.otlp_config.metrics.histograms.mode.clone());
+    consumer.consume_otlp_config_metrics_histograms_send_aggregation_metrics(
+        config.otlp_config.metrics.histograms.send_aggregation_metrics.clone(),
+    );
     consumer.consume_otlp_config_metrics_resource_attributes_as_tags(
         config.otlp_config.metrics.resource_attributes_as_tags.clone(),
     );

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -178,6 +178,15 @@ pub struct HistogramsConfig {
     /// Defaults to `distributions`.
     #[serde(default, deserialize_with = "deserialize_histogram_mode")]
     pub mode: HistogramMode,
+
+    /// Whether to emit histogram count, sum, minimum, and maximum metrics when available.
+    ///
+    /// When disabled, only configured bucket metrics are emitted. The `nobuckets` mode therefore
+    /// requires this setting.
+    ///
+    /// Defaults to `false`.
+    #[serde(default)]
+    pub send_aggregation_metrics: bool,
 }
 
 // TODO: delete when this component uses typed config
@@ -279,8 +288,15 @@ impl Default for MetricsConfig {
 
 //TODO: remove env handling with typed config, unblocked by #2094
 impl MetricsConfig {
-    /// Applies environment-variable overrides for sum settings that normal nested deserialization cannot read.
+    /// Applies flat environment-variable overrides to nested settings.
+    ///
+    /// Figment exposes single-underscore names as flat keys, which nested deserialization cannot read.
     pub(crate) fn apply_env_overrides(&mut self, config: &GenericConfiguration) -> Result<(), GenericError> {
+        if let Some(send_aggregation_metrics) =
+            config.try_get_typed::<bool>("otlp_config_metrics_histograms_send_aggregation_metrics")?
+        {
+            self.histograms.send_aggregation_metrics = send_aggregation_metrics;
+        }
         if let Some(raw_mode) = config.try_get_typed::<String>("otlp_config_metrics_sums_cumulative_monotonic_mode")? {
             self.sums.cumulative_monotonic_mode = raw_mode.parse().map_err(|error| {
                 generic_error!(

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -1277,6 +1277,10 @@ impl OtlpMetricsTranslator {
                 }
             }
 
+            if self.config.hist_mode == HistogramMode::NoBuckets {
+                continue;
+            }
+
             let exp_hist_dd_sketch = match exponential_histogram_to_ddsketch(dp, delta) {
                 Ok(sketch) => sketch,
                 Err(e) => {
@@ -1522,6 +1526,63 @@ mod tests {
     #[test]
     fn mismatched_bucket_and_bound_lengths_emit_no_distribution() {
         assert!(map_malformed_histogram(HistogramMode::Distributions, vec![1], vec![1.0, 2.0]).is_empty());
+    }
+
+    #[test]
+    fn exponential_histogram_nobuckets_emits_aggregations_without_distribution() {
+        let metrics = Metrics::for_tests();
+        let context = TranslationContext {
+            resource_attributes: &[],
+            metrics: &metrics,
+        };
+        let dims = Dimensions {
+            name: "exponential.histogram".to_string(),
+            ..Default::default()
+        };
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        translator.config.hist_mode = HistogramMode::NoBuckets;
+        translator.config.send_histogram_aggregations = true;
+
+        let point = OtlpExponentialHistogramDataPoint {
+            count: 2,
+            sum: Some(3.0),
+            positive: Some(OtlpExponentialHistogramBuckets {
+                bucket_counts: vec![2],
+                ..Default::default()
+            }),
+            min: Some(1.0),
+            max: Some(2.0),
+            time_unix_nano: nanos_from_seconds(1),
+            ..Default::default()
+        };
+
+        let events = translator.map_exponential_histogram_metrics(dims, vec![point], true, &context);
+
+        let metric_names: Vec<_> = events
+            .iter()
+            .map(|event| {
+                event
+                    .try_as_metric()
+                    .expect("event should be a metric")
+                    .context()
+                    .name()
+            })
+            .collect();
+        assert_eq!(
+            metric_names,
+            vec![
+                "exponential.histogram.count",
+                "exponential.histogram.sum",
+                "exponential.histogram.min",
+                "exponential.histogram.max",
+            ]
+        );
+        assert!(events.iter().all(|event| {
+            !matches!(
+                event.try_as_metric().expect("event should be a metric").values(),
+                MetricValues::Distribution(_)
+            )
+        }));
     }
 
     #[test]

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -158,6 +158,7 @@ impl OtlpConfiguration {
             .with_remapping(true)
             .with_quantiles(true)
             .with_histogram_mode(self.otlp_config.metrics.histograms.mode)
+            .with_send_histogram_aggregations(self.otlp_config.metrics.histograms.send_aggregation_metrics)
             .with_cumulative_monotonic_mode(self.otlp_config.metrics.sums.cumulative_monotonic_mode)
             .with_initial_cumulative_monotonic_value(self.otlp_config.metrics.sums.initial_cumulative_monotonic_value)
             .with_resource_attributes_as_tags(self.otlp_config.metrics.resource_attributes_as_tags)
@@ -612,6 +613,104 @@ mod tests {
 
             assert_eq!(otlp_config.metrics_translator_config().hist_mode, expected_mode);
         }
+    }
+
+    #[tokio::test]
+    async fn histogram_aggregation_setting_flows_to_metrics_translator() {
+        let cases = [
+            (json!({ "otlp_config": {} }), false),
+            (
+                json!({
+                    "otlp_config": {
+                        "metrics": {
+                            "histograms": {
+                                "send_aggregation_metrics": false
+                            }
+                        }
+                    }
+                }),
+                false,
+            ),
+            (
+                json!({
+                    "otlp_config": {
+                        "metrics": {
+                            "histograms": {
+                                "send_aggregation_metrics": true
+                            }
+                        }
+                    }
+                }),
+                true,
+            ),
+        ];
+
+        for (raw_config, expected) in cases {
+            let config = config_from(raw_config).await;
+            let otlp_config = OtlpConfiguration::from_configuration(&config).expect("OTLP configuration should parse");
+
+            assert_eq!(
+                otlp_config.metrics_translator_config().send_histogram_aggregations,
+                expected
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn histogram_aggregation_setting_configurable_via_environment_variable() {
+        // Figment exposes this setting as a flat key, so the explicit override must bridge it into `HistogramsConfig`.
+        let env_vars = [(
+            "OTLP_CONFIG_METRICS_HISTOGRAMS_SEND_AGGREGATION_METRICS".to_string(),
+            "true".to_string(),
+        )];
+        let (generic_config, _) = ConfigurationLoader::for_tests_with_provider_factory(
+            Some(json!({ "otlp_config": {} })),
+            Some(&env_vars),
+            false,
+            KEY_ALIASES,
+            DatadogRemapper::new,
+        )
+        .await;
+        let config =
+            OtlpConfiguration::from_configuration(&generic_config).expect("OTLP configuration should deserialize");
+
+        assert!(config.metrics_translator_config().send_histogram_aggregations);
+    }
+
+    #[tokio::test]
+    async fn nobuckets_with_histogram_aggregations_is_valid() {
+        let config = config_from(json!({
+            "otlp_config": {
+                "metrics": {
+                    "histograms": {
+                        "mode": "nobuckets",
+                        "send_aggregation_metrics": true
+                    }
+                }
+            }
+        }))
+        .await;
+        let otlp_config = OtlpConfiguration::from_configuration(&config).expect("OTLP configuration should parse");
+
+        assert!(otlp_config.metrics_translator_config().validate().is_ok());
+    }
+
+    #[tokio::test]
+    async fn nobuckets_without_histogram_aggregations_is_invalid() {
+        // Match the Agent: `nobuckets` without aggregation metrics emits nothing and is invalid.
+        let config = config_from(json!({
+            "otlp_config": {
+                "metrics": {
+                    "histograms": {
+                        "mode": "nobuckets"
+                    }
+                }
+            }
+        }))
+        .await;
+        let otlp_config = OtlpConfiguration::from_configuration(&config).expect("OTLP configuration should parse");
+
+        assert!(otlp_config.metrics_translator_config().validate().is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Human Summary

A fairly simple case of a missing config. Note that there are some ugly parts as we wait for #2094, after which I will move OTLP to typed config and we can delete the env-handlers and deserialization stuff.

## AI Summary
- Wire `otlp_config.metrics.histograms.send_aggregation_metrics` through Datadog and typed OTLP configuration into the metrics translator.
- Support the legacy raw-map environment override and preserve validation for invalid `nobuckets` configurations.
- Keep deprecated `send_count_sum_metrics` unsupported.

## Change Type
- [x] New feature

## How did you test this PR?
- `cargo nextest run -p saluki-components sources::otlp::tests::histogram_aggregation_setting_flows_to_metrics_translator sources::otlp::tests::histogram_aggregation_setting_configurable_via_environment_variable sources::otlp::tests::nobuckets_with_histogram_aggregations_is_valid sources::otlp::tests::nobuckets_without_histogram_aggregations_is_invalid`
- `make fmt`
- `make build-schema-overlay`
- `make check-docs`
- `make check-all`

## References

- Closes: #2021
