### PR TITLE
chore(ci): raise integration test timeout to 15m

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -109,7 +109,7 @@ test-integration:
   needs:
     - build-bundled-agent-adp-image
   retry: 2
-  timeout: 10m
+  timeout: 15m
   image: "${SALUKI_BUILD_CI_IMAGE}"
   artifacts:
     expire_in: 1 week


### PR DESCRIPTION
## Human Summary

I think the integration-test suite has grown but the pipeline job timeout has not. I'm seeing some timeouts at 10m for runs that otherwise seem fine, they just timed out before they were done, so this raises it to 15m.

## AI Summary

Increase the Linux `test-integration` GitLab job timeout from 10 minutes to 15 minutes. This provides additional headroom for integration tests that currently hit the timeout and retry.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

Not run; this changes only the GitLab CI timeout configuration.

## References

