### PR TITLE
chore(config): migrate otlp forwarder to typed configuration

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -825,9 +825,8 @@ async fn add_otlp_pipeline_to_blueprint(
         let otlp_relay_config = OtlpRelayConfiguration::from_configuration(&typed.domains.otlp.receiver);
         let otlp_decoder_config = OtlpDecoderConfiguration::from_configuration(&typed.domains.otlp.traces);
 
-        let raw_map = config_system.raw_map();
         let local_agent_otlp_forwarder_config =
-            OtlpForwarderConfiguration::from_configuration(&raw_map, core_agent_otlp_grpc_endpoint)?;
+            OtlpForwarderConfiguration::from_configuration(&typed.domains.otlp.traces, core_agent_otlp_grpc_endpoint);
 
         blueprint
             // Components.

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -952,7 +952,10 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_otlp_config_traces_internal_port(&mut self, value: i64) {
-        self.config.domains.otlp.traces.internal_port = to_port(value);
+        match u16::try_from(value) {
+            Ok(port) => self.config.domains.otlp.traces.internal_port = port,
+            Err(error) => self.record_error(TranslateError::new("otlp_config.traces.internal_port", error)),
+        }
     }
 
     fn consume_otlp_config_traces_probabilistic_sampler_sampling_percentage(&mut self, value: f64) {
@@ -1298,6 +1301,37 @@ mod tests {
 
         // The error is still surfaced, so startup's strict gate rejects the config.
         assert!(errors.is_some(), "an unknown action must record a translation error");
+    }
+
+    #[test]
+    fn otlp_trace_internal_port_preserves_u16_validation() {
+        // The typed forwarder receives this value after translation. Rejecting conversion here
+        // preserves the u16 validation formerly provided by GenericConfiguration instead of
+        // clamping invalid ports.
+        for value in [0, 5003, u16::MAX as i64] {
+            let datadog: DatadogConfiguration = serde_json::from_value(json!({
+                "otlp_config": { "traces": { "internal_port": value } }
+            }))
+            .expect("datadog source deserializes");
+
+            let (config, errors) = DatadogTranslator::new(&datadog).translate();
+
+            assert!(errors.is_none());
+            assert_eq!(config.domains.otlp.traces.internal_port, value as u16);
+        }
+
+        for value in [-1, u16::MAX as i64 + 1] {
+            let datadog: DatadogConfiguration = serde_json::from_value(json!({
+                "otlp_config": { "traces": { "internal_port": value } }
+            }))
+            .expect("datadog source deserializes");
+
+            let (config, errors) = DatadogTranslator::new(&datadog).translate();
+
+            assert_eq!(config.domains.otlp.traces.internal_port, 0);
+            let errors = errors.expect("an out-of-range port should record a translation error");
+            assert!(errors.to_string().contains("otlp_config.traces.internal_port"));
+        }
     }
 
     #[test]

--- a/lib/saluki-components/src/forwarders/otlp/mod.rs
+++ b/lib/saluki-components/src/forwarders/otlp/mod.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use agent_data_plane_config::domains;
 use async_trait::async_trait;
 use otlp_protos::opentelemetry::proto::collector::logs::v1::logs_service_client::LogsServiceClient;
 use otlp_protos::opentelemetry::proto::collector::logs::v1::ExportLogsServiceRequest;
@@ -10,7 +11,6 @@ use otlp_protos::opentelemetry::proto::collector::trace::v1::{
 };
 use prost::Message;
 use saluki_common::buf::FrozenChunkedBytesBuffer;
-use saluki_config::GenericConfiguration;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::data_model::payload::Payload;
 use saluki_core::{
@@ -36,17 +36,12 @@ pub struct OtlpForwarderConfiguration {
 }
 
 impl OtlpForwarderConfiguration {
-    /// Creates a new `OtlpForwarderConfiguration` from the given configuration.
-    pub fn from_configuration(
-        config: &GenericConfiguration, core_agent_otlp_grpc_endpoint: String,
-    ) -> Result<Self, GenericError> {
-        let core_agent_traces_internal_port = config
-            .try_get_typed("otlp_config.traces.internal_port")?
-            .unwrap_or(5003);
-        Ok(Self {
+    /// Creates a new `OtlpForwarderConfiguration` from the resolved OTLP trace configuration.
+    pub fn from_configuration(traces: &domains::otlp::Traces, core_agent_otlp_grpc_endpoint: String) -> Self {
+        Self {
             core_agent_otlp_grpc_endpoint,
-            core_agent_traces_internal_port,
-        })
+            core_agent_traces_internal_port: traces.internal_port,
+        }
     }
 }
 


### PR DESCRIPTION
## Human Summary

An uneventful cutover to typed configuration.

## AI Summary

Migrate the OTLP forwarder from `GenericConfiguration` to the typed `SalukiConfiguration` model.

- Construct the forwarder from the typed OTLP traces domain and existing typed proxy endpoint.
- Remove the final OTLP proxy `raw_map` plumbing from the topology setup.
- Preserve the forwarder's endpoint normalization behavior.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make build-schema-overlay`
- `make fmt`
- `cargo check -p saluki-components -p agent-data-plane`
- `make check-all`
- Forwarder endpoint normalization unit test

## References

- Progresses: #2171
- Progresses: #2192