### PR TITLE
HOLD-WIP: chore(config): migrate otlp proxy configuration to typed configuration

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -53,7 +53,10 @@ use crate::{
         DogStatsDControlSurface, TopologyControlSurfaces,
     },
 };
-use crate::{config::DataPlaneConfiguration, internal::env::ADPEnvironmentProvider};
+use crate::{
+    config::{DataPlaneConfiguration, DataPlaneOtlpConfiguration},
+    internal::env::ADPEnvironmentProvider,
+};
 
 /// Runs the data plane.
 #[derive(FromArgs, Debug)]
@@ -124,8 +127,11 @@ pub async fn handle_run_command(
 
     // Hand un-migrated components the resolved configuration as the legacy `GenericConfiguration`
     // they still read from. Raw reads go through `config`; typed/live reads go through `config_sys`.
+    // The OTLP activation and proxy decisions are attached from the typed model rather than the raw
+    // map now that the configuration system is resolved.
     let dp_config = DataPlaneConfiguration::from_configuration(&config_sys.raw_map())
-        .error_context("Failed to load data plane configuration.")?;
+        .error_context("Failed to load data plane configuration.")?
+        .with_otlp(DataPlaneOtlpConfiguration::from_configuration(&config_sys.config()));
 
     // Connected mode may have replaced the bootstrap-phase settings with the Agent's authoritative
     // config, so reload logging to match. Standalone resolves the same local sources seen at

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use agent_data_plane_config::{domains::otlp, SalukiConfiguration};
 use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, GenericError};
 use saluki_io::net::ListenAddress;
@@ -43,8 +44,20 @@ impl DataPlaneConfiguration {
                 .unwrap_or_else(|| ListenAddress::any_tcp(5101)),
             checks: DataPlaneChecksConfiguration::from_configuration(config)?,
             dogstatsd: DataPlaneDogStatsDConfiguration::from_configuration(config)?,
-            otlp: DataPlaneOtlpConfiguration::from_configuration(config)?,
+            // The OTLP configuration is sourced from the typed configuration system, which is not
+            // available at bootstrap. It is attached on the runtime path via `with_otlp`; until
+            // then it stays disabled. Bootstrap and the API client never read it.
+            otlp: DataPlaneOtlpConfiguration::default(),
         })
+    }
+
+    /// Attaches the OTLP configuration resolved from the typed configuration system.
+    ///
+    /// The topology-shaping OTLP decisions (activation and proxy gating) come from the typed model
+    /// rather than the raw configuration map, so they are supplied once runtime authority exists.
+    pub fn with_otlp(mut self, otlp: DataPlaneOtlpConfiguration) -> Self {
+        self.otlp = otlp;
+        self
     }
 
     /// Returns `true` if the data plane is enabled.
@@ -214,18 +227,23 @@ impl DataPlaneDogStatsDConfiguration {
 }
 
 /// OTLP-specific data plane configuration.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct DataPlaneOtlpConfiguration {
     enabled: bool,
     proxy: DataPlaneOtlpProxyConfiguration,
 }
 
 impl DataPlaneOtlpConfiguration {
-    fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        Ok(Self {
-            enabled: config.try_get_typed("data_plane.otlp.enabled")?.unwrap_or(false),
-            proxy: DataPlaneOtlpProxyConfiguration::from_configuration(config)?,
-        })
+    /// Builds the OTLP data plane configuration from the resolved typed configuration.
+    ///
+    /// The activation gate is read from the control slice (`data_plane.otlp.enabled`) and the proxy
+    /// settings from the OTLP domain, both resolved by the typed configuration system rather than
+    /// deserialized from the raw configuration map.
+    pub fn from_configuration(config: &SalukiConfiguration) -> Self {
+        Self {
+            enabled: config.control.otlp,
+            proxy: DataPlaneOtlpProxyConfiguration::from_configuration(&config.domains.otlp.proxy),
+        }
     }
 
     /// Returns `true` if the OTLP pipeline is enabled.
@@ -244,20 +262,19 @@ impl DataPlaneOtlpConfiguration {
 /// In proxy mode, ADP takes over the normal "OTLP Ingest" endpoints that the Core Agent would typically listen on,
 /// so the Core Agent must be configured to listen on a different, separate port than it usually would so that ADP
 /// can proxy to it.
-#[derive(Clone, Debug)]
-#[allow(dead_code)]
+#[derive(Clone, Debug, Default)]
 pub struct DataPlaneOtlpProxyConfiguration {
     /// Whether or not to proxy all signals to the Agent.
     ///
     /// When enabled, OTLP signals which aren't supported by ADP will be proxied to the Agent. Depending on the signal
     /// type, they may be proxied to either the Core Agent or Trace Agent.
     ///
-    /// Defaults to `true`.
+    /// Defaults to `false`.
     enabled: bool,
 
     /// OTLP gRPC endpoint on the Core Agent to proxy signals to.
     ///
-    /// Defaults to `http://localhost:4319`.
+    /// Defaults to `127.0.0.1:4319`.
     core_agent_otlp_grpc_endpoint: String,
 
     /// Whether or not to proxy traces to the Core Agent.
@@ -277,28 +294,19 @@ pub struct DataPlaneOtlpProxyConfiguration {
 }
 
 impl DataPlaneOtlpProxyConfiguration {
-    fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let enabled = config.try_get_typed("data_plane.otlp.proxy.enabled")?.unwrap_or(false);
-        let core_agent_otlp_grpc_endpoint = config
-            .try_get_typed("data_plane.otlp.proxy.receiver.protocols.grpc.endpoint")?
-            .unwrap_or("http://localhost:4319".to_string());
-        let proxy_traces = config
-            .try_get_typed("data_plane.otlp.proxy.traces.enabled")?
-            .unwrap_or(true);
-        let proxy_metrics = config
-            .try_get_typed("data_plane.otlp.proxy.metrics.enabled")?
-            .unwrap_or(true);
-        let proxy_logs = config
-            .try_get_typed("data_plane.otlp.proxy.logs.enabled")?
-            .unwrap_or(true);
-
-        Ok(Self {
-            enabled,
-            core_agent_otlp_grpc_endpoint,
-            proxy_traces,
-            proxy_metrics,
-            proxy_logs,
-        })
+    /// Builds the OTLP proxy configuration from the resolved OTLP proxy domain slice.
+    ///
+    /// Every value (the proxy gate, the Core Agent gRPC endpoint, and the per-signal proxy flags)
+    /// comes from the typed OTLP domain, which the typed configuration system populates with the
+    /// Datadog schema defaults.
+    fn from_configuration(proxy: &otlp::Proxy) -> Self {
+        Self {
+            enabled: proxy.enabled,
+            core_agent_otlp_grpc_endpoint: proxy.grpc_endpoint.clone(),
+            proxy_traces: proxy.traces_enabled,
+            proxy_metrics: proxy.metrics_enabled,
+            proxy_logs: proxy.logs_enabled,
+        }
     }
 
     /// Returns `true` if the OTLP proxy is enabled.
@@ -337,6 +345,17 @@ mod tests {
     async fn dp_config_from(value: serde_json::Value) -> DataPlaneConfiguration {
         DataPlaneConfiguration::from_configuration(&config_from(value).await)
             .expect("data plane configuration should parse")
+    }
+
+    // Builds the typed-backed OTLP configuration the way the runtime path does, exercising the
+    // control-slice activation gate and the OTLP proxy domain the migration now reads from. Only
+    // the fields the pipeline-requirement predicates consult are set; the rest keep model defaults.
+    fn otlp_config(enabled: bool, proxy_enabled: bool, proxy_traces: bool) -> DataPlaneOtlpConfiguration {
+        let mut config = SalukiConfiguration::default();
+        config.control.otlp = enabled;
+        config.domains.otlp.proxy.enabled = proxy_enabled;
+        config.domains.otlp.proxy.traces_enabled = proxy_traces;
+        DataPlaneOtlpConfiguration::from_configuration(&config)
     }
 
     // ADP ignores `use_dogstatsd`. The Core Agent evaluates that key and delivers the resolved
@@ -413,7 +432,6 @@ mod tests {
                 "enabled": true,
                 "checks": { "enabled": true },
                 "dogstatsd": { "enabled": false },
-                "otlp": { "enabled": false },
             },
         }))
         .await;
@@ -429,13 +447,10 @@ mod tests {
     #[tokio::test]
     async fn otlp_without_proxy_requires_metrics_logs_and_traces_pipelines() {
         let dp = dp_config_from(json!({
-            "data_plane": {
-                "enabled": true,
-                "dogstatsd": { "enabled": false },
-                "otlp": { "enabled": true, "proxy": { "enabled": false } },
-            },
+            "data_plane": { "enabled": true, "dogstatsd": { "enabled": false } },
         }))
-        .await;
+        .await
+        .with_otlp(otlp_config(true, false, true));
 
         assert!(dp.data_pipelines_enabled());
         assert!(dp.metrics_pipeline_required());
@@ -450,13 +465,10 @@ mod tests {
         // With proxy mode enabled and traces still proxied to the Core Agent (the default), ADP handles no signals
         // itself, so no baseline pipeline is required even though a data pipeline (OTLP) is enabled.
         let dp = dp_config_from(json!({
-            "data_plane": {
-                "enabled": true,
-                "dogstatsd": { "enabled": false },
-                "otlp": { "enabled": true, "proxy": { "enabled": true } },
-            },
+            "data_plane": { "enabled": true, "dogstatsd": { "enabled": false } },
         }))
-        .await;
+        .await
+        .with_otlp(otlp_config(true, true, true));
 
         assert!(dp.data_pipelines_enabled());
         assert!(!dp.metrics_pipeline_required());
@@ -471,16 +483,10 @@ mod tests {
         // Proxy mode is enabled but trace proxying is turned off, so ADP must handle traces locally and the traces
         // pipeline becomes required again while the other baseline pipelines stay off.
         let dp = dp_config_from(json!({
-            "data_plane": {
-                "enabled": true,
-                "dogstatsd": { "enabled": false },
-                "otlp": {
-                    "enabled": true,
-                    "proxy": { "enabled": true, "traces": { "enabled": false } },
-                },
-            },
+            "data_plane": { "enabled": true, "dogstatsd": { "enabled": false } },
         }))
-        .await;
+        .await
+        .with_otlp(otlp_config(true, true, false));
 
         assert!(dp.data_pipelines_enabled());
         assert!(!dp.metrics_pipeline_required());
@@ -497,7 +503,6 @@ mod tests {
                 "enabled": true,
                 "checks": { "enabled": false },
                 "dogstatsd": { "enabled": false },
-                "otlp": { "enabled": false },
             },
         }))
         .await;

--- a/lib/datadog-agent/config-testing/src/config_registry/data_plane.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/data_plane.rs
@@ -78,13 +78,35 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
     };
+    /// `data_plane.otlp.enabled`-Enable the OTLP pipeline
+    DATA_PLANE_OTLP_ENABLED = SalukiAnnotation {
+        schema: &schema::DATA_PLANE_OTLP_ENABLED,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
+    /// `data_plane.otlp.proxy.enabled`-Enable OTLP proxy to Core Agent
+    DATA_PLANE_OTLP_PROXY_ENABLED = SalukiAnnotation {
+        schema: &schema::DATA_PLANE_OTLP_PROXY_ENABLED,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
     /// `data_plane.otlp.proxy.logs.enabled`-Proxy OTLP logs to Core Agent
     DATA_PLANE_OTLP_PROXY_LOGS_ENABLED = SalukiAnnotation {
         schema: &schema::DATA_PLANE_OTLP_PROXY_LOGS_ENABLED,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
-        used_by: &[structs::GET_TYPED],
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
         value_type_override: None,
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
@@ -95,7 +117,18 @@ crate::declare_annotations! {
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
-        used_by: &[structs::GET_TYPED],
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
+    /// `data_plane.otlp.proxy.receiver.protocols.grpc.endpoint`-OTLP proxy gRPC receiver endpoint
+    DATA_PLANE_OTLP_PROXY_RECEIVER_PROTOCOLS_GRPC_ENDPOINT = SalukiAnnotation {
+        schema: &schema::DATA_PLANE_OTLP_PROXY_RECEIVER_PROTOCOLS_GRPC_ENDPOINT,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
         value_type_override: None,
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
@@ -106,7 +139,7 @@ crate::declare_annotations! {
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
-        used_by: &[structs::GET_TYPED],
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
         value_type_override: None,
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -607,21 +607,25 @@ inventory:
     pipelines: [cross_cutting]
     description: "Enable the OTLP pipeline"
     test_support:
-      used_by: [NO_SMOKE]
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: data_plane.rs
 
   data_plane.otlp.proxy.enabled:
     support: full
     pipelines: [otlp]
     description: "Enable OTLP proxy to Core Agent"
     test_support:
-      used_by: [NO_SMOKE]
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: data_plane.rs
 
   data_plane.otlp.proxy.logs.enabled:
     support: full
     pipelines: [otlp]
     description: "Proxy OTLP logs to Core Agent"
     test_support:
-      used_by: [get_typed]
+      used_by: [TypedConfigSystem]
       additional_attributes:
         config_registry_filename: data_plane.rs
 
@@ -630,7 +634,7 @@ inventory:
     pipelines: [otlp]
     description: "Proxy OTLP metrics to Core Agent"
     test_support:
-      used_by: [get_typed]
+      used_by: [TypedConfigSystem]
       additional_attributes:
         config_registry_filename: data_plane.rs
 
@@ -639,14 +643,16 @@ inventory:
     pipelines: [otlp]
     description: "OTLP proxy gRPC receiver endpoint"
     test_support:
-      used_by: [NO_SMOKE]
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: data_plane.rs
 
   data_plane.otlp.proxy.traces.enabled:
     support: full
     pipelines: [otlp]
     description: "Proxy OTLP traces to Core Agent"
     test_support:
-      used_by: [get_typed]
+      used_by: [TypedConfigSystem]
       additional_attributes:
         config_registry_filename: data_plane.rs
 

--- a/test/integration/cases/adp-config-otlp/config.yaml
+++ b/test/integration/cases/adp-config-otlp/config.yaml
@@ -46,6 +46,14 @@ env:
   DD_OTLP_CACHED_TAGSETS_LIMIT: "234567"
   DD_OTLP_ALLOW_CONTEXT_HEAP_ALLOCS: "false"
 
+  # OTLP proxy -- Datadog schema keys. OTLP itself stays disabled so no proxy topology is built;
+  # these assert only that the migrated proxy values resolve through the typed configuration.
+  DD_DATA_PLANE_OTLP_PROXY_ENABLED: "true"
+  DD_DATA_PLANE_OTLP_PROXY_LOGS_ENABLED: "false"
+  DD_DATA_PLANE_OTLP_PROXY_METRICS_ENABLED: "false"
+  DD_DATA_PLANE_OTLP_PROXY_TRACES_ENABLED: "false"
+  DD_DATA_PLANE_OTLP_PROXY_RECEIVER_PROTOCOLS_GRPC_ENDPOINT: "127.0.0.1:24319"
+
 container:
   exposed_ports:
     - "55101/tcp"
@@ -175,6 +183,33 @@ procedure:
     endpoint: "https://localhost:55101/config/internal"
     key: domains.otlp.contexts.allow_context_heap_allocs
     value: false
+    timeout: 60s
+
+  # OTLP proxy -- Datadog schema keys
+  - assertion: adp_config_key_equals
+    endpoint: "https://localhost:55101/config/internal"
+    key: domains.otlp.proxy.enabled
+    value: true
+    timeout: 60s
+  - assertion: adp_config_key_equals
+    endpoint: "https://localhost:55101/config/internal"
+    key: domains.otlp.proxy.logs_enabled
+    value: false
+    timeout: 60s
+  - assertion: adp_config_key_equals
+    endpoint: "https://localhost:55101/config/internal"
+    key: domains.otlp.proxy.metrics_enabled
+    value: false
+    timeout: 60s
+  - assertion: adp_config_key_equals
+    endpoint: "https://localhost:55101/config/internal"
+    key: domains.otlp.proxy.traces_enabled
+    value: false
+    timeout: 60s
+  - assertion: adp_config_key_equals
+    endpoint: "https://localhost:55101/config/internal"
+    key: domains.otlp.proxy.grpc_endpoint
+    value: "127.0.0.1:24319"
     timeout: 60s
 
   - parallel:


### PR DESCRIPTION
## Human Summary

An uneventful cutover to typed configuration.

## AI Summary

Migrate the ADP-local OTLP proxy configuration from `GenericConfiguration` to the typed configuration model.

- Build the OTLP proxy configuration from typed control and OTLP domain slices.
- Keep the bootstrap-only raw configuration path for non-OTLP data-plane settings.
- Remove the runtime OTLP proxy `raw_map` dependency.
- Mark migrated data-plane OTLP keys as `TYPED_CONFIG_SYSTEM` and regenerate the registry.
- Add connected-mode integration assertions for the typed proxy values.
- Reconcile the disabled-proxy gRPC endpoint fallback with the authoritative schema default.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make build-schema-overlay`
- `make fmt`
- `cargo check --workspace --tests`
- `make check-all`
- `cargo nextest run -p agent-data-plane config::` (15 passed)
- Configuration crate and config-system tests (106 passed)

The integration test additions are covered by the integration-test target rather than `make check-all`.

## References

- Progresses: #2172
- Closes: #2192
