### PR TITLE
chore(config): clarify typed configuration updates

### DIFF
--- a/lib/agent-data-plane-config-system/src/system.rs
+++ b/lib/agent-data-plane-config-system/src/system.rs
@@ -155,7 +155,7 @@ impl ConfigurationSystem {
     where
         T: Clone + PartialEq + 'static,
     {
-        Live::dynamic(Arc::clone(&self.current), self.tick.subscribe(), project)
+        Live::new_dynamic(Arc::clone(&self.current), self.tick.subscribe(), project)
     }
 
     /// Loads the current translated configuration.
@@ -604,7 +604,7 @@ mod tests {
         )
         .await;
         let mut view = system.live(|c| &c.domains.dogstatsd.debug_log);
-        assert!(!view.current().metrics_stats_enable);
+        assert!(!view.metrics_stats_enable);
 
         agent_tx
             .send(ConfigUpdate::Partial {
@@ -614,11 +614,11 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::timeout(Duration::from_secs(2), view.changed())
+        let updated = tokio::time::timeout(Duration::from_secs(2), view.changed())
             .await
             .expect("view observes the debug-log update");
-        assert!(view.current().metrics_stats_enable);
-        // `Deref` reflects the value observed at the last `changed`.
+        assert!(updated.metrics_stats_enable);
+        // `Deref` reflects the value returned by the last `changed`.
         assert!(view.metrics_stats_enable);
     }
 
@@ -632,7 +632,7 @@ mod tests {
         )
         .await;
         let mut stats = system.live(|c| &c.domains.dogstatsd.debug_log.metrics_stats_enable);
-        assert!(!stats.current());
+        assert!(!*stats);
 
         agent_tx
             .send(ConfigUpdate::Partial {
@@ -642,17 +642,16 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::timeout(Duration::from_secs(2), stats.changed())
+        let updated = tokio::time::timeout(Duration::from_secs(2), stats.changed())
             .await
             .expect("field view observes its field's update");
-        assert!(stats.current());
+        assert!(updated);
         assert!(*stats);
     }
 
     #[tokio::test]
     async fn fixed_view_never_changes() {
-        let mut view: Live<bool> = Live::fixed(true);
-        assert!(view.current());
+        let mut view: Live<bool> = Live::new_fixed(true);
         assert!(*view);
         // A fixed view never resolves, so this bound is deterministic rather than timing-dependent.
         assert!(tokio::time::timeout(Duration::from_millis(100), view.changed())
@@ -671,18 +670,14 @@ mod tests {
         .expect("system builds");
         let config = system.config();
 
-        assert_eq!(
-            system.live(|c| &c.domains.dogstatsd.debug_log).current(),
-            config.domains.dogstatsd.debug_log
-        );
-        assert_eq!(
-            system.live(|c| &c.domains.dogstatsd.prefix_filter).current(),
-            config.domains.dogstatsd.prefix_filter
-        );
-        assert_eq!(
-            system.live(|c| &c.domains.multi_region_failover).current(),
-            config.domains.multi_region_failover
-        );
+        let debug_log = system.live(|c| &c.domains.dogstatsd.debug_log);
+        assert_eq!(&*debug_log, &config.domains.dogstatsd.debug_log);
+
+        let prefix_filter = system.live(|c| &c.domains.dogstatsd.prefix_filter);
+        assert_eq!(&*prefix_filter, &config.domains.dogstatsd.prefix_filter);
+
+        let multi_region_failover = system.live(|c| &c.domains.multi_region_failover);
+        assert_eq!(&*multi_region_failover, &config.domains.multi_region_failover);
     }
 
     #[test]

--- a/lib/agent-data-plane-config/src/live.rs
+++ b/lib/agent-data-plane-config/src/live.rs
@@ -16,9 +16,13 @@ type Projection<T> = Arc<dyn for<'a> Fn(&'a SalukiConfiguration) -> &'a T + Send
 /// A typed view of one projection of the current configuration.
 ///
 /// A never-dynamic consumer can hold a plain `T`; a dynamic one holds `Live<T>` and never learns
-/// whether it is fixed or tracking the live config. Read with `Deref`/`current`; react with
-/// `changed`. The projection is over `SalukiConfiguration`, so this is a config view, not a
-/// general-purpose watcher.
+/// whether it is fixed or tracking the live config. Read the view's cached snapshot with `Deref`;
+/// wait for and receive the next selected update with `changed`.
+///
+/// For a dynamic view, `Deref` does not perform a fresh read from the shared configuration. It
+/// returns the last snapshot processed by this view. If the configuration advances before this
+/// view awaits `changed`, `Deref` continues to return the older snapshot until `changed` processes
+/// the notification.
 pub struct Live<T> {
     inner: Inner<T>,
 }
@@ -26,24 +30,30 @@ pub struct Live<T> {
 enum Inner<T> {
     Fixed(T),
     Dynamic {
+        // The shared source. It can advance independently of this view's snapshot.
         cell: Arc<ArcSwap<SalukiConfiguration>>,
+
+        // A wake-up signal, not the configuration value itself. The view re-projects the source
+        // after receiving it and ignores notifications that do not change T.
         tick: watch::Receiver<()>,
+
+        // Re-applied to the shared source whenever the view processes a notification.
         project: Projection<T>,
-        // Last observed projected value; backs `Deref` and the change comparison.
+
+        // This value belongs to this Live<T>. It is what Deref returns and what changed() compares
+        // against; a newer value in `cell` does not replace it until changed() processes a tick.
         snapshot: T,
     },
 }
 
 impl<T: Clone + PartialEq + 'static> Live<T> {
-    /// A view that never changes (local mode, tests).
-    pub fn fixed(value: T) -> Self {
-        Self {
-            inner: Inner::Fixed(value),
-        }
-    }
-
-    /// A view projected from the live configuration. Called by the config system.
-    pub fn dynamic(
+    /// Creates a view that re-projects the shared configuration after accepted updates.
+    ///
+    /// The projection selects the subtree this view owns. The initial projected value is captured
+    /// immediately; later calls to `changed` load and project the shared configuration, then update
+    /// this view's local snapshot. Until `changed` processes a notification, `Deref` continues to
+    /// return the previous snapshot even if the shared configuration has advanced.
+    pub fn new_dynamic(
         cell: Arc<ArcSwap<SalukiConfiguration>>, tick: watch::Receiver<()>,
         project: impl for<'a> Fn(&'a SalukiConfiguration) -> &'a T + Send + Sync + 'static,
     ) -> Self {
@@ -58,20 +68,24 @@ impl<T: Clone + PartialEq + 'static> Live<T> {
         }
     }
 
-    /// A fresh clone of the current projected value.
-    pub fn current(&self) -> T {
-        match &self.inner {
-            Inner::Fixed(value) => value.clone(),
-            Inner::Dynamic { cell, project, .. } => project(&cell.load()).clone(),
+    /// Creates a view with a value that never changes.
+    pub fn new_fixed(value: T) -> Self {
+        Self {
+            inner: Inner::Fixed(value),
         }
     }
 
-    /// Resolves when the projected value changes. Parks forever when `Fixed` or the channel closed,
-    /// so a caller can `select!` on it unconditionally; a bare `.await` on a fixed view hangs. On
-    /// return, `Deref` reflects the new value.
-    pub async fn changed(&mut self) {
+    /// Waits for the projected value to change and returns the new value.
+    ///
+    /// The notification only says that the shared source may have changed. This method loads the
+    /// source, applies the projection, compares it with this view's snapshot, and keeps waiting if
+    /// the selected value is unchanged. It parks forever when `Fixed` or the channel is closed, so
+    /// a caller can `select!` on it unconditionally. The returned value and `Deref` reflect the
+    /// same processed snapshot. This is a state-change watcher, not a fresh-read API or an event
+    /// history: multiple source updates may be coalesced before this view processes them.
+    pub async fn changed(&mut self) -> T {
         match &mut self.inner {
-            Inner::Fixed(_) => std::future::pending().await,
+            Inner::Fixed(_) => std::future::pending::<T>().await,
             Inner::Dynamic {
                 cell,
                 tick,
@@ -79,31 +93,36 @@ impl<T: Clone + PartialEq + 'static> Live<T> {
                 snapshot,
             } => loop {
                 if tick.changed().await.is_err() {
-                    std::future::pending::<()>().await;
+                    std::future::pending::<T>().await;
                 }
                 let guard = cell.load();
                 let latest = project(&guard);
                 if *latest != *snapshot {
                     *snapshot = latest.clone();
-                    return;
+                    return snapshot.clone();
                 }
             },
         }
     }
 
-    /// Narrows this view to a child node or a single field. The child shares the same source and
-    /// notification and wakes only when the child value changes.
+    /// Creates a child view by composing this view's projection with `f`.
+    ///
+    /// Use this when code already has a broad `Live<T>` but does not have the
+    /// `ConfigurationSystem` needed to create a narrower view
+    /// directly. A dynamic child shares the source and receives its own notification cursor and
+    /// snapshot; it wakes only when the selected child value changes. A fixed child is projected
+    /// once and remains fixed.
     pub fn project<U>(&self, f: impl for<'a> Fn(&'a T) -> &'a U + Send + Sync + 'static) -> Live<U>
     where
         U: Clone + PartialEq + 'static,
     {
         match &self.inner {
-            Inner::Fixed(value) => Live::fixed(f(value).clone()),
+            Inner::Fixed(value) => Live::new_fixed(f(value).clone()),
             Inner::Dynamic {
                 cell, tick, project, ..
             } => {
                 let parent = Arc::clone(project);
-                Live::dynamic(Arc::clone(cell), tick.clone(), move |c| f(parent(c)))
+                Live::new_dynamic(Arc::clone(cell), tick.clone(), move |c| f(parent(c)))
             }
         }
     }


### PR DESCRIPTION
## Human Summary

This is an improvement to how the interface for dynamic typed config updates is presented. It does not really change the mechanism, but I think it makes it easier to understand.

## AI Summary

- Make `Live::changed()` return the updated projected value, removing the need for a separate read after notification.
- Remove `Live::current()` and rename constructors to `new_dynamic` and `new_fixed`.
- Document the relationship between the shared configuration, notification cursor, projection, and per-view snapshot.

## Change Type
- [x] Non-functional (chore, refactoring, docs)


## How did you test this PR?

- `make fmt`
- `cargo test -p agent-data-plane-config-system`
- `cargo test -p agent-data-plane-config`
- `cargo check --workspace --tests`

## References
- #1788