### PR TITLE
feat(otlp): support summary mode config key

### DIFF
--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -696,6 +696,7 @@ compressed wire payload bytes.
 | `otlp_config.metrics.histograms.mode`                          | OTLP histogram bucket reporting mode               |
 | `otlp_config.metrics.histograms.send_aggregation_metrics`      | Emit OTLP histogram aggregation metrics.           |
 | `otlp_config.metrics.resource_attributes_as_tags`              | Add scalar resource attributes as raw tags.        |
+| `otlp_config.metrics.summaries.mode`                           | OTLP summary quantile reporting mode.              |
 | `otlp_config.metrics.sums.cumulative_monotonic_mode`           | Cumulative monotonic sum reporting mode.           |
 | `otlp_config.metrics.sums.initial_cumulative_monotonic_value`  | Initial cumulative sum reporting behavior.         |
 | `otlp_config.metrics.tags`                                     | Comma-separated tags for all OTLP metrics.         |

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -23,7 +23,9 @@ use agent_data_plane_config::control::ListenAddress;
 use agent_data_plane_config::domains::dogstatsd::{
     FilterAction, MapperProfile, MetricMapping, MetricTagFilterEntry, OriginTagCardinality,
 };
-use agent_data_plane_config::domains::otlp::{CumulativeMonotonicMode, HistogramMode, InitialCumulativeMonotonicValue};
+use agent_data_plane_config::domains::otlp::{
+    CumulativeMonotonicMode, HistogramMode, InitialCumulativeMonotonicValue, SummaryMode,
+};
 use agent_data_plane_config::shared::ForwarderHttpProtocol;
 use agent_data_plane_config::SalukiConfiguration;
 use bytesize::ByteSize;
@@ -911,6 +913,13 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
         }
     }
 
+    fn consume_otlp_config_metrics_summaries_mode(&mut self, value: String) {
+        match value.parse::<SummaryMode>() {
+            Ok(mode) => self.config.domains.otlp.metrics.summaries.mode = mode,
+            Err(error) => self.record_error(TranslateError::new("otlp_config.metrics.summaries.mode", error)),
+        }
+    }
+
     fn consume_otlp_config_metrics_tags(&mut self, value: String) {
         self.config.domains.otlp.metrics.tags = value;
     }
@@ -1129,7 +1138,7 @@ mod tests {
 
     use agent_data_plane_config::domains::{
         dogstatsd::OriginTagCardinality,
-        otlp::{CumulativeMonotonicMode, InitialCumulativeMonotonicValue},
+        otlp::{CumulativeMonotonicMode, InitialCumulativeMonotonicValue, SummaryMode},
     };
     use datadog_agent_config::DatadogConfiguration;
     use serde_json::json;
@@ -1280,6 +1289,46 @@ mod tests {
 
         // The error is still surfaced, so startup's strict gate rejects the config.
         assert!(errors.is_some(), "an unknown action must record a translation error");
+    }
+
+    #[test]
+    fn summary_mode_translates_known_values() {
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "otlp_config": {
+                "metrics": {
+                    "summaries": {
+                        "mode": "noquantiles"
+                    }
+                }
+            }
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, errors) = DatadogTranslator::new(&datadog).translate();
+
+        assert!(errors.is_none());
+        assert_eq!(config.domains.otlp.metrics.summaries.mode, SummaryMode::NoQuantiles);
+    }
+
+    #[test]
+    fn invalid_summary_mode_records_error_and_keeps_default() {
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "otlp_config": {
+                "metrics": {
+                    "summaries": {
+                        "mode": "unsupported"
+                    }
+                }
+            }
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, errors) = DatadogTranslator::new(&datadog).translate();
+
+        assert_eq!(config.domains.otlp.metrics.summaries.mode, SummaryMode::Gauges);
+        let errors = errors.expect("invalid mode should record a translation error");
+        assert!(errors.to_string().contains("otlp_config.metrics.summaries.mode"));
+        assert!(errors.to_string().contains("unknown summary mode `unsupported`"));
     }
 
     #[test]

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -43,6 +43,9 @@ pub struct Metrics {
 
     /// Comma-separated list of tags to add to every emitted metric.
     pub tags: String,
+
+    /// OTLP summary translation settings.
+    pub summaries: Summaries,
 }
 
 /// How explicit OTLP histogram buckets are reported.
@@ -142,6 +145,41 @@ pub struct Sums {
     /// Defaults to `auto`, which reports the value only when its series started after the translator process.
     /// Set this to `drop` to always discard the first value or `keep` to always report it.
     pub initial_cumulative_monotonic_value: InitialCumulativeMonotonicValue,
+}
+
+/// OTLP summary translation settings.
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct Summaries {
+    /// How summary quantiles are reported.
+    ///
+    /// Defaults to `gauges`, which emits one gauge metric per quantile. Set to `noquantiles` to omit quantile
+    /// metrics.
+    pub mode: SummaryMode,
+}
+
+/// How OTLP summary quantiles are reported.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub enum SummaryMode {
+    /// Report one gauge metric per quantile.
+    #[default]
+    Gauges,
+
+    /// Omit quantile metrics.
+    NoQuantiles,
+}
+
+impl FromStr for SummaryMode {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "gauges" => Ok(Self::Gauges),
+            "noquantiles" => Ok(Self::NoQuantiles),
+            other => Err(Error::new_without_source(format!(
+                "unknown summary mode `{other}`; expected `gauges` or `noquantiles`"
+            ))),
+        }
+    }
 }
 
 /// OTLP receiver transports and per-signal activation.

--- a/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
@@ -289,6 +289,17 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
     };
+    /// `otlp_config.metrics.summaries.mode`-OTLP summary quantile reporting mode.
+    OTLP_CONFIG_METRICS_SUMMARIES_MODE = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_METRICS_SUMMARIES_MODE,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::OTLP_CONFIGURATION],
+        value_type_override: None,
+        test_json: Some(r#""noquantiles""#),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
     /// `otlp_config.metrics.sums.cumulative_monotonic_mode`-Cumulative monotonic sum reporting mode.
     OTLP_CONFIG_METRICS_SUMS_CUMULATIVE_MONOTONIC_MODE = SalukiAnnotation {
         schema: &schema::OTLP_CONFIG_METRICS_SUMS_CUMULATIVE_MONOTONIC_MODE,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -2030,6 +2030,19 @@ inventory:
       additional_attributes:
         config_registry_filename: otlp.rs
 
+  otlp_config.metrics.summaries.mode:
+    support: full
+    pipelines: [otlp]
+    description: "OTLP summary quantile reporting mode."
+    documentation: |-
+      Controls how summary quantiles are reported. The default `gauges` emits one gauge metric per quantile. Set this
+      to `noquantiles` to omit quantile metrics.
+    test_support:
+      used_by: [OtlpConfiguration]
+      test_json: '"noquantiles"'
+      additional_attributes:
+        config_registry_filename: otlp.rs
+
   otlp_config.metrics.sums.cumulative_monotonic_mode:
     support: full
     pipelines: [otlp]
@@ -3942,7 +3955,6 @@ excluded:
   otlp_config.metrics.delta_ttl: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.histograms.send_count_sum_metrics: "deprecated; ADP supports only send_aggregation_metrics"
   otlp_config.metrics.instrumentation_scope_metadata_as_tags: "ignored in initial audit 2026-04-23"
-  otlp_config.metrics.summaries.mode: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.tag_cardinality: "ignored in initial audit 2026-04-23"
   otlp_config.receiver.protocols.grpc.include_metadata: "ignored in initial audit 2026-04-23"
   otlp_config.receiver.protocols.grpc.keepalive.enforcement_policy.min_time: "ignored in initial audit 2026-04-23"

--- a/lib/datadog-agent/config/src/generated/datadog_configuration.rs
+++ b/lib/datadog-agent/config/src/generated/datadog_configuration.rs
@@ -1283,6 +1283,9 @@ pub struct OtlpConfigMetrics {
     pub resource_attributes_as_tags: bool,
 
     #[serde(default)]
+    pub summaries: OtlpConfigMetricsSummaries,
+
+    #[serde(default)]
     pub sums: OtlpConfigMetricsSums,
 
     #[serde(default)]
@@ -1295,6 +1298,7 @@ impl Default for OtlpConfigMetrics {
             enabled: defaults::default_bool::<true>(),
             histograms: Default::default(),
             resource_attributes_as_tags: Default::default(),
+            summaries: Default::default(),
             sums: Default::default(),
             tags: Default::default(),
         }
@@ -1317,6 +1321,22 @@ impl Default for OtlpConfigMetricsHistograms {
         Self {
             mode: defaults::datadog_configuration_otlp_config_metrics_histograms_mode(),
             send_aggregation_metrics: Default::default(),
+        }
+    }
+}
+
+#[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+pub struct OtlpConfigMetricsSummaries {
+    #[serde(
+        default = "defaults::datadog_configuration_otlp_config_metrics_summaries_mode"
+    )]
+    pub mode: String,
+}
+
+impl Default for OtlpConfigMetricsSummaries {
+    fn default() -> Self {
+        Self {
+            mode: defaults::datadog_configuration_otlp_config_metrics_summaries_mode(),
         }
     }
 }
@@ -1789,6 +1809,9 @@ pub mod defaults {
     }
     pub(super) fn datadog_configuration_otlp_config_metrics_histograms_mode() -> String {
         "distributions".to_string()
+    }
+    pub(super) fn datadog_configuration_otlp_config_metrics_summaries_mode() -> String {
+        "gauges".to_string()
     }
     pub(super) fn datadog_configuration_otlp_config_metrics_sums_cumulative_monotonic_mode() -> String {
         "to_delta".to_string()

--- a/lib/datadog-agent/config/src/generated/env_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_keys.rs
@@ -766,6 +766,11 @@ pub static DATADOG_ENV_KEYS: &[EnvKey] = &[
         decode: EnvDecode::Bool,
     },
     EnvKey {
+        env_vars: &["DD_OTLP_CONFIG_METRICS_SUMMARIES_MODE"],
+        path: &["otlp_config", "metrics", "summaries", "mode"],
+        decode: EnvDecode::RawString,
+    },
+    EnvKey {
         env_vars: &["DD_OTLP_CONFIG_METRICS_SUMS_CUMULATIVE_MONOTONIC_MODE"],
         path: &["otlp_config", "metrics", "sums", "cumulative_monotonic_mode"],
         decode: EnvDecode::RawString,

--- a/lib/datadog-agent/config/src/generated/env_overlay_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_overlay_keys.rs
@@ -291,6 +291,10 @@ pub static ENV_OVERLAY_KEYS: &[EnvOverlayKey] = &[
         path: &["otlp_config", "metrics", "resource_attributes_as_tags"],
     },
     EnvOverlayKey {
+        flats: &["otlp_config_metrics_summaries_mode"],
+        path: &["otlp_config", "metrics", "summaries", "mode"],
+    },
+    EnvOverlayKey {
         flats: &["otlp_config_metrics_sums_cumulative_monotonic_mode"],
         path: &["otlp_config", "metrics", "sums", "cumulative_monotonic_mode"],
     },

--- a/lib/datadog-agent/config/src/generated/witness.rs
+++ b/lib/datadog-agent/config/src/generated/witness.rs
@@ -163,6 +163,7 @@ pub trait DatadogConfigWitness {
     fn consume_otlp_config_metrics_histograms_mode(&mut self, value: String);
     fn consume_otlp_config_metrics_histograms_send_aggregation_metrics(&mut self, value: bool);
     fn consume_otlp_config_metrics_resource_attributes_as_tags(&mut self, value: bool);
+    fn consume_otlp_config_metrics_summaries_mode(&mut self, value: String);
     fn consume_otlp_config_metrics_sums_cumulative_monotonic_mode(&mut self, value: String);
     fn consume_otlp_config_metrics_sums_initial_cumulative_monotonic_value(&mut self, value: String);
     fn consume_otlp_config_metrics_tags(&mut self, value: String);
@@ -426,6 +427,7 @@ pub fn drive(config: &DatadogConfiguration, consumer: &mut impl DatadogConfigWit
     consumer.consume_otlp_config_metrics_resource_attributes_as_tags(
         config.otlp_config.metrics.resource_attributes_as_tags.clone(),
     );
+    consumer.consume_otlp_config_metrics_summaries_mode(config.otlp_config.metrics.summaries.mode.clone());
     consumer.consume_otlp_config_metrics_sums_cumulative_monotonic_mode(
         config.otlp_config.metrics.sums.cumulative_monotonic_mode.clone(),
     );

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -1,6 +1,8 @@
 //! Shared OTLP receiver configuration.
 
-use agent_data_plane_config::domains::otlp::{CumulativeMonotonicMode, HistogramMode, InitialCumulativeMonotonicValue};
+use agent_data_plane_config::domains::otlp::{
+    CumulativeMonotonicMode, HistogramMode, InitialCumulativeMonotonicValue, SummaryMode,
+};
 use bytesize::ByteSize;
 use facet::Facet;
 use saluki_config::GenericConfiguration;
@@ -207,6 +209,14 @@ where
     String::deserialize(deserializer)?.parse().map_err(D::Error::custom)
 }
 
+// TODO: delete when this component uses typed config
+fn deserialize_summary_mode<'de, D>(deserializer: D) -> Result<SummaryMode, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer)?.parse().map_err(D::Error::custom)
+}
+
 /// Configuration for OTLP metrics processing.
 #[derive(Deserialize, Debug)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
@@ -242,6 +252,10 @@ pub struct MetricsConfig {
     /// Configuration for OTLP sums.
     #[serde(default)]
     pub sums: SumsConfig,
+
+    /// Summary processing configuration.
+    #[serde(default)]
+    pub summaries: SummariesConfig,
 }
 
 /// Configuration for OTLP sums.
@@ -270,6 +284,19 @@ pub struct SumsConfig {
     pub initial_cumulative_monotonic_value: InitialCumulativeMonotonicValue,
 }
 
+/// Configuration for OTLP summaries.
+#[derive(Deserialize, Debug, Default)]
+#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
+pub struct SummariesConfig {
+    /// Controls how summary quantiles are emitted.
+    ///
+    /// The default `gauges` emits one gauge metric per quantile. Set this to `noquantiles` to omit quantile metrics.
+    ///
+    /// Corresponds to `otlp_config.metrics.summaries.mode`.
+    #[serde(default, deserialize_with = "deserialize_summary_mode")]
+    pub mode: SummaryMode,
+}
+
 fn default_metrics_enabled() -> bool {
     true
 }
@@ -282,6 +309,7 @@ impl Default for MetricsConfig {
             resource_attributes_as_tags: false,
             tags: String::new(),
             sums: SumsConfig::default(),
+            summaries: SummariesConfig::default(),
         }
     }
 }
@@ -311,6 +339,11 @@ impl MetricsConfig {
                 generic_error!(
                     "invalid `otlp_config.metrics.sums.initial_cumulative_monotonic_value` environment override: {error}"
                 )
+            })?;
+        }
+        if let Some(raw_mode) = config.try_get_typed::<String>("otlp_config_metrics_summaries_mode")? {
+            self.summaries.mode = raw_mode.parse().map_err(|error| {
+                generic_error!("invalid `otlp_config.metrics.summaries.mode` environment override: {error}")
             })?;
         }
         Ok(())

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
-use agent_data_plane_config::domains::otlp::{CumulativeMonotonicMode, HistogramMode, InitialCumulativeMonotonicValue};
+use agent_data_plane_config::domains::otlp::{
+    CumulativeMonotonicMode, HistogramMode, InitialCumulativeMonotonicValue, SummaryMode,
+};
 use saluki_error::{generic_error, GenericError};
 
 const DEFAULT_DELTA_TTL: Duration = Duration::from_secs(3600);
@@ -77,8 +79,9 @@ impl OtlpMetricsTranslatorConfig {
         self
     }
 
-    pub fn with_quantiles(mut self, quantiles: bool) -> Self {
-        self.quantiles = quantiles;
+    /// Sets how OTLP summary quantiles are reported.
+    pub fn with_summary_mode(mut self, summary_mode: SummaryMode) -> Self {
+        self.quantiles = matches!(summary_mode, SummaryMode::Gauges);
         self
     }
 

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -156,10 +156,7 @@ impl OtlpConfiguration {
     fn metrics_translator_config(&self) -> metrics::config::OtlpMetricsTranslatorConfig {
         metrics::config::OtlpMetricsTranslatorConfig::default()
             .with_remapping(true)
-            .with_quantiles(matches!(
-                self.otlp_config.metrics.summaries.mode,
-                agent_data_plane_config::domains::otlp::SummaryMode::Gauges
-            ))
+            .with_summary_mode(self.otlp_config.metrics.summaries.mode)
             .with_histogram_mode(self.otlp_config.metrics.histograms.mode)
             .with_send_histogram_aggregations(self.otlp_config.metrics.histograms.send_aggregation_metrics)
             .with_cumulative_monotonic_mode(self.otlp_config.metrics.sums.cumulative_monotonic_mode)

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -156,7 +156,10 @@ impl OtlpConfiguration {
     fn metrics_translator_config(&self) -> metrics::config::OtlpMetricsTranslatorConfig {
         metrics::config::OtlpMetricsTranslatorConfig::default()
             .with_remapping(true)
-            .with_quantiles(true)
+            .with_quantiles(matches!(
+                self.otlp_config.metrics.summaries.mode,
+                agent_data_plane_config::domains::otlp::SummaryMode::Gauges
+            ))
             .with_histogram_mode(self.otlp_config.metrics.histograms.mode)
             .with_send_histogram_aggregations(self.otlp_config.metrics.histograms.send_aggregation_metrics)
             .with_cumulative_monotonic_mode(self.otlp_config.metrics.sums.cumulative_monotonic_mode)
@@ -613,6 +616,47 @@ mod tests {
 
             assert_eq!(otlp_config.metrics_translator_config().hist_mode, expected_mode);
         }
+    }
+
+    #[tokio::test]
+    async fn summary_mode_flows_to_metrics_translator() {
+        let cases = [("gauges", true), ("noquantiles", false)];
+
+        for (configured_mode, expected_quantiles) in cases {
+            let config = config_from(json!({
+                "otlp_config": {
+                    "metrics": {
+                        "summaries": {
+                            "mode": configured_mode
+                        }
+                    }
+                }
+            }))
+            .await;
+            let otlp_config = OtlpConfiguration::from_configuration(&config).expect("OTLP configuration should parse");
+
+            assert_eq!(otlp_config.metrics_translator_config().quantiles, expected_quantiles);
+        }
+    }
+
+    #[tokio::test]
+    async fn summary_mode_is_configurable_via_environment_variable() {
+        let env_vars = [(
+            "OTLP_CONFIG_METRICS_SUMMARIES_MODE".to_string(),
+            "noquantiles".to_string(),
+        )];
+        let (generic_config, _) = ConfigurationLoader::for_tests_with_provider_factory(
+            Some(json!({ "otlp_config": {} })),
+            Some(&env_vars),
+            false,
+            KEY_ALIASES,
+            DatadogRemapper::new,
+        )
+        .await;
+        let config =
+            OtlpConfiguration::from_configuration(&generic_config).expect("OTLP configuration should deserialize");
+
+        assert!(!config.metrics_translator_config().quantiles);
     }
 
     #[tokio::test]

--- a/test/correctness/cases/otlp-metrics-summary-mode/config.yaml
+++ b/test/correctness/cases/otlp-metrics-summary-mode/config.yaml
@@ -1,0 +1,21 @@
+type: correctness
+runtime: docker
+analysis_mode: metrics
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=false
+    - DD_DATA_PLANE_OTLP_ENABLED=true
+    - ADP_DD_DATA_PLANE_OTLP_RECEIVER_PROTOCOLS_GRPC_ENDPOINT=0.0.0.0:54317
+    - ADP_DD_DATA_PLANE_OTLP_RECEIVER_PROTOCOLS_HTTP_ENDPOINT=0.0.0.0:54318
+    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/cases/otlp-metrics-summary-mode/datadog.yaml
+++ b/test/correctness/cases/otlp-metrics-summary-mode/datadog.yaml
@@ -1,0 +1,15 @@
+# OTLP correctness test configuration for summary quantile reporting.
+hostname: "correctness-testing"
+api_key: dummy-api-key-correctness-testing
+health_port: 5555
+dd_url: "http://datadog-intake:2049"
+
+otlp_config:
+  metrics:
+    summaries:
+      mode: noquantiles
+  receiver:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:54317"
+        max_recv_msg_size_mib: 4

--- a/test/correctness/cases/otlp-metrics-summary-mode/millstone.yaml
+++ b/test/correctness/cases/otlp-metrics-summary-mode/millstone.yaml
@@ -1,0 +1,9 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "grpc://$GROUP:54317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export"
+aggregation_bucket_width_secs: 10
+volume: 1
+corpus:
+  size: 1
+  payload:
+    # ExportMetricsServiceRequest with one SummaryDataPoint and two quantiles.
+    static_base64: "CmMSYRJfChZvdGxwLnN1bW1hcnkucXVhbnRpbGVzWkUKQxkAACo2/pyXFyEKAAAAAAAAACkAAAAAAABZQDISCQAAAAAAAOA/EQAAAAAAAClAMhIJrkfhehSu7z8RAAAAAAAAOUA="


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Added support for the two summary modes `gauges` and `noquantiles`. Formerly, the quantile setting was hardcoded to `true`, but this adds the configuration plumbing required to allow for external modification. 

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

Unit tests

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

- Closes: https://github.com/DataDog/saluki/issues/2090
<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
