### PR TITLE
feat(io): tag successful HTTP transactions by protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4524,6 +4524,7 @@ dependencies = [
  "libc",
  "memchr",
  "metrics",
+ "metrics-util",
  "nom 8.0.0",
  "pin-project",
  "pin-project-lite",

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -25,7 +25,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_rar_telemetry() {
+    fn render_rar_telemetry() {
         // Simulate internal metrics that match remapper rules.
         let metrics = vec![
             Event::Metric(Metric::counter(
@@ -118,7 +118,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_compat_telemetry() {
+    fn render_compat_telemetry() {
         let metrics = vec![
             Event::Metric(Metric::counter(
                 Context::from_static_parts(
@@ -256,7 +256,7 @@ mod tests {
     }
 
     #[test]
-    fn test_compat_remappings_cover_expected_names() {
+    fn compat_remappings_cover_expected_names() {
         let rules = get_compat_remappings();
         let expected_names = [
             "dogstatsd_event_packets",
@@ -296,7 +296,7 @@ mod tests {
     }
 
     #[test]
-    fn test_match_context() {
+    fn match_context() {
         let rules = get_datadog_agent_remappings();
 
         let context = Context::from_static_parts("adp.object_pool_acquired", &["pool_name:dsd_packet_bufs"]);
@@ -322,7 +322,7 @@ mod tests {
     }
 
     #[test]
-    fn test_match_context_preserves_dogstatsd_origin() {
+    fn match_context_preserves_dogstatsd_origin() {
         let rules = get_datadog_agent_remappings();
 
         let context = Context::from_static_parts(
@@ -346,7 +346,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rar_telemetry_deduplicates_remapped_metrics() {
+    fn rar_telemetry_deduplicates_remapped_metrics() {
         // Two source metrics with different source tags that remap to the same (name, tags) identity
         // should be deduplicated (counters summed) in the RAR output.
         let metrics = vec![
@@ -391,7 +391,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_rar_telemetry_remaps_filterlist_metrics() {
+    fn render_rar_telemetry_remaps_filterlist_metrics() {
         let metrics = vec![
             Event::Metric(Metric::gauge(
                 Context::from_static_parts("adp.metric_filterlist_size", &["component_id:dsd_prefix_filter"]),
@@ -471,7 +471,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rar_rules_carry_expected_help_text() {
+    fn rar_rules_carry_expected_help_text() {
         // Ensure that the help text for overlapped metric names matches what the Datadog Agent expects.
         // The Datadog Agent will fail to parse metrics whose `# HELP` text doesn't match its registered
         // help text, so this guards against drift.

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -50,6 +50,34 @@ mod tests {
                 ),
                 3.0,
             )),
+            // This metric should NOT appear in output (no matching rule).
+            Event::Metric(Metric::counter(
+                Context::from_static_parts("adp.some_unrelated_metric", &[]),
+                100.0,
+            )),
+        ];
+
+        let output = render_with(get_datadog_agent_remappings(), metrics);
+
+        // Matched metrics should appear with remapped names.
+        assert!(output.contains("dogstatsd__packet_pool_get "));
+        assert!(output.contains("dogstatsd__packet_pool "));
+        assert!(output.contains("point__sent{domain=\"https://api.datadoghq.com\"} 12"));
+        assert!(output.contains("point__dropped{domain=\"https://api.datadoghq.com\"} 3"));
+
+        // Unmatched metrics should NOT appear.
+        assert!(!output.contains("some_unrelated_metric"));
+
+        // Should have TYPE headers.
+        assert!(output.contains("# TYPE dogstatsd__packet_pool_get counter"));
+        assert!(output.contains("# TYPE dogstatsd__packet_pool gauge"));
+        assert!(output.contains("# TYPE point__sent gauge"));
+        assert!(output.contains("# TYPE point__dropped gauge"));
+    }
+
+    #[test]
+    fn rar_transaction_success_preserves_protocol_only_for_counts() {
+        let metrics = vec![
             Event::Metric(Metric::counter(
                 Context::from_static_parts(
                     "adp.network_http_requests_success_total",
@@ -72,20 +100,10 @@ mod tests {
                 ),
                 123.0,
             )),
-            // This metric should NOT appear in output (no matching rule).
-            Event::Metric(Metric::counter(
-                Context::from_static_parts("adp.some_unrelated_metric", &[]),
-                100.0,
-            )),
         ];
 
         let output = render_with(get_datadog_agent_remappings(), metrics);
 
-        // Matched metrics should appear with remapped names.
-        assert!(output.contains("dogstatsd__packet_pool_get "));
-        assert!(output.contains("dogstatsd__packet_pool "));
-        assert!(output.contains("point__sent{domain=\"https://api.datadoghq.com\"} 12"));
-        assert!(output.contains("point__dropped{domain=\"https://api.datadoghq.com\"} 3"));
         assert!(output.contains(concat!(
             "transactions__success{domain=\"https://api.datadoghq.com\",",
             "endpoint=\"/api/v1/series\",proto_version=\"HTTP/2.0\"} 5"
@@ -97,15 +115,6 @@ mod tests {
             "transactions__success_bytes{domain=\"https://api.datadoghq.com\",",
             "endpoint=\"/api/v1/series\",proto_version="
         )));
-
-        // Unmatched metrics should NOT appear.
-        assert!(!output.contains("some_unrelated_metric"));
-
-        // Should have TYPE headers.
-        assert!(output.contains("# TYPE dogstatsd__packet_pool_get counter"));
-        assert!(output.contains("# TYPE dogstatsd__packet_pool gauge"));
-        assert!(output.contains("# TYPE point__sent gauge"));
-        assert!(output.contains("# TYPE point__dropped gauge"));
     }
 
     #[test]

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -50,6 +50,28 @@ mod tests {
                 ),
                 3.0,
             )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts(
+                    "adp.network_http_requests_success_total",
+                    &[
+                        "domain:https://api.datadoghq.com",
+                        "endpoint:/api/v1/series",
+                        "proto_version:HTTP/2.0",
+                    ],
+                ),
+                5.0,
+            )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts(
+                    "adp.network_http_requests_success_sent_bytes_total",
+                    &[
+                        "domain:https://api.datadoghq.com",
+                        "endpoint:/api/v1/series",
+                        "proto_version:HTTP/2.0",
+                    ],
+                ),
+                123.0,
+            )),
             // This metric should NOT appear in output (no matching rule).
             Event::Metric(Metric::counter(
                 Context::from_static_parts("adp.some_unrelated_metric", &[]),
@@ -64,6 +86,17 @@ mod tests {
         assert!(output.contains("dogstatsd__packet_pool "));
         assert!(output.contains("point__sent{domain=\"https://api.datadoghq.com\"} 12"));
         assert!(output.contains("point__dropped{domain=\"https://api.datadoghq.com\"} 3"));
+        assert!(output.contains(concat!(
+            "transactions__success{domain=\"https://api.datadoghq.com\",",
+            "endpoint=\"/api/v1/series\",proto_version=\"HTTP/2.0\"} 5"
+        )));
+        assert!(output.contains(
+            "transactions__success_bytes{domain=\"https://api.datadoghq.com\",endpoint=\"/api/v1/series\"} 123"
+        ));
+        assert!(!output.contains(concat!(
+            "transactions__success_bytes{domain=\"https://api.datadoghq.com\",",
+            "endpoint=\"/api/v1/series\",proto_version="
+        )));
 
         // Unmatched metrics should NOT appear.
         assert!(!output.contains("some_unrelated_metric"));

--- a/bin/agent-data-plane/src/state/metrics/rules/transaction.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/transaction.rs
@@ -16,7 +16,7 @@ pub fn get_transaction_remappings() -> Vec<RemapperRule> {
             .with_original_tags(["domain", "endpoint"])
             .with_help_text("Transaction drop count"),
         RemapperRule::by_name("adp.network_http_requests_success_total", "transactions.success")
-            .with_original_tags(["domain", "endpoint"])
+            .with_original_tags(["domain", "endpoint", "proto_version"])
             .with_help_text("Successful transaction count"),
         RemapperRule::by_name(
             "adp.network_http_requests_success_sent_bytes_total",

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -87,6 +87,7 @@ rustls-cng-crypto = { workspace = true }
 
 [dev-dependencies]
 http-body-util = { workspace = true }
+metrics-util = { workspace = true, features = ["debugging"] }
 proptest = { workspace = true }
 rand_distr = { workspace = true }
 tempfile = { workspace = true }

--- a/lib/saluki-io/src/net/client/http/telemetry.rs
+++ b/lib/saluki-io/src/net/client/http/telemetry.rs
@@ -185,18 +185,33 @@ struct SuccessCounters {
     http_11: OnceLock<Counter>,
     http_2: OnceLock<Counter>,
     http_3: OnceLock<Counter>,
+    fallback: OnceLock<Mutex<HashMap<Version, Counter>>>,
 }
 
 impl SuccessCounters {
-    fn slot_for_version(&self, version: Version) -> (&OnceLock<Counter>, &'static str) {
+    fn slot_for_version(&self, version: Version) -> Option<(&OnceLock<Counter>, &'static str)> {
         match version {
-            Version::HTTP_09 => (&self.http_09, "HTTP/0.9"),
-            Version::HTTP_10 => (&self.http_10, "HTTP/1.0"),
-            Version::HTTP_11 => (&self.http_11, "HTTP/1.1"),
-            Version::HTTP_2 => (&self.http_2, "HTTP/2.0"),
-            Version::HTTP_3 => (&self.http_3, "HTTP/3.0"),
-            _ => unreachable!("unsupported HTTP version"),
+            Version::HTTP_09 => Some((&self.http_09, "HTTP/0.9")),
+            Version::HTTP_10 => Some((&self.http_10, "HTTP/1.0")),
+            Version::HTTP_11 => Some((&self.http_11, "HTTP/1.1")),
+            Version::HTTP_2 => Some((&self.http_2, "HTTP/2.0")),
+            Version::HTTP_3 => Some((&self.http_3, "HTTP/3.0")),
+            _ => None,
         }
+    }
+
+    fn fallback_counter(&self, builder: &MetricsBuilder, version: Version) -> Counter {
+        let fallback = self.fallback.get_or_init(|| Mutex::new(HashMap::new()));
+        let mut counters = fallback.lock().unwrap();
+        counters
+            .entry(version)
+            .or_insert_with(|| {
+                builder.register_counter_with_tags(
+                    "network_http_requests_success_total",
+                    [("proto_version", format!("{version:?}"))],
+                )
+            })
+            .clone()
     }
 }
 
@@ -240,14 +255,19 @@ impl PerEndpointTelemetry {
     }
 
     fn increment_success(&self, version: Version) {
-        let (slot, proto_version) = self.success.slot_for_version(version);
-        slot.get_or_init(|| {
-            self.builder.register_counter_with_tags(
-                "network_http_requests_success_total",
-                [("proto_version", proto_version)],
-            )
-        })
-        .increment(1);
+        if let Some((slot, proto_version)) = self.success.slot_for_version(version) {
+            slot.get_or_init(|| {
+                self.builder.register_counter_with_tags(
+                    "network_http_requests_success_total",
+                    [("proto_version", proto_version)],
+                )
+            })
+            .increment(1);
+        } else {
+            // A dependency upgrade may add HTTP versions. The lazy fallback prevents an unfamiliar version from
+            // turning telemetry into a process-level failure without adding overhead to known-version requests.
+            self.success.fallback_counter(&self.builder, version).increment(1);
+        }
     }
 
     fn increment_success_bytes(&self, len: u64) {
@@ -467,10 +487,54 @@ mod tests {
         ];
 
         for (version, expected_slot, expected_label) in cases {
-            let (slot, label) = counters.slot_for_version(version);
+            let (slot, label) = counters
+                .slot_for_version(version)
+                .expect("known HTTP version should have a dedicated counter slot");
             assert!(std::ptr::eq(slot, expected_slot));
             assert_eq!(label, expected_label);
         }
+    }
+
+    #[test]
+    fn fallback_success_counters_are_registered_lazily_and_reused() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let builder = MetricsBuilder::default();
+        let counters = SuccessCounters::default();
+        let version = Version::HTTP_11;
+        let expected_label = "HTTP/1.1";
+
+        assert!(counters.fallback.get().is_none());
+        assert_eq!(format!("{version:?}"), expected_label);
+
+        metrics::with_local_recorder(&recorder, || {
+            counters.fallback_counter(&builder, version).increment(2);
+            counters.fallback_counter(&builder, version).increment(3);
+        });
+
+        let fallback = counters
+            .fallback
+            .get()
+            .expect("fallback cache should be initialized after first use");
+        assert_eq!(fallback.lock().unwrap().len(), 1);
+
+        let snapshot = snapshotter.snapshot().into_hashmap();
+        let success_keys = snapshot
+            .keys()
+            .filter(|key| key.key().name() == "network_http_requests_success_total")
+            .count();
+        assert_eq!(success_keys, 1);
+        let key = CompositeKey::new(
+            MetricKind::Counter,
+            Key::from_parts(
+                "network_http_requests_success_total",
+                vec![Label::new("proto_version", expected_label)],
+            ),
+        );
+        let (_, _, value) = snapshot
+            .get(&key)
+            .expect("fallback success counter should use the version's Debug label");
+        assert_eq!(value, &DebugValue::Counter(5));
     }
 
     #[test]

--- a/lib/saluki-io/src/net/client/http/telemetry.rs
+++ b/lib/saluki-io/src/net/client/http/telemetry.rs
@@ -218,13 +218,18 @@ impl PerEndpointTelemetry {
     }
 
     fn increment_success(&self, version: Version) {
-        let mut success_map = self.success_map.lock().unwrap();
-        let counter = success_map.entry(version).or_insert_with(|| {
-            self.builder.register_counter_with_tags(
-                "network_http_requests_success_total",
-                [("proto_version", format!("{version:?}"))],
-            )
-        });
+        let counter = {
+            let mut success_map = self.success_map.lock().unwrap();
+            success_map
+                .entry(version)
+                .or_insert_with(|| {
+                    self.builder.register_counter_with_tags(
+                        "network_http_requests_success_total",
+                        [("proto_version", format!("{version:?}"))],
+                    )
+                })
+                .clone()
+        };
         counter.increment(1);
     }
 
@@ -437,8 +442,9 @@ mod tests {
     fn successful_requests_are_counted_by_response_protocol_without_splitting_bytes() {
         let recorder = DebuggingRecorder::new();
         let snapshotter = recorder.snapshotter();
-        let inner = tower::service_fn(|request: Request<Full<Bytes>>| {
-            let version = request.version();
+        let mut response_versions = [http::Version::HTTP_11, http::Version::HTTP_2].into_iter();
+        let inner = tower::service_fn(move |_request: Request<Full<Bytes>>| {
+            let version = response_versions.next().expect("response version should be available");
             async move {
                 Ok::<_, Infallible>(
                     Response::builder()
@@ -450,22 +456,22 @@ mod tests {
         });
         let mut service = EndpointTelemetryLayer::default().layer(inner);
 
-        let http_11_request = Request::builder()
+        let first_request = Request::builder()
             .uri("https://example.com/api/v1/series")
-            .version(http::Version::HTTP_11)
+            .version(http::Version::HTTP_10)
             .body(Full::new(Bytes::from_static(b"hello")))
             .expect("request should be valid");
         metrics::with_local_recorder(&recorder, || {
-            tokio_test::block_on(service.call(http_11_request)).expect("request should succeed")
+            tokio_test::block_on(service.call(first_request)).expect("request should succeed")
         });
 
-        let http_2_request = Request::builder()
+        let second_request = Request::builder()
             .uri("https://example.com/api/v1/series")
-            .version(http::Version::HTTP_2)
+            .version(http::Version::HTTP_10)
             .body(Full::new(Bytes::from_static(b"goodbye")))
             .expect("request should be valid");
         metrics::with_local_recorder(&recorder, || {
-            tokio_test::block_on(service.call(http_2_request)).expect("request should succeed")
+            tokio_test::block_on(service.call(second_request)).expect("request should succeed")
         });
 
         let snapshot = snapshotter.snapshot().into_hashmap();

--- a/lib/saluki-io/src/net/client/http/telemetry.rs
+++ b/lib/saluki-io/src/net/client/http/telemetry.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     future::Future,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
     task::{ready, Context, Poll},
 };
 
@@ -178,10 +178,32 @@ impl<S> Layer<S> for EndpointTelemetryLayer {
     }
 }
 
+#[derive(Default)]
+struct SuccessCounters {
+    http_09: OnceLock<Counter>,
+    http_10: OnceLock<Counter>,
+    http_11: OnceLock<Counter>,
+    http_2: OnceLock<Counter>,
+    http_3: OnceLock<Counter>,
+}
+
+impl SuccessCounters {
+    fn slot_for_version(&self, version: Version) -> (&OnceLock<Counter>, &'static str) {
+        match version {
+            Version::HTTP_09 => (&self.http_09, "HTTP/0.9"),
+            Version::HTTP_10 => (&self.http_10, "HTTP/1.0"),
+            Version::HTTP_11 => (&self.http_11, "HTTP/1.1"),
+            Version::HTTP_2 => (&self.http_2, "HTTP/2.0"),
+            Version::HTTP_3 => (&self.http_3, "HTTP/3.0"),
+            _ => unreachable!("unsupported HTTP version"),
+        }
+    }
+}
+
 struct PerEndpointTelemetry {
     builder: MetricsBuilder,
     dropped: Counter,
-    success_map: Mutex<HashMap<Version, Counter>>,
+    success: SuccessCounters,
     success_bytes: Counter,
     http_errors_map: Mutex<HashMap<StatusCode, Counter>>,
 }
@@ -200,14 +222,14 @@ impl PerEndpointTelemetry {
             .add_default_tag(("endpoint", endpoint_name.to_string()));
 
         let dropped = builder.register_counter("network_http_requests_failed_total");
-        let success_map = Mutex::new(HashMap::new());
+        let success = SuccessCounters::default();
         let success_bytes = builder.register_counter("network_http_requests_success_sent_bytes_total");
         let http_errors_map = Mutex::new(HashMap::new());
 
         Self {
             builder,
             dropped,
-            success_map,
+            success,
             success_bytes,
             http_errors_map,
         }
@@ -218,19 +240,14 @@ impl PerEndpointTelemetry {
     }
 
     fn increment_success(&self, version: Version) {
-        let counter = {
-            let mut success_map = self.success_map.lock().unwrap();
-            success_map
-                .entry(version)
-                .or_insert_with(|| {
-                    self.builder.register_counter_with_tags(
-                        "network_http_requests_success_total",
-                        [("proto_version", format!("{version:?}"))],
-                    )
-                })
-                .clone()
-        };
-        counter.increment(1);
+        let (slot, proto_version) = self.success.slot_for_version(version);
+        slot.get_or_init(|| {
+            self.builder.register_counter_with_tags(
+                "network_http_requests_success_total",
+                [("proto_version", proto_version)],
+            )
+        })
+        .increment(1);
     }
 
     fn increment_success_bytes(&self, len: u64) {
@@ -437,6 +454,24 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
+
+    #[test]
+    fn success_counter_slots_cover_supported_http_versions() {
+        let counters = SuccessCounters::default();
+        let cases = [
+            (Version::HTTP_09, &counters.http_09, "HTTP/0.9"),
+            (Version::HTTP_10, &counters.http_10, "HTTP/1.0"),
+            (Version::HTTP_11, &counters.http_11, "HTTP/1.1"),
+            (Version::HTTP_2, &counters.http_2, "HTTP/2.0"),
+            (Version::HTTP_3, &counters.http_3, "HTTP/3.0"),
+        ];
+
+        for (version, expected_slot, expected_label) in cases {
+            let (slot, label) = counters.slot_for_version(version);
+            assert!(std::ptr::eq(slot, expected_slot));
+            assert_eq!(label, expected_label);
+        }
+    }
 
     #[test]
     fn successful_requests_are_counted_by_response_protocol_without_splitting_bytes() {

--- a/lib/saluki-io/src/net/client/http/telemetry.rs
+++ b/lib/saluki-io/src/net/client/http/telemetry.rs
@@ -190,21 +190,15 @@ struct SuccessCounters {
 }
 
 impl SuccessCounters {
-    fn slot_for_version(&self, version: Version) -> Option<(&OnceLock<Counter>, &'static str)> {
+    fn slot_for_version(&self, version: Version) -> (&OnceLock<Counter>, &'static str) {
         match version {
-            Version::HTTP_09 => Some((&self.http_09, "HTTP/0.9")),
-            Version::HTTP_10 => Some((&self.http_10, "HTTP/1.0")),
-            Version::HTTP_11 => Some((&self.http_11, "HTTP/1.1")),
-            Version::HTTP_2 => Some((&self.http_2, "HTTP/2.0")),
-            Version::HTTP_3 => Some((&self.http_3, "HTTP/3.0")),
-            _ => None,
+            Version::HTTP_09 => (&self.http_09, "HTTP/0.9"),
+            Version::HTTP_10 => (&self.http_10, "HTTP/1.0"),
+            Version::HTTP_11 => (&self.http_11, "HTTP/1.1"),
+            Version::HTTP_2 => (&self.http_2, "HTTP/2.0"),
+            Version::HTTP_3 => (&self.http_3, "HTTP/3.0"),
+            _ => (&self.fallback, "unknown"),
         }
-    }
-
-    fn fallback_counter(&self, builder: &MetricsBuilder) -> &Counter {
-        self.fallback.get_or_init(|| {
-            builder.register_counter_with_tags("network_http_requests_success_total", [("proto_version", "unknown")])
-        })
     }
 }
 
@@ -248,19 +242,14 @@ impl PerEndpointTelemetry {
     }
 
     fn increment_success(&self, version: Version) {
-        if let Some((slot, proto_version)) = self.success.slot_for_version(version) {
-            slot.get_or_init(|| {
-                self.builder.register_counter_with_tags(
-                    "network_http_requests_success_total",
-                    [("proto_version", proto_version)],
-                )
-            })
-            .increment(1);
-        } else {
-            // Unknown versions are intentionally grouped until explicit support is added. The lazy fallback keeps
-            // unfamiliar versions non-panicking without adding overhead to known-version requests.
-            self.success.fallback_counter(&self.builder).increment(1);
-        }
+        let (slot, proto_version) = self.success.slot_for_version(version);
+        slot.get_or_init(|| {
+            self.builder.register_counter_with_tags(
+                "network_http_requests_success_total",
+                [("proto_version", proto_version)],
+            )
+        })
+        .increment(1);
     }
 
     fn increment_success_bytes(&self, len: u64) {
@@ -480,51 +469,10 @@ mod tests {
         ];
 
         for (version, expected_slot, expected_label) in cases {
-            let (slot, label) = counters
-                .slot_for_version(version)
-                .expect("known HTTP version should have a dedicated counter slot");
+            let (slot, label) = counters.slot_for_version(version);
             assert!(std::ptr::eq(slot, expected_slot));
             assert_eq!(label, expected_label);
         }
-    }
-
-    #[test]
-    fn fallback_success_counter_is_registered_lazily_and_reused() {
-        let recorder = DebuggingRecorder::new();
-        let snapshotter = recorder.snapshotter();
-        let builder = MetricsBuilder::default();
-        let counters = SuccessCounters::default();
-        let fallback: &OnceLock<Counter> = &counters.fallback;
-
-        assert!(fallback.get().is_none());
-
-        metrics::with_local_recorder(&recorder, || {
-            let first = counters.fallback_counter(&builder);
-            first.increment(2);
-            let second = counters.fallback_counter(&builder);
-            second.increment(3);
-            assert!(std::ptr::eq(first, second));
-        });
-
-        assert!(fallback.get().is_some());
-
-        let snapshot = snapshotter.snapshot().into_hashmap();
-        let success_keys = snapshot
-            .keys()
-            .filter(|key| key.key().name() == "network_http_requests_success_total")
-            .count();
-        assert_eq!(success_keys, 1);
-        let key = CompositeKey::new(
-            MetricKind::Counter,
-            Key::from_parts(
-                "network_http_requests_success_total",
-                vec![Label::new("proto_version", "unknown")],
-            ),
-        );
-        let (_, _, value) = snapshot
-            .get(&key)
-            .expect("fallback success counter should use the unknown protocol label");
-        assert_eq!(value, &DebugValue::Counter(5));
     }
 
     #[test]

--- a/lib/saluki-io/src/net/client/http/telemetry.rs
+++ b/lib/saluki-io/src/net/client/http/telemetry.rs
@@ -113,7 +113,8 @@ fn register_scoped_error(builder: &MetricsBuilder, error_type: &'static str, err
 ///   overall, is sanitized.)
 ///
 /// Successful request counts also include `proto_version`, formatted as the response's HTTP version (for example,
-/// `HTTP/1.1` or `HTTP/2.0`). Successful request bytes remain grouped only by the base tags.
+/// `HTTP/1.1` or `HTTP/2.0`). Versions without dedicated support are grouped under `unknown`. Successful request bytes
+/// remain grouped only by the base tags.
 ///
 /// ### Success bytes calculation
 ///
@@ -185,7 +186,7 @@ struct SuccessCounters {
     http_11: OnceLock<Counter>,
     http_2: OnceLock<Counter>,
     http_3: OnceLock<Counter>,
-    fallback: Mutex<HashMap<Version, Counter>>,
+    fallback: OnceLock<Counter>,
 }
 
 impl SuccessCounters {
@@ -200,17 +201,10 @@ impl SuccessCounters {
         }
     }
 
-    fn fallback_counter(&self, builder: &MetricsBuilder, version: Version) -> Counter {
-        let mut counters = self.fallback.lock().unwrap();
-        counters
-            .entry(version)
-            .or_insert_with(|| {
-                builder.register_counter_with_tags(
-                    "network_http_requests_success_total",
-                    [("proto_version", format!("{version:?}"))],
-                )
-            })
-            .clone()
+    fn fallback_counter(&self, builder: &MetricsBuilder) -> &Counter {
+        self.fallback.get_or_init(|| {
+            builder.register_counter_with_tags("network_http_requests_success_total", [("proto_version", "unknown")])
+        })
     }
 }
 
@@ -263,9 +257,9 @@ impl PerEndpointTelemetry {
             })
             .increment(1);
         } else {
-            // A dependency upgrade may add HTTP versions. The lazy fallback prevents an unfamiliar version from
-            // turning telemetry into a process-level failure without adding overhead to known-version requests.
-            self.success.fallback_counter(&self.builder, version).increment(1);
+            // Unknown versions are intentionally grouped until explicit support is added. The lazy fallback keeps
+            // unfamiliar versions non-panicking without adding overhead to known-version requests.
+            self.success.fallback_counter(&self.builder).increment(1);
         }
     }
 
@@ -495,23 +489,24 @@ mod tests {
     }
 
     #[test]
-    fn fallback_success_counters_are_registered_lazily_and_reused() {
+    fn fallback_success_counter_is_registered_lazily_and_reused() {
         let recorder = DebuggingRecorder::new();
         let snapshotter = recorder.snapshotter();
         let builder = MetricsBuilder::default();
         let counters = SuccessCounters::default();
-        let version = Version::HTTP_11;
-        let expected_label = "HTTP/1.1";
+        let fallback: &OnceLock<Counter> = &counters.fallback;
 
-        assert!(counters.fallback.lock().unwrap().is_empty());
-        assert_eq!(format!("{version:?}"), expected_label);
+        assert!(fallback.get().is_none());
 
         metrics::with_local_recorder(&recorder, || {
-            counters.fallback_counter(&builder, version).increment(2);
-            counters.fallback_counter(&builder, version).increment(3);
+            let first = counters.fallback_counter(&builder);
+            first.increment(2);
+            let second = counters.fallback_counter(&builder);
+            second.increment(3);
+            assert!(std::ptr::eq(first, second));
         });
 
-        assert_eq!(counters.fallback.lock().unwrap().len(), 1);
+        assert!(fallback.get().is_some());
 
         let snapshot = snapshotter.snapshot().into_hashmap();
         let success_keys = snapshot
@@ -523,12 +518,12 @@ mod tests {
             MetricKind::Counter,
             Key::from_parts(
                 "network_http_requests_success_total",
-                vec![Label::new("proto_version", expected_label)],
+                vec![Label::new("proto_version", "unknown")],
             ),
         );
         let (_, _, value) = snapshot
             .get(&key)
-            .expect("fallback success counter should use the version's Debug label");
+            .expect("fallback success counter should use the unknown protocol label");
         assert_eq!(value, &DebugValue::Counter(5));
     }
 

--- a/lib/saluki-io/src/net/client/http/telemetry.rs
+++ b/lib/saluki-io/src/net/client/http/telemetry.rs
@@ -6,7 +6,7 @@ use std::{
     task::{ready, Context, Poll},
 };
 
-use http::{uri::Authority, Request, Response, StatusCode, Uri};
+use http::{uri::Authority, Request, Response, StatusCode, Uri, Version};
 use http_body::Body;
 use metrics::Counter;
 use pin_project_lite::pin_project;
@@ -96,7 +96,7 @@ fn register_scoped_error(builder: &MetricsBuilder, error_type: &'static str, err
 /// - `network_http_requests_failed_total`: The total number of HTTP requests that failed with a status code of 400,
 ///   403, or 413.
 /// - `network_http_requests_success_total`: The total number of successful HTTP requests. (any response with a
-///   non-4xx/5xx status code)
+///   non-4xx/5xx status code) This metric is additionally tagged with the response protocol as `proto_version`.
 /// - `network_http_requests_success_sent_bytes_total`: The total number of body bytes sent in successful HTTP requests.
 ///   (see note below on how this is calculated)
 /// - `network_http_requests_errors_total`: The total number of HTTP requests that had an error, either during the
@@ -111,6 +111,9 @@ fn register_scoped_error(builder: &MetricsBuilder, error_type: &'static str, err
 /// - `endpoint`: The endpoint name, which is derived from the URI path by default but can be customized. (See
 ///   [`EndpointTelemetryLayer::with_endpoint_name_fn`] for information on customization and how the endpoint name,
 ///   overall, is sanitized.)
+///
+/// Successful request counts also include `proto_version`, formatted as the response's HTTP version (for example,
+/// `HTTP/1.1` or `HTTP/2.0`). Successful request bytes remain grouped only by the base tags.
 ///
 /// ### Success bytes calculation
 ///
@@ -178,7 +181,7 @@ impl<S> Layer<S> for EndpointTelemetryLayer {
 struct PerEndpointTelemetry {
     builder: MetricsBuilder,
     dropped: Counter,
-    success: Counter,
+    success_map: Mutex<HashMap<Version, Counter>>,
     success_bytes: Counter,
     http_errors_map: Mutex<HashMap<StatusCode, Counter>>,
 }
@@ -197,14 +200,14 @@ impl PerEndpointTelemetry {
             .add_default_tag(("endpoint", endpoint_name.to_string()));
 
         let dropped = builder.register_counter("network_http_requests_failed_total");
-        let success = builder.register_counter("network_http_requests_success_total");
+        let success_map = Mutex::new(HashMap::new());
         let success_bytes = builder.register_counter("network_http_requests_success_sent_bytes_total");
         let http_errors_map = Mutex::new(HashMap::new());
 
         Self {
             builder,
             dropped,
-            success,
+            success_map,
             success_bytes,
             http_errors_map,
         }
@@ -214,8 +217,15 @@ impl PerEndpointTelemetry {
         self.dropped.increment(1);
     }
 
-    fn increment_success(&self) {
-        self.success.increment(1);
+    fn increment_success(&self, version: Version) {
+        let mut success_map = self.success_map.lock().unwrap();
+        let counter = success_map.entry(version).or_insert_with(|| {
+            self.builder.register_counter_with_tags(
+                "network_http_requests_success_total",
+                [("proto_version", format!("{version:?}"))],
+            )
+        });
+        counter.increment(1);
     }
 
     fn increment_success_bytes(&self, len: u64) {
@@ -363,7 +373,7 @@ where
                             error_telemetry.increment_http_error();
                         }
                     } else {
-                        per_endpoint.increment_success();
+                        per_endpoint.increment_success(response.version());
                         if let Some(body_len) = this.maybe_body_len {
                             per_endpoint.increment_success_bytes(*body_len);
                         }
@@ -410,9 +420,98 @@ fn sanitize_endpoint_name(endpoint_name: MetaString) -> MetaString {
 
 #[cfg(test)]
 mod tests {
+    use std::convert::Infallible;
+
+    use bytes::Bytes;
+    use http_body_util::{Empty, Full};
+    use metrics::{Key, Label};
+    use metrics_util::{
+        debugging::{DebugValue, DebuggingRecorder},
+        CompositeKey, MetricKind,
+    };
     use proptest::prelude::*;
 
     use super::*;
+
+    #[test]
+    fn successful_requests_are_counted_by_response_protocol_without_splitting_bytes() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let inner = tower::service_fn(|request: Request<Full<Bytes>>| {
+            let version = request.version();
+            async move {
+                Ok::<_, Infallible>(
+                    Response::builder()
+                        .version(version)
+                        .body(Empty::<Bytes>::new())
+                        .expect("response should be valid"),
+                )
+            }
+        });
+        let mut service = EndpointTelemetryLayer::default().layer(inner);
+
+        let http_11_request = Request::builder()
+            .uri("https://example.com/api/v1/series")
+            .version(http::Version::HTTP_11)
+            .body(Full::new(Bytes::from_static(b"hello")))
+            .expect("request should be valid");
+        metrics::with_local_recorder(&recorder, || {
+            tokio_test::block_on(service.call(http_11_request)).expect("request should succeed")
+        });
+
+        let http_2_request = Request::builder()
+            .uri("https://example.com/api/v1/series")
+            .version(http::Version::HTTP_2)
+            .body(Full::new(Bytes::from_static(b"goodbye")))
+            .expect("request should be valid");
+        metrics::with_local_recorder(&recorder, || {
+            tokio_test::block_on(service.call(http_2_request)).expect("request should succeed")
+        });
+
+        let snapshot = snapshotter.snapshot().into_hashmap();
+        let success_keys = snapshot
+            .keys()
+            .filter(|key| key.key().name() == "network_http_requests_success_total")
+            .count();
+        assert_eq!(success_keys, 2);
+        for proto_version in ["HTTP/1.1", "HTTP/2.0"] {
+            let key = CompositeKey::new(
+                MetricKind::Counter,
+                Key::from_parts(
+                    "network_http_requests_success_total",
+                    vec![
+                        Label::new("domain", "https://example.com"),
+                        Label::new("endpoint", "/api/v1/series"),
+                        Label::new("proto_version", proto_version),
+                    ],
+                ),
+            );
+            let (_, _, value) = snapshot
+                .get(&key)
+                .expect("protocol-specific success counter should exist");
+            assert_eq!(value, &DebugValue::Counter(1));
+        }
+
+        let success_bytes_keys = snapshot
+            .keys()
+            .filter(|key| key.key().name() == "network_http_requests_success_sent_bytes_total")
+            .count();
+        assert_eq!(success_bytes_keys, 1);
+        let success_bytes_key = CompositeKey::new(
+            MetricKind::Counter,
+            Key::from_parts(
+                "network_http_requests_success_sent_bytes_total",
+                vec![
+                    Label::new("domain", "https://example.com"),
+                    Label::new("endpoint", "/api/v1/series"),
+                ],
+            ),
+        );
+        let (_, _, value) = snapshot
+            .get(&success_bytes_key)
+            .expect("protocol-agnostic success bytes counter should exist");
+        assert_eq!(value, &DebugValue::Counter(12));
+    }
 
     proptest! {
         #[test]

--- a/lib/saluki-io/src/net/client/http/telemetry.rs
+++ b/lib/saluki-io/src/net/client/http/telemetry.rs
@@ -185,7 +185,7 @@ struct SuccessCounters {
     http_11: OnceLock<Counter>,
     http_2: OnceLock<Counter>,
     http_3: OnceLock<Counter>,
-    fallback: OnceLock<Mutex<HashMap<Version, Counter>>>,
+    fallback: Mutex<HashMap<Version, Counter>>,
 }
 
 impl SuccessCounters {
@@ -201,8 +201,7 @@ impl SuccessCounters {
     }
 
     fn fallback_counter(&self, builder: &MetricsBuilder, version: Version) -> Counter {
-        let fallback = self.fallback.get_or_init(|| Mutex::new(HashMap::new()));
-        let mut counters = fallback.lock().unwrap();
+        let mut counters = self.fallback.lock().unwrap();
         counters
             .entry(version)
             .or_insert_with(|| {
@@ -504,7 +503,7 @@ mod tests {
         let version = Version::HTTP_11;
         let expected_label = "HTTP/1.1";
 
-        assert!(counters.fallback.get().is_none());
+        assert!(counters.fallback.lock().unwrap().is_empty());
         assert_eq!(format!("{version:?}"), expected_label);
 
         metrics::with_local_recorder(&recorder, || {
@@ -512,11 +511,7 @@ mod tests {
             counters.fallback_counter(&builder, version).increment(3);
         });
 
-        let fallback = counters
-            .fallback
-            .get()
-            .expect("fallback cache should be initialized after first use");
-        assert_eq!(fallback.lock().unwrap().len(), 1);
+        assert_eq!(counters.fallback.lock().unwrap().len(), 1);
 
         let snapshot = snapshotter.snapshot().into_hashmap();
         let success_keys = snapshot


### PR DESCRIPTION
## Summary

- tag successful ADP HTTP transaction counts with the actual response protocol version
- retain `proto_version` when exposing `transactions.success` through Remote Agent Registry telemetry
- keep `transactions.success_bytes` aggregated by domain and endpoint to match the Core Agent
- use fixed lazy `OnceLock` slots for known protocols, avoiding per-success allocation, locking, hashing, formatting, and handle cloning
- group unfamiliar future HTTP versions in one lazy `proto_version:unknown` counter instead of panicking

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- `make fmt`
- `cargo check --workspace`
- `cargo check --workspace --tests`
- `cargo nextest run -p saluki-io` (113 passed)
- `cargo nextest run -p agent-data-plane state::metrics` (9 passed)
- `make test-all`
- Commit hooks: formatting, Clippy, dependency checks, documentation, and API documentation

`make check-all` passed its normal checks and reached the feature compatibility matrix. The local host could not build the AWS-LC FIPS variants because `cmake` is not installed.

## References

- [DADP-156](https://datadoghq.atlassian.net/browse/DADP-156)


[DADP-156]: https://datadoghq.atlassian.net/browse/DADP-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ