### PR TITLE
enhancement(agent-data-plane): add reporter to forward diagnostic events to Core Agent as Remote Agent events

### DIFF
--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -58,10 +58,9 @@ pub async fn create_control_plane_supervisor(
 
     privileged_api = control_surfaces.register_control_surfaces(privileged_api);
 
-    // If we bootstrapped ourselves as a remote agent, add the necessary gRPC services to the API
-    // and a worker that captures the dataspace for diagnostic artifact collection.
     if let Some(ra_bootstrap) = &ra_bootstrap {
         supervisor.add_worker(ra_bootstrap.create_dataspace_anchor());
+        supervisor.add_worker(ra_bootstrap.create_event_reporter());
         privileged_api = privileged_api
             .with_grpc_service(ra_bootstrap.create_status_service())
             .with_grpc_service(ra_bootstrap.create_flare_service())

--- a/bin/agent-data-plane/src/internal/remote_agent.rs
+++ b/bin/agent-data-plane/src/internal/remote_agent.rs
@@ -6,6 +6,10 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use datadog_agent_commons::ipc::client::RemoteAgentClient;
 use datadog_agent_commons::ipc::session::{SessionId, SessionIdHandle};
+use datadog_protos::agent::v1::{
+    event::Details as RemoteAgentEventDetails, Event as RemoteAgentEvent, InvalidApiKeyEvent,
+    ReportRemoteAgentEventRequest,
+};
 use datadog_protos::agent::{
     config_event,
     flare::v1::{flare_provider_server::*, *},
@@ -20,10 +24,10 @@ use saluki_common::sync::shutdown::ShutdownHandle;
 use saluki_common::task::spawn_traced_named;
 use saluki_config::{dynamic::ConfigUpdate, upsert, GenericConfiguration};
 use saluki_core::{
-    diagnostic::DiagnosticCollector,
+    diagnostic::{subscribe_events, DiagnosticCollector, DiagnosticDetails, DiagnosticEvent},
     observability::metrics::{get_shared_metrics_state, AggregatedMetricsProcessor, Reflector, TelemetryProcessor},
     runtime::{
-        state::{DataspaceRegistry, IdentifierFilter},
+        state::{DataspaceRegistry, DataspaceUpdate, IdentifierFilter, Subscription},
         InitializationError, Supervisable, SupervisorFuture,
     },
 };
@@ -33,6 +37,7 @@ use serde_json::{Map, Value};
 use tokio::task::spawn_blocking;
 use tokio::time::{timeout, Instant};
 use tokio::{
+    select,
     sync::{mpsc, oneshot, Mutex},
     time::{interval, MissedTickBehavior},
 };
@@ -133,17 +138,24 @@ impl RemoteAgentBootstrap {
         }
     }
 
-    /// Creates a worker that captures the dataspace from the supervisor context and makes it
-    /// available to the diagnostic artifact collection service.
+    /// Creates a worker that captures the dataspace from the supervisor context and makes it available to the
+    /// diagnostic artifact collection service.
     ///
-    /// This worker must be added to the control plane supervisor. When it initializes, it runs
-    /// inside the supervisor process where the dataspace task-local is set, and fills the shared
-    /// [`OnceLock`] so that `get_flare_files` can collect diagnostic artifacts at request time.
-    /// Without this, the gRPC handler tasks spawned by tonic would not have access to the
-    /// dataspace since tonic's `tokio::spawn` does not propagate task-locals.
+    /// This worker must be added to the control plane supervisor. When it initializes, it runs inside the supervisor
+    /// process where the dataspace task-local is set, and fills the shared [`OnceLock`] so that `get_flare_files` can
+    /// collect diagnostic artifacts at request time. Without this, the gRPC handler tasks spawned by tonic would not
+    /// have access to the dataspace since tonic's `tokio::spawn` does not propagate task-locals.
     pub fn create_dataspace_anchor(&self) -> DataspaceAnchorWorker {
         DataspaceAnchorWorker {
             dataspace: Arc::clone(&self.dataspace),
+        }
+    }
+
+    /// Creates a worker that reports diagnostic events to the Core Agent as remote agent events.
+    pub fn create_event_reporter(&self) -> RemoteAgentEventReporter {
+        RemoteAgentEventReporter {
+            client: self.client.clone(),
+            session_id: self.session_id.clone(),
         }
     }
 
@@ -701,6 +713,89 @@ impl Supervisable for DataspaceAnchorWorker {
     }
 }
 
+/// A worker that reports diagnostic events to the Core Agent as remote agent events.
+///
+/// It subscribes to [`DiagnosticEvent`]s emitted anywhere in the process converts the ones it recognizes into the
+/// Datadog Agent's remote agent event representation, and reports them to the Core Agent over the remote agent gRPC
+/// API.
+pub struct RemoteAgentEventReporter {
+    client: RemoteAgentClient,
+    session_id: SessionIdHandle,
+}
+
+#[async_trait]
+impl Supervisable for RemoteAgentEventReporter {
+    fn name(&self) -> &str {
+        "remote_agent_event_reporter"
+    }
+
+    async fn initialize(&self, process_shutdown: ShutdownHandle) -> Result<SupervisorFuture, InitializationError> {
+        let client = self.client.clone();
+        let session_id = self.session_id.clone();
+
+        Ok(Box::pin(async move {
+            let subscription = subscribe_events(IdentifierFilter::all())
+                .map_err(|e| generic_error!("Failed to subscribe to diagnostic events: {}", e))?;
+
+            select! {
+                _ = process_shutdown => Ok(()),
+                result = run_event_reporter(client, session_id, subscription) => result,
+            }
+        }))
+    }
+}
+
+async fn run_event_reporter(
+    mut client: RemoteAgentClient, session_id: SessionIdHandle, mut subscription: Subscription<DiagnosticEvent>,
+) -> Result<(), GenericError> {
+    debug!("Remote Agent event reporter started.");
+
+    while let Some(update) = subscription.recv().await {
+        let DataspaceUpdate::Message(_, event) = update else {
+            continue;
+        };
+
+        let Some(remote_agent_event) = diagnostic_to_remote_agent_event(&event) else {
+            debug!("Received diagnostic event with no remote agent event mapping; skipping.");
+            continue;
+        };
+
+        let Some(session_id) = session_id.get() else {
+            debug!("No active remote agent session; dropping diagnostic event.");
+            continue;
+        };
+
+        let request = ReportRemoteAgentEventRequest {
+            session_id: session_id.as_str().to_string(),
+            events: vec![remote_agent_event],
+        };
+
+        if let Err(e) = client.report_remote_agent_event(request).await {
+            warn!(error = %e, "Failed to report remote agent event to the Datadog Agent.");
+        }
+    }
+
+    debug!("Remote Agent event reporter stopped.");
+    Ok(())
+}
+
+/// Converts a [`DiagnosticEvent`] into the Datadog Agent's remote agent event representation.
+///
+/// Returns `None` for diagnostic details that have no corresponding remote agent event variant, in which case the
+/// event is not reported.
+fn diagnostic_to_remote_agent_event(event: &DiagnosticEvent) -> Option<RemoteAgentEvent> {
+    let details = match event.details() {
+        DiagnosticDetails::InvalidApiKey => RemoteAgentEventDetails::InvalidApiKey(InvalidApiKeyEvent {}),
+        // `DiagnosticDetails` is `#[non_exhaustive]`; any future variant without a remote agent mapping is skipped.
+        _ => return None,
+    };
+
+    Some(RemoteAgentEvent {
+        message: event.message().to_string(),
+        details: Some(details),
+    })
+}
+
 struct StatusBuilder {
     main_section: StatusSection,
     named_sections: HashMap<String, StatusSection>,
@@ -787,5 +882,18 @@ mod tests {
         let input = vec![b'y'; DIAGNOSTIC_ARTIFACT_MAX_BYTES];
         let output = cap_artifact_data(input.clone());
         assert_eq!(output, input);
+    }
+
+    #[test]
+    fn diagnostic_to_remote_agent_event_maps_invalid_api_key() {
+        let event = DiagnosticEvent::new("credentials rejected", DiagnosticDetails::InvalidApiKey);
+        let converted =
+            diagnostic_to_remote_agent_event(&event).expect("InvalidApiKey should map to a remote agent event");
+
+        assert_eq!(converted.message, "credentials rejected");
+        assert!(matches!(
+            converted.details,
+            Some(RemoteAgentEventDetails::InvalidApiKey(_))
+        ));
     }
 }

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -26,11 +26,11 @@ use saluki_common::{
 use saluki_config::GenericConfiguration;
 use saluki_core::components::ComponentContext;
 use saluki_core::diagnostic::{DiagnosticDetails, DiagnosticEvent, DiagnosticsEmitter};
-use saluki_error::{generic_error, GenericError};
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use saluki_io::net::{
     client::http::{into_client_body, HttpClient, HttpClientBuilder},
     util::{
-        middleware::{RetryCircuitBreakerError, RetryCircuitBreakerLayer},
+        middleware::{HttpInspectionLayer, RetryCircuitBreakerError, RetryCircuitBreakerLayer},
         retry::{DiskUsageRetrieverImpl, PersistedQueueArgs, PushResult, RetryQueue, Retryable},
     },
 };
@@ -123,7 +123,7 @@ pub struct TransactionForwarder<B> {
     endpoint_name: Arc<EndpointNameFn>,
     endpoints: Vec<RoutableEndpoint>,
     endpoint_request_mapper_factory: EndpointRequestMapperFactory<B>,
-    emitter: Option<DiagnosticsEmitter>,
+    emitter: DiagnosticsEmitter,
     _marker: PhantomData<B>,
 }
 
@@ -244,6 +244,9 @@ where
 
         let client = client_builder.build()?;
 
+        let emitter = DiagnosticsEmitter::from_current(context.identity())
+            .error_context("Failed to create diagnostics emitter for transaction forwarder.")?;
+
         Ok(Self {
             context,
             config,
@@ -254,18 +257,9 @@ where
             endpoint_name,
             endpoints,
             endpoint_request_mapper_factory,
-            emitter: None,
+            emitter,
             _marker: PhantomData,
         })
-    }
-
-    /// Sets the diagnostics emitter used to surface forwarder-level diagnostic events, such as an invalid API key.
-    ///
-    /// The emitter is used by both the API key validation task and the request I/O path. When no emitter is set (the
-    /// default), no diagnostic events are emitted.
-    pub(crate) fn with_diagnostics_emitter(mut self, emitter: Option<DiagnosticsEmitter>) -> Self {
-        self.emitter = emitter;
-        self
     }
 
     /// Spawns the I/O task for the forwarder, and any associated endpoint I/O tasks.
@@ -337,7 +331,7 @@ async fn run_io_loop<B>(
     context: ComponentContext, config: ForwarderConfiguration, live_config: Option<GenericConfiguration>,
     service: HttpClient, telemetry: ComponentTelemetry, metrics_builder: MetricsBuilder,
     endpoint_name: Arc<EndpointNameFn>, resolved_endpoints: Vec<RoutableEndpoint>,
-    endpoint_request_mapper_factory: EndpointRequestMapperFactory<B>, emitter: Option<DiagnosticsEmitter>,
+    endpoint_request_mapper_factory: EndpointRequestMapperFactory<B>, emitter: DiagnosticsEmitter,
 ) where
     B: Body + Buf + Clone + Send + Sync + 'static,
     B::Data: Send,
@@ -474,7 +468,7 @@ async fn run_endpoint_io_loop<B>(
     config: ForwarderConfiguration, live_config: Option<GenericConfiguration>, service: HttpClient,
     telemetry: ComponentTelemetry, txnq_telemetry: TransactionQueueTelemetry, endpoint_name: Arc<EndpointNameFn>,
     route: EndpointRoute, endpoint: ResolvedEndpoint, endpoint_request_mapper_factory: EndpointRequestMapperFactory<B>,
-    emitter: Option<DiagnosticsEmitter>,
+    emitter: DiagnosticsEmitter,
 ) where
     B: Body + Buf + Clone + Send + Sync + 'static,
     B::Data: Send,
@@ -526,6 +520,11 @@ async fn run_endpoint_io_loop<B>(
     // The body type conversion from `TransactionBody<B>` to `ClientBody` happens as the innermost layer,
     // after the retry circuit breaker. This ensures that `RetryCircuitBreakerError::Open(req)` returns
     // the original `Request<TransactionBody<B>>` so we can reassemble it into a `Transaction<B>` for re-enqueuing.
+    //
+    // The invalid API key inspection layer sits *below* the retry circuit breaker so that it observes the raw response
+    // from the client. When secrets management is enabled, a 403 is classified as retriable and the circuit breaker
+    // converts it into a `RetryCircuitBreakerError::Open` error that only re-enqueues the transaction — it never
+    // surfaces the response to the loop below — so this layer is the only place that reliably sees the rejection.
     let mut service = ServiceBuilder::new()
         // Set the request's URI and endpoint-specific headers.
         .map_request({
@@ -545,6 +544,7 @@ async fn run_endpoint_io_loop<B>(
         .layer(RetryCircuitBreakerLayer::new(
             config.retry().to_default_http_retry_policy(live_config),
         ))
+        .layer(build_diagnostics_layer(emitter, endpoint_url.clone()))
         .map_request(|req: Request<TransactionBody<B>>| req.map(into_client_body))
         .service(service);
 
@@ -581,7 +581,6 @@ async fn run_endpoint_io_loop<B>(
     let mut in_flight = JoinSet::new();
     let mut transaction_input_telemetry_by_endpoint = FastHashMap::<MetaString, TransactionInputTelemetry>::default();
     let mut done = false;
-    let mut last_invalid_key_emit = None;
 
     loop {
         select! {
@@ -653,12 +652,11 @@ async fn run_endpoint_io_loop<B>(
                 let task_result = maybe_result.expect("in_flight marked as not being empty");
                 match task_result {
                     Ok((metadata, result)) => match result {
-                        // We got a response -- maybe successful, maybe not -- so just process that.
+                        // We got a response -- maybe successful, maybe not -- so just process that. A rejected API key
+                        // (HTTP 403) is surfaced by the invalid API key inspection layer in the service stack rather
+                        // than here, since a retriable 403 never reaches this arm.
                         Ok(http_response) => {
-                            let response_status = process_http_response(http_response, metadata, &telemetry, &endpoint_url, &endpoint_domain).await;
-                            if response_status == StatusCode::FORBIDDEN {
-                                maybe_emit_invalid_api_key(emitter.as_ref(), &mut last_invalid_key_emit, &endpoint_url);
-                            }
+                            process_http_response(http_response, metadata, &telemetry, &endpoint_url, &endpoint_domain).await;
                         }
 
                         // The service itself encountered an error while sending the request or receiving the response:
@@ -770,11 +768,9 @@ fn track_queue_drops(telemetry: &ComponentTelemetry, domain: &str, push_result: 
 }
 
 /// Processes an HTTP response to a forwarded intake request, updating telemetry and logging as appropriate.
-///
-/// Returns the status code from the responses.
 async fn process_http_response(
     response: Response<Incoming>, metadata: Metadata, telemetry: &ComponentTelemetry, endpoint_url: &str, domain: &str,
-) -> StatusCode {
+) {
     let status = response.status();
     if status.is_success() {
         debug!(endpoint_url, %status, "Request completed.");
@@ -806,31 +802,27 @@ async fn process_http_response(
             }
         }
     }
-
-    status
 }
 
-/// Emits an `InvalidApiKey` diagnostic event via `emitter`, rate-limited to at most once per
-/// [`INVALID_API_KEY_EMIT_INTERVAL`].
-///
-/// `last_emit` records the previous emission time and is updated in place. Does nothing when no emitter is configured.
-fn maybe_emit_invalid_api_key(
-    emitter: Option<&DiagnosticsEmitter>, last_emit: &mut Option<Instant>, endpoint_url: &str,
-) {
-    let Some(emitter) = emitter else {
-        return;
+fn build_diagnostics_layer(emitter: DiagnosticsEmitter, endpoint_url: String) -> HttpInspectionLayer {
+    let last_emit = Mutex::new(None::<Instant>);
+    let forbidden_inspector = move || {
+        let now = Instant::now();
+        {
+            let mut last_emit = last_emit.lock().expect("invalid API key emit mutex poisoned");
+            if last_emit.is_some_and(|last| now.duration_since(last) < INVALID_API_KEY_EMIT_INTERVAL) {
+                return;
+            }
+            *last_emit = Some(now);
+        }
+
+        emitter.emit(DiagnosticEvent::new(
+            format!("Datadog API key rejected as invalid (HTTP 403) when forwarding to '{endpoint_url}'."),
+            DiagnosticDetails::InvalidApiKey,
+        ));
     };
 
-    let now = Instant::now();
-    if last_emit.is_some_and(|last| now.duration_since(last) < INVALID_API_KEY_EMIT_INTERVAL) {
-        return;
-    }
-    *last_emit = Some(now);
-
-    emitter.emit(DiagnosticEvent::new(
-        format!("Datadog API key rejected as invalid (HTTP 403) when forwarding to '{endpoint_url}'."),
-        DiagnosticDetails::InvalidApiKey,
-    ));
+    HttpInspectionLayer::new().with_inspector(StatusCode::FORBIDDEN, forbidden_inspector)
 }
 
 /// A queue of pending transactions waiting to be sent.
@@ -1048,7 +1040,10 @@ mod tests {
     use rustls::{version::TLS12, RootCertStore, ServerConfig};
     use saluki_common::buf::FrozenChunkedBytesBuffer;
     use saluki_config::config_from;
-    use saluki_core::observability::ComponentMetricsExt as _;
+    use saluki_core::{
+        observability::ComponentMetricsExt as _,
+        runtime::state::{DataspaceRegistry, DataspaceUpdate, IdentifierFilter},
+    };
     use saluki_io::net::client::http::TlsMinimumVersion;
     use saluki_metrics::test::TestRecorder;
     use saluki_tls::test_util::SelfSignedCert;
@@ -1569,7 +1564,7 @@ app.datadoghq.com: [key-a, key-b]
 
     fn build_test_forwarder(
         forwarder_url: &str, live_config: Option<GenericConfiguration>,
-    ) -> TransactionForwarder<FrozenChunkedBytesBuffer> {
+    ) -> (DataspaceRegistry, TransactionForwarder<FrozenChunkedBytesBuffer>) {
         // The HTTP client builder requires the process-wide TLS crypto provider to be initialized, even when the
         // forwarder is pointed at a plain HTTP endpoint.
         init_tls_crypto_provider();
@@ -1595,15 +1590,21 @@ app.datadoghq.com: [key-a, key-b]
         let metrics_builder = MetricsBuilder::from_component_context(&context);
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
 
-        TransactionForwarder::<FrozenChunkedBytesBuffer>::from_config(
-            context,
-            forwarder_config,
-            live_config,
-            |_uri: &Uri| None,
-            telemetry,
-            metrics_builder,
-        )
-        .expect("forwarder should build")
+        let dataspace = DataspaceRegistry::new();
+        let forwarder = dataspace
+            .with_current(|| {
+                TransactionForwarder::<FrozenChunkedBytesBuffer>::from_config(
+                    context,
+                    forwarder_config,
+                    live_config,
+                    |_uri: &Uri| None,
+                    telemetry,
+                    metrics_builder,
+                )
+            })
+            .expect("forwarder should build");
+
+        (dataspace, forwarder)
     }
 
     fn build_test_transaction() -> Transaction<FrozenChunkedBytesBuffer> {
@@ -1643,7 +1644,7 @@ app.datadoghq.com: [key-a, key-b]
         // at least one retry to observe the second request.
         let (server_url, counter) = start_recording_http_server(vec![StatusCode::FORBIDDEN, StatusCode::OK]).await;
         let live_config = config_with(json!({ "secret_backend_command": "/bin/true" })).await;
-        let forwarder = build_test_forwarder(&server_url, Some(live_config));
+        let (_, forwarder) = build_test_forwarder(&server_url, Some(live_config));
 
         let handle = forwarder.spawn().await;
         handle
@@ -1663,20 +1664,14 @@ app.datadoghq.com: [key-a, key-b]
 
     #[tokio::test]
     async fn forwarder_emits_invalid_api_key_diagnostic_on_403() {
-        use saluki_core::runtime::state::{DataspaceRegistry, DataspaceUpdate, IdentifierFilter};
-        use saluki_core::support::SubsystemIdentifier;
-
         // The intake server rejects every request with a 403. Without secrets configured, a 403 is not retried, so the
         // single forwarded request flows straight through to response handling.
         let (server_url, _counter) = start_recording_http_server(vec![StatusCode::FORBIDDEN]).await;
 
-        // Subscribe to diagnostic events, then build a forwarder whose emitter publishes to that same dataspace.
-        let dataspace = DataspaceRegistry::new();
+        // Build a forwarder and then subscribe to diagnostic events from the dataspace it's attached to.
+        let (dataspace, forwarder) = build_test_forwarder(&server_url, None);
         let mut events = dataspace.subscribe::<DiagnosticEvent>(IdentifierFilter::all());
-        let emitter =
-            DiagnosticsEmitter::from_dataspace(SubsystemIdentifier::from_segments(["test-forwarder"]), dataspace);
 
-        let forwarder = build_test_forwarder(&server_url, None).with_diagnostics_emitter(Some(emitter));
         let handle = forwarder.spawn().await;
         handle
             .send_transaction(build_test_transaction())
@@ -1684,6 +1679,35 @@ app.datadoghq.com: [key-a, key-b]
             .expect("send should succeed");
 
         // The 403 response to the real request must produce an `InvalidApiKey` diagnostic event.
+        match timeout(Duration::from_secs(3), events.recv()).await {
+            Ok(Some(DataspaceUpdate::Message(_, event))) => {
+                assert_eq!(event.details(), &DiagnosticDetails::InvalidApiKey);
+            }
+            other => panic!("expected an InvalidApiKey diagnostic event, got: {other:?}"),
+        }
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn forwarder_emits_invalid_api_key_diagnostic_on_403_when_secrets_in_use() {
+        // With secrets management enabled, a 403 is classified as retriable, so the retry circuit breaker converts it
+        // into an `Open` error that never reaches the response-handling arm of the I/O loop. The diagnostic must still
+        // be emitted, because it is produced by the inspection layer sitting below the retry circuit breaker. Without
+        // that layer, the rejected key would be retried indefinitely without ever notifying anyone.
+        let (server_url, _counter) = start_recording_http_server(vec![StatusCode::FORBIDDEN]).await;
+        let live_config = config_with(json!({ "secret_backend_command": "/bin/true" })).await;
+
+        // Build a forwarder and then subscribe to diagnostic events from the dataspace it's attached to.
+        let (dataspace, forwarder) = build_test_forwarder(&server_url, Some(live_config));
+        let mut events = dataspace.subscribe::<DiagnosticEvent>(IdentifierFilter::all());
+
+        let handle = forwarder.spawn().await;
+        handle
+            .send_transaction(build_test_transaction())
+            .await
+            .expect("send should succeed");
+
         match timeout(Duration::from_secs(3), events.recv()).await {
             Ok(Some(DataspaceUpdate::Message(_, event))) => {
                 assert_eq!(event.details(), &DiagnosticDetails::InvalidApiKey);

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -8,6 +8,7 @@
 use std::{
     collections::VecDeque,
     error::Error as _,
+    marker::PhantomData,
     path::PathBuf,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
@@ -15,7 +16,7 @@ use std::{
 
 use bytes::Buf;
 use futures::FutureExt as _;
-use http::{Request, Uri};
+use http::{Request, StatusCode, Uri};
 use http_body::Body;
 use http_body_util::BodyExt as _;
 use hyper::{body::Incoming, Response};
@@ -106,10 +107,10 @@ where
 /// Minimum interval between successive `InvalidApiKey` diagnostic events emitted from the request I/O path for a single
 /// endpoint.
 ///
-/// A persistently rejected API key returns `403` on every forwarded request, so the raw event rate is unbounded. This
-/// interval rate-limits emission so that the first rejection is surfaced immediately while a continuously invalid key
-/// cannot flood subscribers with one event per failed request.
-const INVALID_API_KEY_EMIT_INTERVAL: Duration = Duration::from_secs(60);
+/// We want to ensure there's a steady stream of these events while the invalid API key condition is still present, but
+/// we want to avoid sending a deluge of events if there happens to be some bug that causes us to rapidly fire off
+/// requests at a rate of more than one per second.
+const INVALID_API_KEY_EMIT_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Transaction forwarder for Datadog endpoints.
 pub struct TransactionForwarder<B> {
@@ -123,7 +124,7 @@ pub struct TransactionForwarder<B> {
     endpoints: Vec<RoutableEndpoint>,
     endpoint_request_mapper_factory: EndpointRequestMapperFactory<B>,
     emitter: Option<DiagnosticsEmitter>,
-    _marker: std::marker::PhantomData<B>,
+    _marker: PhantomData<B>,
 }
 
 /// Builds request mappers for resolved endpoints.
@@ -254,7 +255,7 @@ where
             endpoints,
             endpoint_request_mapper_factory,
             emitter: None,
-            _marker: std::marker::PhantomData,
+            _marker: PhantomData,
         })
     }
 
@@ -580,10 +581,7 @@ async fn run_endpoint_io_loop<B>(
     let mut in_flight = JoinSet::new();
     let mut transaction_input_telemetry_by_endpoint = FastHashMap::<MetaString, TransactionInputTelemetry>::default();
     let mut done = false;
-
-    // Tracks the last time we emitted an `InvalidApiKey` diagnostic from this endpoint's request path, so a
-    // continuously-rejected key is surfaced promptly but not on every single failed request.
-    let mut last_invalid_key_emit: Option<Instant> = None;
+    let mut last_invalid_key_emit = None;
 
     loop {
         select! {
@@ -657,11 +655,8 @@ async fn run_endpoint_io_loop<B>(
                     Ok((metadata, result)) => match result {
                         // We got a response -- maybe successful, maybe not -- so just process that.
                         Ok(http_response) => {
-                            let credentials_rejected = process_http_response(http_response, metadata, &telemetry, &endpoint_url, &endpoint_domain).await;
-
-                            // A `403` from a real forwarded request means the API key is invalid. Surface it right away
-                            // (rate-limited) rather than waiting for the next API key validation cycle.
-                            if credentials_rejected {
+                            let response_status = process_http_response(http_response, metadata, &telemetry, &endpoint_url, &endpoint_domain).await;
+                            if response_status == StatusCode::FORBIDDEN {
                                 maybe_emit_invalid_api_key(emitter.as_ref(), &mut last_invalid_key_emit, &endpoint_url);
                             }
                         }
@@ -776,11 +771,10 @@ fn track_queue_drops(telemetry: &ComponentTelemetry, domain: &str, push_result: 
 
 /// Processes an HTTP response to a forwarded intake request, updating telemetry and logging as appropriate.
 ///
-/// Returns `true` if the response indicates the configured API key was rejected as invalid (HTTP 403), so the caller
-/// can surface an `InvalidApiKey` diagnostic event.
+/// Returns the status code from the responses.
 async fn process_http_response(
     response: Response<Incoming>, metadata: Metadata, telemetry: &ComponentTelemetry, endpoint_url: &str, domain: &str,
-) -> bool {
+) -> StatusCode {
     let status = response.status();
     if status.is_success() {
         debug!(endpoint_url, %status, "Request completed.");
@@ -798,8 +792,6 @@ async fn process_http_response(
         );
 
         telemetry.track_successful_transaction(&metadata, domain);
-
-        false
     } else {
         telemetry.track_permanently_failed_transaction(&metadata, Some(status), domain);
 
@@ -813,9 +805,9 @@ async fn process_http_response(
                 error!(endpoint_url, %status, error = %e, "Failed to read response body of non-success response.");
             }
         }
-
-        status == http::StatusCode::FORBIDDEN
     }
+
+    status
 }
 
 /// Emits an `InvalidApiKey` diagnostic event via `emitter`, rate-limited to at most once per

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -10,7 +10,7 @@ use std::{
     error::Error as _,
     path::PathBuf,
     sync::{Arc, Mutex},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use bytes::Buf;
@@ -24,6 +24,7 @@ use saluki_common::{
 };
 use saluki_config::GenericConfiguration;
 use saluki_core::components::ComponentContext;
+use saluki_core::diagnostic::{DiagnosticDetails, DiagnosticEvent, DiagnosticsEmitter};
 use saluki_error::{generic_error, GenericError};
 use saluki_io::net::{
     client::http::{into_client_body, HttpClient, HttpClientBuilder},
@@ -102,6 +103,14 @@ where
     }
 }
 
+/// Minimum interval between successive `InvalidApiKey` diagnostic events emitted from the request I/O path for a single
+/// endpoint.
+///
+/// A persistently rejected API key returns `403` on every forwarded request, so the raw event rate is unbounded. This
+/// interval rate-limits emission so that the first rejection is surfaced immediately while a continuously invalid key
+/// cannot flood subscribers with one event per failed request.
+const INVALID_API_KEY_EMIT_INTERVAL: Duration = Duration::from_secs(60);
+
 /// Transaction forwarder for Datadog endpoints.
 pub struct TransactionForwarder<B> {
     context: ComponentContext,
@@ -113,6 +122,7 @@ pub struct TransactionForwarder<B> {
     endpoint_name: Arc<EndpointNameFn>,
     endpoints: Vec<RoutableEndpoint>,
     endpoint_request_mapper_factory: EndpointRequestMapperFactory<B>,
+    emitter: Option<DiagnosticsEmitter>,
     _marker: std::marker::PhantomData<B>,
 }
 
@@ -243,8 +253,18 @@ where
             endpoint_name,
             endpoints,
             endpoint_request_mapper_factory,
+            emitter: None,
             _marker: std::marker::PhantomData,
         })
+    }
+
+    /// Sets the diagnostics emitter used to surface forwarder-level diagnostic events, such as an invalid API key.
+    ///
+    /// The emitter is used by both the API key validation task and the request I/O path. When no emitter is set (the
+    /// default), no diagnostic events are emitted.
+    pub(crate) fn with_diagnostics_emitter(mut self, emitter: Option<DiagnosticsEmitter>) -> Self {
+        self.emitter = emitter;
+        self
     }
 
     /// Spawns the I/O task for the forwarder, and any associated endpoint I/O tasks.
@@ -266,6 +286,7 @@ where
             endpoint_name,
             endpoints,
             endpoint_request_mapper_factory,
+            emitter,
             _marker,
         } = self;
 
@@ -283,6 +304,7 @@ where
                 endpoint_name,
                 endpoints,
                 endpoint_request_mapper_factory,
+                emitter,
             ),
         );
 
@@ -293,12 +315,17 @@ where
     }
 
     /// Returns API key validation for the startup endpoint set.
+    ///
+    /// The forwarder's diagnostics emitter (see [`with_diagnostics_emitter`][Self::with_diagnostics_emitter]) is used to
+    /// surface a diagnostic event when validation determines that every configured API key is invalid, allowing
+    /// interested subscribers to react to the credentials being rejected.
     pub(crate) fn api_key_validator(&self) -> ApiKeyValidator {
         ApiKeyValidator::new(
             self.endpoints.clone(),
             self.client.clone(),
             self.live_config.clone(),
             self.config.api_key_validation_interval(),
+            self.emitter.clone(),
         )
     }
 }
@@ -309,7 +336,7 @@ async fn run_io_loop<B>(
     context: ComponentContext, config: ForwarderConfiguration, live_config: Option<GenericConfiguration>,
     service: HttpClient, telemetry: ComponentTelemetry, metrics_builder: MetricsBuilder,
     endpoint_name: Arc<EndpointNameFn>, resolved_endpoints: Vec<RoutableEndpoint>,
-    endpoint_request_mapper_factory: EndpointRequestMapperFactory<B>,
+    endpoint_request_mapper_factory: EndpointRequestMapperFactory<B>, emitter: Option<DiagnosticsEmitter>,
 ) where
     B: Body + Buf + Clone + Send + Sync + 'static,
     B::Data: Send,
@@ -350,6 +377,7 @@ async fn run_io_loop<B>(
                 route,
                 resolved_endpoint,
                 endpoint_request_mapper_factory.clone(),
+                emitter.clone(),
             ),
         );
 
@@ -445,6 +473,7 @@ async fn run_endpoint_io_loop<B>(
     config: ForwarderConfiguration, live_config: Option<GenericConfiguration>, service: HttpClient,
     telemetry: ComponentTelemetry, txnq_telemetry: TransactionQueueTelemetry, endpoint_name: Arc<EndpointNameFn>,
     route: EndpointRoute, endpoint: ResolvedEndpoint, endpoint_request_mapper_factory: EndpointRequestMapperFactory<B>,
+    emitter: Option<DiagnosticsEmitter>,
 ) where
     B: Body + Buf + Clone + Send + Sync + 'static,
     B::Data: Send,
@@ -552,6 +581,10 @@ async fn run_endpoint_io_loop<B>(
     let mut transaction_input_telemetry_by_endpoint = FastHashMap::<MetaString, TransactionInputTelemetry>::default();
     let mut done = false;
 
+    // Tracks the last time we emitted an `InvalidApiKey` diagnostic from this endpoint's request path, so a
+    // continuously-rejected key is surfaced promptly but not on every single failed request.
+    let mut last_invalid_key_emit: Option<Instant> = None;
+
     loop {
         select! {
             // Try and drain the next transaction from our channel, and push it into the pending transactions queue.
@@ -623,7 +656,15 @@ async fn run_endpoint_io_loop<B>(
                 match task_result {
                     Ok((metadata, result)) => match result {
                         // We got a response -- maybe successful, maybe not -- so just process that.
-                        Ok(http_response) => process_http_response(http_response, metadata, &telemetry, &endpoint_url, &endpoint_domain).await,
+                        Ok(http_response) => {
+                            let credentials_rejected = process_http_response(http_response, metadata, &telemetry, &endpoint_url, &endpoint_domain).await;
+
+                            // A `403` from a real forwarded request means the API key is invalid. Surface it right away
+                            // (rate-limited) rather than waiting for the next API key validation cycle.
+                            if credentials_rejected {
+                                maybe_emit_invalid_api_key(emitter.as_ref(), &mut last_invalid_key_emit, &endpoint_url);
+                            }
+                        }
 
                         // The service itself encountered an error while sending the request or receiving the response:
                         // connection reset by peer, I/O error, etc.
@@ -733,9 +774,13 @@ fn track_queue_drops(telemetry: &ComponentTelemetry, domain: &str, push_result: 
     telemetry.track_data_points_dropped(domain, push_result.data_points_dropped);
 }
 
+/// Processes an HTTP response to a forwarded intake request, updating telemetry and logging as appropriate.
+///
+/// Returns `true` if the response indicates the configured API key was rejected as invalid (HTTP 403), so the caller
+/// can surface an `InvalidApiKey` diagnostic event.
 async fn process_http_response(
     response: Response<Incoming>, metadata: Metadata, telemetry: &ComponentTelemetry, endpoint_url: &str, domain: &str,
-) {
+) -> bool {
     let status = response.status();
     if status.is_success() {
         debug!(endpoint_url, %status, "Request completed.");
@@ -753,6 +798,8 @@ async fn process_http_response(
         );
 
         telemetry.track_successful_transaction(&metadata, domain);
+
+        false
     } else {
         telemetry.track_permanently_failed_transaction(&metadata, Some(status), domain);
 
@@ -766,7 +813,32 @@ async fn process_http_response(
                 error!(endpoint_url, %status, error = %e, "Failed to read response body of non-success response.");
             }
         }
+
+        status == http::StatusCode::FORBIDDEN
     }
+}
+
+/// Emits an `InvalidApiKey` diagnostic event via `emitter`, rate-limited to at most once per
+/// [`INVALID_API_KEY_EMIT_INTERVAL`].
+///
+/// `last_emit` records the previous emission time and is updated in place. Does nothing when no emitter is configured.
+fn maybe_emit_invalid_api_key(
+    emitter: Option<&DiagnosticsEmitter>, last_emit: &mut Option<Instant>, endpoint_url: &str,
+) {
+    let Some(emitter) = emitter else {
+        return;
+    };
+
+    let now = Instant::now();
+    if last_emit.is_some_and(|last| now.duration_since(last) < INVALID_API_KEY_EMIT_INTERVAL) {
+        return;
+    }
+    *last_emit = Some(now);
+
+    emitter.emit(DiagnosticEvent::new(
+        format!("Datadog API key rejected as invalid (HTTP 403) when forwarding to '{endpoint_url}'."),
+        DiagnosticDetails::InvalidApiKey,
+    ));
 }
 
 /// A queue of pending transactions waiting to be sent.
@@ -1595,5 +1667,38 @@ app.datadoghq.com: [key-a, key-b]
             "with secrets configured, 403 must be retried at least once (saw {} requests)",
             observed
         );
+    }
+
+    #[tokio::test]
+    async fn forwarder_emits_invalid_api_key_diagnostic_on_403() {
+        use saluki_core::runtime::state::{DataspaceRegistry, DataspaceUpdate, IdentifierFilter};
+        use saluki_core::support::SubsystemIdentifier;
+
+        // The intake server rejects every request with a 403. Without secrets configured, a 403 is not retried, so the
+        // single forwarded request flows straight through to response handling.
+        let (server_url, _counter) = start_recording_http_server(vec![StatusCode::FORBIDDEN]).await;
+
+        // Subscribe to diagnostic events, then build a forwarder whose emitter publishes to that same dataspace.
+        let dataspace = DataspaceRegistry::new();
+        let mut events = dataspace.subscribe::<DiagnosticEvent>(IdentifierFilter::all());
+        let emitter =
+            DiagnosticsEmitter::from_dataspace(SubsystemIdentifier::from_segments(["test-forwarder"]), dataspace);
+
+        let forwarder = build_test_forwarder(&server_url, None).with_diagnostics_emitter(Some(emitter));
+        let handle = forwarder.spawn().await;
+        handle
+            .send_transaction(build_test_transaction())
+            .await
+            .expect("send should succeed");
+
+        // The 403 response to the real request must produce an `InvalidApiKey` diagnostic event.
+        match timeout(Duration::from_secs(3), events.recv()).await {
+            Ok(Some(DataspaceUpdate::Message(_, event))) => {
+                assert_eq!(event.details(), &DiagnosticDetails::InvalidApiKey);
+            }
+            other => panic!("expected an InvalidApiKey diagnostic event, got: {other:?}"),
+        }
+
+        handle.shutdown().await;
     }
 }

--- a/lib/saluki-components/src/common/datadog/validation.rs
+++ b/lib/saluki-components/src/common/datadog/validation.rs
@@ -209,14 +209,10 @@ async fn validate_and_send_readiness(
     let targets = collect_validation_targets(endpoints);
     let readiness = validate_targets(client, &targets).await;
 
-    // When every configured key has been proven invalid, surface a diagnostic event so that interested subscribers
-    // (such as the Core Agent, via the remote agent event reporter) can react to the credentials being rejected. This
-    // mirrors the `NotReady` health signal, and re-emits on each validation cycle so that a subscriber which appears
-    // later still observes the condition.
     if readiness == ValidationReadiness::NotReady {
         if let Some(emitter) = emitter {
             emitter.emit(DiagnosticEvent::new(
-                "The configured Datadog API key(s) were rejected as invalid.",
+                "All configured Datadog API key(s) were rejected as invalid.",
                 DiagnosticDetails::InvalidApiKey,
             ));
         }

--- a/lib/saluki-components/src/common/datadog/validation.rs
+++ b/lib/saluki-components/src/common/datadog/validation.rs
@@ -5,7 +5,7 @@ use http::{Request, StatusCode, Uri};
 use http_body_util::Empty;
 use regex::Regex;
 use saluki_common::task::spawn_traced_named;
-use saluki_config::GenericConfiguration;
+use saluki_config::{dynamic::ConfigChangeEvent, GenericConfiguration};
 use saluki_core::diagnostic::{DiagnosticDetails, DiagnosticEvent, DiagnosticsEmitter};
 use saluki_error::{generic_error, GenericError};
 use saluki_io::net::client::http::HttpClient;
@@ -42,7 +42,7 @@ pub(crate) struct ApiKeyValidator {
     client: HttpClient,
     live_config: Option<GenericConfiguration>,
     interval: Duration,
-    emitter: Option<DiagnosticsEmitter>,
+    emitter: DiagnosticsEmitter,
 }
 
 impl ApiKeyValidator {
@@ -52,7 +52,7 @@ impl ApiKeyValidator {
     /// configured API key is invalid.
     pub(crate) fn new(
         endpoints: Vec<RoutableEndpoint>, client: HttpClient, live_config: Option<GenericConfiguration>,
-        interval: Duration, emitter: Option<DiagnosticsEmitter>,
+        interval: Duration, emitter: DiagnosticsEmitter,
     ) -> Self {
         Self {
             endpoints,
@@ -133,7 +133,7 @@ enum KeyValidationResult {
 
 fn spawn_validation_task(
     endpoints: Vec<RoutableEndpoint>, client: HttpClient, live_config: Option<GenericConfiguration>,
-    interval: Duration, readiness_tx: mpsc::Sender<ValidationReadiness>, emitter: Option<DiagnosticsEmitter>,
+    interval: Duration, readiness_tx: mpsc::Sender<ValidationReadiness>, emitter: DiagnosticsEmitter,
 ) -> JoinHandle<()> {
     spawn_traced_named(
         "dd-api-key-validation",
@@ -143,9 +143,9 @@ fn spawn_validation_task(
 
 async fn run_validation_loop(
     mut endpoints: Vec<RoutableEndpoint>, mut client: HttpClient, live_config: Option<GenericConfiguration>,
-    interval: Duration, readiness_tx: mpsc::Sender<ValidationReadiness>, emitter: Option<DiagnosticsEmitter>,
+    interval: Duration, readiness_tx: mpsc::Sender<ValidationReadiness>, emitter: DiagnosticsEmitter,
 ) {
-    if !validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx, emitter.as_ref()).await {
+    if !validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx, &emitter).await {
         return;
     }
 
@@ -161,12 +161,12 @@ async fn run_validation_loop(
     loop {
         select! {
             _ = interval.tick() => {
-                if !validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx, emitter.as_ref()).await {
+                if !validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx, &emitter).await {
                     return;
                 }
             },
             _ = wait_for_validation_config_change(&mut config_updates_rx) => {
-                if !validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx, emitter.as_ref()).await {
+                if !validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx, &emitter).await {
                     return;
                 }
             },
@@ -174,9 +174,7 @@ async fn run_validation_loop(
     }
 }
 
-async fn wait_for_validation_config_change(
-    rx: &mut Option<broadcast::Receiver<saluki_config::dynamic::ConfigChangeEvent>>,
-) {
+async fn wait_for_validation_config_change(rx: &mut Option<broadcast::Receiver<ConfigChangeEvent>>) {
     let Some(rx) = rx else {
         std::future::pending::<()>().await;
         return;
@@ -204,18 +202,16 @@ fn is_validation_trigger_key(key: &str) -> bool {
 
 async fn validate_and_send_readiness(
     endpoints: &mut [RoutableEndpoint], client: &mut HttpClient, readiness_tx: &mpsc::Sender<ValidationReadiness>,
-    emitter: Option<&DiagnosticsEmitter>,
+    emitter: &DiagnosticsEmitter,
 ) -> bool {
     let targets = collect_validation_targets(endpoints);
     let readiness = validate_targets(client, &targets).await;
 
     if readiness == ValidationReadiness::NotReady {
-        if let Some(emitter) = emitter {
-            emitter.emit(DiagnosticEvent::new(
-                "All configured Datadog API key(s) were rejected as invalid.",
-                DiagnosticDetails::InvalidApiKey,
-            ));
-        }
+        emitter.emit(DiagnosticEvent::new(
+            "All configured Datadog API key(s) were rejected as invalid.",
+            DiagnosticDetails::InvalidApiKey,
+        ));
     }
 
     if readiness_tx.send(readiness).await.is_err() {
@@ -621,7 +617,7 @@ mod tests {
         let mut client = test_client(Duration::from_secs(1));
         let (readiness_tx, mut readiness_rx) = mpsc::channel(1);
 
-        assert!(validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx, Some(&emitter)).await);
+        assert!(validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx, &emitter).await);
         assert_eq!(readiness_rx.recv().await, Some(ValidationReadiness::NotReady));
 
         // The rejected key must have produced an `InvalidApiKey` diagnostic event.
@@ -661,7 +657,7 @@ mod tests {
         let mut client = test_client(Duration::from_secs(1));
         let (readiness_tx, mut readiness_rx) = mpsc::channel(1);
 
-        assert!(validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx, Some(&emitter)).await);
+        assert!(validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx, &emitter).await);
         assert_eq!(readiness_rx.recv().await, Some(ValidationReadiness::Ready));
 
         // A valid key must not produce any diagnostic event.

--- a/lib/saluki-components/src/common/datadog/validation.rs
+++ b/lib/saluki-components/src/common/datadog/validation.rs
@@ -6,6 +6,7 @@ use http_body_util::Empty;
 use regex::Regex;
 use saluki_common::task::spawn_traced_named;
 use saluki_config::GenericConfiguration;
+use saluki_core::diagnostic::{DiagnosticDetails, DiagnosticEvent, DiagnosticsEmitter};
 use saluki_error::{generic_error, GenericError};
 use saluki_io::net::client::http::HttpClient;
 use tokio::{
@@ -41,19 +42,24 @@ pub(crate) struct ApiKeyValidator {
     client: HttpClient,
     live_config: Option<GenericConfiguration>,
     interval: Duration,
+    emitter: Option<DiagnosticsEmitter>,
 }
 
 impl ApiKeyValidator {
     /// Creates API key validation for the given startup endpoint set.
+    ///
+    /// When present, `emitter` is used to surface a diagnostic event whenever validation determines that every
+    /// configured API key is invalid.
     pub(crate) fn new(
         endpoints: Vec<RoutableEndpoint>, client: HttpClient, live_config: Option<GenericConfiguration>,
-        interval: Duration,
+        interval: Duration, emitter: Option<DiagnosticsEmitter>,
     ) -> Self {
         Self {
             endpoints,
             client,
             live_config,
             interval,
+            emitter,
         }
     }
 
@@ -66,6 +72,7 @@ impl ApiKeyValidator {
             self.live_config,
             self.interval,
             readiness_tx,
+            self.emitter,
         );
 
         ApiKeyValidationHandle {
@@ -126,19 +133,19 @@ enum KeyValidationResult {
 
 fn spawn_validation_task(
     endpoints: Vec<RoutableEndpoint>, client: HttpClient, live_config: Option<GenericConfiguration>,
-    interval: Duration, readiness_tx: mpsc::Sender<ValidationReadiness>,
+    interval: Duration, readiness_tx: mpsc::Sender<ValidationReadiness>, emitter: Option<DiagnosticsEmitter>,
 ) -> JoinHandle<()> {
     spawn_traced_named(
         "dd-api-key-validation",
-        run_validation_loop(endpoints, client, live_config, interval, readiness_tx),
+        run_validation_loop(endpoints, client, live_config, interval, readiness_tx, emitter),
     )
 }
 
 async fn run_validation_loop(
     mut endpoints: Vec<RoutableEndpoint>, mut client: HttpClient, live_config: Option<GenericConfiguration>,
-    interval: Duration, readiness_tx: mpsc::Sender<ValidationReadiness>,
+    interval: Duration, readiness_tx: mpsc::Sender<ValidationReadiness>, emitter: Option<DiagnosticsEmitter>,
 ) {
-    if !validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx).await {
+    if !validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx, emitter.as_ref()).await {
         return;
     }
 
@@ -154,12 +161,12 @@ async fn run_validation_loop(
     loop {
         select! {
             _ = interval.tick() => {
-                if !validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx).await {
+                if !validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx, emitter.as_ref()).await {
                     return;
                 }
             },
             _ = wait_for_validation_config_change(&mut config_updates_rx) => {
-                if !validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx).await {
+                if !validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx, emitter.as_ref()).await {
                     return;
                 }
             },
@@ -197,9 +204,23 @@ fn is_validation_trigger_key(key: &str) -> bool {
 
 async fn validate_and_send_readiness(
     endpoints: &mut [RoutableEndpoint], client: &mut HttpClient, readiness_tx: &mpsc::Sender<ValidationReadiness>,
+    emitter: Option<&DiagnosticsEmitter>,
 ) -> bool {
     let targets = collect_validation_targets(endpoints);
     let readiness = validate_targets(client, &targets).await;
+
+    // When every configured key has been proven invalid, surface a diagnostic event so that interested subscribers
+    // (such as the Core Agent, via the remote agent event reporter) can react to the credentials being rejected. This
+    // mirrors the `NotReady` health signal, and re-emits on each validation cycle so that a subscriber which appears
+    // later still observes the condition.
+    if readiness == ValidationReadiness::NotReady {
+        if let Some(emitter) = emitter {
+            emitter.emit(DiagnosticEvent::new(
+                "The configured Datadog API key(s) were rejected as invalid.",
+                DiagnosticDetails::InvalidApiKey,
+            ));
+        }
+    }
 
     if readiness_tx.send(readiness).await.is_err() {
         debug!("API key validation readiness receiver dropped; stopping validation task.");
@@ -573,6 +594,87 @@ mod tests {
             ValidationReadiness::Ready
         );
         assert_eq!(later_requests.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn not_ready_emits_invalid_api_key_diagnostic() {
+        use saluki_core::runtime::state::{DataspaceRegistry, DataspaceUpdate, IdentifierFilter};
+        use saluki_core::support::SubsystemIdentifier;
+
+        let _ = initialize_default_crypto_provider();
+
+        // A validation server that rejects the key with a 403, so validation concludes it is invalid.
+        let invalid_url = start_validation_server(StatusCode::FORBIDDEN).await;
+        let (config, _) = ConfigurationLoader::for_tests(
+            Some(json!({ "api_key": "primary-key", "dd_url": invalid_url })),
+            None,
+            false,
+        )
+        .await;
+        let forwarder_config = ForwarderConfiguration::from_configuration(&config).expect("config should parse");
+        let mut endpoints = forwarder_config
+            .build_routable_endpoints(Some(config))
+            .expect("endpoints should resolve");
+
+        // Subscribe to diagnostic events on a dataspace, then build an emitter that publishes to that same dataspace.
+        let dataspace = DataspaceRegistry::new();
+        let mut events = dataspace.subscribe::<DiagnosticEvent>(IdentifierFilter::all());
+        let emitter =
+            DiagnosticsEmitter::from_dataspace(SubsystemIdentifier::from_segments(["test-forwarder"]), dataspace);
+
+        let mut client = test_client(Duration::from_secs(1));
+        let (readiness_tx, mut readiness_rx) = mpsc::channel(1);
+
+        assert!(validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx, Some(&emitter)).await);
+        assert_eq!(readiness_rx.recv().await, Some(ValidationReadiness::NotReady));
+
+        // The rejected key must have produced an `InvalidApiKey` diagnostic event.
+        match events.recv().await {
+            Some(DataspaceUpdate::Message(_, event)) => {
+                assert_eq!(event.details(), &DiagnosticDetails::InvalidApiKey);
+            }
+            other => panic!("expected an InvalidApiKey diagnostic event, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn ready_does_not_emit_diagnostic() {
+        use saluki_core::runtime::state::{DataspaceRegistry, IdentifierFilter};
+        use saluki_core::support::SubsystemIdentifier;
+
+        let _ = initialize_default_crypto_provider();
+
+        // A validation server that accepts the key, so validation concludes it is valid.
+        let valid_url = start_validation_server(StatusCode::OK).await;
+        let (config, _) = ConfigurationLoader::for_tests(
+            Some(json!({ "api_key": "primary-key", "dd_url": valid_url })),
+            None,
+            false,
+        )
+        .await;
+        let forwarder_config = ForwarderConfiguration::from_configuration(&config).expect("config should parse");
+        let mut endpoints = forwarder_config
+            .build_routable_endpoints(Some(config))
+            .expect("endpoints should resolve");
+
+        let dataspace = DataspaceRegistry::new();
+        let mut events = dataspace.subscribe::<DiagnosticEvent>(IdentifierFilter::all());
+        let emitter =
+            DiagnosticsEmitter::from_dataspace(SubsystemIdentifier::from_segments(["test-forwarder"]), dataspace);
+
+        let mut client = test_client(Duration::from_secs(1));
+        let (readiness_tx, mut readiness_rx) = mpsc::channel(1);
+
+        assert!(validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx, Some(&emitter)).await);
+        assert_eq!(readiness_rx.recv().await, Some(ValidationReadiness::Ready));
+
+        // A valid key must not produce any diagnostic event.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), events.recv())
+                .await
+                .is_err(),
+            "no diagnostic event should be emitted when the API key is valid"
+        );
     }
 
     fn target_for(base_url: &str) -> ValidationTarget {

--- a/lib/saluki-components/src/forwarders/datadog/mod.rs
+++ b/lib/saluki-components/src/forwarders/datadog/mod.rs
@@ -6,7 +6,6 @@ use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder, UsageExpr};
 use saluki_core::{
     components::{forwarders::*, ComponentContext},
     data_model::payload::{PayloadMetadata, PayloadType},
-    diagnostic::DiagnosticsEmitter,
     observability::ComponentMetricsExt as _,
 };
 use saluki_error::GenericError;
@@ -142,9 +141,6 @@ impl Forwarder for Datadog {
         let Self { forwarder } = *self;
 
         let mut health = context.take_health_handle();
-
-        let emitter = DiagnosticsEmitter::from_current(context.component_context().identity()).ok();
-        let forwarder = forwarder.with_diagnostics_emitter(emitter);
 
         let mut validation = forwarder.api_key_validator().spawn();
 

--- a/lib/saluki-components/src/forwarders/datadog/mod.rs
+++ b/lib/saluki-components/src/forwarders/datadog/mod.rs
@@ -143,11 +143,6 @@ impl Forwarder for Datadog {
 
         let mut health = context.take_health_handle();
 
-        // Build a diagnostics emitter scoped to this forwarder so that both API key validation and the request I/O path
-        // can surface an "invalid API key" diagnostic event to interested subscribers. The dataspace is captured here,
-        // where it is available, and handed to the forwarder explicitly, since its tasks are spawned onto fresh runtime
-        // tasks that do not inherit the ambient dataspace. Diagnostics are best-effort, so a missing dataspace simply
-        // disables emission rather than failing the forwarder.
         let emitter = DiagnosticsEmitter::from_current(context.component_context().identity()).ok();
         let forwarder = forwarder.with_diagnostics_emitter(emitter);
 

--- a/lib/saluki-components/src/forwarders/datadog/mod.rs
+++ b/lib/saluki-components/src/forwarders/datadog/mod.rs
@@ -6,6 +6,7 @@ use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder, UsageExpr};
 use saluki_core::{
     components::{forwarders::*, ComponentContext},
     data_model::payload::{PayloadMetadata, PayloadType},
+    diagnostic::DiagnosticsEmitter,
     observability::ComponentMetricsExt as _,
 };
 use saluki_error::GenericError;
@@ -141,6 +142,14 @@ impl Forwarder for Datadog {
         let Self { forwarder } = *self;
 
         let mut health = context.take_health_handle();
+
+        // Build a diagnostics emitter scoped to this forwarder so that both API key validation and the request I/O path
+        // can surface an "invalid API key" diagnostic event to interested subscribers. The dataspace is captured here,
+        // where it is available, and handed to the forwarder explicitly, since its tasks are spawned onto fresh runtime
+        // tasks that do not inherit the ambient dataspace. Diagnostics are best-effort, so a missing dataspace simply
+        // disables emission rather than failing the forwarder.
+        let emitter = DiagnosticsEmitter::from_current(context.component_context().identity()).ok();
+        let forwarder = forwarder.with_diagnostics_emitter(emitter);
 
         let mut validation = forwarder.api_key_validator().spawn();
 

--- a/lib/saluki-core/src/runtime/state/dataspace.rs
+++ b/lib/saluki-core/src/runtime/state/dataspace.rs
@@ -45,14 +45,14 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use tokio::sync::broadcast;
+use tokio::{sync::broadcast, task_local};
 
 use super::{Identifier, IdentifierFilter};
 use crate::runtime::process::Id;
 
 const DEFAULT_CHANNEL_CAPACITY: usize = 16;
 
-tokio::task_local! {
+task_local! {
     pub(crate) static CURRENT_DATASPACE: DataspaceRegistry;
 }
 
@@ -269,6 +269,19 @@ impl DataspaceRegistry {
     /// Returns the dataspace registry for the current supervision tree, if one exists.
     pub fn try_current() -> Option<Self> {
         CURRENT_DATASPACE.try_with(|ds| ds.clone()).ok()
+    }
+
+    /// Runs the given closure with this dataspace set as the current dataspace.
+    ///
+    /// This can be used to override the dataspace that gets returned in calls to
+    /// [`DataspaceRegistry::try_current`][Self::try_current], which can be difficult to achieve otherwise without fully
+    /// executing code under supervision.
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn with_current<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        CURRENT_DATASPACE.sync_scope(self.clone(), f)
     }
 
     /// Creates a new empty registry with the given channel capacity for broadcast channels.

--- a/lib/saluki-io/src/net/util/middleware/http_inspection.rs
+++ b/lib/saluki-io/src/net/util/middleware/http_inspection.rs
@@ -1,0 +1,283 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{ready, Context, Poll},
+};
+
+use http::{Response, StatusCode};
+use pin_project_lite::pin_project;
+use tower::{Layer, Service};
+
+/// A callback invoked when a response with a matching status code is observed.
+type InspectorFn = Arc<dyn Fn() + Send + Sync>;
+
+#[derive(Clone)]
+struct Inspector {
+    status: StatusCode,
+    callback: InspectorFn,
+}
+
+/// A [`Layer`] that observes HTTP responses and invokes registered callbacks based on their status code.
+///
+/// Inspectors are registered against a specific [`StatusCode`] via [`with_inspector`][Self::with_inspector]. Whenever
+/// the wrapped service produces a successful (`Ok`) response whose status matches, the corresponding callback is
+/// invoked. Multiple inspectors may be registered, including more than one for the same status, in which case all
+/// matching callbacks are invoked. The response itself is always passed through unchanged, and service errors never
+/// trigger callbacks.
+///
+/// This layer is purely observational: it does not modify requests or responses, retry, or short-circuit. Because it
+/// sees the raw response from the inner service, placing it *below* a layer that transforms responses into errors (such
+/// as a retry circuit breaker) allows callbacks to observe responses that would otherwise never surface to the caller.
+///
+/// Callbacks are invoked from within the response future, which may be polled concurrently, so they must be `Send` and
+/// `Sync`. Any throttling or deduplication of callback invocations is the caller's responsibility.
+#[derive(Clone, Default)]
+pub struct HttpInspectionLayer {
+    inspectors: Vec<Inspector>,
+}
+
+impl HttpInspectionLayer {
+    /// Creates a new `HttpInspectionLayer` with no registered inspectors.
+    ///
+    /// Without any inspectors, the layer passes every response through unchanged and invokes nothing.
+    pub fn new() -> Self {
+        Self { inspectors: Vec::new() }
+    }
+
+    /// Registers a callback to be invoked whenever a response with the given status code is observed.
+    ///
+    /// The callback is invoked once per matching response, including responses produced by retried requests when this
+    /// layer sits below a retrying layer.
+    pub fn with_inspector<F>(mut self, status: StatusCode, callback: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.inspectors.push(Inspector {
+            status,
+            callback: Arc::new(callback),
+        });
+        self
+    }
+}
+
+impl<S> Layer<S> for HttpInspectionLayer {
+    type Service = HttpInspection<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        HttpInspection {
+            inner,
+            inspectors: Arc::new(self.inspectors.clone()),
+        }
+    }
+}
+
+/// Service produced by [`HttpInspectionLayer`].
+///
+/// See [`HttpInspectionLayer`] for details on the inspection behavior.
+#[derive(Clone)]
+pub struct HttpInspection<S> {
+    inner: S,
+    inspectors: Arc<Vec<Inspector>>,
+}
+
+impl<S, Request, ResBody> Service<Request> for HttpInspection<S>
+where
+    S: Service<Request, Response = Response<ResBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        ResponseFuture {
+            inner: self.inner.call(req),
+            inspectors: Arc::clone(&self.inspectors),
+        }
+    }
+}
+
+pin_project! {
+    /// Response future for [`HttpInspection`].
+    pub struct ResponseFuture<F> {
+        #[pin]
+        inner: F,
+        inspectors: Arc<Vec<Inspector>>,
+    }
+}
+
+impl<F, ResBody, E> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<Response<ResBody>, E>>,
+{
+    type Output = Result<Response<ResBody>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let result = ready!(this.inner.poll(cx));
+
+        // Only successful responses carry a status code to inspect; errors are passed through untouched.
+        if let Ok(response) = &result {
+            let status = response.status();
+            for inspector in this.inspectors.iter() {
+                if inspector.status == status {
+                    (inspector.callback)();
+                }
+            }
+        }
+
+        Poll::Ready(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        convert::Infallible,
+        future::{ready, Ready},
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    use tower::ServiceExt as _;
+
+    use super::*;
+
+    /// A service that always responds with a fixed status code.
+    #[derive(Clone)]
+    struct StatusService(StatusCode);
+
+    impl Service<()> for StatusService {
+        type Response = Response<()>;
+        type Error = Infallible;
+        type Future = Ready<Result<Response<()>, Infallible>>;
+
+        fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _: ()) -> Self::Future {
+            ready(Ok(Response::builder().status(self.0).body(()).unwrap()))
+        }
+    }
+
+    /// A service that always fails, to exercise the error pass-through path.
+    #[derive(Clone)]
+    struct ErrorService;
+
+    impl Service<()> for ErrorService {
+        type Response = Response<()>;
+        type Error = &'static str;
+        type Future = Ready<Result<Response<()>, &'static str>>;
+
+        fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _: ()) -> Self::Future {
+            ready(Err("boom"))
+        }
+    }
+
+    fn counting_inspector(counter: &Arc<AtomicUsize>) -> impl Fn() + Send + Sync + 'static {
+        let counter = Arc::clone(counter);
+        move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn fires_callback_on_matching_status() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let layer = HttpInspectionLayer::new().with_inspector(StatusCode::FORBIDDEN, counting_inspector(&hits));
+
+        let response = layer
+            .layer(StatusService(StatusCode::FORBIDDEN))
+            .oneshot(())
+            .await
+            .expect("service should not error");
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn does_not_fire_callback_on_other_status() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let layer = HttpInspectionLayer::new().with_inspector(StatusCode::FORBIDDEN, counting_inspector(&hits));
+
+        let response = layer
+            .layer(StatusService(StatusCode::OK))
+            .oneshot(())
+            .await
+            .expect("service should not error");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(hits.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn does_not_fire_callback_on_service_error() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let layer = HttpInspectionLayer::new().with_inspector(StatusCode::FORBIDDEN, counting_inspector(&hits));
+
+        let error = layer
+            .layer(ErrorService)
+            .oneshot(())
+            .await
+            .expect_err("service should error");
+
+        assert_eq!(error, "boom");
+        assert_eq!(hits.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn only_matching_inspectors_fire() {
+        let forbidden_hits = Arc::new(AtomicUsize::new(0));
+        let ok_hits = Arc::new(AtomicUsize::new(0));
+        let layer = HttpInspectionLayer::new()
+            .with_inspector(StatusCode::FORBIDDEN, counting_inspector(&forbidden_hits))
+            .with_inspector(StatusCode::OK, counting_inspector(&ok_hits));
+
+        layer
+            .layer(StatusService(StatusCode::OK))
+            .oneshot(())
+            .await
+            .expect("service should not error");
+
+        assert_eq!(forbidden_hits.load(Ordering::SeqCst), 0);
+        assert_eq!(ok_hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn all_inspectors_for_a_status_fire() {
+        let first = Arc::new(AtomicUsize::new(0));
+        let second = Arc::new(AtomicUsize::new(0));
+        let layer = HttpInspectionLayer::new()
+            .with_inspector(StatusCode::FORBIDDEN, counting_inspector(&first))
+            .with_inspector(StatusCode::FORBIDDEN, counting_inspector(&second));
+
+        layer
+            .layer(StatusService(StatusCode::FORBIDDEN))
+            .oneshot(())
+            .await
+            .expect("service should not error");
+
+        assert_eq!(first.load(Ordering::SeqCst), 1);
+        assert_eq!(second.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn passes_response_through_without_inspectors() {
+        let response = HttpInspectionLayer::new()
+            .layer(StatusService(StatusCode::IM_A_TEAPOT))
+            .oneshot(())
+            .await
+            .expect("service should not error");
+
+        assert_eq!(response.status(), StatusCode::IM_A_TEAPOT);
+    }
+}

--- a/lib/saluki-io/src/net/util/middleware/mod.rs
+++ b/lib/saluki-io/src/net/util/middleware/mod.rs
@@ -1,3 +1,6 @@
+mod http_inspection;
+pub use self::http_inspection::{HttpInspection, HttpInspectionLayer};
+
 mod retry_circuit_breaker;
 pub use self::retry_circuit_breaker::{
     Error as RetryCircuitBreakerError, RetryCircuitBreaker, RetryCircuitBreakerLayer,


### PR DESCRIPTION
## Summary

This PR adds the ability to collect internal "diagnostic events" and forward them to the Core Agent as Remote Agent events.

Following on the work done in #2096 to add an emitter for diagnostic events, we're now at the stage of wanting to actually send them to the Core Agent so they can be used to drive behavior, such as refreshing secrets when an invalid API key is detected.

This PR adds a new worker that collects these diagnostic events, which converts them to their respective Remote Agent event types and sends them to the Core Agent, as well as adds handling of 403 errors in the Datadog forwarder/API key validator to trigger emitting these diagnostic events. We've made a few small changes around how we create the emitter to try and bake it more into the forwarder internals so it's not created at the top and then forced to be threaded through a zillion different places.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [x] New unit tests for the behavior of emitting the diagnostic events themselves.
- [x] Manually ran ADP alongside the Core Agent and observed debug log messages when the Core Agent received the Remote Agent events.

## References

DADP-2