### PR TITLE
docs(otlp): document metrics.batch related configuration keys as not planned

### DIFF
--- a/.vale/styles/config/vocabularies/technical/accept.txt
+++ b/.vale/styles/config/vocabularies/technical/accept.txt
@@ -30,6 +30,7 @@ apis
 inlined
 json
 backoff
+batcher(s?)
 proxied
 linux
 darwin

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -74,6 +74,9 @@ architecture is fundamentally different or the feature is platform-specific.
 | `forwarder_requeue_buffer_size`                                   | In-memory re-queue buffer size                     | See below                                                                                                                                                                                                                                                                 |
 | `heroku_dyno`                                                     | Heroku dyno telemetry mode                         | See below                                                                                                                                                                                                                                                                 |
 | `logging_frequency`                                               | Transaction success log interval                   | The core agent uses `logging_frequency` to throttle repetitive successful transaction logs. ADP logs successful forwarder operations below the default `info` level, so there is no matching info-level success-log stream to throttle. This key is intentionally unused. |
+| `otlp_config.metrics.batch.flush_timeout`                         | OTLP metrics batch flush timeout                   | See below                                                                                                                                                                                                                                                                 |
+| `otlp_config.metrics.batch.max_size`                              | Maximum OTLP metrics batch size                    | See below                                                                                                                                                                                                                                                                 |
+| `otlp_config.metrics.batch.min_size`                              | Minimum OTLP metrics batch size                    | See below                                                                                                                                                                                                                                                                 |
 | `telemetry.dogstatsd.aggregator_channel_latency_buckets`          | Histogram buckets: DSD-to-aggregator channel lag   | ADP already tracks this latency with histogram buckets determined by logarithmic calculation, so pre-defined bucket configuration is not applicable.                                                                                                                      |
 | `telemetry.dogstatsd.listeners_channel_latency_buckets`           | Histogram buckets: listener packet-channel latency | ADP already tracks this latency with histogram buckets determined by logarithmic calculation, so pre-defined bucket configuration is not applicable.                                                                                                                      |
 | `telemetry.dogstatsd.listeners_latency_buckets`                   | Histogram buckets: listener processing latency     | ADP already tracks this latency with histogram buckets determined by logarithmic calculation, so pre-defined bucket configuration is not applicable.                                                                                                                      |
@@ -213,6 +216,31 @@ core Agent's `datadog.<agentName>.running` series.
 
 Because the affected heartbeat is core-Agent-owned and ADP is not part of the supported Heroku
 deployment path, ADP does not implement `heroku_dyno`. See [#1753].
+
+### `otlp_config.metrics.batch.flush_timeout`
+
+The core Agent batches OTLP metric input before translation through its serializer exporter queue.
+ADP translates each OTLP resource before batching the resulting metric events for topology dispatch.
+The shared metrics encoder then batches, limits, and splits encoded payloads before forwarding.
+
+ADP does not expose a separate pre-translation timeout because its bounded source channel, event
+dispatcher, and encoder already provide backpressure and batching at their respective stages.
+The encoder enforces payload byte limits after translation, which is the relevant boundary for
+avoiding oversized intake requests. Setting this key has no effect in ADP.
+
+### `otlp_config.metrics.batch.max_size`
+
+ADP does not implement the core Agent's pre-translation OTLP metrics batcher. Its source channel
+bounds in-flight resources, and its shared metrics encoder applies item-count and byte-size limits
+to the encoded payload that is ultimately forwarded. A raw OTLP item count cannot reliably bound
+encoded payload size after translation. Setting this key has no effect in ADP.
+
+### `otlp_config.metrics.batch.min_size`
+
+ADP batches translated metric events before enrichment and batches encoded payloads before forwarding.
+It does not wait for a configured number of raw OTLP metric items before translation. This avoids
+adding a second buffering stage without a demonstrated translation-throughput requirement.
+Setting this key has no effect in ADP.
 
 
 ## Behavioral Differences

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -220,27 +220,17 @@ deployment path, ADP does not implement `heroku_dyno`. See [#1753].
 ### `otlp_config.metrics.batch.flush_timeout`
 
 The core Agent batches OTLP metric input before translation through its serializer exporter queue.
-ADP translates each OTLP resource before batching the resulting metric events for topology dispatch.
-The shared metrics encoder then batches, limits, and splits encoded payloads before forwarding.
-
-ADP does not expose a separate pre-translation timeout because its bounded source channel, event
-dispatcher, and encoder already provide backpressure and batching at their respective stages.
-The encoder enforces payload byte limits after translation, which is the relevant boundary for
-avoiding oversized intake requests. Setting this key has no effect in ADP.
+ADP's architecture does not have the same batching mechanism and is unaffected by this configuration value.
 
 ### `otlp_config.metrics.batch.max_size`
 
-ADP does not implement the core Agent's pre-translation OTLP metrics batcher. Its source channel
-bounds in-flight resources, and its shared metrics encoder applies item-count and byte-size limits
-to the encoded payload that is ultimately forwarded. A raw OTLP item count cannot reliably bound
-encoded payload size after translation. Setting this key has no effect in ADP.
+The core Agent batches OTLP metric input before translation through its serializer exporter queue.
+ADP's architecture does not have the same batching mechanism and is unaffected by this configuration value.
 
 ### `otlp_config.metrics.batch.min_size`
 
-ADP batches translated metric events before enrichment and batches encoded payloads before forwarding.
-It does not wait for a configured number of raw OTLP metric items before translation. This avoids
-adding a second buffering stage without a demonstrated translation-throughput requirement.
-Setting this key has no effect in ADP.
+The core Agent batches OTLP metric input before translation through its serializer exporter queue.
+ADP's architecture does not have the same batching mechanism and is unaffected by this configuration value.
 
 
 ## Behavioral Differences

--- a/lib/datadog-agent/config-testing/src/config_registry/unsupported.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/unsupported.rs
@@ -467,6 +467,39 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::CrossCutting,
     };
+    /// `otlp_config.metrics.batch.flush_timeout`-OTLP metrics batch flush timeout
+    OTLP_CONFIG_METRICS_BATCH_FLUSH_TIMEOUT = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_METRICS_BATCH_FLUSH_TIMEOUT,
+        support_level: SupportLevel::Incompatible(Severity::Low),
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
+    /// `otlp_config.metrics.batch.max_size`-Maximum OTLP metrics batch size
+    OTLP_CONFIG_METRICS_BATCH_MAX_SIZE = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_METRICS_BATCH_MAX_SIZE,
+        support_level: SupportLevel::Incompatible(Severity::Low),
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
+    /// `otlp_config.metrics.batch.min_size`-Minimum OTLP metrics batch size
+    OTLP_CONFIG_METRICS_BATCH_MIN_SIZE = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_METRICS_BATCH_MIN_SIZE,
+        support_level: SupportLevel::Incompatible(Severity::Low),
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
     /// `use_dogstatsd`-Master DogStatsD enable toggle
     USE_DOGSTATSD = SalukiAnnotation {
         schema: &schema::USE_DOGSTATSD,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -2000,13 +2000,7 @@ inventory:
     description: "OTLP metrics batch flush timeout"
     documentation: |-
       The core Agent batches OTLP metric input before translation through its serializer exporter queue.
-      ADP translates each OTLP resource before batching the resulting metric events for topology dispatch.
-      The shared metrics encoder then batches, limits, and splits encoded payloads before forwarding.
-
-      ADP does not expose a separate pre-translation timeout because its bounded source channel, event
-      dispatcher, and encoder already provide backpressure and batching at their respective stages.
-      The encoder enforces payload byte limits after translation, which is the relevant boundary for
-      avoiding oversized intake requests. Setting this key has no effect in ADP.
+      ADP's architecture does not have the same batching mechanism and is unaffected by this configuration value.
 
   otlp_config.metrics.batch.max_size:
     support: none
@@ -2015,10 +2009,8 @@ inventory:
     pipelines: [otlp]
     description: "Maximum OTLP metrics batch size"
     documentation: |-
-      ADP does not implement the core Agent's pre-translation OTLP metrics batcher. Its source channel
-      bounds in-flight resources, and its shared metrics encoder applies item-count and byte-size limits
-      to the encoded payload that is ultimately forwarded. A raw OTLP item count cannot reliably bound
-      encoded payload size after translation. Setting this key has no effect in ADP.
+      The core Agent batches OTLP metric input before translation through its serializer exporter queue.
+      ADP's architecture does not have the same batching mechanism and is unaffected by this configuration value.
 
   otlp_config.metrics.batch.min_size:
     support: none
@@ -2027,10 +2019,8 @@ inventory:
     pipelines: [otlp]
     description: "Minimum OTLP metrics batch size"
     documentation: |-
-      ADP batches translated metric events before enrichment and batches encoded payloads before forwarding.
-      It does not wait for a configured number of raw OTLP metric items before translation. This avoids
-      adding a second buffering stage without a demonstrated translation-throughput requirement.
-      Setting this key has no effect in ADP.
+      The core Agent batches OTLP metric input before translation through its serializer exporter queue.
+      ADP's architecture does not have the same batching mechanism and is unaffected by this configuration value.
 
   otlp_config.metrics.enabled:
     support: full

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -1992,6 +1992,46 @@ inventory:
       additional_attributes:
         config_registry_filename: otlp.rs
 
+  otlp_config.metrics.batch.flush_timeout:
+    support: none
+    severity: low
+    planned: false
+    pipelines: [otlp]
+    description: "OTLP metrics batch flush timeout"
+    documentation: |-
+      The core Agent batches OTLP metric input before translation through its serializer exporter queue.
+      ADP translates each OTLP resource before batching the resulting metric events for topology dispatch.
+      The shared metrics encoder then batches, limits, and splits encoded payloads before forwarding.
+
+      ADP does not expose a separate pre-translation timeout because its bounded source channel, event
+      dispatcher, and encoder already provide backpressure and batching at their respective stages.
+      The encoder enforces payload byte limits after translation, which is the relevant boundary for
+      avoiding oversized intake requests. Setting this key has no effect in ADP.
+
+  otlp_config.metrics.batch.max_size:
+    support: none
+    severity: low
+    planned: false
+    pipelines: [otlp]
+    description: "Maximum OTLP metrics batch size"
+    documentation: |-
+      ADP does not implement the core Agent's pre-translation OTLP metrics batcher. Its source channel
+      bounds in-flight resources, and its shared metrics encoder applies item-count and byte-size limits
+      to the encoded payload that is ultimately forwarded. A raw OTLP item count cannot reliably bound
+      encoded payload size after translation. Setting this key has no effect in ADP.
+
+  otlp_config.metrics.batch.min_size:
+    support: none
+    severity: low
+    planned: false
+    pipelines: [otlp]
+    description: "Minimum OTLP metrics batch size"
+    documentation: |-
+      ADP batches translated metric events before enrichment and batches encoded payloads before forwarding.
+      It does not wait for a configured number of raw OTLP metric items before translation. This avoids
+      adding a second buffering stage without a demonstrated translation-throughput requirement.
+      Setting this key has no effect in ADP.
+
   otlp_config.metrics.enabled:
     support: full
     pipelines: [otlp]
@@ -3936,9 +3976,6 @@ excluded:
   otlp_config.logs.batch.flush_timeout: "ignored in initial audit 2026-04-23"
   otlp_config.logs.batch.max_size: "ignored in initial audit 2026-04-23"
   otlp_config.logs.batch.min_size: "ignored in initial audit 2026-04-23"
-  otlp_config.metrics.batch.flush_timeout: "ignored in initial audit 2026-04-23"
-  otlp_config.metrics.batch.max_size: "ignored in initial audit 2026-04-23"
-  otlp_config.metrics.batch.min_size: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.delta_ttl: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.histograms.send_count_sum_metrics: "deprecated; ADP supports only send_aggregation_metrics"
   otlp_config.metrics.instrumentation_scope_metadata_as_tags: "ignored in initial audit 2026-04-23"

--- a/lib/datadog-agent/config/src/generated/classifier_data.rs
+++ b/lib/datadog-agent/config/src/generated/classifier_data.rs
@@ -285,6 +285,27 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         default: DefaultValue::Json("500"),
     },
     ClassifierEntry {
+        yaml_path: "otlp_config.metrics.batch.flush_timeout",
+        aliases: &[],
+        support_level: SupportLevel::Incompatible(Severity::Low),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+        default: DefaultValue::Json("\"200ms\""),
+    },
+    ClassifierEntry {
+        yaml_path: "otlp_config.metrics.batch.max_size",
+        aliases: &[],
+        support_level: SupportLevel::Incompatible(Severity::Low),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+        default: DefaultValue::Json("0"),
+    },
+    ClassifierEntry {
+        yaml_path: "otlp_config.metrics.batch.min_size",
+        aliases: &[],
+        support_level: SupportLevel::Incompatible(Severity::Low),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+        default: DefaultValue::Json("8192"),
+    },
+    ClassifierEntry {
         yaml_path: "telemetry.dogstatsd.aggregator_channel_latency_buckets",
         aliases: &[],
         support_level: SupportLevel::Incompatible(Severity::Low),


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

The config options `otlp_config.metrics.batch.*` describe batching behavior in the Core Agent before translation to DogSketch; however, ADP batches elsewhere downstream (before enrichment and before forwarding).

The benefits that this posits in the Core Agent does not apply for us and is effectively already taken care of, so this document serves to highlight this choice to intentional diverge. 

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

N/A

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

- Closes: https://github.com/DataDog/saluki/issues/2061

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
