### PR TITLE
fix(ci): use locked deps when preinstalling Cargo utilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1002,4 +1002,4 @@ cargo-preinstall: ## Pre-installs all necessary Cargo tools (used for CI)
 cargo-install-%: override TOOL = $(@:cargo-install-%=%)
 cargo-install-%: override VERSIONED_TOOL = ${TOOL}@$(CARGO_TOOL_VERSION_$(TOOL))
 cargo-install-%: check-rust-build-tools
-	@$(if $(findstring true,$(AUTOINSTALL)),test -f ${CARGO_BIN_DIR}/${TOOL} || (echo "[*] Installing ${VERSIONED_TOOL}..." && cargo binstall --strategies ${CARGO_BINSTALL_STRATEGIES} ${VERSIONED_TOOL} --quiet -y),)
+	@$(if $(findstring true,$(AUTOINSTALL)),test -f ${CARGO_BIN_DIR}/${TOOL} || (echo "[*] Installing ${VERSIONED_TOOL}..." && cargo binstall --locked --strategies ${CARGO_BINSTALL_STRATEGIES} ${VERSIONED_TOOL} --quiet -y),)


### PR DESCRIPTION
## Summary

This PR fixes an issue with the preinstallation of Cargo utilities in our build CI build job due to using a version of a transitive dependency that doesn't align with our pinned version of Rust.

We pass `--locked` when installing which uses the dependencies as described by the utility when it was published to crates.io. This doesn't mean we get off free: we might still end up with issues down the road if we select a version of a utility that can't be built as-is with our pinned Rust version... but at least the builds should be reproducible now for a given Rust version and set of utilities/versions for those utilities.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ran a manual CI pipeline to trigger the build CI image build job, and ensured that the image was successfully built.

## References

DADP-2
