### PR TITLE
chore(config): migrate trace sampler to typed configuration

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -675,12 +675,12 @@ async fn add_baseline_traces_pipeline_to_blueprint(
     )
     .with_environment_provider(env_provider.clone())
     .await?;
+    let trace_sampler_config =
+        TraceSamplerConfiguration::from_configuration(&config.domains.traces, &config.domains.otlp.traces);
 
     // The remaining trace-enrichment components still read from the raw compatibility map.
     let raw_config = config_system.raw_map();
     let trace_obfuscation_config = TraceObfuscationConfiguration::from_apm_configuration(&raw_config)?;
-    let trace_sampler_config = TraceSamplerConfiguration::from_configuration(&raw_config)
-        .error_context("Failed to configure Trace Sampler transform.")?;
     let ottl_filter_config = OttlFilterConfiguration::from_configuration(&raw_config)
         .error_context("Failed to configure OTTL filter processor.")?;
     let ottl_transform_config = OttlTransformConfiguration::from_configuration(&raw_config)

--- a/lib/agent-data-plane-config-system/src/saluki_only.rs
+++ b/lib/agent-data-plane-config-system/src/saluki_only.rs
@@ -571,7 +571,10 @@ impl SalukiOnly {
 
 #[cfg(test)]
 mod tests {
-    use agent_data_plane_config::defaults::DEFAULT_ENCODER_FLUSH_TIMEOUT;
+    use agent_data_plane_config::defaults::{
+        DEFAULT_ENCODER_FLUSH_TIMEOUT, DEFAULT_ERROR_SAMPLING_ENABLED, DEFAULT_RARE_SAMPLER_CARDINALITY,
+        DEFAULT_RARE_SAMPLER_COOLDOWN_SECS, DEFAULT_RARE_SAMPLER_TPS, DEFAULT_TRACE_ENV,
+    };
     use serde_json::json;
 
     use super::*;
@@ -805,5 +808,14 @@ mod tests {
             config.shared.metrics_encoding.flush_timeout,
             DEFAULT_ENCODER_FLUSH_TIMEOUT
         );
+
+        // Saluki-only trace defaults live in the traces-domain model, so absent keys must leave
+        // ADP's historical sampler defaults in place.
+        let traces = &config.domains.traces;
+        assert_eq!(traces.default_env, DEFAULT_TRACE_ENV);
+        assert_eq!(traces.error_sampling_enabled, DEFAULT_ERROR_SAMPLING_ENABLED);
+        assert_eq!(traces.rare_sampler.tps, DEFAULT_RARE_SAMPLER_TPS);
+        assert_eq!(traces.rare_sampler.cooldown, DEFAULT_RARE_SAMPLER_COOLDOWN_SECS);
+        assert_eq!(traces.rare_sampler.cardinality, DEFAULT_RARE_SAMPLER_CARDINALITY);
     }
 }

--- a/lib/agent-data-plane-config/src/defaults.rs
+++ b/lib/agent-data-plane-config/src/defaults.rs
@@ -10,6 +10,21 @@ use std::{num::NonZeroUsize, time::Duration};
 /// Default timeout before a partially filled encoder payload is flushed.
 pub const DEFAULT_ENCODER_FLUSH_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Default environment for traces that do not provide one.
+pub const DEFAULT_TRACE_ENV: &str = "none";
+
+/// Whether error traces are sampled independently of the base sampler by default.
+pub const DEFAULT_ERROR_SAMPLING_ENABLED: bool = true;
+
+/// Default rare-sampler traces-per-second budget.
+pub const DEFAULT_RARE_SAMPLER_TPS: f64 = 5.0;
+
+/// Default rare-sampler cooldown, in seconds.
+pub const DEFAULT_RARE_SAMPLER_COOLDOWN_SECS: f64 = 300.0;
+
+/// Default rare-sampler signature cardinality.
+pub const DEFAULT_RARE_SAMPLER_CARDINALITY: usize = 200;
+
 /// Default OTLP trace string interner capacity: 512 KiB.
 pub const DEFAULT_STRING_INTERNER_SIZE_BYTES: NonZeroUsize = NonZeroUsize::new(512 * 1024).unwrap();
 

--- a/lib/agent-data-plane-config/src/domains/traces.rs
+++ b/lib/agent-data-plane-config/src/domains/traces.rs
@@ -2,8 +2,13 @@
 
 use serde::Serialize;
 
+use crate::defaults::{
+    DEFAULT_ERROR_SAMPLING_ENABLED, DEFAULT_RARE_SAMPLER_CARDINALITY, DEFAULT_RARE_SAMPLER_COOLDOWN_SECS,
+    DEFAULT_RARE_SAMPLER_TPS, DEFAULT_TRACE_ENV,
+};
+
 /// Resolved traces configuration.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Domain {
     /// Environment tag applied to traces.
     pub env: String,
@@ -53,8 +58,32 @@ pub struct Domain {
     pub ottl_transform: OttlTransform,
 }
 
+impl Default for Domain {
+    fn default() -> Self {
+        Self {
+            // Witnessed fields start as placeholders and are overwritten by Datadog `drive`.
+            env: String::new(),
+            compute_stats_by_span_kind: false,
+            peer_tags: Vec::new(),
+            peer_tags_aggregation: false,
+            error_tracking_standalone_enabled: false,
+            errors_per_second: 0.0,
+            target_traces_per_second: 0.0,
+            enable_rare_sampler: false,
+            probabilistic_sampler: ProbabilisticSampler::default(),
+            obfuscation: Obfuscation::default(),
+            // Saluki-only fields own their absent-key behavior here.
+            default_env: DEFAULT_TRACE_ENV.to_owned(),
+            error_sampling_enabled: DEFAULT_ERROR_SAMPLING_ENABLED,
+            rare_sampler: RareSampler::default(),
+            ottl_filter: OttlFilter::default(),
+            ottl_transform: OttlTransform::default(),
+        }
+    }
+}
+
 /// Rare-span sampler.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct RareSampler {
     /// Maximum number of distinct span signatures tracked. (not in Datadog Agent config schema)
     pub cardinality: usize,
@@ -65,6 +94,16 @@ pub struct RareSampler {
 
     /// Target rare-span traces sampled per second. (not in Datadog Agent config schema)
     pub tps: f64,
+}
+
+impl Default for RareSampler {
+    fn default() -> Self {
+        Self {
+            cardinality: DEFAULT_RARE_SAMPLER_CARDINALITY,
+            cooldown: DEFAULT_RARE_SAMPLER_COOLDOWN_SECS,
+            tps: DEFAULT_RARE_SAMPLER_TPS,
+        }
+    }
 }
 
 /// APM probabilistic sampler.

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -1,47 +1,10 @@
+use agent_data_plane_config::defaults::DEFAULT_TRACE_ENV;
 use saluki_config::GenericConfiguration;
 use saluki_error::GenericError;
 use serde::Deserialize;
 use stringtheory::MetaString;
 
 use super::obfuscation::ObfuscationConfig;
-
-const fn default_target_traces_per_second() -> f64 {
-    10.0
-}
-
-const fn default_errors_per_second() -> f64 {
-    10.0
-}
-const fn default_sampling_percentage() -> f64 {
-    100.0
-}
-
-const fn default_error_sampling_enabled() -> bool {
-    true
-}
-
-const fn default_error_tracking_standalone_enabled() -> bool {
-    false
-}
-
-const fn default_probabilistic_sampling_enabled() -> bool {
-    false
-}
-const fn default_rare_sampler_enabled() -> bool {
-    false
-}
-
-const fn default_rare_sampler_tps() -> f64 {
-    5.0
-}
-
-const fn default_rare_sampler_cooldown_secs() -> f64 {
-    300.0 // 5 minutes
-}
-
-const fn default_rare_sampler_cardinality() -> usize {
-    200
-}
 
 const fn default_peer_tags_aggregation() -> bool {
     true
@@ -52,31 +15,7 @@ const fn default_compute_stats_by_span_kind() -> bool {
 }
 
 fn default_env() -> MetaString {
-    MetaString::from("none")
-}
-
-/// Rare sampler tuning configuration (`apm_config.rare_sampler.*`).
-#[derive(Clone, Debug, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
-struct RareSamplerConfig {
-    #[serde(default = "default_rare_sampler_tps")]
-    tps: f64,
-
-    #[serde(default = "default_rare_sampler_cooldown_secs")]
-    cooldown: f64,
-
-    #[serde(default = "default_rare_sampler_cardinality")]
-    cardinality: usize,
-}
-
-impl Default for RareSamplerConfig {
-    fn default() -> Self {
-        Self {
-            tps: default_rare_sampler_tps(),
-            cooldown: default_rare_sampler_cooldown_secs(),
-            cardinality: default_rare_sampler_cardinality(),
-        }
-    }
+    MetaString::from(DEFAULT_TRACE_ENV)
 }
 
 /// APM configuration.
@@ -89,92 +28,9 @@ struct ApmConfiguration {
     apm_config: ApmConfig,
 }
 
-/// Error Tracking Standalone settings (`apm_config.error_tracking_standalone`).
-#[derive(Clone, Debug, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
-struct ErrorTrackingStandaloneConfig {
-    /// Whether Error Tracking Standalone mode is enabled.
-    ///
-    /// Defaults to `false`.
-    #[serde(default = "default_error_tracking_standalone_enabled")]
-    enabled: bool,
-}
-
-impl Default for ErrorTrackingStandaloneConfig {
-    fn default() -> Self {
-        Self {
-            enabled: default_error_tracking_standalone_enabled(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
-struct ProbabilisticSamplerConfig {
-    /// Enables probabilistic sampling.
-    ///
-    /// When enabled, the trace sampler keeps approximately `sampling_percentage` of traces using a
-    /// deterministic hash of the trace ID.
-    ///
-    /// Defaults to `false`.
-    #[serde(default = "default_probabilistic_sampling_enabled")]
-    enabled: bool,
-
-    /// Sampling percentage (0-100).
-    ///
-    /// Determines the percentage of traces to keep. A value of 100 keeps all traces,
-    /// while 50 keeps approximately half. Values outside 0-100 are treated as 100.
-    ///
-    /// Defaults to 100.0 (keep all traces).
-    #[serde(default = "default_sampling_percentage")]
-    sampling_percentage: f64,
-}
-
-impl Default for ProbabilisticSamplerConfig {
-    fn default() -> Self {
-        Self {
-            enabled: default_probabilistic_sampling_enabled(),
-            sampling_percentage: default_sampling_percentage(),
-        }
-    }
-}
-
 #[derive(Clone, Debug, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct ApmConfig {
-    /// Target traces per second for priority sampling.
-    ///
-    /// Defaults to 10.0.
-    #[serde(default = "default_target_traces_per_second")]
-    target_traces_per_second: f64,
-
-    /// Target traces per second for error sampling.
-    ///
-    /// Defaults to 10.0.
-    #[serde(default = "default_errors_per_second")]
-    errors_per_second: f64,
-
-    /// Probabilistic sampler configuration.
-    ///
-    /// Defaults to enabled with `sampling_percentage` set to 100.0 (keep all traces).
-    #[serde(default)]
-    probabilistic_sampler: ProbabilisticSamplerConfig,
-
-    /// Enable error sampling in the trace sampler.
-    ///
-    /// When enabled, traces containing errors will be kept even if they would be dropped by
-    /// probabilistic sampling. This ensures error visibility at low sampling rates.
-    ///
-    /// Defaults to `true`.
-    #[serde(default = "default_error_sampling_enabled")]
-    error_sampling_enabled: bool,
-
-    /// Error Tracking Standalone settings.
-    ///
-    /// Defaults to disabled.
-    #[serde(default)]
-    error_tracking_standalone: ErrorTrackingStandaloneConfig,
-
     /// Enables an additional stats computation check on spans to see if they have an eligible `span.kind` (server, consumer, client, producer).
     /// If enabled, a span with an eligible `span.kind` will have stats computed. If disabled, only top-level and measured spans will have stats computed.
     ///
@@ -207,15 +63,6 @@ pub struct ApmConfig {
     #[serde(skip)]
     hostname: MetaString,
 
-    /// Enables the rare sampler.
-    ///
-    /// Defaults to `false`.
-    #[serde(default = "default_rare_sampler_enabled")]
-    enable_rare_sampler: bool,
-
-    #[serde(default)]
-    rare_sampler: RareSamplerConfig,
-
     /// Obfuscation configuration for trace data.
     ///
     /// Defaults to every obfuscator disabled.
@@ -226,36 +73,6 @@ pub struct ApmConfig {
 impl ApmConfig {
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         Ok(config.as_typed::<ApmConfiguration>()?.apm_config)
-    }
-
-    /// Returns the target traces per second for priority sampling.
-    pub const fn target_traces_per_second(&self) -> f64 {
-        self.target_traces_per_second
-    }
-
-    /// Returns the target traces per second for error sampling.
-    pub const fn errors_per_second(&self) -> f64 {
-        self.errors_per_second
-    }
-
-    /// Returns `true` if probabilistic sampling is enabled.
-    pub const fn probabilistic_sampler_enabled(&self) -> bool {
-        self.probabilistic_sampler.enabled
-    }
-
-    /// Returns the probabilistic sampler sampling percentage.
-    pub const fn probabilistic_sampler_sampling_percentage(&self) -> f64 {
-        self.probabilistic_sampler.sampling_percentage
-    }
-
-    /// Returns `true` if error sampling is enabled.
-    pub const fn error_sampling_enabled(&self) -> bool {
-        self.error_sampling_enabled
-    }
-
-    /// Returns `true` if error tracking standalone mode is enabled.
-    pub const fn error_tracking_standalone_enabled(&self) -> bool {
-        self.error_tracking_standalone.enabled
     }
 
     /// Returns `true` if stats computation by span kind is enabled.
@@ -290,26 +107,6 @@ impl ApmConfig {
         }
     }
 
-    /// Returns `true` if the rare sampler is enabled.
-    pub const fn rare_sampler_enabled(&self) -> bool {
-        self.enable_rare_sampler
-    }
-
-    /// Returns the rare sampler target traces per second.
-    pub const fn rare_sampler_tps(&self) -> f64 {
-        self.rare_sampler.tps
-    }
-
-    /// Returns the rare sampler cooldown period in seconds.
-    pub const fn rare_sampler_cooldown_period_secs(&self) -> f64 {
-        self.rare_sampler.cooldown
-    }
-
-    /// Returns the rare sampler cardinality limit per shard.
-    pub const fn rare_sampler_cardinality(&self) -> usize {
-        self.rare_sampler.cardinality
-    }
-
     /// Returns the obfuscation configuration.
     pub fn obfuscation(&self) -> &ObfuscationConfig {
         &self.obfuscation
@@ -319,121 +116,12 @@ impl ApmConfig {
 impl Default for ApmConfig {
     fn default() -> Self {
         Self {
-            target_traces_per_second: default_target_traces_per_second(),
-            errors_per_second: default_errors_per_second(),
-            probabilistic_sampler: ProbabilisticSamplerConfig::default(),
-            error_sampling_enabled: default_error_sampling_enabled(),
-            error_tracking_standalone: ErrorTrackingStandaloneConfig::default(),
             compute_stats_by_span_kind: default_compute_stats_by_span_kind(),
             peer_tags_aggregation: default_peer_tags_aggregation(),
             peer_tags: Vec::new(),
             default_env: default_env(),
             hostname: MetaString::default(),
-            enable_rare_sampler: default_rare_sampler_enabled(),
-            rare_sampler: RareSamplerConfig::default(),
             obfuscation: ObfuscationConfig::default(),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use datadog_agent_config::DatadogEnvProvider;
-    use saluki_config::ConfigurationLoader;
-
-    use super::*;
-
-    /// Builds an `ApmConfig` from file values plus environment variables named exactly as the
-    /// Datadog Agent spells them, resolved through the schema-driven provider.
-    async fn apm_config_from(file_values: Option<serde_json::Value>, env_vars: Vec<(String, String)>) -> ApmConfig {
-        let (cfg, _) = ConfigurationLoader::for_tests_with_provider_factory(file_values, None, false, |_| {
-            DatadogEnvProvider::from_env_vars(env_vars).expect("test environment values should decode")
-        })
-        .await;
-        ApmConfig::from_configuration(&cfg).expect("ApmConfig should deserialize")
-    }
-
-    fn env(name: &str, value: &str) -> Vec<(String, String)> {
-        vec![(name.to_string(), value.to_string())]
-    }
-
-    #[tokio::test]
-    async fn rare_sampler_disabled_by_default() {
-        let config = apm_config_from(None, Vec::new()).await;
-        assert!(!config.rare_sampler_enabled());
-    }
-
-    #[tokio::test]
-    async fn rare_sampler_enabled_via_yaml() {
-        let config = apm_config_from(
-            Some(serde_json::json!({ "apm_config": { "enable_rare_sampler": true } })),
-            Vec::new(),
-        )
-        .await;
-        assert!(config.rare_sampler_enabled());
-    }
-
-    #[tokio::test]
-    async fn rare_sampler_enabled_via_env_var() {
-        let config = apm_config_from(None, env("DD_APM_ENABLE_RARE_SAMPLER", "true")).await;
-        assert!(config.rare_sampler_enabled());
-    }
-
-    #[tokio::test]
-    async fn rare_sampler_env_var_overrides_yaml() {
-        let config = apm_config_from(
-            Some(serde_json::json!({ "apm_config": { "enable_rare_sampler": false } })),
-            env("DD_APM_ENABLE_RARE_SAMPLER", "true"),
-        )
-        .await;
-        assert!(config.rare_sampler_enabled());
-    }
-
-    #[tokio::test]
-    async fn ets_disabled_by_default() {
-        let config = apm_config_from(None, Vec::new()).await;
-        assert!(!config.error_tracking_standalone_enabled());
-    }
-
-    #[tokio::test]
-    async fn ets_enabled_via_yaml() {
-        let config = apm_config_from(
-            Some(serde_json::json!({ "apm_config": { "error_tracking_standalone": { "enabled": true } } })),
-            Vec::new(),
-        )
-        .await;
-        assert!(config.error_tracking_standalone_enabled());
-    }
-
-    #[tokio::test]
-    async fn ets_enabled_via_env_var() {
-        let config = apm_config_from(None, env("DD_APM_ERROR_TRACKING_STANDALONE_ENABLED", "true")).await;
-        assert!(config.error_tracking_standalone_enabled());
-    }
-
-    #[tokio::test]
-    async fn ets_env_var_overrides_yaml() {
-        let config = apm_config_from(
-            Some(serde_json::json!({ "apm_config": { "error_tracking_standalone": { "enabled": false } } })),
-            env("DD_APM_ERROR_TRACKING_STANDALONE_ENABLED", "true"),
-        )
-        .await;
-        assert!(config.error_tracking_standalone_enabled());
-    }
-
-    #[tokio::test]
-    async fn rare_sampler_tuning_via_yaml() {
-        let config = apm_config_from(
-            Some(serde_json::json!({
-                "apm_config": {
-                    "rare_sampler": { "tps": 10, "cooldown": 60, "cardinality": 100 }
-                }
-            })),
-            Vec::new(),
-        )
-        .await;
-        assert_eq!(config.rare_sampler_tps(), 10.0);
-        assert_eq!(config.rare_sampler_cooldown_period_secs(), 60.0);
-        assert_eq!(config.rare_sampler_cardinality(), 100);
     }
 }

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -27,39 +27,6 @@ pub struct TracesConfig {
     /// Defaults to `true`.
     #[serde(default = "default_enable_otlp_compute_top_level_by_span_kind")]
     pub enable_otlp_compute_top_level_by_span_kind: bool,
-
-    /// Probabilistic sampler configuration for OTLP traces.
-    ///
-    /// Corresponds to `otlp_config.traces.probabilistic_sampler` in the Agent.
-    #[serde(default)]
-    pub probabilistic_sampler: ProbabilisticSampler,
-}
-
-/// Configuration for OTLP traces probabilistic sampling.
-#[derive(Clone, Deserialize, Debug)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-pub struct ProbabilisticSampler {
-    /// Percentage of traces to ingest (0, 100].
-    ///
-    /// Invalid values (<= 0 || > 100) are disregarded and the default is used.
-    ///
-    /// Corresponds to `otlp_config.traces.probabilistic_sampler.sampling_percentage` in the Agent.
-    ///
-    /// Defaults to 100.0 (100% sampling).
-    #[serde(default = "default_sampling_percentage")]
-    pub sampling_percentage: f64,
-}
-
-const fn default_sampling_percentage() -> f64 {
-    100.0
-}
-
-impl Default for ProbabilisticSampler {
-    fn default() -> Self {
-        Self {
-            sampling_percentage: default_sampling_percentage(),
-        }
-    }
 }
 
 const fn default_enable_otlp_compute_top_level_by_span_kind() -> bool {
@@ -71,7 +38,6 @@ impl Default for TracesConfig {
         Self {
             ignore_missing_datadog_fields: false,
             enable_otlp_compute_top_level_by_span_kind: default_enable_otlp_compute_top_level_by_span_kind(),
-            probabilistic_sampler: ProbabilisticSampler::default(),
         }
     }
 }

--- a/lib/saluki-components/src/decoders/otlp/mod.rs
+++ b/lib/saluki-components/src/decoders/otlp/mod.rs
@@ -55,7 +55,6 @@ impl DecoderBuilder for OtlpDecoderConfiguration {
         let traces_config = TracesConfig {
             enable_otlp_compute_top_level_by_span_kind: self.traces.enable_compute_top_level_by_span_kind,
             ignore_missing_datadog_fields: self.traces.ignore_missing_datadog_fields,
-            ..Default::default()
         };
         let traces_translator = OtlpTracesTranslator::new(traces_config, self.traces.string_interner_size);
 

--- a/lib/saluki-components/src/encoders/datadog/stats/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/stats/mod.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use agent_data_plane_config::defaults::DEFAULT_ENCODER_FLUSH_TIMEOUT;
+use agent_data_plane_config::defaults::{DEFAULT_ENCODER_FLUSH_TIMEOUT, DEFAULT_TRACE_ENV};
 use async_trait::async_trait;
 use datadog_protos::traces::{
     ClientGroupedStats as ProtoClientGroupedStats, ClientStatsBucket as ProtoClientStatsBucket,
@@ -53,7 +53,7 @@ const fn default_flush_timeout_secs() -> u64 {
 }
 
 fn default_env() -> String {
-    "none".to_string()
+    DEFAULT_TRACE_ENV.to_owned()
 }
 
 /// Configuration for the Datadog APM Stats encoder.

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Write, time::Duration};
 
-use agent_data_plane_config::{domains, SharedConfiguration};
+use agent_data_plane_config::{defaults::DEFAULT_TRACE_ENV, domains, SharedConfiguration};
 use async_trait::async_trait;
 use datadog_protos::traces::builders::{
     attribute_any_value::AttributeAnyValueType, attribute_array_value::AttributeArrayValueType, AgentPayloadBuilder,
@@ -121,7 +121,7 @@ impl DatadogTraceConfiguration {
         // ADP defaults the global environment tag to `none` rather than the Core Agent's empty
         // string, so normalize an empty resolved value back to `none`.
         let env = if traces.env.is_empty() {
-            "none".to_string()
+            DEFAULT_TRACE_ENV.to_owned()
         } else {
             traces.env.clone()
         };

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -166,7 +166,6 @@ impl SourceBuilder for OtlpConfiguration {
         let traces_config = TracesConfig {
             enable_otlp_compute_top_level_by_span_kind: self.otlp.traces.enable_compute_top_level_by_span_kind,
             ignore_missing_datadog_fields: self.otlp.traces.ignore_missing_datadog_fields,
-            ..Default::default()
         };
         let traces_translator = OtlpTracesTranslator::new(traces_config, self.otlp.traces.string_interner_size);
         let grpc_max_recv_msg_size_bytes = self.otlp.receiver.grpc.max_recv_msg_size_mib as usize * 1024 * 1024;

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -12,9 +12,9 @@
 //! - adding missing samplers (priority, nopriority)
 //! - add error tracking standalone mode
 
+use agent_data_plane_config::domains;
 use async_trait::async_trait;
 use saluki_common::collections::FastHashMap;
-use saluki_config::GenericConfiguration;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
     components::{transforms::*, ComponentContext},
@@ -39,10 +39,9 @@ mod signature;
 
 use self::probabilistic::PROB_RATE_KEY;
 use crate::common::datadog::{
-    apm::ApmConfig, sample_by_rate, DECISION_MAKER_MANUAL, DECISION_MAKER_PROBABILISTIC, OTEL_TRACE_ID_META_KEY,
+    sample_by_rate, DECISION_MAKER_MANUAL, DECISION_MAKER_PROBABILISTIC, OTEL_TRACE_ID_META_KEY,
     SAMPLING_PRIORITY_METRIC_KEY, TAG_DECISION_MAKER,
 };
-use crate::common::otlp::config::TracesConfig;
 
 // Sampling priority constants (matching datadog-agent)
 const PRIORITY_AUTO_DROP: i32 = 0;
@@ -68,20 +67,41 @@ fn normalize_sampling_rate(rate: f64) -> f64 {
 /// Configuration for the trace sampler transform.
 #[derive(Debug)]
 pub struct TraceSamplerConfiguration {
-    apm_config: ApmConfig,
+    probabilistic_sampler_enabled: bool,
+    sampling_percentage: f64,
+    error_sampling_enabled: bool,
+    error_tracking_standalone: bool,
+    errors_per_second: f64,
+    target_traces_per_second: f64,
+    default_env: MetaString,
+    rare_sampler_enabled: bool,
+    rare_sampler_tps: f64,
+    rare_sampler_cooldown_secs: f64,
+    rare_sampler_cardinality: usize,
     otlp_sampling_rate: f64,
 }
 
 impl TraceSamplerConfiguration {
-    /// Creates a new `TraceSamplerConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let apm_config = ApmConfig::from_configuration(config)?;
-        let otlp_traces: TracesConfig = config.try_get_typed("otlp_config.traces")?.unwrap_or_default();
-        let otlp_sampling_rate = normalize_sampling_rate(otlp_traces.probabilistic_sampler.sampling_percentage / 100.0);
-        Ok(Self {
-            apm_config,
+    /// Creates a new `TraceSamplerConfiguration` from the resolved traces domain.
+    ///
+    /// The OTLP trace settings live in their own domain, so they arrive as a separate slice rather
+    /// than through the traces domain.
+    pub fn from_configuration(traces: &domains::traces::Domain, otlp_traces: &domains::otlp::Traces) -> Self {
+        let otlp_sampling_rate = normalize_sampling_rate(otlp_traces.probabilistic_sampler_sampling_percentage / 100.0);
+        Self {
+            probabilistic_sampler_enabled: traces.probabilistic_sampler.enabled,
+            sampling_percentage: traces.probabilistic_sampler.sampling_percentage,
+            error_sampling_enabled: traces.error_sampling_enabled,
+            error_tracking_standalone: traces.error_tracking_standalone_enabled,
+            errors_per_second: traces.errors_per_second,
+            target_traces_per_second: traces.target_traces_per_second,
+            default_env: MetaString::from(traces.default_env.clone()),
+            rare_sampler_enabled: traces.enable_rare_sampler,
+            rare_sampler_tps: traces.rare_sampler.tps,
+            rare_sampler_cooldown_secs: traces.rare_sampler.cooldown,
+            rare_sampler_cardinality: traces.rare_sampler.cardinality,
             otlp_sampling_rate,
-        })
+        }
     }
 }
 
@@ -91,26 +111,26 @@ impl SynchronousTransformBuilder for TraceSamplerConfiguration {
         // TODO: Need to support remote configuration changing these at runtime
         // See https://github.com/DataDog/saluki/issues/1326
         let sampler = TraceSampler {
-            sampling_rate: self.apm_config.probabilistic_sampler_sampling_percentage() / 100.0,
-            error_sampling_enabled: self.apm_config.error_sampling_enabled(),
-            error_tracking_standalone: self.apm_config.error_tracking_standalone_enabled(),
-            probabilistic_sampler_enabled: self.apm_config.probabilistic_sampler_enabled(),
+            sampling_rate: self.sampling_percentage / 100.0,
+            error_sampling_enabled: self.error_sampling_enabled,
+            error_tracking_standalone: self.error_tracking_standalone,
+            probabilistic_sampler_enabled: self.probabilistic_sampler_enabled,
             otlp_sampling_rate: self.otlp_sampling_rate,
-            error_sampler: errors::ErrorsSampler::new(self.apm_config.errors_per_second(), ERROR_SAMPLE_RATE),
+            error_sampler: errors::ErrorsSampler::new(self.errors_per_second, ERROR_SAMPLE_RATE),
             priority_sampler: priority_sampler::PrioritySampler::new(
-                self.apm_config.default_env().clone(),
+                self.default_env.clone(),
                 ERROR_SAMPLE_RATE,
-                self.apm_config.target_traces_per_second(),
+                self.target_traces_per_second,
             ),
             no_priority_sampler: score_sampler::NoPrioritySampler::new(
-                self.apm_config.target_traces_per_second(),
+                self.target_traces_per_second,
                 ERROR_SAMPLE_RATE,
             ),
             rare_sampler: rare_sampler::RareSampler::new(
-                self.apm_config.rare_sampler_enabled(),
-                self.apm_config.rare_sampler_tps(),
-                std::time::Duration::from_secs_f64(self.apm_config.rare_sampler_cooldown_period_secs()),
-                self.apm_config.rare_sampler_cardinality(),
+                self.rare_sampler_enabled,
+                self.rare_sampler_tps,
+                std::time::Duration::from_secs_f64(self.rare_sampler_cooldown_secs),
+                self.rare_sampler_cardinality,
             ),
         };
 


### PR DESCRIPTION
## Human Summary

This is a relatively straightforward conversion of `TraceSamplerConfiguration` to typed config. No issues were encountered. The Codex flag is because we are changing our default to match the Agent (which is what we want).

## AI Summary

Migrate the trace sampler transform to the typed traces configuration domain.

- Construct `TraceSamplerConfiguration` from `domains.traces` instead of `GenericConfiguration` and `ApmConfig`.
- Preserve the Saluki-only defaults for the trace sampler in the typed model.
- Remove sampler-only fields, accessors, and legacy deserialization tests from `ApmConfig`.
- Update the traces pipeline construction to use the typed configuration.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make fmt`
- `make build-schema-overlay` (no generated drift)
- `cargo check --workspace --tests`
- `cargo clippy -p saluki-components -p agent-data-plane-config-system -p agent-data-plane -p agent-data-plane-config --all-targets`
- `cargo nextest run -p saluki-components -p agent-data-plane-config-system -p agent-data-plane-config` (843 passed, 1 skipped)

## References

- Progresses: #2169
- Progresses: #2193
- Progresses: #1802
