### PR TITLE
chore(config): expose local typed config during bootstrap

### DIFF
--- a/lib/agent-data-plane-config-system/src/loaded.rs
+++ b/lib/agent-data-plane-config-system/src/loaded.rs
@@ -1,13 +1,14 @@
-//! [`LoadedConfiguration`]: the local configuration sources loaded once, ready to be bound to a
-//! runtime authority.
+//! Loads local configuration before selecting its runtime authority.
 //!
-//! The configuration system owns loading. [`LoadedConfiguration::load`] reads the local file and
-//! environment using the requested precedence, then one of the two terminals binds those sources to
-//! an authority: [`LoadedConfiguration::run`] uses the Datadog Agent's config stream, while
-//! [`LoadedConfiguration::standalone`] treats the local sources as authoritative.
+//! [`LoadedConfiguration::load`] prepares a typed snapshot of the local file and environment, which
+//! [`LoadedConfiguration::local`] exposes before values from the Datadog Agent stream are applied.
+//! [`LoadedConfiguration::run`] layers the Agent's configuration stream over the local sources,
+//! while [`LoadedConfiguration::standalone`] keeps the local sources authoritative. Both methods
+//! consume the loaded sources and return a [`ConfigurationSystem`].
 
 use std::path::Path;
 
+use agent_data_plane_config::SalukiConfiguration;
 use datadog_agent_config::apply_datadog_env;
 // TODO: remove after migration to typed config; these support the legacy flat-key loader.
 use datadog_agent_config::{DatadogRemapper, EnvOverlayMode, KEY_ALIASES};
@@ -17,7 +18,7 @@ use serde_json::Value;
 use tokio::sync::mpsc;
 
 use crate::saluki_env_overlay;
-use crate::system::{ConfigurationSystem, Error};
+use crate::system::{translate_strict, ConfigurationSystem, Error};
 
 // The environment-variable prefix ADP reads (`DD_`). Mirrors
 // `PlatformSettings::get_env_var_prefix()`; hardcoded so the configuration system need not depend on
@@ -59,45 +60,60 @@ impl EnvPrecedence {
     }
 }
 
-/// Local configuration sources loaded once, not yet bound to a runtime authority.
+/// Local configuration prepared before a runtime authority is selected.
 ///
-/// Holds both the nested typed value and the by-key view so they resolve the local sources
-/// identically.
+/// Retains a nested base for the typed path and a loader for the legacy by-key path. Both use the
+/// same source path and precedence but build their representations independently.
 pub struct LoadedConfiguration {
     loader: ConfigurationLoader,
-    // The complete configuration read from the file and environment at startup. It is retained so
-    // the typed path and the by-key compatibility view use the same local sources.
+    // Nested local base used for typed translation and Agent-layer merges.
     base: Value,
     env: EnvPrecedence,
+    // Strictly translated local snapshot exposed before authority selection and used by standalone
+    // mode.
+    local: SalukiConfiguration,
 }
 
 impl LoadedConfiguration {
-    /// Loads the local sources once from `path` and the environment, at the given precedence.
+    /// Loads and strictly translates the local file and environment using the requested precedence.
     ///
     /// # Errors
     ///
-    /// Returns an error if the file cannot be read or is not valid YAML, or if the environment
-    /// prefix is invalid.
+    /// Returns an error if a local source cannot be read, decoded, deserialized, or translated.
     pub async fn load(path: impl AsRef<Path>, env: EnvPrecedence) -> Result<Self, Error> {
         let loader = build_loader(path.as_ref(), env)?;
         let base = build_base(path.as_ref(), env)?;
-        Ok(Self { loader, base, env })
+        let local = translate_strict(&base, env.overlay_mode())?;
+        Ok(Self {
+            loader,
+            base,
+            env,
+            local,
+        })
     }
 
-    /// A static snapshot of the local sources for startup phase configuration.
-    // TODO: remove this backdoor and use typed configuration for the bootstrap phase
+    /// Returns the typed snapshot of the local file and environment.
+    ///
+    /// Values from the Datadog Agent stream have not been applied to this snapshot.
+    pub fn local(&self) -> &SalukiConfiguration {
+        &self.local
+    }
+
+    /// Returns the local file and environment through the legacy by-key configuration API.
+    // TODO: Remove this compatibility view once bootstrap consumers use `local`.
     pub fn raw_config(&self) -> GenericConfiguration {
         self.loader.bootstrap_generic()
     }
 
-    /// Connected authority: attach the Datadog Agent's config stream, block for the first
-    /// authoritative snapshot, deserialize and translate it, and start the update task. This is the
-    /// strict startup gate: a snapshot that cannot be received, deserialized, or translated fails
-    /// the boot.
+    /// Uses the Datadog Agent's configuration stream as the runtime authority.
+    ///
+    /// Waits for the initial Agent snapshot, layers it over the local sources, strictly translates
+    /// the result, and then starts the update task.
     ///
     /// # Errors
     ///
-    /// Returns an error if the initial configuration cannot be built.
+    /// Returns an error if the compatibility map cannot be built, the stream closes before its
+    /// initial snapshot, or the merged configuration cannot be deserialized or translated.
     pub async fn run(self, config_stream: mpsc::Receiver<ConfigUpdate>) -> Result<ConfigurationSystem, Error> {
         // The configuration system owns the Agent stream and forwards each update into this
         // compatibility map, so `raw_map()` keeps serving un-migrated components.
@@ -107,15 +123,16 @@ impl LoadedConfiguration {
         ConfigurationSystem::connected(config_stream, compat_tx, compat_map, self.base, self.env.overlay_mode()).await
     }
 
-    /// Standalone authority: the local sources are authoritative, with no stream and no update task.
-    /// Also a strict startup gate.
+    /// Uses the translated local configuration as the runtime authority.
+    ///
+    /// No configuration stream or update task is created.
     ///
     /// # Errors
     ///
-    /// Returns an error if the configuration cannot be built from the local sources.
+    /// Returns an error if the compatibility map cannot be built from the local sources.
     pub async fn standalone(self) -> Result<ConfigurationSystem, Error> {
         let compat_map = self.loader.into_generic().await?;
-        ConfigurationSystem::standalone(compat_map, self.base, self.env.overlay_mode())
+        Ok(ConfigurationSystem::standalone(compat_map, self.local))
     }
 }
 
@@ -215,6 +232,35 @@ mod tests {
 
         std::env::remove_var("DD_DOGSTATSD_PORT");
         std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn local_exposes_translated_configuration() {
+        // Disable environment reads so this test does not need `ENV_MUTEX`.
+        let path = std::env::temp_dir().join(format!("adp_local_{}.yaml", std::process::id()));
+        std::fs::write(&path, "log_level: warn\ndogstatsd_port: 9125\n").unwrap();
+
+        let loaded = LoadedConfiguration::load(&path, EnvPrecedence::Disabled)
+            .await
+            .expect("local sources load");
+        let config = loaded.local();
+
+        assert_eq!(config.control.logging.level, "warn");
+        assert_eq!(config.domains.dogstatsd.listeners.port, 9125);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn load_rejects_translation_invalid_local_sources() {
+        let path = std::env::temp_dir().join(format!("adp_local_bad_{}.yaml", std::process::id()));
+        // The compatibility loader accepts this value, but typed translation rejects it.
+        std::fs::write(&path, "dogstatsd_tag_cardinality: bogus\n").unwrap();
+
+        let result = LoadedConfiguration::load(&path, EnvPrecedence::Disabled).await;
+
+        std::fs::remove_file(&path).ok();
+        assert!(matches!(result, Err(Error::Translate { .. })));
     }
 
     #[test]

--- a/lib/agent-data-plane-config-system/src/system.rs
+++ b/lib/agent-data-plane-config-system/src/system.rs
@@ -107,7 +107,7 @@ impl ConfigurationSystem {
         // check instead rejects the offending update and keeps the last-known-good configuration,
         // because a runtime update must never take the system down.
         let merged = deep_merge(base.clone(), agent.clone());
-        let config = translate_gate(&merged, overlay)?;
+        let config = translate_strict(&merged, overlay)?;
 
         let current = Arc::new(ArcSwap::from_pointee(config));
         // The initial receiver is dropped immediately; `send_replace` works with zero receivers, and
@@ -132,21 +132,17 @@ impl ConfigurationSystem {
         })
     }
 
-    /// Standalone authority: the local sources are authoritative, with no stream and no update task.
-    /// Also a strict startup gate.
+    /// Installs a static configuration without an update task.
     ///
-    /// # Errors
-    ///
-    /// Returns an error if the configuration cannot be deserialized or translated from `base`.
-    pub(crate) fn standalone(compat_map: GenericConfiguration, base: Value, overlay: EnvOverlayMode) -> Result<Self> {
-        let config = translate_gate(&base, overlay)?;
+    /// Live views retain their initial values because this system sends no update notifications.
+    pub(crate) fn standalone(compat_map: GenericConfiguration, config: SalukiConfiguration) -> Self {
         let current = Arc::new(ArcSwap::from_pointee(config));
         let (tick, _) = watch::channel(());
-        Ok(Self {
+        Self {
             raw_map: compat_map,
             current,
             tick: Arc::new(tick),
-        })
+        }
     }
 
     /// Returns a live view of the given projection of the current configuration. Narrow further with
@@ -194,7 +190,7 @@ async fn agent_loop(
         let mut tentative = agent.clone();
         fold(&mut tentative, &update);
         let merged = deep_merge(base.clone(), tentative.clone());
-        match translate_gate(&merged, overlay) {
+        match translate_strict(&merged, overlay) {
             Ok(config) => {
                 agent = tentative;
                 current.store(Arc::new(config));
@@ -239,9 +235,12 @@ async fn forward(compat_tx: &mpsc::Sender<ConfigUpdate>, update: ConfigUpdate) {
     let _ = compat_tx.send(update).await;
 }
 
-/// Startup gate: deserialize and translate the merged sources, failing on any translation error so
-/// the process never boots on bad config.
-fn translate_gate(merged: &Value, overlay: EnvOverlayMode) -> Result<SalukiConfiguration> {
+/// Deserializes and translates merged source values, rejecting partially translated configuration.
+///
+/// # Errors
+///
+/// Returns an error if either source model cannot be deserialized or any key fails translation.
+pub(crate) fn translate_strict(merged: &Value, overlay: EnvOverlayMode) -> Result<SalukiConfiguration> {
     let Sources { datadog, saluki } = deserialize_sources(merged, overlay)?;
     let (config, errors) = translate(&datadog, &saluki);
     if let Some(errors) = errors {
@@ -363,7 +362,7 @@ mod tests {
     use serde_json::{json, Value};
     use tokio::sync::mpsc;
 
-    use super::{deep_merge, translate, ConfigurationSystem, Error, SalukiOnly};
+    use super::{deep_merge, translate, translate_strict, ConfigurationSystem, Error, SalukiOnly};
 
     /// Builds a standalone system whose authority is the local sources (`file` + `env`).
     async fn standalone_system(
@@ -371,7 +370,8 @@ mod tests {
     ) -> Result<ConfigurationSystem, Error> {
         let (compat_map, _) = ConfigurationLoader::for_tests(file, env, false).await;
         let base = compat_map.as_typed::<Value>().expect("base extracts");
-        ConfigurationSystem::standalone(compat_map, base, overlay)
+        let config = translate_strict(&base, overlay)?;
+        Ok(ConfigurationSystem::standalone(compat_map, config))
     }
 
     /// Builds a connected system whose base is `base` and whose authority is the returned Agent


### PR DESCRIPTION
## Human Summary

This fixes a small flaw in the design of the configuration loading process. During bootstrap, when we read the file and environment variables, we need to translate that "static" or "local" config into our typed configuration object, `SalukiConfiguration` and make it accessible. That way `run.rs` can use if for things like `DataPlaneConfiguration` before the remote agent channel is configured. In fact, it is needed to configure the remote Agent channel.

## AI Summary

Add `LoadedConfiguration::local`, which returns the `SalukiConfiguration` translated from the local file and environment alone, before any runtime authority is bound. The bootstrap phase can read it for decisions the Agent stream can never change, such as standalone mode and remote-agent registration, instead of the raw by-key snapshot.

The accessor reuses the same strict translation gate as the run and standalone terminals, run against the local sources rather than the sources folded with the Agent stream. The result is translated once and cached in a `OnceLock` so callers get a borrow; translation is deterministic given the sources, so a benign race stores the same value.

Translation can fail on the local sources, so `local` returns a `Result` rather than an infallible borrow.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?
- unit tests

## References
- Closes: #2195
- Progresses: #2169
- Unblocks: #2173