### PR TITLE
chore(config): migrate `DataPlaneConfiguration` to typed config 

### DIFF
--- a/bin/agent-data-plane/src/cli/config.rs
+++ b/bin/agent-data-plane/src/cli/config.rs
@@ -1,10 +1,11 @@
+use agent_data_plane_config_system::LoadedConfiguration;
 use argh::FromArgs;
 use saluki_common::scrubber;
-use saluki_config::GenericConfiguration;
 use saluki_error::{ErrorContext as _, GenericError};
 use tracing::{error, info};
 
-use crate::cli::utils::DataPlaneAPIClient;
+use crate::cli::utils::api_or_exit;
+use crate::config::DataPlaneConfiguration;
 
 /// Prints the current configuration.
 #[derive(FromArgs, Debug)]
@@ -29,14 +30,10 @@ fn parse_config_response(response_body: &[u8]) -> Result<serde_json::Value, Gene
 }
 
 /// Entrypoint for the `config` command.
-pub async fn handle_config_command(bootstrap_config: &GenericConfiguration, command: ConfigCommand) {
-    let mut api_client = match DataPlaneAPIClient::from_config(bootstrap_config).await {
-        Ok(client) => client,
-        Err(e) => {
-            error!("Failed to create data plane API client: {:#}", e);
-            std::process::exit(1);
-        }
-    };
+pub async fn handle_config_command(local_config: LoadedConfiguration, command: ConfigCommand) {
+    let config = local_config.local();
+    let dp = DataPlaneConfiguration::from_configuration(config);
+    let mut api_client = api_or_exit(&dp, &local_config.raw_config()).await;
 
     let response_body = match if command.runtime {
         api_client.config_runtime().await

--- a/bin/agent-data-plane/src/cli/config.rs
+++ b/bin/agent-data-plane/src/cli/config.rs
@@ -4,8 +4,7 @@ use saluki_common::scrubber;
 use saluki_error::{ErrorContext as _, GenericError};
 use tracing::{error, info};
 
-use crate::cli::utils::api_or_exit;
-use crate::config::DataPlaneConfiguration;
+use crate::cli::utils::get_api_client_or_exit;
 
 /// Prints the current configuration.
 #[derive(FromArgs, Debug)]
@@ -31,9 +30,7 @@ fn parse_config_response(response_body: &[u8]) -> Result<serde_json::Value, Gene
 
 /// Entrypoint for the `config` command.
 pub async fn handle_config_command(local_config: LoadedConfiguration, command: ConfigCommand) {
-    let config = local_config.local();
-    let dp = DataPlaneConfiguration::from_configuration(config);
-    let mut api_client = api_or_exit(&dp, &local_config.raw_config()).await;
+    let mut api_client = get_api_client_or_exit(&local_config).await;
 
     let response_body = match if command.runtime {
         api_client.config_runtime().await

--- a/bin/agent-data-plane/src/cli/debug/mod.rs
+++ b/bin/agent-data-plane/src/cli/debug/mod.rs
@@ -1,8 +1,9 @@
+use agent_data_plane_config_system::LoadedConfiguration;
 use argh::FromArgs;
-use saluki_config::GenericConfiguration;
 use tracing::{error, info};
 
-use crate::cli::utils::DataPlaneAPIClient;
+use crate::cli::utils::{api_or_exit, DataPlaneAPIClient};
+use crate::config::DataPlaneConfiguration;
 
 mod workload;
 use self::workload::{handle_workload_command, WorkloadCommand};
@@ -62,14 +63,10 @@ pub struct SetMetricLevelCommand {
 }
 
 /// Entrypoint for the `debug` commands.
-pub async fn handle_debug_command(bootstrap_config: &GenericConfiguration, cmd: DebugCommand) {
-    let mut api_client = match DataPlaneAPIClient::from_config(bootstrap_config).await {
-        Ok(client) => client,
-        Err(e) => {
-            error!("Failed to create data plane API client: {:#}", e);
-            std::process::exit(1);
-        }
-    };
+pub async fn handle_debug_command(local_config: LoadedConfiguration, cmd: DebugCommand) {
+    let config = local_config.local();
+    let dp = DataPlaneConfiguration::from_configuration(config);
+    let mut api_client = api_or_exit(&dp, &local_config.raw_config()).await;
 
     match cmd.subcommand {
         DebugSubcommand::ResetLogLevel(_) => reset_log_level(&mut api_client).await,

--- a/bin/agent-data-plane/src/cli/debug/mod.rs
+++ b/bin/agent-data-plane/src/cli/debug/mod.rs
@@ -2,8 +2,7 @@ use agent_data_plane_config_system::LoadedConfiguration;
 use argh::FromArgs;
 use tracing::{error, info};
 
-use crate::cli::utils::{api_or_exit, DataPlaneAPIClient};
-use crate::config::DataPlaneConfiguration;
+use crate::cli::utils::{get_api_client_or_exit, DataPlaneAPIClient};
 
 mod workload;
 use self::workload::{handle_workload_command, WorkloadCommand};
@@ -64,9 +63,7 @@ pub struct SetMetricLevelCommand {
 
 /// Entrypoint for the `debug` commands.
 pub async fn handle_debug_command(local_config: LoadedConfiguration, cmd: DebugCommand) {
-    let config = local_config.local();
-    let dp = DataPlaneConfiguration::from_configuration(config);
-    let mut api_client = api_or_exit(&dp, &local_config.raw_config()).await;
+    let mut api_client = get_api_client_or_exit(&local_config).await;
 
     match cmd.subcommand {
         DebugSubcommand::ResetLogLevel(_) => reset_log_level(&mut api_client).await,

--- a/bin/agent-data-plane/src/cli/dogstatsd.rs
+++ b/bin/agent-data-plane/src/cli/dogstatsd.rs
@@ -20,7 +20,6 @@ use saluki_components::sources::REPLAY_CREDENTIALS_GID;
 use saluki_config::DurationString;
 // The privileged API client's IPC identity, and the Linux replay path, read bootstrap keys through
 // the by-key view.
-use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 #[cfg(target_os = "linux")]
 use saluki_io::net::{unix::uds_sendmsg_with_creds, ProcessCredentials};
@@ -34,8 +33,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use tracing::{error, info};
 
-use crate::cli::utils::DataPlaneAPIClient;
-use crate::config::DataPlaneConfiguration;
+use crate::cli::utils::{get_api_client_or_exit, DataPlaneAPIClient};
 
 mod top;
 use self::top::{handle_dogstatsd_dump_contexts, handle_dogstatsd_top, DumpContextsCommand, TopCommand};
@@ -183,17 +181,15 @@ pub async fn handle_dogstatsd_command(local_config: LoadedConfiguration, cmd: Do
 }
 
 async fn run_dogstatsd_command(local_config: &LoadedConfiguration, cmd: DogstatsdCommand) -> Result<(), GenericError> {
-    let dp = DataPlaneConfiguration::from_configuration(local_config.local());
-    let raw_config = local_config.raw_config();
     match cmd.subcommand {
         DogstatsdSubcommand::Stats(config) => {
-            let mut api_client = data_plane_api_client(&dp, &raw_config).await?;
+            let mut api_client = get_api_client_or_exit(local_config).await;
             handle_dogstatsd_stats(&mut api_client, config)
                 .await
                 .error_context("Failed to run stats subcommand")
         }
         DogstatsdSubcommand::Capture(config) => {
-            let mut api_client = data_plane_api_client(&dp, &raw_config).await?;
+            let mut api_client = get_api_client_or_exit(local_config).await;
             handle_dogstatsd_capture(&mut api_client, config)
                 .await
                 .error_context("Failed to start DogStatsD capture")
@@ -201,7 +197,8 @@ async fn run_dogstatsd_command(local_config: &LoadedConfiguration, cmd: Dogstats
         DogstatsdSubcommand::Replay(config) => {
             #[cfg(target_os = "linux")]
             {
-                let mut api_client = data_plane_api_client(&dp, &raw_config).await?;
+                let mut api_client = get_api_client_or_exit(local_config).await;
+                let raw_config = local_config.raw_config();
                 handle_dogstatsd_replay(&mut api_client, &raw_config, config)
                     .await
                     .error_context("Failed to replay DogStatsD traffic")
@@ -223,24 +220,16 @@ async fn run_dogstatsd_command(local_config: &LoadedConfiguration, cmd: Dogstats
             if config.is_offline() {
                 handle_dogstatsd_top(None, config, &mut output).await
             } else {
-                let mut api_client = data_plane_api_client(&dp, &raw_config).await?;
+                let mut api_client = get_api_client_or_exit(local_config).await;
                 handle_dogstatsd_top(Some(&mut api_client), config, &mut output).await
             }
         }
         DogstatsdSubcommand::DumpContexts(_) => {
-            let mut api_client = data_plane_api_client(&dp, &raw_config).await?;
+            let mut api_client = get_api_client_or_exit(local_config).await;
             let mut output = std::io::stdout();
             handle_dogstatsd_dump_contexts(&mut api_client, &mut output).await
         }
     }
-}
-
-async fn data_plane_api_client(
-    dp: &DataPlaneConfiguration<'_>, raw_config: &GenericConfiguration,
-) -> Result<DataPlaneAPIClient, GenericError> {
-    DataPlaneAPIClient::from_configuration(dp, raw_config)
-        .await
-        .error_context("Failed to create data plane API client")
 }
 
 async fn handle_dogstatsd_stats(api_client: &mut DataPlaneAPIClient, cmd: StatsCommand) -> Result<(), GenericError> {

--- a/bin/agent-data-plane/src/cli/dogstatsd.rs
+++ b/bin/agent-data-plane/src/cli/dogstatsd.rs
@@ -18,8 +18,10 @@ use saluki_components::sources::DEFAULT_REPLAY_LOOPS;
 #[cfg(target_os = "linux")]
 use saluki_components::sources::REPLAY_CREDENTIALS_GID;
 use saluki_config::DurationString;
-// The privileged API client's IPC identity, and the Linux replay path, read bootstrap keys through
-// the by-key view.
+// The Linux replay path resolves the DogStatsD socket through the by-key view. Its resolver is also
+// compiled for tests, so this import carries the same gate the resolver does.
+#[cfg(any(target_os = "linux", test))]
+use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 #[cfg(target_os = "linux")]
 use saluki_io::net::{unix::uds_sendmsg_with_creds, ProcessCredentials};

--- a/bin/agent-data-plane/src/cli/dogstatsd.rs
+++ b/bin/agent-data-plane/src/cli/dogstatsd.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 #[cfg(target_os = "linux")]
 use std::time::Instant;
 
+use agent_data_plane_config_system::LoadedConfiguration;
 use argh::{FromArgValue, FromArgs};
 use comfy_table::{presets::ASCII_FULL_CONDENSED, Cell, ContentArrangement, Row, Table};
 #[cfg(any(target_os = "linux", test))]
@@ -16,7 +17,10 @@ use saluki_components::sources::TrafficCaptureReader;
 use saluki_components::sources::DEFAULT_REPLAY_LOOPS;
 #[cfg(target_os = "linux")]
 use saluki_components::sources::REPLAY_CREDENTIALS_GID;
-use saluki_config::{DurationString, GenericConfiguration};
+use saluki_config::DurationString;
+// The privileged API client's IPC identity, and the Linux replay path, read bootstrap keys through
+// the by-key view.
+use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 #[cfg(target_os = "linux")]
 use saluki_io::net::{unix::uds_sendmsg_with_creds, ProcessCredentials};
@@ -31,6 +35,7 @@ use tracing::debug;
 use tracing::{error, info};
 
 use crate::cli::utils::DataPlaneAPIClient;
+use crate::config::DataPlaneConfiguration;
 
 mod top;
 use self::top::{handle_dogstatsd_dump_contexts, handle_dogstatsd_top, DumpContextsCommand, TopCommand};
@@ -170,25 +175,25 @@ struct StatsResponse<'a> {
 }
 
 /// Entrypoint for the `dogstatsd` commands.
-pub async fn handle_dogstatsd_command(bootstrap_config: &GenericConfiguration, cmd: DogstatsdCommand) {
-    if let Err(error) = run_dogstatsd_command(bootstrap_config, cmd).await {
+pub async fn handle_dogstatsd_command(local_config: LoadedConfiguration, cmd: DogstatsdCommand) {
+    if let Err(error) = run_dogstatsd_command(&local_config, cmd).await {
         error!("{:#}", error);
         std::process::exit(1);
     }
 }
 
-async fn run_dogstatsd_command(
-    bootstrap_config: &GenericConfiguration, cmd: DogstatsdCommand,
-) -> Result<(), GenericError> {
+async fn run_dogstatsd_command(local_config: &LoadedConfiguration, cmd: DogstatsdCommand) -> Result<(), GenericError> {
+    let dp = DataPlaneConfiguration::from_configuration(local_config.local());
+    let raw_config = local_config.raw_config();
     match cmd.subcommand {
         DogstatsdSubcommand::Stats(config) => {
-            let mut api_client = data_plane_api_client(bootstrap_config).await?;
+            let mut api_client = data_plane_api_client(&dp, &raw_config).await?;
             handle_dogstatsd_stats(&mut api_client, config)
                 .await
                 .error_context("Failed to run stats subcommand")
         }
         DogstatsdSubcommand::Capture(config) => {
-            let mut api_client = data_plane_api_client(bootstrap_config).await?;
+            let mut api_client = data_plane_api_client(&dp, &raw_config).await?;
             handle_dogstatsd_capture(&mut api_client, config)
                 .await
                 .error_context("Failed to start DogStatsD capture")
@@ -196,8 +201,8 @@ async fn run_dogstatsd_command(
         DogstatsdSubcommand::Replay(config) => {
             #[cfg(target_os = "linux")]
             {
-                let mut api_client = data_plane_api_client(bootstrap_config).await?;
-                handle_dogstatsd_replay(&mut api_client, bootstrap_config, config)
+                let mut api_client = data_plane_api_client(&dp, &raw_config).await?;
+                handle_dogstatsd_replay(&mut api_client, &raw_config, config)
                     .await
                     .error_context("Failed to replay DogStatsD traffic")
             }
@@ -218,20 +223,22 @@ async fn run_dogstatsd_command(
             if config.is_offline() {
                 handle_dogstatsd_top(None, config, &mut output).await
             } else {
-                let mut api_client = data_plane_api_client(bootstrap_config).await?;
+                let mut api_client = data_plane_api_client(&dp, &raw_config).await?;
                 handle_dogstatsd_top(Some(&mut api_client), config, &mut output).await
             }
         }
         DogstatsdSubcommand::DumpContexts(_) => {
-            let mut api_client = data_plane_api_client(bootstrap_config).await?;
+            let mut api_client = data_plane_api_client(&dp, &raw_config).await?;
             let mut output = std::io::stdout();
             handle_dogstatsd_dump_contexts(&mut api_client, &mut output).await
         }
     }
 }
 
-async fn data_plane_api_client(config: &GenericConfiguration) -> Result<DataPlaneAPIClient, GenericError> {
-    DataPlaneAPIClient::from_config(config)
+async fn data_plane_api_client(
+    dp: &DataPlaneConfiguration<'_>, raw_config: &GenericConfiguration,
+) -> Result<DataPlaneAPIClient, GenericError> {
+    DataPlaneAPIClient::from_configuration(dp, raw_config)
         .await
         .error_context("Failed to create data plane API client")
 }

--- a/bin/agent-data-plane/src/cli/mod.rs
+++ b/bin/agent-data-plane/src/cli/mod.rs
@@ -18,7 +18,7 @@ mod run;
 pub use self::run::handle_run_command;
 use self::run::RunCommand;
 
-mod utils;
+pub(super) mod utils;
 
 mod version;
 pub use self::version::handle_version_command;

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use agent_data_plane_config::shared::{Endpoints, MetricsEncoding};
-use agent_data_plane_config_system::{ConfigurationSystem, EnvPrecedence, LoadedConfiguration};
+use agent_data_plane_config_system::{ConfigurationSystem, LoadedConfiguration};
 use argh::FromArgs;
 use datadog_agent_commons::platform::PlatformSettings;
 use datadog_agent_config::classifier::{ConfigClassifier, Pipeline, PipelineAffinity, Severity, SupportLevel};
@@ -71,7 +71,8 @@ pub struct RunCommand {
 
 /// Entrypoint for the `run` commands.
 pub async fn handle_run_command(
-    started: Instant, config_path: PathBuf, bootstrap_guard: &mut BootstrapGuard, bootstrap_supervisor: Supervisor,
+    started: Instant, local_config: LoadedConfiguration, bootstrap_guard: &mut BootstrapGuard,
+    bootstrap_supervisor: Supervisor,
 ) -> Result<(), GenericError> {
     let app_details = saluki_metadata::get_app_details();
     info!(
@@ -83,17 +84,8 @@ pub async fn handle_run_command(
         "Agent Data Plane starting..."
     );
 
-    // Load the local configuration sources (file + environment) once. The configuration system owns
-    // the loader wiring; we supply the file path and the environment precedence. Environment
-    // variables sit above the file so ADP-specific overrides (log level, etc.) win.
-    let loaded = LoadedConfiguration::load(&config_path, EnvPrecedence::AfterFile)
-        .await
-        .error_context("Failed to load configuration.")?;
-
-    // A static snapshot of the local sources, used only for decisions the Agent stream can never
-    // change: whether we run standalone, and the remote-agent registration parameters.
-    let bootstrap_dp_config = DataPlaneConfiguration::from_configuration(&loaded.raw_config())
-        .error_context("Failed to load data plane configuration.")?;
+    // Use local sources for decisions required before the Agent configuration stream is available.
+    let bootstrap_dp_config = DataPlaneConfiguration::from_configuration(local_config.local());
     let standalone = bootstrap_dp_config.standalone_mode();
 
     // Resolve the authoritative configuration. Connected mode registers as a remote agent and takes
@@ -101,14 +93,14 @@ pub async fn handle_run_command(
     // authoritative. Both terminals block until the first configuration is received, deserialized,
     // and translated, failing the boot if it cannot be -- the strict startup gate.
     let (config_sys, ra_bootstrap) = if standalone {
-        let config_sys = loaded
+        let config_sys = local_config
             .standalone()
             .await
             .error_context("Failed to load configuration.")?;
         (config_sys, None)
     } else {
         // Blocks until the Core Agent acknowledges registration.
-        let ra_bootstrap = RemoteAgentBootstrap::from_configuration(&loaded.raw_config(), &bootstrap_dp_config)
+        let ra_bootstrap = RemoteAgentBootstrap::from_configuration(&local_config.raw_config(), &bootstrap_dp_config)
             .await
             .error_context("Failed to bootstrap remote agent state.")?;
 
@@ -118,7 +110,7 @@ pub async fn handle_run_command(
         let config_stream = ra_bootstrap.create_config_stream();
 
         info!("Waiting for initial configuration from Datadog Agent...");
-        let config_sys = loaded
+        let config_sys = local_config
             .run(config_stream)
             .await
             .error_context("Failed to load initial configuration from the Datadog Agent.")?;
@@ -126,11 +118,6 @@ pub async fn handle_run_command(
 
         (config_sys, Some(ra_bootstrap))
     };
-
-    // Hand un-migrated components the resolved configuration as the legacy `GenericConfiguration`
-    // they still read from. Raw reads go through `config`; typed/live reads go through `config_sys`.
-    let dp_config = DataPlaneConfiguration::from_configuration(&config_sys.raw_map())
-        .error_context("Failed to load data plane configuration.")?;
 
     // Connected mode may have replaced the bootstrap-phase settings with the Agent's authoritative
     // config, so reload logging to match. Standalone resolves the same local sources seen at
@@ -152,29 +139,36 @@ pub async fn handle_run_command(
         }
     }
 
-    if !standalone && !dp_config.enabled() {
+    let (enabled, active_pipelines) = {
+        let config = config_sys.config();
+        let dp = DataPlaneConfiguration::from_configuration(&config);
+        (dp.enabled(), dp.active_pipelines())
+    };
+
+    if !standalone && !enabled {
         info!("Agent Data Plane is not enabled. Exiting.");
         return Ok(());
     }
 
-    let active_pipelines = active_pipelines(&dp_config);
     check_and_warn_config(&config_sys, &active_pipelines).error_context("Incompatible configuration detected.")?;
 
     // Set up all of the building blocks for building our topologies and launching internal processes.
     let component_registry = ComponentRegistry::default();
     let health_registry = HealthRegistry::new();
-    let (env_provider, maybe_env_supervisor) =
-        ADPEnvironmentProvider::from_configuration(&config_sys, &dp_config, &component_registry, &health_registry)
-            .await?;
+    let (env_provider, maybe_env_supervisor) = ADPEnvironmentProvider::from_configuration(
+        standalone,
+        &config_sys.raw_map(),
+        &component_registry,
+        &health_registry,
+    )
+    .await?;
 
     // Create the blueprint for our primary topology.
-    let (mut blueprint, control_surfaces) =
-        create_topology(&config_sys, &dp_config, &env_provider, &component_registry).await?;
+    let (mut blueprint, control_surfaces) = create_topology(&config_sys, &env_provider, &component_registry).await?;
 
     // Create the internal supervisor which drives our control plane and internal observability.
     let mut internal_supervisor = create_internal_supervisor(
         &config_sys,
-        &dp_config,
         &component_registry,
         health_registry.clone(),
         control_surfaces,
@@ -264,24 +258,6 @@ async fn wait_for_sigint() {
     let _ = tokio::signal::ctrl_c().await;
 
     info!("Received SIGINT, shutting down...");
-}
-
-/// Returns the set of [`Pipeline`] variants that are active based on our configuration.
-fn active_pipelines(dp_config: &DataPlaneConfiguration) -> HashSet<Pipeline> {
-    let mut s = HashSet::new();
-    if dp_config.dogstatsd().enabled() {
-        s.insert(Pipeline::DogStatsD);
-    }
-    if dp_config.checks().enabled() {
-        s.insert(Pipeline::Checks);
-    }
-    if dp_config.otlp().enabled() {
-        s.insert(Pipeline::Otlp);
-    }
-    if dp_config.traces_pipeline_required() {
-        s.insert(Pipeline::Traces);
-    }
-    s
 }
 
 /// Check the resolved configuration against the config registry for incompatibilities.
@@ -377,19 +353,19 @@ fn is_a_pipeline_affected(active_pipelines: &HashSet<Pipeline>, pipeline_affinit
 }
 
 async fn create_topology(
-    config_system: &ConfigurationSystem, dp_config: &DataPlaneConfiguration, env_provider: &ADPEnvironmentProvider,
-    component_registry: &ComponentRegistry,
+    config_system: &ConfigurationSystem, env_provider: &ADPEnvironmentProvider, component_registry: &ComponentRegistry,
 ) -> Result<(TopologyBlueprint, TopologyControlSurfaces), GenericError> {
+    let config = config_system.config();
+    let dp = DataPlaneConfiguration::from_configuration(&config);
     let mut blueprint = TopologyBlueprint::new("primary", component_registry);
-    blueprint.with_shutdown_timeout(dp_config.stop_timeout());
-    let shared_config = config_system.config();
-    let metrics_encoding = shared_config.shared.metrics_encoding.clone();
-    let endpoints = shared_config.shared.endpoints.clone();
+    blueprint.with_shutdown_timeout(dp.stop_timeout());
+    let metrics_encoding = config.shared.metrics_encoding.clone();
+    let endpoints = config.shared.endpoints.clone();
 
     let mut control_surfaces = TopologyControlSurfaces::default();
 
     // If no data pipelines are enabled, then there's nothing for us to do.
-    if !dp_config.data_pipelines_enabled() {
+    if !dp.data_pipelines_enabled() {
         return Err(generic_error!("No data pipelines are enabled. Exiting."));
     }
 
@@ -403,11 +379,11 @@ async fn create_topology(
     // Notably, we _don't_ need either of these if all we're doing is running the OTLP pipeline in proxy mode, which
     // is the only reason we're differentiating here. Connected mode is the exception: liveness deliberately
     // provisions metric and service-check output paths even for proxy-only topologies.
-    if dp_config.metrics_pipeline_required()
-        || dp_config.logs_pipeline_required()
-        || dp_config.events_pipeline_required()
-        || dp_config.service_checks_pipeline_required()
-        || dp_config.traces_pipeline_required()
+    if dp.metrics_pipeline_required()
+        || dp.logs_pipeline_required()
+        || dp.events_pipeline_required()
+        || dp.service_checks_pipeline_required()
+        || dp.traces_pipeline_required()
     {
         let dd_forwarder_config = DatadogForwarderConfiguration::from_configuration_with_metrics_routing(
             &config_system.raw_map(),
@@ -418,55 +394,54 @@ async fn create_topology(
         blueprint.add_forwarder("dd_out", dd_forwarder_config)?;
     }
 
-    if dp_config.metrics_pipeline_required() {
+    if dp.metrics_pipeline_required() {
         add_baseline_metrics_pipeline_to_blueprint(
             &mut blueprint,
-            &config_system.raw_map(),
+            config_system,
             &metrics_encoding,
             &endpoints,
-            dp_config,
             env_provider,
         )
         .await?;
     }
 
-    if dp_config.logs_pipeline_required() {
+    if dp.logs_pipeline_required() {
         add_baseline_logs_pipeline_to_blueprint(&mut blueprint, &config_system.raw_map()).await?;
     }
 
-    if dp_config.events_pipeline_required() {
+    if dp.events_pipeline_required() {
         add_baseline_events_pipeline_to_blueprint(&mut blueprint, &config_system.raw_map()).await?;
     }
 
-    if dp_config.service_checks_pipeline_required() {
+    if dp.service_checks_pipeline_required() {
         add_baseline_service_checks_pipeline_to_blueprint(&mut blueprint, &config_system.raw_map()).await?;
     }
 
-    if dp_config.traces_pipeline_required() {
+    if dp.traces_pipeline_required() {
         add_baseline_traces_pipeline_to_blueprint(&mut blueprint, &config_system.raw_map(), env_provider).await?;
     }
 
     // Connected topologies emit liveness through the metric and service-check baselines created above. Standalone
     // OTLP proxy mode must not construct liveness or output paths that it does not otherwise need.
-    if !dp_config.standalone_mode() {
+    if !dp.standalone_mode() {
         let add_container_tags = config_system.config().shared.basic_telemetry.add_container_tags;
         add_liveness_source_to_blueprint(&mut blueprint, env_provider, add_container_tags).await?;
     }
 
     // Now we move on to our actual data pipelines.
-    if dp_config.checks().enabled() {
+    if dp.checks_enabled() {
         add_checks_pipeline_to_blueprint(&mut blueprint, &config_system.raw_map(), env_provider).await?;
     }
 
-    if dp_config.dogstatsd().enabled() {
+    if dp.dogstatsd_enabled() {
         let dsd_control_surface =
             add_dsd_pipeline_to_blueprint(&mut blueprint, &config_system.raw_map(), config_system, env_provider)
                 .await?;
         control_surfaces.attach_dogstatsd(dsd_control_surface);
     }
 
-    if dp_config.otlp().enabled() {
-        add_otlp_pipeline_to_blueprint(&mut blueprint, config_system, dp_config, env_provider).await?;
+    if dp.otlp_enabled() {
+        add_otlp_pipeline_to_blueprint(&mut blueprint, config_system, env_provider).await?;
     }
 
     Ok((blueprint, control_surfaces))
@@ -508,24 +483,29 @@ async fn add_checks_pipeline_to_blueprint(
 }
 
 async fn add_baseline_metrics_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration, metrics: &MetricsEncoding, endpoints: &Endpoints,
-    dp_config: &DataPlaneConfiguration, env_provider: &ADPEnvironmentProvider,
+    blueprint: &mut TopologyBlueprint, config_system: &ConfigurationSystem, metrics: &MetricsEncoding,
+    endpoints: &Endpoints, env_provider: &ADPEnvironmentProvider,
 ) -> Result<(), GenericError> {
     // Create the back half of the metrics processing pipeline.
     let host_enrichment_config = HostEnrichmentConfiguration::from_environment_provider(env_provider.clone());
     let mut metrics_enrich_config =
         ChainedConfiguration::default().with_transform_builder("host_enrichment", host_enrichment_config);
 
-    if !dp_config.standalone_mode() {
-        let host_tags_config = HostTagsConfiguration::from_configuration(config)?;
+    let config = config_system.config();
+    let dp = DataPlaneConfiguration::from_configuration(&config);
+    if !dp.standalone_mode() {
+        let host_tags_config = HostTagsConfiguration::from_configuration(&config_system.raw_map())?;
         if host_tags_config.enabled() {
             metrics_enrich_config = metrics_enrich_config.with_transform_builder("host_tags", host_tags_config);
         }
     }
 
-    let dd_metrics_config =
-        DatadogMetricsConfiguration::from_configuration_with_metrics_routing(config, metrics, endpoints)
-            .error_context("Failed to configure Datadog Metrics encoder.")?;
+    let dd_metrics_config = DatadogMetricsConfiguration::from_configuration_with_metrics_routing(
+        &config_system.raw_map(),
+        metrics,
+        endpoints,
+    )
+    .error_context("Failed to configure Datadog Metrics encoder.")?;
 
     blueprint
         // Components.
@@ -534,8 +514,8 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
         // Metrics, then forwarding.
         .connect_components_in_order(["metrics_enrich", "dd_metrics_encode", "dd_out"])?;
 
-    add_mrf_metrics_pipeline_to_blueprint(blueprint, config, metrics, endpoints)?;
-    add_autoscaling_failover_metrics_pipeline_to_blueprint(blueprint, config, metrics, endpoints)?;
+    add_mrf_metrics_pipeline_to_blueprint(blueprint, &config_system.raw_map(), metrics, endpoints)?;
+    add_autoscaling_failover_metrics_pipeline_to_blueprint(blueprint, &config_system.raw_map(), metrics, endpoints)?;
 
     Ok(())
 }
@@ -870,14 +850,15 @@ async fn add_dsd_pipeline_to_blueprint(
 }
 
 async fn add_otlp_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config_system: &ConfigurationSystem, dp_config: &DataPlaneConfiguration,
-    env_provider: &ADPEnvironmentProvider,
+    blueprint: &mut TopologyBlueprint, config_system: &ConfigurationSystem, env_provider: &ADPEnvironmentProvider,
 ) -> Result<(), GenericError> {
-    if dp_config.otlp().proxy().enabled() {
-        let core_agent_otlp_grpc_endpoint = dp_config.otlp().proxy().core_agent_otlp_grpc_endpoint().to_string();
-        let proxy_metrics = dp_config.otlp().proxy().proxy_metrics();
-        let proxy_logs = dp_config.otlp().proxy().proxy_logs();
-        let proxy_traces = dp_config.otlp().proxy().proxy_traces();
+    let config = config_system.config();
+    let dp = DataPlaneConfiguration::from_configuration(&config);
+    if dp.otlp_proxy_enabled() {
+        let core_agent_otlp_grpc_endpoint = config.domains.otlp.proxy.grpc_endpoint.clone();
+        let proxy_metrics = config.domains.otlp.proxy.metrics_enabled;
+        let proxy_logs = config.domains.otlp.proxy.logs_enabled;
+        let proxy_traces = config.domains.otlp.proxy.traces_enabled;
 
         info!(
             proxy_grpc_endpoint = %core_agent_otlp_grpc_endpoint,
@@ -901,7 +882,7 @@ async fn add_otlp_pipeline_to_blueprint(
             // Metrics and logs directly to the forwarders.
             .connect_components(["otlp_relay_in.metrics", "otlp_relay_in.logs"], "local_agent_otlp_out")?;
 
-        if dp_config.otlp().proxy().proxy_traces() {
+        if proxy_traces {
             blueprint.connect_components("otlp_relay_in.traces", "local_agent_otlp_out")?;
         } else {
             blueprint

--- a/bin/agent-data-plane/src/cli/utils.rs
+++ b/bin/agent-data-plane/src/cli/utils.rs
@@ -18,6 +18,7 @@ use saluki_io::net::{
     ListenAddress,
 };
 use serde::{Deserialize, Serialize};
+use tracing::error;
 
 use crate::{config::DataPlaneConfiguration, dogstatsd_contexts::CONTEXT_DUMP_ROUTE};
 
@@ -25,6 +26,19 @@ use crate::{config::DataPlaneConfiguration, dogstatsd_contexts::CONTEXT_DUMP_ROU
 pub struct DataPlaneAPIClient {
     client: HttpClient,
     authority: String,
+}
+
+/// Builds a data plane API client or exits after logging the error.
+pub(super) async fn api_or_exit(
+    dp: &DataPlaneConfiguration<'_>, raw_config: &GenericConfiguration,
+) -> DataPlaneAPIClient {
+    match DataPlaneAPIClient::from_configuration(dp, raw_config).await {
+        Ok(client) => client,
+        Err(e) => {
+            error!("Failed to create data plane API client: {:#}", e);
+            std::process::exit(1);
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -47,17 +61,22 @@ struct DogStatsDReplaySessionResponseBody {
 }
 
 impl DataPlaneAPIClient {
-    /// Creates a new `DataPlaneAPIClient` from the given generic configuration.
+    /// Creates a new `DataPlaneAPIClient` from the typed data plane configuration.
+    ///
+    /// The listen address for the privileged API comes from the typed model. The shared Agent IPC identity does not: the
+    /// schema overlay excludes `ipc_cert_file_path` and `auth_token_file_path`, so they are deliberately absent from
+    /// `SalukiConfiguration` and are still read by key, the same way the privileged API server reads them.
     ///
     /// # Errors
     ///
-    /// If the data plane or IPC authentication configuration can't be loaded, the IPC certificate can't be read or
-    /// parsed into a client TLS configuration, the privileged API endpoint isn't connection-oriented, or the HTTP
-    /// client can't be constructed, an error is returned.
-    pub async fn from_config(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let dp_config = DataPlaneConfiguration::from_configuration(config)
-            .error_context("Failed to load data plane configuration for privileged API client.")?;
-        let ipc_config = IpcAuthConfiguration::from_configuration(config)
+    /// If the IPC authentication configuration can't be loaded, the IPC certificate can't be read or parsed into a
+    /// client TLS configuration, the privileged API endpoint isn't connection-oriented, or the HTTP client can't be
+    /// constructed, an error is returned.
+    pub async fn from_configuration(
+        dp: &DataPlaneConfiguration<'_>, raw_config: &GenericConfiguration,
+    ) -> Result<Self, GenericError> {
+        let listen_address = dp.secure_api_listen_address()?;
+        let ipc_config = IpcAuthConfiguration::from_configuration(raw_config)
             .error_context("Failed to load IPC authentication configuration for privileged API client.")?;
 
         let ipc_cert_file_path = ipc_config.ipc_cert_file_path();
@@ -70,7 +89,7 @@ impl DataPlaneAPIClient {
                 )
             })?;
         let builder = HttpClient::builder().with_client_tls_config(client_tls_config);
-        Self::from_builder(builder, dp_config.secure_api_listen_address())
+        Self::from_builder(builder, &listen_address)
     }
 
     fn from_builder(builder: HttpClientBuilder, listen_address: &ListenAddress) -> Result<Self, GenericError> {

--- a/bin/agent-data-plane/src/cli/utils.rs
+++ b/bin/agent-data-plane/src/cli/utils.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use agent_data_plane_config_system::LoadedConfiguration;
 use datadog_agent_commons::ipc::{config::IpcAuthConfiguration, tls::build_ipc_client_ipc_tls_config};
 use futures::TryFutureExt as _;
 use http::{header::CONTENT_TYPE, uri::PathAndQuery, Request, Response, StatusCode, Uri};
@@ -11,7 +12,6 @@ use hyper::body::Bytes;
 use hyper::body::Incoming;
 #[cfg(target_os = "linux")]
 use prost::Message as _;
-use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use saluki_io::net::{
     client::http::{HttpClient, HttpClientBuilder},
@@ -29,10 +29,8 @@ pub struct DataPlaneAPIClient {
 }
 
 /// Builds a data plane API client or exits after logging the error.
-pub(super) async fn api_or_exit(
-    dp: &DataPlaneConfiguration<'_>, raw_config: &GenericConfiguration,
-) -> DataPlaneAPIClient {
-    match DataPlaneAPIClient::from_configuration(dp, raw_config).await {
+pub(super) async fn get_api_client_or_exit(local_config: &LoadedConfiguration) -> DataPlaneAPIClient {
+    match DataPlaneAPIClient::from_configuration(local_config).await {
         Ok(client) => client,
         Err(e) => {
             error!("Failed to create data plane API client: {:#}", e);
@@ -63,20 +61,17 @@ struct DogStatsDReplaySessionResponseBody {
 impl DataPlaneAPIClient {
     /// Creates a new `DataPlaneAPIClient` from the typed data plane configuration.
     ///
-    /// The listen address for the privileged API comes from the typed model. The shared Agent IPC identity does not: the
-    /// schema overlay excludes `ipc_cert_file_path` and `auth_token_file_path`, so they are deliberately absent from
-    /// `SalukiConfiguration` and are still read by key, the same way the privileged API server reads them.
-    ///
     /// # Errors
     ///
     /// If the IPC authentication configuration can't be loaded, the IPC certificate can't be read or parsed into a
     /// client TLS configuration, the privileged API endpoint isn't connection-oriented, or the HTTP client can't be
     /// constructed, an error is returned.
-    pub async fn from_configuration(
-        dp: &DataPlaneConfiguration<'_>, raw_config: &GenericConfiguration,
-    ) -> Result<Self, GenericError> {
+    pub async fn from_configuration(loaded_config: &LoadedConfiguration) -> Result<Self, GenericError> {
+        let config = loaded_config.local();
+        let raw_config = loaded_config.raw_config();
+        let dp = DataPlaneConfiguration::from_configuration(config);
         let listen_address = dp.secure_api_listen_address()?;
-        let ipc_config = IpcAuthConfiguration::from_configuration(raw_config)
+        let ipc_config = IpcAuthConfiguration::from_configuration(&raw_config)
             .error_context("Failed to load IPC authentication configuration for privileged API client.")?;
 
         let ipc_cert_file_path = ipc_config.ipc_cert_file_path();

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -34,7 +34,7 @@ impl<'a> DataPlaneConfiguration<'a> {
     /// Returns the topology shutdown timeout.
     ///
     /// Uses `data_plane.stop_timeout` when configured. Otherwise, it sums `aggregator_stop_timeout`
-    /// and `forwarder_stop_timeout`, returning 4 seconds if the sum overflows.
+    /// and `forwarder_stop_timeout`, returning `Duration::MAX` if the sum overflows.
     pub fn stop_timeout(&self) -> Duration {
         match self.config.control.stop_timeout {
             Some(timeout) => timeout,
@@ -42,9 +42,7 @@ impl<'a> DataPlaneConfiguration<'a> {
                 .config
                 .control
                 .aggregator_stop_timeout
-                .checked_add(self.config.shared.endpoints.forwarder.stop_timeout)
-                // arbitrary fallback in case of overflow
-                .unwrap_or(Duration::from_secs(4)),
+                .saturating_add(self.config.shared.endpoints.forwarder.stop_timeout),
         }
     }
 

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -1,99 +1,109 @@
+use std::collections::HashSet;
 use std::time::Duration;
 
-use saluki_config::GenericConfiguration;
+use agent_data_plane_config::SalukiConfiguration;
+use datadog_agent_config::classifier::Pipeline;
 use saluki_error::{generic_error, GenericError};
 use saluki_io::net::ListenAddress;
 
 /// General data plane configuration.
+///
+/// This wrapper provides orchestration-level accessors and pipeline decisions over the typed configuration. It lives
+/// during bootstrap and topology construction and is then discarded.
 #[derive(Clone, Debug)]
-pub struct DataPlaneConfiguration {
-    enabled: bool,
-    standalone_mode: bool,
-    stop_timeout: Duration,
-    api_listen_address: ListenAddress,
-    secure_api_listen_address: ListenAddress,
-    checks: DataPlaneChecksConfiguration,
-    dogstatsd: DataPlaneDogStatsDConfiguration,
-    otlp: DataPlaneOtlpConfiguration,
+pub struct DataPlaneConfiguration<'a> {
+    config: &'a SalukiConfiguration,
 }
 
-impl DataPlaneConfiguration {
+impl<'a> DataPlaneConfiguration<'a> {
     /// Creates a new `DataPlaneConfiguration` instance from the given configuration.
-    ///
-    /// # Errors
-    ///
-    /// If the configuration can't be deserialized, an error is returned.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        // TODO: We're explicitly querying each individual field from the configuration because if we don't, then our
-        // environment variable overrides end up requiring double underscores to indicate nesting (i.e. we have to do
-        // `DD_DATA_PLANE__OTLP__ENABLED` instead of just `DD_DATA_PLANE_OTLP_ENABLED`). I find this personally ugly,
-        // and it would also fly in the face of environment variable naming conventions for existing Agent settings.
-        //
-        // In the future, we plan on updating `saluki-config` to allow us to support both deserializing from "native"
-        // nested data like JSON/YAML as well as with the idiomatically-named environment variables.
-        Ok(Self {
-            enabled: config.try_get_typed("data_plane.enabled")?.unwrap_or(false),
-            standalone_mode: config.try_get_typed("data_plane.standalone_mode")?.unwrap_or(false),
-            stop_timeout: topology_stop_timeout_from_configuration(config)?,
-            api_listen_address: config
-                .try_get_typed("data_plane.api_listen_address")?
-                .unwrap_or_else(|| ListenAddress::any_tcp(5100)),
-            secure_api_listen_address: config
-                .try_get_typed("data_plane.secure_api_listen_address")?
-                .unwrap_or_else(|| ListenAddress::any_tcp(5101)),
-            checks: DataPlaneChecksConfiguration::from_configuration(config)?,
-            dogstatsd: DataPlaneDogStatsDConfiguration::from_configuration(config)?,
-            otlp: DataPlaneOtlpConfiguration::from_configuration(config)?,
-        })
+    pub fn from_configuration(config: &'a SalukiConfiguration) -> Self {
+        Self { config }
     }
 
     /// Returns `true` if the data plane is enabled.
     pub const fn enabled(&self) -> bool {
-        self.enabled
+        self.config.control.enabled
     }
 
     /// Returns `true` if the data plane is running in standalone mode.
     pub const fn standalone_mode(&self) -> bool {
-        self.standalone_mode
+        self.config.control.standalone_mode
     }
 
     /// Returns the topology shutdown timeout.
-    pub const fn stop_timeout(&self) -> Duration {
-        self.stop_timeout
+    ///
+    /// Uses `data_plane.stop_timeout` when configured. Otherwise, it sums `aggregator_stop_timeout`
+    /// and `forwarder_stop_timeout`, returning 4 seconds if the sum overflows.
+    pub fn stop_timeout(&self) -> Duration {
+        match self.config.control.stop_timeout {
+            Some(timeout) => timeout,
+            None => self
+                .config
+                .control
+                .aggregator_stop_timeout
+                .checked_add(self.config.shared.endpoints.forwarder.stop_timeout)
+                // arbitrary fallback in case of overflow
+                .unwrap_or(Duration::from_secs(4)),
+        }
     }
 
-    /// Returns a reference to the API listen address
+    /// Resolves the API listen address.
     ///
     /// This is also referred to as the "unprivileged" API.
-    pub const fn api_listen_address(&self) -> &ListenAddress {
-        &self.api_listen_address
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the configured value is not a valid listen address.
+    pub fn api_listen_address(&self) -> Result<ListenAddress, GenericError> {
+        ListenAddress::try_from(self.config.control.api_listen_address.as_str())
+            .map_err(|e| generic_error!("Invalid listen address for `data_plane.api_listen_address`: {}", e))
     }
 
-    /// Returns a reference to the secure, or privileged, API listen address.
+    /// Resolves the secure, or privileged, API listen address.
     ///
     /// Every HTTP and gRPC client must present the exact configured Agent IPC certificate during the TLS handshake.
-    pub const fn secure_api_listen_address(&self) -> &ListenAddress {
-        &self.secure_api_listen_address
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the configured value is not a valid listen address.
+    pub fn secure_api_listen_address(&self) -> Result<ListenAddress, GenericError> {
+        ListenAddress::try_from(self.config.control.secure_api_listen_address.as_str()).map_err(|e| {
+            generic_error!(
+                "Invalid listen address for `data_plane.secure_api_listen_address`: {}",
+                e
+            )
+        })
     }
 
-    /// Returns a reference to the Checks-specific data plane configuration.
-    pub const fn checks(&self) -> &DataPlaneChecksConfiguration {
-        &self.checks
+    /// Returns `true` if Checks is enabled.
+    pub const fn checks_enabled(&self) -> bool {
+        self.config.control.checks
     }
 
-    /// Returns a reference to the DogStatsD-specific data plane configuration.
-    pub const fn dogstatsd(&self) -> &DataPlaneDogStatsDConfiguration {
-        &self.dogstatsd
+    /// Returns `true` if DogStatsD is enabled.
+    pub const fn dogstatsd_enabled(&self) -> bool {
+        self.config.control.dogstatsd
     }
 
-    /// Returns a reference to the OTLP-specific data plane configuration.
-    pub const fn otlp(&self) -> &DataPlaneOtlpConfiguration {
-        &self.otlp
+    /// Returns `true` if the OTLP pipeline is enabled.
+    pub const fn otlp_enabled(&self) -> bool {
+        self.config.control.otlp
+    }
+
+    /// Returns `true` if the OTLP proxy is enabled.
+    pub const fn otlp_proxy_enabled(&self) -> bool {
+        self.config.domains.otlp.proxy.enabled
+    }
+
+    /// Returns `true` if OTLP traces should be proxied to the Core Agent.
+    pub const fn otlp_proxy_traces_enabled(&self) -> bool {
+        self.config.domains.otlp.proxy.traces_enabled
     }
 
     /// Returns `true` if any data pipelines are enabled.
     pub const fn data_pipelines_enabled(&self) -> bool {
-        self.checks().enabled() || self.dogstatsd().enabled() || self.otlp().enabled()
+        self.checks_enabled() || self.dogstatsd_enabled() || self.otlp_enabled()
     }
 
     /// Returns `true` if the metrics pipeline is required.
@@ -102,9 +112,9 @@ impl DataPlaneConfiguration {
     /// enriched and forwarded, including when the only data pipeline is an OTLP proxy. Standalone mode only creates
     /// the pipeline for data sources that use it directly.
     pub const fn metrics_pipeline_required(&self) -> bool {
-        self.checks().enabled()
-            || self.dogstatsd().enabled()
-            || (self.otlp().enabled() && !self.otlp().proxy().enabled())
+        self.checks_enabled()
+            || self.dogstatsd_enabled()
+            || (self.otlp_enabled() && !self.otlp_proxy_enabled())
             || (!self.standalone_mode() && self.data_pipelines_enabled())
     }
 
@@ -116,7 +126,7 @@ impl DataPlaneConfiguration {
         // We consider the logs pipeline to be enabled if:
         // - Checks is enabled
         // - OTLP is enabled and not in proxy mode
-        self.checks().enabled() || (self.otlp().enabled() && !self.otlp().proxy().enabled())
+        self.checks_enabled() || (self.otlp_enabled() && !self.otlp_proxy_enabled())
     }
 
     /// Returns `true` if the events pipeline is required.
@@ -124,7 +134,7 @@ impl DataPlaneConfiguration {
     /// This indicates that the "baseline" events pipeline (encoding, forwarding) is required by higher-level data
     /// pipelines, such as Checks or DogStatsD.
     pub const fn events_pipeline_required(&self) -> bool {
-        self.checks().enabled() || self.dogstatsd().enabled()
+        self.checks_enabled() || self.dogstatsd_enabled()
     }
 
     /// Returns `true` if the service checks pipeline is required.
@@ -133,9 +143,7 @@ impl DataPlaneConfiguration {
     /// be encoded and forwarded, including when the only data pipeline is an OTLP proxy. Standalone mode only creates
     /// the pipeline for data sources that use it directly.
     pub const fn service_checks_pipeline_required(&self) -> bool {
-        self.checks().enabled()
-            || self.dogstatsd().enabled()
-            || (!self.standalone_mode() && self.data_pipelines_enabled())
+        self.checks_enabled() || self.dogstatsd_enabled() || (!self.standalone_mode() && self.data_pipelines_enabled())
     }
 
     /// Returns `true` if the traces pipeline is required.
@@ -145,259 +153,53 @@ impl DataPlaneConfiguration {
     pub const fn traces_pipeline_required(&self) -> bool {
         // We consider the traces pipeline to be enabled if:
         // - OTLP is enabled and not in proxy mode or proxy mode is enabled and proxy traces are disabled
-        self.otlp().enabled() && (!self.otlp().proxy().enabled() || !self.otlp().proxy().proxy_traces())
-    }
-}
-
-fn topology_stop_timeout_from_configuration(config: &GenericConfiguration) -> Result<Duration, GenericError> {
-    if let Some(stop_timeout_secs) = config.try_get_typed::<u64>("data_plane.stop_timeout")? {
-        return Ok(Duration::from_secs(stop_timeout_secs));
+        self.otlp_enabled() && (!self.otlp_proxy_enabled() || !self.otlp_proxy_traces_enabled())
     }
 
-    let aggregator_stop_timeout_secs = config.try_get_typed::<u64>("aggregator_stop_timeout")?.unwrap_or(2);
-    let forwarder_stop_timeout_secs = config.try_get_typed::<u64>("forwarder_stop_timeout")?.unwrap_or(2);
-
-    Duration::from_secs(aggregator_stop_timeout_secs)
-        .checked_add(Duration::from_secs(forwarder_stop_timeout_secs))
-        .ok_or_else(|| generic_error!("Topology stop timeout overflowed."))
-}
-
-/// Checks-specific data plane configuration.
-#[derive(Clone, Debug)]
-pub struct DataPlaneChecksConfiguration {
-    /// Whether Checks is enabled.
-    ///
-    /// When disabled, Checks won't be started.
-    ///
-    /// Defaults to `false`.
-    enabled: bool,
-}
-
-impl DataPlaneChecksConfiguration {
-    fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        Ok(Self {
-            enabled: config.try_get_typed("data_plane.checks.enabled")?.unwrap_or(false),
-        })
-    }
-
-    /// Returns `true` if Checks is enabled.
-    pub const fn enabled(&self) -> bool {
-        self.enabled
-    }
-}
-
-/// DogStatsD-specific data plane configuration.
-#[derive(Clone, Debug)]
-pub struct DataPlaneDogStatsDConfiguration {
-    /// Whether DogStatsD is enabled.
-    ///
-    /// When disabled, DogStatsD won't be started.
-    ///
-    /// Defaults to `true`.
-    enabled: bool,
-}
-
-impl DataPlaneDogStatsDConfiguration {
-    // We intentionally do NOT read the Core Agent's `use_dogstatsd` key here. The Core Agent is the
-    // sole authority on whether ADP should run DogStatsD: it evaluates `use_dogstatsd` (along with
-    // other signals) and sets `data_plane.dogstatsd.enabled` on our behalf. Reading both would risk
-    // ADP and the Core Agent disagreeing. See `docs/agent-data-plane/configuration/configuration.md`.
-    fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        Ok(Self {
-            enabled: config.try_get_typed("data_plane.dogstatsd.enabled")?.unwrap_or(true),
-        })
-    }
-
-    /// Returns `true` if DogStatsD is enabled.
-    pub const fn enabled(&self) -> bool {
-        self.enabled
-    }
-}
-
-/// OTLP-specific data plane configuration.
-#[derive(Clone, Debug)]
-pub struct DataPlaneOtlpConfiguration {
-    enabled: bool,
-    proxy: DataPlaneOtlpProxyConfiguration,
-}
-
-impl DataPlaneOtlpConfiguration {
-    fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        Ok(Self {
-            enabled: config.try_get_typed("data_plane.otlp.enabled")?.unwrap_or(false),
-            proxy: DataPlaneOtlpProxyConfiguration::from_configuration(config)?,
-        })
-    }
-
-    /// Returns `true` if the OTLP pipeline is enabled.
-    pub const fn enabled(&self) -> bool {
-        self.enabled
-    }
-
-    /// Returns a reference to the OTLP proxying configuration.
-    pub const fn proxy(&self) -> &DataPlaneOtlpProxyConfiguration {
-        &self.proxy
-    }
-}
-
-/// OTLP proxying configuration.
-///
-/// In proxy mode, ADP takes over the normal "OTLP Ingest" endpoints that the Core Agent would typically listen on,
-/// so the Core Agent must be configured to listen on a different, separate port than it usually would so that ADP
-/// can proxy to it.
-#[derive(Clone, Debug)]
-#[allow(dead_code)]
-pub struct DataPlaneOtlpProxyConfiguration {
-    /// Whether or not to proxy all signals to the Agent.
-    ///
-    /// When enabled, OTLP signals which aren't supported by ADP will be proxied to the Agent. Depending on the signal
-    /// type, they may be proxied to either the Core Agent or Trace Agent.
-    ///
-    /// Defaults to `true`.
-    enabled: bool,
-
-    /// OTLP gRPC endpoint on the Core Agent to proxy signals to.
-    ///
-    /// Defaults to `http://localhost:4319`.
-    core_agent_otlp_grpc_endpoint: String,
-
-    /// Whether or not to proxy traces to the Core Agent.
-    ///
-    /// Defaults to `true`.
-    proxy_traces: bool,
-
-    /// Whether or not to proxy metrics to the Core Agent.
-    ///
-    /// Defaults to `true`.
-    proxy_metrics: bool,
-
-    /// Whether or not to proxy logs to the Core Agent.
-    ///
-    /// Defaults to `true`.
-    proxy_logs: bool,
-}
-
-impl DataPlaneOtlpProxyConfiguration {
-    fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let enabled = config.try_get_typed("data_plane.otlp.proxy.enabled")?.unwrap_or(false);
-        let core_agent_otlp_grpc_endpoint = config
-            .try_get_typed("data_plane.otlp.proxy.receiver.protocols.grpc.endpoint")?
-            .unwrap_or("http://localhost:4319".to_string());
-        let proxy_traces = config
-            .try_get_typed("data_plane.otlp.proxy.traces.enabled")?
-            .unwrap_or(true);
-        let proxy_metrics = config
-            .try_get_typed("data_plane.otlp.proxy.metrics.enabled")?
-            .unwrap_or(true);
-        let proxy_logs = config
-            .try_get_typed("data_plane.otlp.proxy.logs.enabled")?
-            .unwrap_or(true);
-
-        Ok(Self {
-            enabled,
-            core_agent_otlp_grpc_endpoint,
-            proxy_traces,
-            proxy_metrics,
-            proxy_logs,
-        })
-    }
-
-    /// Returns `true` if the OTLP proxy is enabled.
-    pub const fn enabled(&self) -> bool {
-        self.enabled
-    }
-
-    /// Returns the OTLP gRPC endpoint on the Core Agent to proxy signals to.
-    pub fn core_agent_otlp_grpc_endpoint(&self) -> &str {
-        &self.core_agent_otlp_grpc_endpoint
-    }
-
-    /// Returns `true` if the OTLP traces should be proxied to the Core Agent.
-    pub const fn proxy_traces(&self) -> bool {
-        self.proxy_traces
-    }
-
-    /// Returns `true` if the OTLP metrics should be proxied to the Core Agent.
-    pub const fn proxy_metrics(&self) -> bool {
-        self.proxy_metrics
-    }
-
-    /// Returns `true` if the OTLP logs should be proxied to the Core Agent.
-    pub const fn proxy_logs(&self) -> bool {
-        self.proxy_logs
+    /// Returns the set of [`Pipeline`] variants that are active based on our configuration.
+    pub fn active_pipelines(&self) -> HashSet<Pipeline> {
+        let mut s = HashSet::new();
+        if self.dogstatsd_enabled() {
+            s.insert(Pipeline::DogStatsD);
+        }
+        if self.checks_enabled() {
+            s.insert(Pipeline::Checks);
+        }
+        if self.otlp_enabled() {
+            s.insert(Pipeline::Otlp);
+        }
+        if self.traces_pipeline_required() {
+            s.insert(Pipeline::Traces);
+        }
+        s
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use saluki_config::config_from;
-    use serde_json::json;
-
     use super::*;
 
-    async fn dp_config_from(value: serde_json::Value) -> DataPlaneConfiguration {
-        DataPlaneConfiguration::from_configuration(&config_from(value).await)
-            .expect("data plane configuration should parse")
-    }
-
-    // ADP ignores `use_dogstatsd`. The Core Agent evaluates that key and delivers the resolved
-    // decision to ADP by setting `data_plane.dogstatsd.enabled` via the config stream.
-
-    #[tokio::test]
-    async fn default_enables_dogstatsd() {
-        let dp = dp_config_from(json!({ "data_plane": { "enabled": true } })).await;
-        assert!(dp.enabled());
-        assert!(dp.dogstatsd().enabled());
-    }
-
-    #[tokio::test]
-    async fn use_dogstatsd_false_does_not_disable_dogstatsd_by_default() {
-        let dp = dp_config_from(json!({ "use_dogstatsd": false, "data_plane": { "enabled": true } })).await;
-        assert!(dp.enabled());
-        assert!(dp.dogstatsd().enabled());
-    }
-
-    #[tokio::test]
-    async fn explicit_false_disables_dogstatsd() {
-        let dp = dp_config_from(json!({ "data_plane": { "enabled": true, "dogstatsd": { "enabled": false } } })).await;
-        assert!(dp.enabled());
-        assert!(!dp.dogstatsd().enabled());
-    }
-
-    #[tokio::test]
-    async fn use_dogstatsd_true_does_not_override_explicit_false() {
-        // `use_dogstatsd=true` must not enable DSD when `data_plane.dogstatsd.enabled=false` is
-        // set explicitly. ADP reads only its own key.
-        let dp = dp_config_from(json!({
-            "use_dogstatsd": true,
-            "data_plane": { "enabled": true, "dogstatsd": { "enabled": false } },
-        }))
-        .await;
-        assert!(dp.enabled());
-        assert!(!dp.dogstatsd().enabled());
-    }
-
-    #[tokio::test]
-    async fn use_dogstatsd_false_does_not_disable_dogstatsd_when_explicitly_enabled() {
-        // `use_dogstatsd=false` must not disable DSD when `data_plane.dogstatsd.enabled=true` is
-        // set explicitly. The Core Agent communicates its resolved decision via that key.
-        let dp = dp_config_from(json!({
-            "use_dogstatsd": false,
-            "data_plane": { "enabled": true, "dogstatsd": { "enabled": true } },
-        }))
-        .await;
-        assert!(dp.enabled());
-        assert!(dp.dogstatsd().enabled());
+    fn pipeline_configuration(
+        checks_enabled: bool, dogstatsd_enabled: bool, otlp_enabled: bool, otlp_proxy_enabled: bool,
+        otlp_proxy_traces_enabled: bool,
+    ) -> SalukiConfiguration {
+        let mut config = SalukiConfiguration::default();
+        config.control.checks = checks_enabled;
+        config.control.dogstatsd = dogstatsd_enabled;
+        config.control.otlp = otlp_enabled;
+        config.domains.otlp.proxy.enabled = otlp_proxy_enabled;
+        config.domains.otlp.proxy.traces_enabled = otlp_proxy_traces_enabled;
+        config
     }
 
     // Pipeline-requirement predicates. Each scenario is chosen to walk one documented branch of the
     // `*_pipeline_required` predicates on `DataPlaneConfiguration`, asserting the full predicate set so that a
     // regression in any single predicate surfaces.
 
-    #[tokio::test]
-    async fn default_dogstatsd_only_requires_metrics_events_and_service_checks_pipelines() {
-        // Only DogStatsD is enabled (it defaults to on); Checks and OTLP are off.
-        let dp = dp_config_from(json!({ "data_plane": { "enabled": true } })).await;
+    #[test]
+    fn dogstatsd_only_requires_metrics_events_and_service_checks_pipelines() {
+        let config = pipeline_configuration(false, true, false, false, false);
+        let dp = DataPlaneConfiguration::from_configuration(&config);
 
         assert!(dp.data_pipelines_enabled());
         assert!(dp.metrics_pipeline_required());
@@ -407,17 +209,10 @@ mod tests {
         assert!(!dp.traces_pipeline_required());
     }
 
-    #[tokio::test]
-    async fn checks_enabled_requires_every_pipeline_except_traces() {
-        let dp = dp_config_from(json!({
-            "data_plane": {
-                "enabled": true,
-                "checks": { "enabled": true },
-                "dogstatsd": { "enabled": false },
-                "otlp": { "enabled": false },
-            },
-        }))
-        .await;
+    #[test]
+    fn checks_enabled_requires_every_pipeline_except_traces() {
+        let config = pipeline_configuration(true, false, false, false, false);
+        let dp = DataPlaneConfiguration::from_configuration(&config);
 
         assert!(dp.data_pipelines_enabled());
         assert!(dp.metrics_pipeline_required());
@@ -427,16 +222,10 @@ mod tests {
         assert!(!dp.traces_pipeline_required());
     }
 
-    #[tokio::test]
-    async fn otlp_without_proxy_requires_metrics_logs_and_traces_pipelines() {
-        let dp = dp_config_from(json!({
-            "data_plane": {
-                "enabled": true,
-                "dogstatsd": { "enabled": false },
-                "otlp": { "enabled": true, "proxy": { "enabled": false } },
-            },
-        }))
-        .await;
+    #[test]
+    fn otlp_without_proxy_requires_metrics_logs_and_traces_pipelines() {
+        let config = pipeline_configuration(false, false, true, false, false);
+        let dp = DataPlaneConfiguration::from_configuration(&config);
 
         assert!(dp.data_pipelines_enabled());
         assert!(dp.metrics_pipeline_required());
@@ -446,18 +235,12 @@ mod tests {
         assert!(dp.traces_pipeline_required());
     }
 
-    #[tokio::test]
-    async fn standalone_otlp_proxy_mode_does_not_require_liveness_baseline_pipelines() {
+    #[test]
+    fn standalone_otlp_proxy_mode_does_not_require_liveness_baseline_pipelines() {
         // Standalone OTLP proxy mode must only construct the local proxy path, which avoids resolving output endpoints.
-        let dp = dp_config_from(json!({
-            "data_plane": {
-                "enabled": true,
-                "standalone_mode": true,
-                "dogstatsd": { "enabled": false },
-                "otlp": { "enabled": true, "proxy": { "enabled": true } },
-            },
-        }))
-        .await;
+        let mut config = pipeline_configuration(false, false, true, true, true);
+        config.control.standalone_mode = true;
+        let dp = DataPlaneConfiguration::from_configuration(&config);
 
         assert!(dp.data_pipelines_enabled());
         assert!(!dp.metrics_pipeline_required());
@@ -467,16 +250,12 @@ mod tests {
         assert!(!dp.traces_pipeline_required());
     }
 
-    #[tokio::test]
-    async fn connected_otlp_proxy_mode_requires_liveness_baseline_pipelines() {
-        let dp = dp_config_from(json!({
-            "data_plane": {
-                "enabled": true,
-                "dogstatsd": { "enabled": false },
-                "otlp": { "enabled": true, "proxy": { "enabled": true } },
-            },
-        }))
-        .await;
+    #[test]
+    fn connected_otlp_proxy_mode_requires_liveness_baseline_pipelines() {
+        // Connected mode still forwards the liveness metric and service check, so those baselines stay required even
+        // when every OTLP signal is proxied.
+        let config = pipeline_configuration(false, false, true, true, true);
+        let dp = DataPlaneConfiguration::from_configuration(&config);
 
         assert!(dp.data_pipelines_enabled());
         assert!(dp.metrics_pipeline_required());
@@ -486,21 +265,12 @@ mod tests {
         assert!(!dp.traces_pipeline_required());
     }
 
-    #[tokio::test]
-    async fn otlp_proxy_mode_with_local_traces_requires_liveness_and_traces_pipelines() {
+    #[test]
+    fn otlp_proxy_mode_with_local_traces_requires_liveness_and_traces_pipelines() {
         // Proxy mode is enabled but trace proxying is turned off, so ADP must handle traces locally. The liveness
         // metric and service-check baselines remain required regardless of the OTLP routing.
-        let dp = dp_config_from(json!({
-            "data_plane": {
-                "enabled": true,
-                "dogstatsd": { "enabled": false },
-                "otlp": {
-                    "enabled": true,
-                    "proxy": { "enabled": true, "traces": { "enabled": false } },
-                },
-            },
-        }))
-        .await;
+        let config = pipeline_configuration(false, false, true, true, false);
+        let dp = DataPlaneConfiguration::from_configuration(&config);
 
         assert!(dp.data_pipelines_enabled());
         assert!(dp.metrics_pipeline_required());
@@ -510,17 +280,10 @@ mod tests {
         assert!(dp.traces_pipeline_required());
     }
 
-    #[tokio::test]
-    async fn topology_without_data_pipelines_requires_no_baseline_pipelines() {
-        let dp = dp_config_from(json!({
-            "data_plane": {
-                "enabled": true,
-                "checks": { "enabled": false },
-                "dogstatsd": { "enabled": false },
-                "otlp": { "enabled": false },
-            },
-        }))
-        .await;
+    #[test]
+    fn no_pipelines_enabled_requires_no_baseline_pipelines() {
+        let config = pipeline_configuration(false, false, false, false, false);
+        let dp = DataPlaneConfiguration::from_configuration(&config);
 
         assert!(!dp.data_pipelines_enabled());
         assert!(!dp.metrics_pipeline_required());
@@ -530,57 +293,34 @@ mod tests {
         assert!(!dp.traces_pipeline_required());
     }
 
-    // Stop-timeout resolution: explicit override, default, sum of Core Agent component timeouts, and overflow.
-
-    #[tokio::test]
-    async fn data_plane_stop_timeout_overrides_core_agent_shutdown_timeout_sum() {
-        let dp = dp_config_from(json!({
-            "aggregator_stop_timeout": 3,
-            "forwarder_stop_timeout": 7,
-            "data_plane": { "stop_timeout": 11 },
-        }))
-        .await;
+    #[test]
+    fn stop_timeout_uses_saluki_override() {
+        let mut config = SalukiConfiguration::default();
+        config.control.stop_timeout = Some(Duration::from_secs(11));
+        config.control.aggregator_stop_timeout = Duration::from_secs(3);
+        config.shared.endpoints.forwarder.stop_timeout = Duration::from_secs(7);
+        let dp = DataPlaneConfiguration::from_configuration(&config);
 
         assert_eq!(dp.stop_timeout(), Duration::from_secs(11));
     }
 
-    #[tokio::test]
-    async fn stop_timeout_defaults_to_sum_of_core_agent_component_defaults() {
-        // With neither `data_plane.stop_timeout` nor the Core Agent component timeouts set, the timeout falls back
-        // to the sum of the documented per-component defaults (2s aggregator + 2s forwarder).
-        let dp = dp_config_from(json!({ "data_plane": { "enabled": true } })).await;
-
-        assert_eq!(dp.stop_timeout(), Duration::from_secs(4));
-    }
-
-    #[tokio::test]
-    async fn stop_timeout_sums_core_agent_component_timeouts() {
-        // Without a `data_plane.stop_timeout` override, the timeout is the sum of the aggregator and forwarder
-        // stop timeouts.
-        let dp = dp_config_from(json!({
-            "aggregator_stop_timeout": 3,
-            "forwarder_stop_timeout": 7,
-        }))
-        .await;
+    #[test]
+    fn stop_timeout_sums_component_timeouts() {
+        let mut config = SalukiConfiguration::default();
+        config.control.aggregator_stop_timeout = Duration::from_secs(3);
+        config.shared.endpoints.forwarder.stop_timeout = Duration::from_secs(7);
+        let dp = DataPlaneConfiguration::from_configuration(&config);
 
         assert_eq!(dp.stop_timeout(), Duration::from_secs(10));
     }
 
-    #[tokio::test]
-    async fn stop_timeout_overflow_is_rejected() {
-        // When the summed Core Agent component timeouts overflow a `Duration`, `from_configuration` surfaces an
-        // error rather than silently wrapping.
-        let config = config_from(json!({
-            "aggregator_stop_timeout": 9_223_372_036_854_775_808_u64,
-            "forwarder_stop_timeout": 9_223_372_036_854_775_808_u64,
-        }))
-        .await;
+    #[test]
+    fn stop_timeout_uses_fallback_when_sum_overflows() {
+        let mut config = SalukiConfiguration::default();
+        config.control.aggregator_stop_timeout = Duration::MAX;
+        config.shared.endpoints.forwarder.stop_timeout = Duration::from_secs(1);
+        let dp = DataPlaneConfiguration::from_configuration(&config);
 
-        let error = DataPlaneConfiguration::from_configuration(&config)
-            .expect_err("summed stop timeout should overflow and be rejected");
-        assert!(
-            error.to_string().contains("stop timeout overflowed"),
-            "unexpected error message: {error}"
-        );
+        assert_eq!(dp.stop_timeout(), Duration::from_secs(4));
     }
 }

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -313,12 +313,12 @@ mod tests {
     }
 
     #[test]
-    fn stop_timeout_uses_fallback_when_sum_overflows() {
+    fn stop_timeout_saturates_when_sum_overflows() {
         let mut config = SalukiConfiguration::default();
         config.control.aggregator_stop_timeout = Duration::MAX;
         config.shared.endpoints.forwarder.stop_timeout = Duration::from_secs(1);
         let dp = DataPlaneConfiguration::from_configuration(&config);
 
-        assert_eq!(dp.stop_timeout(), Duration::from_secs(4));
+        assert_eq!(dp.stop_timeout(), Duration::MAX);
     }
 }

--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -35,11 +35,13 @@ use crate::{
 ///
 /// If the supervisor can't be created, an error is returned.
 pub async fn create_control_plane_supervisor(
-    config: &ConfigurationSystem, dp_config: &DataPlaneConfiguration, component_registry: &ComponentRegistry,
-    health_registry: HealthRegistry, control_surfaces: TopologyControlSurfaces,
-    ra_bootstrap: Option<RemoteAgentBootstrap>, logging_controller: LoggingOverrideController,
-    current_config: Arc<ArcSwap<SalukiConfiguration>>,
+    config_system: &ConfigurationSystem, component_registry: &ComponentRegistry, health_registry: HealthRegistry,
+    control_surfaces: TopologyControlSurfaces, ra_bootstrap: Option<RemoteAgentBootstrap>,
+    logging_controller: LoggingOverrideController, current_config: Arc<ArcSwap<SalukiConfiguration>>,
 ) -> Result<Supervisor, GenericError> {
+    let config = config_system.config();
+    let dp = DataPlaneConfiguration::from_configuration(&config);
+    let raw_map = config_system.raw_map();
     let mut supervisor = Supervisor::new("ctrl-pln")?
         .with_dedicated_runtime(RuntimeConfiguration::single_threaded())
         .with_restart_strategy(RestartStrategy::one_to_one());
@@ -47,20 +49,19 @@ pub async fn create_control_plane_supervisor(
     supervisor.add_worker(health_registry.worker());
     supervisor.add_worker(ResourceTelemetryWorker::new(component_registry));
     supervisor.add_worker(InternalTelemetryAPIWorker::new());
-    supervisor.add_worker(DynamicLogLevelWorker::new(&config.raw_map(), logging_controller));
-    supervisor.add_worker(ConfigWorker::new(config.raw_map()));
+    supervisor.add_worker(DynamicLogLevelWorker::new(&raw_map, logging_controller));
+    supervisor.add_worker(ConfigWorker::new(raw_map.clone()));
     supervisor.add_worker(ConfigRuntimeWorker::new(current_config));
 
-    supervisor.add_worker(DynamicAPIBuilder::new(
-        EndpointType::Unprivileged,
-        dp_config.api_listen_address().clone(),
-    ));
-    let ipc_config = IpcAuthConfiguration::from_configuration(&config.raw_map())?;
+    let api_listen_address = dp.api_listen_address()?;
+    let secure_api_listen_address = dp.secure_api_listen_address()?;
+
+    supervisor.add_worker(DynamicAPIBuilder::new(EndpointType::Unprivileged, api_listen_address));
+    let ipc_config = IpcAuthConfiguration::from_configuration(&raw_map)?;
     let tls_config = build_ipc_server_tls_config(ipc_config.ipc_cert_file_path()).await?;
 
     let mut privileged_api =
-        DynamicAPIBuilder::new(EndpointType::Privileged, dp_config.secure_api_listen_address().clone())
-            .with_tls_config(tls_config);
+        DynamicAPIBuilder::new(EndpointType::Privileged, secure_api_listen_address).with_tls_config(tls_config);
 
     privileged_api = control_surfaces.register_control_surfaces(privileged_api);
 

--- a/bin/agent-data-plane/src/internal/env/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/mod.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-use agent_data_plane_config_system::ConfigurationSystem;
+use saluki_config::GenericConfiguration;
 use saluki_core::accounting::ComponentRegistry;
 use saluki_core::health::HealthRegistry;
 use saluki_core::runtime::Supervisor;
@@ -12,8 +12,6 @@ use saluki_env::{
 };
 use saluki_error::GenericError;
 use tracing::warn;
-
-use crate::config::DataPlaneConfiguration;
 
 mod autodiscovery;
 pub use self::autodiscovery::RemoteAgentAutodiscoveryProvider;
@@ -56,17 +54,15 @@ impl ADPEnvironmentProvider {
     /// In standalone mode, no supervisor is returned as all behavior/functionality is either provided via
     /// fixed configuration or operates in a no-op fashion.
     pub async fn from_configuration(
-        config: &ConfigurationSystem, dp_config: &DataPlaneConfiguration, component_registry: &ComponentRegistry,
+        standalone: bool, raw_map: &GenericConfiguration, component_registry: &ComponentRegistry,
         health_registry: &HealthRegistry,
     ) -> Result<(Self, Option<Supervisor>), GenericError> {
         // When we're in standalone mode, all of our functionality is either fixed or a no-op.
-        if dp_config.standalone_mode() {
+        if standalone {
             warn!("Running in standalone mode. Origin detection/enrichment and other features dependent upon the Datadog Agent will not be available.");
 
             let env = Self {
-                host_provider: BoxedHostProvider::from_provider(FixedHostProvider::from_configuration(
-                    &config.raw_map(),
-                )?),
+                host_provider: BoxedHostProvider::from_provider(FixedHostProvider::from_configuration(raw_map)?),
                 workload_provider: None,
                 autodiscovery_provider: None,
                 health_registry: health_registry.clone(),
@@ -77,15 +73,14 @@ impl ADPEnvironmentProvider {
         // Otherwise, construct our real providers that will interact directly with the Datadog Agent.
         let mut env_supervisor = Supervisor::new("env-provider")?;
 
-        let host_provider = RemoteAgentHostProvider::from_configuration(&config.raw_map(), component_registry).await?;
+        let host_provider = RemoteAgentHostProvider::from_configuration(raw_map, component_registry).await?;
 
         let (workload_provider, workload_supervisor) =
-            RemoteAgentWorkloadProvider::from_configuration(&config.raw_map(), component_registry, health_registry)
-                .await?;
+            RemoteAgentWorkloadProvider::from_configuration(raw_map, component_registry, health_registry).await?;
         env_supervisor.add_worker(workload_supervisor);
 
         let (autodiscovery_provider, autodiscovery_supervisor) =
-            RemoteAgentAutodiscoveryProvider::from_configuration(&config.raw_map()).await?;
+            RemoteAgentAutodiscoveryProvider::from_configuration(raw_map).await?;
         env_supervisor.add_worker(autodiscovery_supervisor);
 
         let env = Self {

--- a/bin/agent-data-plane/src/internal/mod.rs
+++ b/bin/agent-data-plane/src/internal/mod.rs
@@ -9,8 +9,6 @@ use saluki_core::health::HealthRegistry;
 use saluki_core::runtime::Supervisor;
 use saluki_error::GenericError;
 
-use crate::config::DataPlaneConfiguration;
-
 mod config_runtime;
 
 mod control_plane;
@@ -41,10 +39,9 @@ mod telemetry;
 ///
 /// If the supervisor can't be created, an error is returned.
 pub async fn create_internal_supervisor(
-    config: &ConfigurationSystem, dp_config: &DataPlaneConfiguration, component_registry: &ComponentRegistry,
-    health_registry: HealthRegistry, control_surfaces: TopologyControlSurfaces,
-    ra_bootstrap: Option<RemoteAgentBootstrap>, logging_controller: LoggingOverrideController,
-    current_config: Arc<ArcSwap<SalukiConfiguration>>,
+    config: &ConfigurationSystem, component_registry: &ComponentRegistry, health_registry: HealthRegistry,
+    control_surfaces: TopologyControlSurfaces, ra_bootstrap: Option<RemoteAgentBootstrap>,
+    logging_controller: LoggingOverrideController, current_config: Arc<ArcSwap<SalukiConfiguration>>,
 ) -> Result<Supervisor, GenericError> {
     // The root supervisor runs in ambient mode (caller's runtime) since its children each have their own
     // dedicated runtimes. The default restart strategy (one-for-one, 1 restart per 5s) applies to the child
@@ -55,7 +52,6 @@ pub async fn create_internal_supervisor(
     root.add_worker(
         create_control_plane_supervisor(
             config,
-            dp_config,
             component_registry,
             health_registry.clone(),
             control_surfaces,

--- a/bin/agent-data-plane/src/internal/remote_agent.rs
+++ b/bin/agent-data-plane/src/internal/remote_agent.rs
@@ -85,10 +85,11 @@ impl RemoteAgentBootstrap {
     /// # Errors
     ///
     /// If the configuration is invalid, an error is returned.
-    pub async fn from_configuration(
-        config: &GenericConfiguration, dp_config: &DataPlaneConfiguration,
+    pub async fn from_configuration<'a>(
+        config: &GenericConfiguration, dp_config: &DataPlaneConfiguration<'a>,
     ) -> Result<Self, GenericError> {
-        let api_listen_addr = GrpcTargetAddress::try_from_listen_addr(dp_config.secure_api_listen_address())
+        let secure_api_listen_address = dp_config.secure_api_listen_address()?;
+        let api_listen_addr = GrpcTargetAddress::try_from_listen_addr(&secure_api_listen_address)
             .ok_or_else(|| generic_error!("Failed to get valid gRPC target address from secure API listen address."))?;
 
         // Generate our remote agent state, which is mostly fixed but has a few dynamic bits.

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -5,10 +5,9 @@
 
 #![deny(warnings)]
 #![deny(missing_docs)]
-use std::path::{Path, PathBuf};
-use std::time::Instant;
+use std::{path::Path, time::Instant};
 
-use agent_data_plane_config_system::EnvironmentProvider;
+use agent_data_plane_config_system::{EnvPrecedence, LoadedConfiguration};
 // Pull in the Antithesis coverage-instrumentation runtime shim only when
 // building for antithesis. Load-baring: equired to avoid the shim being dropped
 // as unused.
@@ -17,7 +16,7 @@ use antithesis_instrumentation as _;
 use datadog_agent_commons::platform::PlatformSettings;
 use metrics::Level;
 use saluki_app::bootstrap::{AppBootstrapper, Bootstrap, BootstrapGuard};
-use saluki_config::{ConfigurationLoader, GenericConfiguration};
+use saluki_config::GenericConfiguration;
 use saluki_core::runtime::Supervisor;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use tracing::{error, info, warn};
@@ -61,23 +60,23 @@ async fn main() -> Result<(), GenericError> {
     // Load our "bootstrap" configuration -- static configuration on disk or from environment variables -- so we can
     // initialize basic subsystems before executing the given subcommand.
     let bootstrap_config_path = cli.config_file.unwrap_or_else(PlatformSettings::get_config_file_path);
-    let bootstrap_config = load_bootstrap_config(&bootstrap_config_path)?.bootstrap_generic();
+    let local_config = load_bootstrap_config(&bootstrap_config_path).await?;
 
     // Translate the bootstrap configuration into ADP's logging configuration, applying ADP-specific rules
     // (per-subagent log file key, never sharing a file with the Core Agent).
-    let mut bootstrap_logging_config = LoggingConfigurationTranslator::translate(&bootstrap_config)
+    let mut bootstrap_logging_config = LoggingConfigurationTranslator::translate(&local_config.raw_config())
         .error_context("Failed to translate logging configuration during bootstrap phase.")?;
     if matches!(&cli.action, Action::Config(command) if command.json) {
         bootstrap_logging_config.log_to_console = false;
     }
 
-    let metrics_default_level = parse_metrics_level(&bootstrap_config)?;
+    let metrics_default_level = parse_metrics_level(&local_config.raw_config())?;
 
     // Proceed with bootstrapping.
     //
     // This initializes logging, metrics, allocator telemetry, TLS, and more. We get handled a guard that we need to
     // hold until the application is about to exit, which ensures things like flushing any buffered logs, and so on.
-    let bootstrapper = AppBootstrapper::from_configuration(&bootstrap_config)
+    let bootstrapper = AppBootstrapper::from_configuration(&local_config.raw_config())
         .error_context("Failed to parse bootstrap configuration during bootstrap phase.")?
         .with_metrics_prefix("adp")
         .with_metrics_default_level(metrics_default_level)
@@ -100,8 +99,7 @@ async fn main() -> Result<(), GenericError> {
     let maybe_exit_code = run_inner(
         cli.action,
         started,
-        bootstrap_config_path,
-        bootstrap_config,
+        local_config,
         &mut bootstrap_guard,
         bootstrap_supervisor,
     )
@@ -143,22 +141,14 @@ fn initialize_antithesis() {
 
 /// Loads bootstrap configuration from the on-disk file and environment
 /// variables.
-fn load_bootstrap_config(bootstrap_config_path: &Path) -> Result<ConfigurationLoader, GenericError> {
-    let loaded = ConfigurationLoader::default()
-        .from_yaml(bootstrap_config_path)
-        .error_context("Failed to load Datadog Agent configuration file during bootstrap.")
-        .and_then(|loader| {
-            loader
-                .from_environment(PlatformSettings::get_env_var_prefix())
-                .error_context("Environment variable prefix should not be empty.")
-        })
-        .and_then(|loader| {
-            // Modeled keys are also contributed at their canonical (potentially nested) paths, so a
-            // consumer reading the Datadog Agent's own configuration shape sees environment values
-            // where it expects them.
-            let provider = EnvironmentProvider::new()
-                .map_err(|message| generic_error!("Failed to read configuration from the environment: {}", message))?;
-            Ok(loader.add_providers([provider]))
+async fn load_bootstrap_config(bootstrap_config_path: &Path) -> Result<LoadedConfiguration, GenericError> {
+    let loaded = LoadedConfiguration::load(bootstrap_config_path, EnvPrecedence::AfterFile)
+        .await
+        .with_error_context(|| {
+            format!(
+                "Failed to load local configuration from {} and the environment",
+                bootstrap_config_path.display()
+            )
         });
     // A graceful config rejection exits 1 rather than crashing; classify that against a clean boot.
     saluki_antithesis::always_or_unreachable!(
@@ -182,8 +172,8 @@ fn parse_metrics_level(config: &GenericConfiguration) -> Result<Level, GenericEr
 }
 
 async fn run_inner(
-    action: Action, started: Instant, config_path: PathBuf, bootstrap_config: GenericConfiguration,
-    bootstrap_guard: &mut BootstrapGuard, bootstrap_supervisor: Supervisor,
+    action: Action, started: Instant, local_config: LoadedConfiguration, bootstrap_guard: &mut BootstrapGuard,
+    bootstrap_supervisor: Supervisor,
 ) -> Result<Option<i32>, GenericError> {
     match action {
         Action::Run(cmd) => {
@@ -196,9 +186,8 @@ async fn run_inner(
                 }
             }
 
-            // `Run` owns the full configuration lifecycle, so it takes the config path and builds the
-            // loader itself; the static `bootstrap_config` serves only the other subcommands below.
-            let exit_code = match handle_run_command(started, config_path, bootstrap_guard, bootstrap_supervisor).await
+            // `Run` consumes the local configuration and selects its runtime authority.
+            let exit_code = match handle_run_command(started, local_config, bootstrap_guard, bootstrap_supervisor).await
             {
                 Ok(()) => {
                     info!("Agent Data Plane stopped.");
@@ -225,9 +214,9 @@ async fn run_inner(
 
             return Ok(exit_code);
         }
-        Action::Debug(cmd) => handle_debug_command(&bootstrap_config, cmd).await,
-        Action::Config(cmd) => handle_config_command(&bootstrap_config, cmd).await,
-        Action::Dogstatsd(cmd) => handle_dogstatsd_command(&bootstrap_config, cmd).await,
+        Action::Debug(cmd) => handle_debug_command(local_config, cmd).await,
+        Action::Config(cmd) => handle_config_command(local_config, cmd).await,
+        Action::Dogstatsd(cmd) => handle_dogstatsd_command(local_config, cmd).await,
         Action::Version(v) => handle_version_command(v.json).await,
     }
 

--- a/lib/agent-data-plane-config-system/src/saluki_only.rs
+++ b/lib/agent-data-plane-config-system/src/saluki_only.rs
@@ -68,7 +68,6 @@
 
 use std::{num::NonZeroUsize, time::Duration};
 
-use agent_data_plane_config::control::ListenAddress;
 use agent_data_plane_config::defaults::{DEFAULT_STRING_INTERNER_SIZE_BYTES, MAX_STRING_INTERNER_SIZE_BYTES};
 use agent_data_plane_config::domains::traces::{OttlErrorMode, OttlFilter, OttlTransform};
 use agent_data_plane_config::SalukiConfiguration;
@@ -171,6 +170,9 @@ pub struct SalukiOnly {
 #[serde(default)]
 pub struct DataPlane {
     /// ADP graceful shutdown timeout, in seconds (`data_plane.stop_timeout`).
+    ///
+    /// If present, this will override the Datadog schema's `aggregator_stop_timeout` and
+    /// `forwarder_stop_timeout` values.
     pub stop_timeout: Option<u64>,
     /// Whether ADP runs in standalone mode (`data_plane.standalone_mode`).
     pub standalone_mode: Option<bool>,
@@ -391,9 +393,7 @@ impl SalukiOnly {
     /// of fields, so it does not matter whether `seed` runs before or after the drive.
     pub(crate) fn seed(&self, config: &mut SalukiConfiguration) {
         // control
-        if let Some(v) = self.data_plane.stop_timeout {
-            config.control.stop_timeout = v;
-        }
+        config.control.stop_timeout = self.data_plane.stop_timeout.map(Duration::from_secs);
         if let Some(v) = self.data_plane.standalone_mode {
             config.control.standalone_mode = v;
         }
@@ -563,8 +563,8 @@ impl SalukiOnly {
         }
 
         // domains.checks
-        if let Some(v) = self.checks_ipc_endpoint.clone() {
-            config.domains.checks.ipc_endpoint = ListenAddress(v);
+        if let Some(v) = &self.checks_ipc_endpoint {
+            config.domains.checks.ipc_endpoint = v.clone();
         }
     }
 }
@@ -660,7 +660,7 @@ mod tests {
         saluki_only.seed(&mut config);
 
         // control
-        assert_eq!(config.control.stop_timeout, 45);
+        assert_eq!(config.control.stop_timeout, Some(Duration::from_secs(45)));
         assert!(config.control.standalone_mode);
         assert!(config.control.checks);
         assert_eq!(config.control.memory_limit, ByteSize::mb(512).as_u64());
@@ -732,7 +732,7 @@ mod tests {
         );
 
         // domains.checks
-        assert_eq!(config.domains.checks.ipc_endpoint.0, "localhost:5006");
+        assert_eq!(config.domains.checks.ipc_endpoint, "localhost:5006");
     }
 
     /// `memory_limit` is a byte size the source may express as a bare integer (bytes) or a suffixed

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -3,7 +3,7 @@
 //! [`DatadogTranslator`] implements [`DatadogConfigWitness`], so the generated `drive` calls each
 //! `consume_<key>` exactly once with the corresponding value from `DatadogConfiguration`. Each
 //! method converts the Datadog value (`i64`, `String`, `Vec<serde_json::Value>`, ...) into the
-//! refined model type (`u16`, `Duration`, `PathBuf`, `ListenAddress`, an enum, ...) and assigns it
+//! refined model type (`u16`, `Duration`, `PathBuf`, an enum, ...) and assigns it
 //! to its `SalukiConfiguration` destination.
 //!
 //! Most keys assign a single field directly. The endpoint keys (`api_key`, `dd_url`, `site`,
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use agent_data_plane_config::control::ListenAddress;
 use agent_data_plane_config::domains::dogstatsd::{
     FilterAction, MapperProfile, MetricMapping, MetricTagFilterEntry, OriginTagCardinality,
 };
@@ -43,6 +42,8 @@ pub(crate) struct DatadogTranslator<'a> {
     config: SalukiConfiguration,
     errors: Vec<TranslateError>,
 }
+
+type Result<T> = std::result::Result<T, TranslateError>;
 
 impl<'a> DatadogTranslator<'a> {
     /// Creates a translator that will read from `datadog`.
@@ -120,7 +121,7 @@ fn to_port(value: i64) -> u16 {
 /// `Vec<serde_json::Value>`. This parser imposes the typed model shape via a local
 /// `#[derive(Deserialize)]` shim, mirroring how the `saluki-components` `dogstatsd_mapper`
 /// deserializes profiles.
-fn parse_mapper_profile(key: &str, raw: serde_json::Value) -> Result<MapperProfile, TranslateError> {
+fn parse_mapper_profile(key: &str, raw: serde_json::Value) -> Result<MapperProfile> {
     #[derive(serde::Deserialize)]
     struct RawMapping {
         #[serde(rename = "match")]
@@ -228,7 +229,12 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_aggregator_stop_timeout(&mut self, value: i64) {
-        self.config.control.aggregator_stop_timeout = value.max(0) as u64;
+        // The schema explicitly says this value is denominated in seconds. We disambiguate here at
+        // the earliest possible opportunity.
+        match parse_seconds("aggregator_stop_timeout", value) {
+            Ok(duration) => self.config.control.aggregator_stop_timeout = duration,
+            Err(e) => self.record_error(e),
+        }
     }
 
     fn consume_allow_arbitrary_tags(&mut self, value: bool) {
@@ -405,7 +411,7 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_data_plane_api_listen_address(&mut self, value: String) {
-        self.config.control.api_listen_address = ListenAddress(value);
+        self.config.control.api_listen_address = value;
     }
 
     fn consume_data_plane_dogstatsd_aggregator_tag_filter_cache_capacity(&mut self, value: i64) {
@@ -457,7 +463,7 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_data_plane_secure_api_listen_address(&mut self, value: String) {
-        self.config.control.secure_api_listen_address = ListenAddress(value);
+        self.config.control.secure_api_listen_address = value;
     }
 
     fn consume_data_plane_use_new_config_stream_endpoint(&mut self, value: bool) {
@@ -722,7 +728,12 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_forwarder_stop_timeout(&mut self, value: i64) {
-        self.config.shared.endpoints.forwarder.stop_timeout = value.max(0) as u64;
+        // The schema explicitly says this value is denominated in seconds. We disambiguate here at
+        // the earliest possible opportunity.
+        match parse_seconds("forwarder_stop_timeout", value) {
+            Ok(duration) => self.config.shared.endpoints.forwarder.stop_timeout = duration,
+            Err(e) => self.record_error(e),
+        }
     }
 
     fn consume_forwarder_storage_max_disk_ratio(&mut self, value: f64) {
@@ -1144,6 +1155,14 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     fn translate_errors(&mut self) -> Vec<TranslateError> {
         std::mem::take(&mut self.errors)
     }
+}
+
+/// A helper to parse values in the schema that are denominated in seconds (per documentation) but
+/// represented as i64 values.
+fn parse_seconds(key: &str, value: i64) -> Result<Duration> {
+    let seconds =
+        u64::try_from(value).map_err(|e| TranslateError::new_with_context(key, "invalid duration seconds value", e))?;
+    Ok(Duration::from_secs(seconds))
 }
 
 #[cfg(test)]

--- a/lib/agent-data-plane-config/src/control.rs
+++ b/lib/agent-data-plane-config/src/control.rs
@@ -4,14 +4,9 @@
 //! components. It carries pipeline activation gates, topology-shaping decisions, listen addresses,
 //! logging (read before topology exists), bootstrap IPC parameters, and process-lifecycle knobs.
 
-use serde::Serialize;
+use std::time::Duration;
 
-/// A network listen address (for example, `tcp://127.0.0.1:5000`, `unix:///var/run/dsd.sock`).
-///
-/// Held as the source string; the orchestration layer parses it when binding. Source-agnostic and
-/// `Default`-able (unlike `std::net::SocketAddr`), so the model can derive `Default`.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
-pub struct ListenAddress(pub String);
+use serde::Serialize;
 
 /// Topology gates and orchestration decisions. Static for the process lifetime.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
@@ -40,10 +35,11 @@ pub struct ControlConfiguration {
     pub use_new_config_stream_endpoint: bool,
 
     /// Address the unsecured control API listens on.
-    pub api_listen_address: ListenAddress,
+    pub api_listen_address: String,
 
-    /// Listen address for the mutually authenticated control API, which requires TLS client certificates.
-    pub secure_api_listen_address: ListenAddress,
+    /// Address the mutually authenticated control API listens on. Every HTTP and gRPC client must
+    /// present the exact configured Agent IPC certificate during the TLS handshake.
+    pub secure_api_listen_address: String,
 
     /// Logging configuration, read before runtime authority exists.
     pub logging: Logging,
@@ -51,12 +47,14 @@ pub struct ControlConfiguration {
     /// Bootstrap IPC and remote-agent connection parameters.
     pub ipc: ControlIpc,
 
-    /// Grace period, in seconds, the aggregator is given to flush before shutdown.
-    pub aggregator_stop_timeout: u64,
+    /// Grace period the aggregator is given to flush before shutdown.
+    pub aggregator_stop_timeout: Duration,
 
-    /// Grace period, in seconds, for the whole topology to shut down. (not in Datadog Agent config
-    /// schema)
-    pub stop_timeout: u64,
+    /// Override for the topology shutdown grace period.
+    ///
+    /// Defaults to `None`. When absent, the topology timeout is the sum of
+    /// `aggregator_stop_timeout` and `forwarder_stop_timeout`.
+    pub stop_timeout: Option<Duration>,
 
     /// Process memory ceiling, in bytes. (not in Datadog Agent config schema)
     pub memory_limit: u64,

--- a/lib/agent-data-plane-config/src/domains/checks.rs
+++ b/lib/agent-data-plane-config/src/domains/checks.rs
@@ -4,13 +4,11 @@
 
 use serde::Serialize;
 
-use crate::control::ListenAddress;
-
 // TODO: better name than Domain? Pipeline? Topology? BlueprintConfig?
 /// Resolved checks configuration.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct Domain {
     /// Address the checks pipeline exposes for IPC with the core Agent. This is a Saluki-only field,
     /// seeded from the Saluki-only source; it is absent from the Datadog Agent config schema.
-    pub ipc_endpoint: ListenAddress,
+    pub ipc_endpoint: String,
 }

--- a/lib/agent-data-plane-config/src/lib.rs
+++ b/lib/agent-data-plane-config/src/lib.rs
@@ -22,7 +22,7 @@ pub mod domains;
 pub mod live;
 pub mod shared;
 
-pub use control::{ControlConfiguration, ListenAddress, Logging};
+pub use control::{ControlConfiguration, Logging};
 pub use domains::DomainConfiguration;
 pub use live::Live;
 pub use shared::SharedConfiguration;

--- a/lib/agent-data-plane-config/src/shared.rs
+++ b/lib/agent-data-plane-config/src/shared.rs
@@ -204,8 +204,8 @@ pub struct Forwarder {
     /// Maximum total size, in bytes, of payloads held in the retry queue.
     pub retry_queue_payloads_max_size: Option<u64>,
 
-    /// Grace period, in seconds, the forwarder is given to drain before shutdown.
-    pub stop_timeout: u64,
+    /// Grace period the forwarder is given to drain before shutdown.
+    pub stop_timeout: Duration,
 
     /// Fraction of available disk the on-disk retry store may use.
     pub storage_max_disk_ratio: f64,

--- a/lib/saluki-components/src/forwarders/otlp/mod.rs
+++ b/lib/saluki-components/src/forwarders/otlp/mod.rs
@@ -260,7 +260,9 @@ fn normalize_endpoint(endpoint: &str) -> String {
     if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
         endpoint.to_string()
     } else {
-        format!("https://{}", endpoint)
+        // Agent configuration defaults to 127.0.0.1:4319 intending http://localhost:4319, so http:// is the right
+        // fallback protocol.
+        format!("http://{}", endpoint)
     }
 }
 
@@ -269,14 +271,14 @@ mod tests {
     use super::normalize_endpoint;
 
     #[test]
-    fn normalize_endpoint_prepends_https_only_when_scheme_missing() {
-        // Endpoints that already carry an `http://`/`https://` scheme are passed through untouched; anything else
-        // (a bare host:port, as the Core Agent gRPC endpoint is typically configured) gets an `https://` prefix.
+    fn normalize_endpoint_defaults_to_plaintext_when_scheme_is_missing() {
+        // Preserve explicit transport security. Bare endpoints use plaintext; TLS callers must
+        // provide an `https://` scheme.
         let cases = [
             ("http://localhost:4317", "http://localhost:4317"),
             ("https://api.datadoghq.com:443", "https://api.datadoghq.com:443"),
-            ("localhost:4317", "https://localhost:4317"),
-            ("127.0.0.1:5003", "https://127.0.0.1:5003"),
+            ("localhost:4317", "http://localhost:4317"),
+            ("127.0.0.1:4319", "http://127.0.0.1:4319"),
         ];
 
         for (input, expected) in cases {


### PR DESCRIPTION
## Human Summary

In this PR we are migrating `DataPlaneConfiguration` to use typed config. This is a bit more involved than migrating a component to typed config because `DataPlaneConfiguration` is involved in system startup.

Several of the related startup-config sub-types proved to be unnecessary and were deleted. However `DataPlaneConfiguration` remains a nice abstraction because it offers some additional logic helpers over the pure configuration values. It is retained but its guts become typed config.

## AI Summary

 - Make LoadedConfiguration the single authoritative configuration snapshot used during startup.
 - Replace the duplicate raw-map DataPlaneConfiguration with a borrowed decision view over the typed configuration.
 - Route startup, pipeline, topology, API, control-plane, and subcommand decisions through the typed model.
 - Keep configuration-layer endpoint values as text and resolve runtime ListenAddress values only at their consumers, removing unnecessary saluki-io coupling.
 - Convert source-level timeout values to Duration at the configuration boundary and remove obsolete defaults and manual implementations.
 - Preserve the plaintext http:// fallback for bare Core Agent OTLP endpoints.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

We are relying on the existing integration and correctness tests not breaking. Unit tests have been added, removed and changed as dictated by the code changes.

## References

- Progresses #2197
- Progresses #2169