### PR TITLE
enhancement(metrics): add new attribute macro for defining static metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4576,6 +4576,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "saluki-metrics-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "saluki-tls"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
   "lib/saluki-io",
   "lib/saluki-metadata",
   "lib/saluki-metrics",
+  "lib/saluki-metrics-macros",
   "lib/saluki-tls",
   "lib/stringtheory",
   "test/antithesis/harness",
@@ -76,6 +77,7 @@ saluki-error = { path = "lib/saluki-error" }
 saluki-io = { path = "lib/saluki-io" }
 saluki-metadata = { path = "lib/saluki-metadata" }
 saluki-metrics = { path = "lib/saluki-metrics" }
+saluki-metrics-macros = { path = "lib/saluki-metrics-macros" }
 saluki-tls = { path = "lib/saluki-tls" }
 stele = { path = "bin/correctness/stele" }
 stringtheory = { path = "lib/stringtheory" }
@@ -136,6 +138,8 @@ pastey = { version = "0.2", default-features = false }
 pin-project = { version = "1.1", default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
 prettyplease = { version = "0.2", features = ["verbatim"] }
+proc-macro2 = { version = "1", default-features = false, features = ["proc-macro"] }
+quote = { version = "1", default-features = false, features = ["proc-macro"] }
 derive-where = { version = "1.6", default-features = false }
 proptest = { version = "1.11", default-features = false, features = ["std"] }
 prost = { version = "0.14", default-features = false }

--- a/lib/saluki-metrics-macros/Cargo.toml
+++ b/lib/saluki-metrics-macros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "saluki-metrics-macros"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+
+[lib]
+proc-macro = true
+
+[lints]
+workspace = true
+
+[dependencies]
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, features = ["clone-impls", "derive", "printing", "proc-macro"] }

--- a/lib/saluki-metrics-macros/src/lib.rs
+++ b/lib/saluki-metrics-macros/src/lib.rs
@@ -1,0 +1,419 @@
+//! Procedural macros for `saluki-metrics`.
+//!
+//! This crate provides the [`static_metrics`] attribute macro. It is an implementation detail of `saluki-metrics` and
+//! should be used through the re-export there (`saluki_metrics::static_metrics`) rather than depended on directly.
+
+#![deny(missing_docs)]
+
+use proc_macro::TokenStream;
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::{format_ident, quote};
+use syn::{parse::Parser, Fields, Ident, ItemStruct, LitStr, Type};
+
+/// Defines a container struct of statically defined metrics.
+///
+/// Applied to a struct whose fields are metric handles, this generates the registration, accessors, and metadata for
+/// the whole group. It is re-exported (and intended to be used) as `saluki_metrics::static_metrics`.
+///
+/// Because it rewrites the annotated struct, it must appear **before** any `#[derive(...)]` on the struct.
+///
+/// # Fields
+///
+/// Every field must be typed as `Counter`, `Gauge`, or `Histogram` (from the `metrics` crate, re-exported by
+/// `saluki-metrics`). Each field becomes one registered metric whose name is `"<prefix>_<field_name>"`.
+///
+/// # Arguments
+///
+/// - `prefix = <ident>` (**required**): a bare identifier prefixed to every metric name, for example `prefix = cache`.
+/// - `labels(a, b, ...)` (optional): the names of labels applied to every metric in the group. The label *values*
+///   are supplied to the generated `new()` and may be of any type implementing `saluki_metrics::Stringable`.
+///
+/// # Field attributes
+///
+/// - `#[metric(level = info | debug | trace)]` (optional, default `info`): the metric's verbosity level.
+///
+/// # Generated code
+///
+/// For a struct `Foo`, this generates `Foo::new(<label>, ...) -> Foo` (generic over each label value's type), a
+/// `Foo::<field>(&self) -> &<Handle>` accessor per metric, a `Foo::<field>_name() -> &'static str` helper, and a
+/// `Debug` implementation that prints only the struct name. `Clone` is not generated; derive it directly where needed.
+#[proc_macro_attribute]
+pub fn static_metrics(attr: TokenStream, item: TokenStream) -> TokenStream {
+    expand(attr.into(), item.into())
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+/// The metric kind, inferred from a field's declared type.
+#[derive(Clone, Copy)]
+enum MetricKind {
+    Counter,
+    Gauge,
+    Histogram,
+}
+
+impl MetricKind {
+    /// Returns the `metrics` registration macro name for this kind (`counter`/`gauge`/`histogram`).
+    fn macro_ident(self) -> Ident {
+        match self {
+            MetricKind::Counter => format_ident!("counter"),
+            MetricKind::Gauge => format_ident!("gauge"),
+            MetricKind::Histogram => format_ident!("histogram"),
+        }
+    }
+}
+
+/// The verbosity level of a metric.
+#[derive(Clone, Copy)]
+enum Level {
+    Info,
+    Debug,
+    Trace,
+}
+
+impl Level {
+    /// Returns the fully qualified `metrics::Level` variant for this level.
+    fn to_tokens(self) -> TokenStream2 {
+        match self {
+            Level::Info => quote! { ::saluki_metrics::reexport::metrics::Level::INFO },
+            Level::Debug => quote! { ::saluki_metrics::reexport::metrics::Level::DEBUG },
+            Level::Trace => quote! { ::saluki_metrics::reexport::metrics::Level::TRACE },
+        }
+    }
+}
+
+/// A single metric parsed from a struct field.
+struct MetricField {
+    ident: Ident,
+    ty: Type,
+    kind: MetricKind,
+    level: Level,
+}
+
+/// The struct-level configuration parsed from the attribute arguments.
+struct Container {
+    prefix: Ident,
+    labels: Vec<Ident>,
+}
+
+fn parse_container(attr: TokenStream2) -> syn::Result<Container> {
+    let mut prefix = None;
+    let mut labels = Vec::new();
+
+    let parser = syn::meta::parser(|meta| {
+        if meta.path.is_ident("prefix") {
+            // The prefix is a bare identifier, matching the declarative `static_metrics!` macro (`prefix => cache`).
+            // Parsing it as an `Ident` deliberately rejects a quoted `prefix = "cache"`.
+            let value: Ident = meta.value()?.parse()?;
+            prefix = Some(value);
+            Ok(())
+        } else if meta.path.is_ident("labels") {
+            meta.parse_nested_meta(|label| {
+                let ident = label
+                    .path
+                    .get_ident()
+                    .ok_or_else(|| label.error("label names must be simple identifiers"))?
+                    .clone();
+                labels.push(ident);
+                Ok(())
+            })
+        } else {
+            Err(meta.error("unknown `static_metrics` argument; expected `prefix` or `labels`"))
+        }
+    });
+    parser.parse2(attr)?;
+
+    let prefix = prefix.ok_or_else(|| {
+        syn::Error::new(
+            Span::call_site(),
+            "`static_metrics` requires a `prefix = <ident>` argument",
+        )
+    })?;
+
+    Ok(Container { prefix, labels })
+}
+
+/// Infers the metric kind from a field's type, matching on the last path segment so both `Counter` and
+/// `metrics::Counter` resolve.
+fn metric_kind(ty: &Type) -> Option<MetricKind> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+
+    match type_path.path.segments.last()?.ident.to_string().as_str() {
+        "Counter" => Some(MetricKind::Counter),
+        "Gauge" => Some(MetricKind::Gauge),
+        "Histogram" => Some(MetricKind::Histogram),
+        _ => None,
+    }
+}
+
+fn parse_field(field: &syn::Field) -> syn::Result<MetricField> {
+    let ident = field
+        .ident
+        .clone()
+        .ok_or_else(|| syn::Error::new_spanned(field, "metric fields must be named"))?;
+    let ty = field.ty.clone();
+    let kind = metric_kind(&ty).ok_or_else(|| {
+        syn::Error::new_spanned(
+            &field.ty,
+            "metric field type must be `Counter`, `Gauge`, or `Histogram`",
+        )
+    })?;
+
+    let mut level = Level::Info;
+    for attr in &field.attrs {
+        if !attr.path().is_ident("metric") {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("level") {
+                let value: Ident = meta.value()?.parse()?;
+                level = match value.to_string().as_str() {
+                    "info" => Level::Info,
+                    "debug" => Level::Debug,
+                    "trace" => Level::Trace,
+                    _ => {
+                        return Err(syn::Error::new_spanned(
+                            &value,
+                            "metric level must be `info`, `debug`, or `trace`",
+                        ))
+                    }
+                };
+                Ok(())
+            } else {
+                Err(meta.error("unknown `metric` key; expected `level`"))
+            }
+        })?;
+    }
+
+    Ok(MetricField { ident, ty, kind, level })
+}
+
+fn expand(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenStream2> {
+    let mut item = syn::parse2::<ItemStruct>(item)?;
+    let container = parse_container(attr)?;
+
+    let named = match &item.fields {
+        Fields::Named(named) => named,
+        _ => {
+            return Err(syn::Error::new_spanned(
+                &item,
+                "`static_metrics` requires a struct with named fields",
+            ))
+        }
+    };
+    if named.named.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &item,
+            "`static_metrics` requires at least one metric field",
+        ));
+    }
+
+    // Parse every field, accumulating errors so multiple problems surface at once.
+    let mut errors = Vec::new();
+    let mut metrics = Vec::new();
+    for field in &named.named {
+        match parse_field(field) {
+            Ok(metric) => metrics.push(metric),
+            Err(error) => errors.push(error),
+        }
+    }
+    if let Some(error) = combine_errors(errors) {
+        return Err(error);
+    }
+
+    let prefix = container.prefix.to_string();
+
+    // The struct-level labels become generic, `Stringable`-bounded parameters on `new()`.
+    let label_generics: Vec<Ident> = (0..container.labels.len()).map(|i| format_ident!("L{}", i)).collect();
+    let new_params = container
+        .labels
+        .iter()
+        .zip(&label_generics)
+        .map(|(key, generic)| quote! { #key: #generic });
+    let new_generics = if label_generics.is_empty() {
+        quote! {}
+    } else {
+        quote! { < #(#label_generics),* > }
+    };
+    let new_where = if label_generics.is_empty() {
+        quote! {}
+    } else {
+        quote! { where #(#label_generics: ::saluki_metrics::Stringable,)* }
+    };
+    let label_entries = container.labels.iter().map(|key| {
+        let key_str = LitStr::new(&key.to_string(), key.span());
+        quote! {
+            ::saluki_metrics::reexport::metrics::Label::new(
+                #key_str,
+                ::saluki_metrics::Stringable::to_shared_string(&#key),
+            )
+        }
+    });
+
+    let field_inits = metrics.iter().map(|metric| field_init(metric, &prefix));
+    let methods = metrics.iter().map(|metric| field_methods(metric, &prefix));
+
+    // Strip the `#[metric(...)]` field attributes (they are not inert for an attribute macro). Everything else
+    // (visibility, other attributes such as `#[derive(Clone)]`, generics) is preserved.
+    if let Fields::Named(named) = &mut item.fields {
+        for field in &mut named.named {
+            field.attrs.retain(|attr| !attr.path().is_ident("metric"));
+        }
+    }
+
+    let struct_name = &item.ident;
+    let struct_name_str = struct_name.to_string();
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    Ok(quote! {
+        #item
+
+        impl #impl_generics #struct_name #ty_generics #where_clause {
+            pub fn new #new_generics ( #(#new_params),* ) -> Self #new_where {
+                let labels: ::std::vec::Vec<::saluki_metrics::reexport::metrics::Label> = ::std::vec![ #(#label_entries,)* ];
+
+                Self {
+                    #(#field_inits,)*
+                }
+            }
+
+            #(#methods)*
+        }
+
+        impl #impl_generics ::std::fmt::Debug for #struct_name #ty_generics #where_clause {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                f.write_str(#struct_name_str)
+            }
+        }
+    })
+}
+
+/// Generates the code that sets a field inside `new()`.
+fn field_init(metric: &MetricField, prefix: &str) -> TokenStream2 {
+    let ident = &metric.ident;
+    let macro_ident = metric.kind.macro_ident();
+    let level = metric.level.to_tokens();
+    let name = LitStr::new(&format!("{}_{}", prefix, ident), ident.span());
+    quote! {
+        #ident: ::saluki_metrics::reexport::metrics::#macro_ident!(level: #level, #name, labels.iter())
+    }
+}
+
+/// Generates the accessor and `<field>_name()` helper for a metric field.
+fn field_methods(metric: &MetricField, prefix: &str) -> TokenStream2 {
+    let ident = &metric.ident;
+    let ty = &metric.ty;
+    let name_fn = format_ident!("{}_name", ident);
+    let name = LitStr::new(&format!("{}_{}", prefix, ident), ident.span());
+    let name_doc = format!("Gets the full name of the `{}` metric as it will be registered.", ident);
+    quote! {
+        pub fn #ident(&self) -> &#ty {
+            &self.#ident
+        }
+
+        #[doc = #name_doc]
+        #[doc = ""]
+        #[doc = "This can be useful when testing metrics, as it ensures you can grab the correct metric name to search for."]
+        pub fn #name_fn() -> &'static str {
+            #name
+        }
+    }
+}
+
+/// Combines a collection of errors into a single error, if any are present.
+fn combine_errors(errors: Vec<syn::Error>) -> Option<syn::Error> {
+    let mut iter = errors.into_iter();
+    let mut combined = iter.next()?;
+    for error in iter {
+        combined.combine(error);
+    }
+    Some(combined)
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::quote;
+
+    use super::*;
+
+    /// Expands the input and returns the generated tokens with all whitespace removed, so assertions can match token
+    /// sequences without depending on `TokenStream`'s inter-token spacing.
+    fn expand_str(attr: TokenStream2, item: TokenStream2) -> String {
+        expand(attr, item)
+            .expect("expansion failed")
+            .to_string()
+            .replace(char::is_whitespace, "")
+    }
+
+    fn expand_err(attr: TokenStream2, item: TokenStream2) -> String {
+        expand(attr, item)
+            .expect_err("expansion should have failed")
+            .to_string()
+    }
+
+    #[test]
+    fn generates_names_levels_accessors_and_debug() {
+        let out = expand_str(
+            quote! { prefix = cache, labels(id) },
+            quote! {
+                struct Telemetry {
+                    hits_total: Counter,
+                    #[metric(level = debug)]
+                    items_inserted_total: Counter,
+                }
+            },
+        );
+
+        assert!(out.contains("\"cache_hits_total\""));
+        assert!(out.contains("\"cache_items_inserted_total\""));
+        assert!(out.contains("Level::INFO"));
+        assert!(out.contains("Level::DEBUG"));
+        assert!(out.contains("fnnew<L0>"));
+        assert!(out.contains("hits_total_name"));
+        assert!(out.contains("write_str(\"Telemetry\")"));
+    }
+
+    #[test]
+    fn rejects_warn_level() {
+        let err = expand_err(
+            quote! { prefix = p },
+            quote! { struct M { #[metric(level = warn)] bar: Counter } },
+        );
+        assert_eq!(err, "metric level must be `info`, `debug`, or `trace`");
+    }
+
+    #[test]
+    fn rejects_unknown_field_type() {
+        let err = expand_err(quote! { prefix = p }, quote! { struct M { bar: String } });
+        assert_eq!(err, "metric field type must be `Counter`, `Gauge`, or `Histogram`");
+    }
+
+    #[test]
+    fn requires_prefix() {
+        let err = expand_err(quote! { labels(id) }, quote! { struct M { bar: Counter } });
+        assert_eq!(err, "`static_metrics` requires a `prefix = <ident>` argument");
+    }
+
+    #[test]
+    fn rejects_string_literal_prefix() {
+        // The prefix must be a bare identifier (`prefix = cache`), mirroring the declarative `static_metrics!` macro; a
+        // quoted `prefix = "cache"` is rejected during parsing.
+        let err = expand_err(quote! { prefix = "cache" }, quote! { struct M { bar: Counter } });
+        assert!(err.contains("expected identifier"), "unexpected error message: {err}");
+    }
+
+    #[test]
+    fn rejects_non_struct() {
+        let err = expand_err(quote! { prefix = p }, quote! { enum E { A } });
+        assert_eq!(err, "expected `struct`");
+    }
+
+    #[test]
+    fn requires_at_least_one_field() {
+        let err = expand_err(quote! { prefix = p }, quote! { struct M {} });
+        assert_eq!(err, "`static_metrics` requires at least one metric field");
+    }
+}

--- a/lib/saluki-metrics/src/lib.rs
+++ b/lib/saluki-metrics/src/lib.rs
@@ -4,6 +4,10 @@
 
 mod builder;
 
+// The `metrics` handle types are re-exported so that structs using the `static_metrics` macro can name their fields
+// (`Counter`/`Gauge`/`Histogram`) via `saluki_metrics` without depending on `metrics` directly.
+pub use ::metrics::{Counter, Gauge, Histogram};
+
 pub use self::builder::{MetricTag, MetricsBuilder};
 
 mod macros;


### PR DESCRIPTION
## Summary

This PR introduces a new attribute macro-based approach for generating "static metrics" structs in a similar way to the existing `static_metrics!` macro.

Currently, we support the generation of "static" metrics structs through a declarative macro in the `saluki_metrics` crate: `static_metrics!`. This has a somewhat bespoke syntax but ultimately supports generating a struct and struct impl to hold metric handles, register them, and allows for setting the level of each metric as well as defining labels to apply to every metric. It works well enough but is somewhat opaque and very cargo culted: blindly copying existing examples without really knowing _why_ or _how_ the thing works.

This PR introduces a new attribute macro-based approach to (eventually) replace `static_metrics!`. Attribute macros fall under a class of macros called "procedural" macros: macros which are written in Rust themselves and have programmatic access to the actual Abstract Syntax Tree, which allows for more powerful transformations. What this ultimately enables us to do is demystify (in my opinion) what it means to define a static metrics struct:

```rust
// Before:

static_metrics!(
    name => CacheTelemetry,
    prefix => cache,
    labels => [cache_id: String],
    metrics => [
        gauge(current_items),
        debug_counter(miss_fills_total)
    ],
);

// After:

#[static_metrics(prefix = cache, labels(cache_id))]
struct CacheTelemetry {
    current_items: Gauge,

    #[metric(level = debug)]
    miss_fills_total: Counter,
}
```

We can now see the actual struct and the fields/metrics that are present: really, we're just annotating the fields to help drive the code generation for registering them, but the overall structure is closer to if we wrote the struct ourselves, and so is more obvious.

Right now, this attribute macro is doing the same thing -- feature-wise -- as the declarative macro, and so we're just trading code complexity in one place for code complexity in another place. However, the goal is to then build more advanced features on top of the attribute macro that are only reasonably achievable with an attribute macro, such as automatically generating the code for metrics that have variable label values at runtime, or label values that are derived exclusively from enum variants, and so on. Likewise, it will allow us to do additional things like add normal Rust doc comments and then convert those into metric descriptions, suitable for emitting alongside the metric values when appropriate (think Prometheus scrape endpoint).

Currently, we're _just_ adding the attribute macro. We're not actually yet exposing it through `saluki_metrics` because it would shadow the equivalently named declarative macro, and so we're doing that in the subsequent stacked PR that switches all existing usages of the declarative macro over to the attribute macro.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New tests for the attribute macro.

## References

DADP-2
