### PR TITLE
enhancement(metrics): support mapped metric handles in `static_metrics!`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4575,6 +4575,7 @@ name = "saluki-metrics"
 version = "0.1.0"
 dependencies = [
  "metrics",
+ "papaya",
  "saluki-metrics-macros",
  "trybuild",
 ]

--- a/lib/saluki-metrics-macros/src/lib.rs
+++ b/lib/saluki-metrics-macros/src/lib.rs
@@ -8,14 +8,18 @@
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
-use syn::{parse::Parser, Fields, Ident, ItemStruct, LitStr, Type};
+use syn::{
+    parse::{Parse, ParseStream, Parser},
+    parse_quote, Fields, Ident, ItemStruct, LitStr, Token, Type,
+};
 
 /// Defines a container struct of statically defined metrics.
 ///
 /// Applied to a struct whose fields are metric handles, this generates the registration, accessors, and metadata for
 /// the whole group. It is re-exported (and intended to be used) as `saluki_metrics::static_metrics`.
 ///
-/// Because it rewrites the annotated struct, it must appear **before** any `#[derive(...)]` on the struct.
+/// Because it can rewrite field storage (see "Mapped metrics" below), it must appear **before** any `#[derive(...)]`
+/// on the struct.
 ///
 /// # Fields
 ///
@@ -31,12 +35,45 @@ use syn::{parse::Parser, Fields, Ident, ItemStruct, LitStr, Type};
 /// # Field attributes
 ///
 /// - `#[metric(level = info | debug | trace)]` (optional, default `info`): the metric's verbosity level.
+/// - `#[metric(mapped(...))]` (optional): see below.
 ///
 /// # Generated code
 ///
 /// For a struct `Foo`, this generates `Foo::new(<label>, ...) -> Foo` (generic over each label value's type), a
 /// `Foo::<field>(&self) -> &<Handle>` accessor per metric, a `Foo::<field>_name() -> &'static str` helper, and a
 /// `Debug` implementation that prints only the struct name. `Clone` is not generated; derive it directly where needed.
+///
+/// # Mapped metrics
+///
+/// A field can be *mapped* by one or more labels whose values are supplied at emission time rather than at
+/// construction:
+///
+/// ```ignore
+/// #[static_metrics(prefix = component, labels(component_id))]
+/// #[derive(Clone)]
+/// struct Metrics {
+///     events_sent_total: Counter,
+///     // one label, sourced from any `Stringable`:
+///     #[metric(mapped(reason))]
+///     events_discarded_total: Counter,
+///     // or pinned to a concrete type for misuse resistance (and, potentially, cheaper conversion):
+///     #[metric(mapped(reason: DiscardReason))]
+///     other_total: Counter,
+/// }
+/// ```
+///
+/// A mapped field's storage is rewritten to hold a concurrent map of the dynamic label values to lazily registered
+/// handles (the source keeps writing `Counter`/`Gauge`/`Histogram`). Its accessor takes the label values by
+/// reference and returns an owned handle:
+///
+/// ```ignore
+/// // bare label -> generic parameter; typed label -> the concrete type
+/// metrics.events_discarded_total(&"queue_full").increment(1);
+/// metrics.other_total(&DiscardReason::QueueFull).increment(1);
+/// ```
+///
+/// Each mapped handle is registered with the fixed struct labels plus the mapped labels. One or many labels may be
+/// given, comma-separated, mixing bare and typed forms.
 #[proc_macro_attribute]
 pub fn static_metrics(attr: TokenStream, item: TokenStream) -> TokenStream {
     expand(attr.into(), item.into())
@@ -82,12 +119,38 @@ impl Level {
     }
 }
 
+/// A single mapped label: a bare name (`reason`), optionally pinned to a concrete type (`reason: DiscardReason`).
+struct MappedLabel {
+    name: Ident,
+    ty: Option<Type>,
+}
+
+impl Parse for MappedLabel {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let name = input.parse()?;
+        let ty = if input.peek(Token![:]) {
+            input.parse::<Token![:]>()?;
+            Some(input.parse()?)
+        } else {
+            None
+        };
+        Ok(Self { name, ty })
+    }
+}
+
 /// A single metric parsed from a struct field.
 struct MetricField {
     ident: Ident,
     ty: Type,
     kind: MetricKind,
     level: Level,
+    mapped: Vec<MappedLabel>,
+}
+
+impl MetricField {
+    fn is_mapped(&self) -> bool {
+        !self.mapped.is_empty()
+    }
 }
 
 /// The struct-level configuration parsed from the attribute arguments.
@@ -162,6 +225,7 @@ fn parse_field(field: &syn::Field) -> syn::Result<MetricField> {
     })?;
 
     let mut level = Level::Info;
+    let mut mapped = Vec::new();
     for attr in &field.attrs {
         if !attr.path().is_ident("metric") {
             continue;
@@ -182,13 +246,28 @@ fn parse_field(field: &syn::Field) -> syn::Result<MetricField> {
                     }
                 };
                 Ok(())
+            } else if meta.path.is_ident("mapped") {
+                let content;
+                syn::parenthesized!(content in meta.input);
+                let parsed = content.parse_terminated(MappedLabel::parse, Token![,])?;
+                if parsed.is_empty() {
+                    return Err(meta.error("`mapped(...)` requires at least one label name"));
+                }
+                mapped.extend(parsed);
+                Ok(())
             } else {
-                Err(meta.error("unknown `metric` key; expected `level`"))
+                Err(meta.error("unknown `metric` key; expected `level` or `mapped`"))
             }
         })?;
     }
 
-    Ok(MetricField { ident, ty, kind, level })
+    Ok(MetricField {
+        ident,
+        ty,
+        kind,
+        level,
+        mapped,
+    })
 }
 
 fn expand(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenStream2> {
@@ -225,6 +304,7 @@ fn expand(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenStream2> {
     }
 
     let prefix = container.prefix.to_string();
+    let any_mapped = metrics.iter().any(MetricField::is_mapped);
 
     // The struct-level labels become generic, `Stringable`-bounded parameters on `new()`.
     let label_generics: Vec<Ident> = (0..container.labels.len()).map(|i| format_ident!("L{}", i)).collect();
@@ -252,15 +332,31 @@ fn expand(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenStream2> {
             )
         }
     });
+    // When any field is mapped, the fixed label set is shared (via `Arc`) into each mapped field's storage.
+    let labels_binding = if any_mapped {
+        quote! {
+            let labels: ::std::vec::Vec<::saluki_metrics::reexport::metrics::Label> = ::std::vec![ #(#label_entries,)* ];
+            let labels = ::std::sync::Arc::new(labels);
+        }
+    } else {
+        quote! {
+            let labels: ::std::vec::Vec<::saluki_metrics::reexport::metrics::Label> = ::std::vec![ #(#label_entries,)* ];
+        }
+    };
 
     let field_inits = metrics.iter().map(|metric| field_init(metric, &prefix));
     let methods = metrics.iter().map(|metric| field_methods(metric, &prefix));
 
-    // Strip the `#[metric(...)]` field attributes (they are not inert for an attribute macro). Everything else
-    // (visibility, other attributes such as `#[derive(Clone)]`, generics) is preserved.
+    // Rewrite the struct: strip the `#[metric(...)]` field attributes (they are not inert for an attribute macro) and
+    // rewrite mapped fields' storage to `MappedMetric<Handle>`. Everything else (visibility, other attributes such as
+    // `#[derive(Clone)]`, generics) is preserved.
     if let Fields::Named(named) = &mut item.fields {
-        for field in &mut named.named {
+        for (field, metric) in named.named.iter_mut().zip(&metrics) {
             field.attrs.retain(|attr| !attr.path().is_ident("metric"));
+            if metric.is_mapped() {
+                let handle_ty = &metric.ty;
+                field.ty = parse_quote! { ::saluki_metrics::MappedMetric<#handle_ty> };
+            }
         }
     }
 
@@ -273,7 +369,7 @@ fn expand(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenStream2> {
 
         impl #impl_generics #struct_name #ty_generics #where_clause {
             pub fn new #new_generics ( #(#new_params),* ) -> Self #new_where {
-                let labels: ::std::vec::Vec<::saluki_metrics::reexport::metrics::Label> = ::std::vec![ #(#label_entries,)* ];
+                #labels_binding
 
                 Self {
                     #(#field_inits,)*
@@ -294,32 +390,90 @@ fn expand(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenStream2> {
 /// Generates the code that sets a field inside `new()`.
 fn field_init(metric: &MetricField, prefix: &str) -> TokenStream2 {
     let ident = &metric.ident;
-    let macro_ident = metric.kind.macro_ident();
-    let level = metric.level.to_tokens();
-    let name = LitStr::new(&format!("{}_{}", prefix, ident), ident.span());
-    quote! {
-        #ident: ::saluki_metrics::reexport::metrics::#macro_ident!(level: #level, #name, labels.iter())
+    if metric.is_mapped() {
+        quote! {
+            #ident: ::saluki_metrics::MappedMetric::new(::std::sync::Arc::clone(&labels))
+        }
+    } else {
+        let macro_ident = metric.kind.macro_ident();
+        let level = metric.level.to_tokens();
+        let name = LitStr::new(&format!("{}_{}", prefix, ident), ident.span());
+        quote! {
+            #ident: ::saluki_metrics::reexport::metrics::#macro_ident!(level: #level, #name, labels.iter())
+        }
     }
 }
 
-/// Generates the accessor and `<field>_name()` helper for a metric field.
+/// Generates the accessors and `<field>_name()` helper for a metric field.
 fn field_methods(metric: &MetricField, prefix: &str) -> TokenStream2 {
     let ident = &metric.ident;
     let ty = &metric.ty;
     let name_fn = format_ident!("{}_name", ident);
     let name = LitStr::new(&format!("{}_{}", prefix, ident), ident.span());
     let name_doc = format!("Gets the full name of the `{}` metric as it will be registered.", ident);
-    quote! {
-        pub fn #ident(&self) -> &#ty {
-            &self.#ident
-        }
-
+    let name_helper = quote! {
         #[doc = #name_doc]
         #[doc = ""]
         #[doc = "This can be useful when testing metrics, as it ensures you can grab the correct metric name to search for."]
         pub fn #name_fn() -> &'static str {
             #name
         }
+    };
+
+    if !metric.is_mapped() {
+        return quote! {
+            pub fn #ident(&self) -> &#ty {
+                &self.#ident
+            }
+
+            #name_helper
+        };
+    }
+
+    // Mapped accessor: bare labels contribute a generic `Stringable` parameter; typed labels use their concrete type.
+    let mut generics = Vec::new();
+    let mut params = Vec::new();
+    let mut key_lits = Vec::new();
+    let mut value_exprs = Vec::new();
+    for label in &metric.mapped {
+        let label_name = &label.name;
+        key_lits.push(LitStr::new(&label_name.to_string(), label_name.span()));
+        value_exprs.push(quote! { ::saluki_metrics::Stringable::to_shared_string(#label_name) });
+        match &label.ty {
+            Some(ty) => params.push(quote! { #label_name: &#ty }),
+            None => {
+                let generic = format_ident!("L{}", generics.len());
+                params.push(quote! { #label_name: &#generic });
+                generics.push(generic);
+            }
+        }
+    }
+
+    let getter_generics = if generics.is_empty() {
+        quote! {}
+    } else {
+        quote! { < #(#generics),* > }
+    };
+    let getter_where = if generics.is_empty() {
+        quote! {}
+    } else {
+        quote! { where #(#generics: ::saluki_metrics::Stringable,)* }
+    };
+
+    let macro_ident = metric.kind.macro_ident();
+    let level = metric.level.to_tokens();
+
+    quote! {
+        pub fn #ident #getter_generics (&self, #(#params),*) -> #ty #getter_where {
+            let values = [ #(#value_exprs,)* ];
+            self.#ident.get_or_register(
+                &[ #(#key_lits,)* ],
+                &values,
+                |labels| ::saluki_metrics::reexport::metrics::#macro_ident!(level: #level, #name, labels.iter()),
+            )
+        }
+
+        #name_helper
     }
 }
 
@@ -374,6 +528,65 @@ mod tests {
         assert!(out.contains("fnnew<L0>"));
         assert!(out.contains("hits_total_name"));
         assert!(out.contains("write_str(\"Telemetry\")"));
+        // Nothing is mapped, so no map storage is emitted.
+        assert!(!out.contains("MappedMetric"));
+    }
+
+    #[test]
+    fn mapped_bare_label_generates_generic_getter() {
+        let out = expand_str(
+            quote! { prefix = component, labels(component_id) },
+            quote! {
+                struct Telemetry {
+                    #[metric(mapped(reason))]
+                    events_discarded_total: Counter,
+                }
+            },
+        );
+
+        // The field storage is rewritten to a `MappedMetric`, and the fixed labels are shared via `Arc`.
+        assert!(out.contains("MappedMetric<Counter>"));
+        assert!(out.contains("Arc::new(labels)"));
+        // The accessor is generic over the bare label's value type and resolves the handle lazily.
+        assert!(out.contains("fnevents_discarded_total<L0>"));
+        assert!(out.contains("reason:&L0"));
+        assert!(out.contains("get_or_register"));
+        assert!(out.contains("\"reason\""));
+    }
+
+    #[test]
+    fn mapped_typed_label_uses_concrete_type() {
+        let out = expand_str(
+            quote! { prefix = component },
+            quote! {
+                struct Telemetry {
+                    #[metric(mapped(reason: DiscardReason))]
+                    events_discarded_total: Counter,
+                }
+            },
+        );
+
+        // A typed-only mapped label pins the parameter to the concrete type and emits no getter generic.
+        assert!(out.contains("fnevents_discarded_total(&self,reason:&DiscardReason)"));
+    }
+
+    #[test]
+    fn mapped_mixed_multi_label() {
+        let out = expand_str(
+            quote! { prefix = component },
+            quote! {
+                struct Telemetry {
+                    #[metric(mapped(origin, reason: DiscardReason))]
+                    events_discarded_total: Counter,
+                }
+            },
+        );
+
+        assert!(out.contains("fnevents_discarded_total<L0>"));
+        assert!(out.contains("origin:&L0"));
+        assert!(out.contains("reason:&DiscardReason"));
+        assert!(out.contains("\"origin\""));
+        assert!(out.contains("\"reason\""));
     }
 
     #[test]
@@ -415,5 +628,14 @@ mod tests {
     fn requires_at_least_one_field() {
         let err = expand_err(quote! { prefix = p }, quote! { struct M {} });
         assert_eq!(err, "`static_metrics` requires at least one metric field");
+    }
+
+    #[test]
+    fn rejects_empty_mapped() {
+        let err = expand_err(
+            quote! { prefix = p },
+            quote! { struct M { #[metric(mapped())] bar: Counter } },
+        );
+        assert_eq!(err, "`mapped(...)` requires at least one label name");
     }
 }

--- a/lib/saluki-metrics-macros/src/lib.rs
+++ b/lib/saluki-metrics-macros/src/lib.rs
@@ -63,12 +63,14 @@ use syn::{
 /// ```
 ///
 /// A mapped field's storage is rewritten to hold a concurrent map of the dynamic label values to lazily registered
-/// handles (the source keeps writing `Counter`/`Gauge`/`Histogram`). Its accessor takes the label values by
-/// reference and returns an owned handle:
+/// handles (the source keeps writing `Counter`/`Gauge`/`Histogram`). Its accessor accepts each label value either by
+/// value or by reference and returns an owned handle. A typed label still only accepts its concrete type (or a
+/// reference to it), so lightweight `Copy` values can be passed directly without borrowing:
 ///
 /// ```ignore
-/// // bare label -> generic parameter; typed label -> the concrete type
-/// metrics.events_discarded_total(&"queue_full").increment(1);
+/// // bare label -> generic `Stringable` parameter; typed label -> `Borrow<T>`, so `T` or `&T` are both accepted
+/// metrics.events_discarded_total("queue_full").increment(1);
+/// metrics.other_total(DiscardReason::QueueFull).increment(1);
 /// metrics.other_total(&DiscardReason::QueueFull).increment(1);
 /// ```
 ///
@@ -430,23 +432,35 @@ fn field_methods(metric: &MetricField, prefix: &str) -> TokenStream2 {
         };
     }
 
-    // Mapped accessor: bare labels contribute a generic `Stringable` parameter; typed labels use their concrete type.
+    // Mapped accessor: every label is accepted by value *or* by reference through a generic parameter, so lightweight
+    // `Copy` values (enums, integers) need not be borrowed at the call site. A bare label's parameter is bounded by
+    // `Stringable` directly; a typed label's parameter is bounded by `Borrow<T>`, which keeps the concrete type pinned
+    // (for misuse resistance) while accepting both `T` and `&T` (`T: Borrow<T>` and `&T: Borrow<T>` both hold). In
+    // either case we only ever need a shared reference to stringify the value via its `Display` impl.
     let mut generics = Vec::new();
+    let mut bounds = Vec::new();
     let mut params = Vec::new();
     let mut key_lits = Vec::new();
     let mut value_exprs = Vec::new();
     for label in &metric.mapped {
         let label_name = &label.name;
         key_lits.push(LitStr::new(&label_name.to_string(), label_name.span()));
-        value_exprs.push(quote! { ::saluki_metrics::Stringable::to_shared_string(#label_name) });
+
+        let generic = format_ident!("L{}", generics.len());
+        params.push(quote! { #label_name: #generic });
         match &label.ty {
-            Some(ty) => params.push(quote! { #label_name: &#ty }),
+            Some(ty) => {
+                bounds.push(quote! { #generic: ::std::borrow::Borrow<#ty> });
+                value_exprs.push(quote! {
+                    ::saluki_metrics::Stringable::to_shared_string(::std::borrow::Borrow::borrow(&#label_name))
+                });
+            }
             None => {
-                let generic = format_ident!("L{}", generics.len());
-                params.push(quote! { #label_name: &#generic });
-                generics.push(generic);
+                bounds.push(quote! { #generic: ::saluki_metrics::Stringable });
+                value_exprs.push(quote! { ::saluki_metrics::Stringable::to_shared_string(&#label_name) });
             }
         }
+        generics.push(generic);
     }
 
     let getter_generics = if generics.is_empty() {
@@ -454,10 +468,10 @@ fn field_methods(metric: &MetricField, prefix: &str) -> TokenStream2 {
     } else {
         quote! { < #(#generics),* > }
     };
-    let getter_where = if generics.is_empty() {
+    let getter_where = if bounds.is_empty() {
         quote! {}
     } else {
-        quote! { where #(#generics: ::saluki_metrics::Stringable,)* }
+        quote! { where #(#bounds,)* }
     };
 
     let macro_ident = metric.kind.macro_ident();
@@ -547,9 +561,11 @@ mod tests {
         // The field storage is rewritten to a `MappedMetric`, and the fixed labels are shared via `Arc`.
         assert!(out.contains("MappedMetric<Counter>"));
         assert!(out.contains("Arc::new(labels)"));
-        // The accessor is generic over the bare label's value type and resolves the handle lazily.
+        // The accessor is generic over the bare label's value type (accepted by value or reference) and resolves the
+        // handle lazily.
         assert!(out.contains("fnevents_discarded_total<L0>"));
-        assert!(out.contains("reason:&L0"));
+        assert!(out.contains("reason:L0"));
+        assert!(out.contains("L0:::saluki_metrics::Stringable"));
         assert!(out.contains("get_or_register"));
         assert!(out.contains("\"reason\""));
     }
@@ -566,8 +582,10 @@ mod tests {
             },
         );
 
-        // A typed-only mapped label pins the parameter to the concrete type and emits no getter generic.
-        assert!(out.contains("fnevents_discarded_total(&self,reason:&DiscardReason)"));
+        // A typed mapped label pins the parameter through `Borrow<T>`, so both `T` and `&T` are accepted at the call
+        // site while the concrete type stays fixed.
+        assert!(out.contains("fnevents_discarded_total<L0>(&self,reason:L0)"));
+        assert!(out.contains("L0:::std::borrow::Borrow<DiscardReason>"));
     }
 
     #[test]
@@ -582,9 +600,11 @@ mod tests {
             },
         );
 
-        assert!(out.contains("fnevents_discarded_total<L0>"));
-        assert!(out.contains("origin:&L0"));
-        assert!(out.contains("reason:&DiscardReason"));
+        assert!(out.contains("fnevents_discarded_total<L0,L1>"));
+        assert!(out.contains("origin:L0"));
+        assert!(out.contains("reason:L1"));
+        assert!(out.contains("L0:::saluki_metrics::Stringable"));
+        assert!(out.contains("L1:::std::borrow::Borrow<DiscardReason>"));
         assert!(out.contains("\"origin\""));
         assert!(out.contains("\"reason\""));
     }

--- a/lib/saluki-metrics/Cargo.toml
+++ b/lib/saluki-metrics/Cargo.toml
@@ -14,6 +14,7 @@ test = []
 
 [dependencies]
 metrics = { workspace = true }
+papaya = { workspace = true }
 saluki-metrics-macros = { workspace = true }
 
 [dev-dependencies]

--- a/lib/saluki-metrics/src/lib.rs
+++ b/lib/saluki-metrics/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(missing_docs)]
 
 mod builder;
+mod mapped;
 
 // The `metrics` handle types are re-exported so that structs using the `static_metrics` macro can name their fields
 // (`Counter`/`Gauge`/`Histogram`) via `saluki_metrics` without depending on `metrics` directly.
@@ -10,6 +11,7 @@ pub use ::metrics::{Counter, Gauge, Histogram};
 pub use saluki_metrics_macros::static_metrics;
 
 pub use self::builder::{MetricTag, MetricsBuilder};
+pub use self::mapped::MappedMetric;
 
 #[cfg(feature = "test")]
 pub mod test;

--- a/lib/saluki-metrics/src/mapped.rs
+++ b/lib/saluki-metrics/src/mapped.rs
@@ -1,0 +1,67 @@
+//! Support for "mapped" metrics whose labels are resolved dynamically at emission time.
+
+use std::sync::Arc;
+
+use metrics::{Label, SharedString};
+use papaya::HashMap;
+
+/// A metric that is resolved dynamically by one or more label values.
+///
+/// Unlike a plain metric handle, a mapped metric does not hold a single handle. Instead it holds a concurrent map
+/// from a set of dynamic label values to the corresponding registered handle. Handles are registered lazily on first
+/// use and cached for subsequent lookups.
+///
+/// The underlying map (and the fixed label set) is shared across clones, so every clone of the containing metrics
+/// struct observes the same cache. Lookups are lock-free once a handle has been registered.
+///
+/// This type is an implementation detail of the `static_metrics` attribute macro and is not meant to be constructed
+/// or used directly.
+pub struct MappedMetric<H> {
+    labels: Arc<Vec<Label>>,
+    handles: Arc<HashMap<Box<[SharedString]>, H>>,
+}
+
+impl<H> Clone for MappedMetric<H> {
+    fn clone(&self) -> Self {
+        // Only the shared handles are cloned (via `Arc`), never the handles themselves, so all clones share one cache.
+        Self {
+            labels: Arc::clone(&self.labels),
+            handles: Arc::clone(&self.handles),
+        }
+    }
+}
+
+impl<H> MappedMetric<H>
+where
+    H: Clone,
+{
+    /// Creates a new `MappedMetric` whose handles are registered with the given fixed labels.
+    pub fn new(labels: Arc<Vec<Label>>) -> Self {
+        Self {
+            labels,
+            handles: Arc::new(HashMap::new()),
+        }
+    }
+
+    /// Returns the handle for the given dynamic label values, registering and caching it on the first lookup.
+    ///
+    /// `keys` are the dynamic label names and `values` their stringified values, in the same order and of the same
+    /// length. The `register` closure is invoked only on a cache miss and receives the full label set (the fixed
+    /// labels followed by the dynamic labels) with which to register the handle.
+    pub fn get_or_register(
+        &self, keys: &[&'static str], values: &[SharedString], register: impl FnOnce(&[Label]) -> H,
+    ) -> H {
+        let map_key: Box<[SharedString]> = values.into();
+        self.handles
+            .pin()
+            .get_or_insert_with(map_key, || {
+                let mut labels = Vec::with_capacity(self.labels.len() + values.len());
+                labels.extend(self.labels.iter().cloned());
+                for (key, value) in keys.iter().zip(values.iter()) {
+                    labels.push(Label::new(*key, value.clone()));
+                }
+                register(&labels)
+            })
+            .clone()
+    }
+}

--- a/lib/saluki-metrics/tests/macros.rs
+++ b/lib/saluki-metrics/tests/macros.rs
@@ -5,6 +5,10 @@ pub fn macros() {
     t.pass("tests/macros/02_no_labels.rs");
     t.pass("tests/macros/03_levels.rs");
     t.pass("tests/macros/04_multi_label.rs");
+    t.pass("tests/macros/10_mapped_bare.rs");
+    t.pass("tests/macros/11_mapped_typed.rs");
+    t.pass("tests/macros/12_mapped_mixed.rs");
+    t.pass("tests/macros/13_mapped_concurrent.rs");
     t.compile_fail("tests/macros/05_empty_struct.rs");
     t.compile_fail("tests/macros/06_invalid_level.rs");
     t.compile_fail("tests/macros/07_not_a_struct.rs");

--- a/lib/saluki-metrics/tests/macros/10_mapped_bare.rs
+++ b/lib/saluki-metrics/tests/macros/10_mapped_bare.rs
@@ -15,12 +15,12 @@ fn main() {
     // Non-mapped accessor is unchanged.
     metrics.events_sent_total().increment(1);
 
-    // Mapped accessor takes the label value by reference and returns an owned handle.
-    metrics.events_discarded_total(&"queue_full").increment(1);
+    // Mapped accessor accepts the label value by value or by reference and returns an owned handle.
+    metrics.events_discarded_total("queue_full").increment(1);
     let owned = String::from("invalid");
     metrics.events_discarded_total(&owned).increment(1);
     // Looking up the same value again resolves the cached handle.
-    metrics.events_discarded_total(&"queue_full").increment(1);
+    metrics.events_discarded_total("queue_full").increment(1);
 
     assert_eq!(Metrics::events_discarded_total_name(), "mapped_events_discarded_total");
 }

--- a/lib/saluki-metrics/tests/macros/10_mapped_bare.rs
+++ b/lib/saluki-metrics/tests/macros/10_mapped_bare.rs
@@ -1,0 +1,26 @@
+use saluki_metrics::{static_metrics, Counter};
+
+#[static_metrics(prefix = mapped, labels(component_id))]
+#[derive(Clone)]
+struct Metrics {
+    events_sent_total: Counter,
+    // A bare mapped label accepts any `Stringable` value, supplied at emission time.
+    #[metric(mapped(reason))]
+    events_discarded_total: Counter,
+}
+
+fn main() {
+    let metrics = Metrics::new("component-1".to_string());
+
+    // Non-mapped accessor is unchanged.
+    metrics.events_sent_total().increment(1);
+
+    // Mapped accessor takes the label value by reference and returns an owned handle.
+    metrics.events_discarded_total(&"queue_full").increment(1);
+    let owned = String::from("invalid");
+    metrics.events_discarded_total(&owned).increment(1);
+    // Looking up the same value again resolves the cached handle.
+    metrics.events_discarded_total(&"queue_full").increment(1);
+
+    assert_eq!(Metrics::events_discarded_total_name(), "mapped_events_discarded_total");
+}

--- a/lib/saluki-metrics/tests/macros/11_mapped_typed.rs
+++ b/lib/saluki-metrics/tests/macros/11_mapped_typed.rs
@@ -1,0 +1,29 @@
+use saluki_metrics::{static_metrics, Counter};
+
+enum DiscardReason {
+    QueueFull,
+    Invalid,
+}
+
+impl std::fmt::Display for DiscardReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            DiscardReason::QueueFull => "queue_full",
+            DiscardReason::Invalid => "invalid",
+        })
+    }
+}
+
+#[static_metrics(prefix = mapped, labels(component_id))]
+#[derive(Clone)]
+struct Metrics {
+    // A typed mapped label pins the accessor parameter to a concrete type for misuse resistance.
+    #[metric(level = debug, mapped(reason: DiscardReason))]
+    events_discarded_total: Counter,
+}
+
+fn main() {
+    let metrics = Metrics::new("component-1".to_string());
+    metrics.events_discarded_total(&DiscardReason::QueueFull).increment(1);
+    metrics.events_discarded_total(&DiscardReason::Invalid).increment(1);
+}

--- a/lib/saluki-metrics/tests/macros/11_mapped_typed.rs
+++ b/lib/saluki-metrics/tests/macros/11_mapped_typed.rs
@@ -24,6 +24,8 @@ struct Metrics {
 
 fn main() {
     let metrics = Metrics::new("component-1".to_string());
-    metrics.events_discarded_total(&DiscardReason::QueueFull).increment(1);
-    metrics.events_discarded_total(&DiscardReason::Invalid).increment(1);
+
+    let discard_reason = DiscardReason::QueueFull;
+    metrics.events_discarded_total(&discard_reason).increment(1);
+    metrics.events_discarded_total(DiscardReason::Invalid).increment(1);
 }

--- a/lib/saluki-metrics/tests/macros/12_mapped_mixed.rs
+++ b/lib/saluki-metrics/tests/macros/12_mapped_mixed.rs
@@ -25,9 +25,9 @@ struct Metrics {
 fn main() {
     let metrics = Metrics::new("component-1".to_string());
     metrics
-        .send_latency_seconds(&"upstream", &DiscardReason::QueueFull)
+        .send_latency_seconds("upstream", DiscardReason::QueueFull)
         .record(0.5);
     metrics
-        .send_latency_seconds(&"downstream", &DiscardReason::Invalid)
+        .send_latency_seconds("downstream", DiscardReason::Invalid)
         .record(1.5);
 }

--- a/lib/saluki-metrics/tests/macros/12_mapped_mixed.rs
+++ b/lib/saluki-metrics/tests/macros/12_mapped_mixed.rs
@@ -1,0 +1,33 @@
+use saluki_metrics::{static_metrics, Histogram};
+
+enum DiscardReason {
+    QueueFull,
+    Invalid,
+}
+
+impl std::fmt::Display for DiscardReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            DiscardReason::QueueFull => "queue_full",
+            DiscardReason::Invalid => "invalid",
+        })
+    }
+}
+
+#[static_metrics(prefix = component, labels(component_id))]
+#[derive(Clone)]
+struct Metrics {
+    // Many mapped labels, mixing a bare (generic) label with a typed one.
+    #[metric(level = trace, mapped(origin, reason: DiscardReason))]
+    send_latency_seconds: Histogram,
+}
+
+fn main() {
+    let metrics = Metrics::new("component-1".to_string());
+    metrics
+        .send_latency_seconds(&"upstream", &DiscardReason::QueueFull)
+        .record(0.5);
+    metrics
+        .send_latency_seconds(&"downstream", &DiscardReason::Invalid)
+        .record(1.5);
+}

--- a/lib/saluki-metrics/tests/macros/13_mapped_concurrent.rs
+++ b/lib/saluki-metrics/tests/macros/13_mapped_concurrent.rs
@@ -1,0 +1,31 @@
+use std::thread;
+
+use saluki_metrics::{static_metrics, Counter};
+
+#[static_metrics(prefix = concurrent, labels(id))]
+#[derive(Clone)]
+struct Metrics {
+    #[metric(mapped(shard))]
+    ops_total: Counter,
+}
+
+fn main() {
+    let metrics = Metrics::new("x".to_string());
+
+    // Exercise concurrent lookups/registrations across threads with overlapping and unique keys. The struct is
+    // cheaply cloned into each thread and all clones share one handle cache.
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let metrics = metrics.clone();
+        handles.push(thread::spawn(move || {
+            for i in 0..1_000 {
+                let shard = (i % 4).to_string();
+                metrics.ops_total(&shard).increment(1);
+            }
+        }));
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}

--- a/lib/saluki-metrics/tests/macros/13_mapped_concurrent.rs
+++ b/lib/saluki-metrics/tests/macros/13_mapped_concurrent.rs
@@ -19,8 +19,8 @@ fn main() {
         let metrics = metrics.clone();
         handles.push(thread::spawn(move || {
             for i in 0..1_000 {
-                let shard = (i % 4).to_string();
-                metrics.ops_total(&shard).increment(1);
+                let shard = i % 4;
+                metrics.ops_total(shard).increment(1);
             }
         }));
     }


### PR DESCRIPTION
## Summary

This PR adds support to `static_metrics!` for declaring a metric handle as being "mapped", generating the necessary code to support dynamic registration of the underlying metric with label values provided at runtime.

In many cases, telemetry structs for components have a fixed set of labels applied to all metrics: the labels don't change or vary at runtime. We support this already through `static_metrics!`. In other cases, however, we have metrics where label values are dynamic, such as when incrementing error metrics related to network failures: we might put the host or operation name as a label value, and so on. Currently, we handle this by manually writing out telemetry structs to include the necessary maps that hold the label-to-metric handle mappings, the functions that take the label values as parameters and then look up the right metric handle, and so on. This is less than optimal because not only is it cumbersome and prone to having mismatched implementations, but it means we have to go _full_ manual: we have to implement all of the other metric fields manually as well.

This PR introduces an enhancement to `static_metrics!` which allows defining a metric field as being "mapped", which generates all of the necessary code for that field to support it having dynamic labels. When a metric field should be mapped, we simply add an additional item to the `#[metric]` attribute that defines the dynamic labels, and the rest is handled for us in a similar fashion to the overall struct labels:

```rust
enum DiscardReason {
  Intentional,
  Unintentional,
}

// impl fmt::Display for DiscardReason { ... }

#[static_metrics(prefix = basic)]
#[derive(Clone)]
struct Telemetry {
    received_total: Counter,

    #[metric(mapped(endpoint))]
    sent_total: Counter,

    #[metric(mapped(reason: DiscardReason))]
    discarded_total: Counter,
}

// We specify the label values when getting the metric handles:
let telemetry = Telemetry::new();
telemetry.received_total().increment(1);
telemetry.sent_total("some_endpoint").increment(1);
telemetry.discarded_total(DiscardReason::Intentional).increment(1);
```

Like struct labels, we can specify multiple dynamic labels for a metric, each of which can be untyped (simply has to be `Stringable`) or typed, and the generated method parameters can accept those label values either by referenced or by value, making it trivial to use whatever value is at hand -- `usize`, `&str`, `DiscardReason`, etc -- so long as it either can be formatted as a string or fits the specified concrete type.

This PR specifically does _not_ convert existing hand-rolled examples of this pattern, and will be done as a follow-up PR.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New and existing unit tests.

## References

DADP-2
