### PR TITLE
chore(antithesis): Alter dogstatsd generation to is_malformed regime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,6 +1955,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "simdutf8",
 ]
 
 [[package]]

--- a/test/antithesis/harness/Cargo.toml
+++ b/test/antithesis/harness/Cargo.toml
@@ -24,6 +24,7 @@ ryu = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+simdutf8 = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/test/antithesis/harness/proptest-regressions/payload/dogstatsd.txt
+++ b/test/antithesis/harness/proptest-regressions/payload/dogstatsd.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 377cba92b14295b3fe5c6f2738a398ee042be8e35f529398ecf9e275e6b0a1da # shrinks to seed = 0
+cc 1f807f27fdbf0b983fc773b815b21d6023e1bce87691d07133b438b862edcc5b # shrinks to seed = 6079028945602138863, limit_bytes = 21

--- a/test/antithesis/harness/src/dogstatsd.rs
+++ b/test/antithesis/harness/src/dogstatsd.rs
@@ -1,0 +1,884 @@
+//! Datadog-Agent-normative `DogStatsD` payload classification.
+//!
+//! [`is_malformed`] is a predicate on the SERIALIZED datagram bytes a driver emits. It re-parses the
+//! datagram the way the Datadog Agent's `DogStatsD` parser at `comp/dogstatsd/server/impl` does. It
+//! splits on `\n` and routes each message by prefix: `_e{` to event, `_sc` to service check, else
+//! metric. Then it applies that message type's drop rules, and returns `Ok(())` when the Agent
+//! forwards every message, or the first [`PayloadError`] it drops on.
+//!
+//! The Agent is the differential's reference lane, so a message it drops produces no context even on
+//! the normative side. Malformed is the Agent's behavior, NOT ADP's and NOT the backend intake's. The
+//! Agent does no UTF-8 or charset validation. It forwards non-UTF-8 and exotic names, tags, titles,
+//! and text verbatim, so `PayloadError` covers only the hard structural and numeric-parse failures,
+//! never content bytes.
+//!
+//! The `PayloadError` variants are the contract the load generators are written against: the clean
+//! generator emits only payloads for which this returns `Ok(())`, and a later malformed generator
+//! induces exactly one variant and asserts the Agent drops for it.
+
+/// The first drop rule a serialized `DogStatsD` payload violates, tagged with the 0-based index of
+/// the offending message among the payload's `\n`-split segments. Blank segments are counted in the
+/// index but are never malformed.
+///
+/// One variant per Agent drop rule, across all three message types. The metric `T` timestamp rule is
+/// intentionally absent. See the note in `classify_metric`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PayloadError {
+    /// Metric: the line carries no `|`.
+    MetricNoPipe {
+        /// Message index.
+        line: usize,
+    },
+    /// Metric: field-0 carries no `:` splitting name from value.
+    MetricNameValueNoColon {
+        /// Message index.
+        line: usize,
+    },
+    /// Metric: the name is empty.
+    MetricEmptyName {
+        /// Message index.
+        line: usize,
+    },
+    /// Metric: the value is empty.
+    MetricEmptyValue {
+        /// Message index.
+        line: usize,
+    },
+    /// Metric: the type is not byte-exactly one of `g` `c` `h` `d` `s` `ms`.
+    MetricBadType {
+        /// Message index.
+        line: usize,
+    },
+    /// Metric: a non-set value segment fails the Go float parse, or none survives.
+    MetricUnparseableValue {
+        /// Message index.
+        line: usize,
+    },
+    /// Metric: an `@` sample-rate chunk fails the Go float parse.
+    MetricBadRate {
+        /// Message index.
+        line: usize,
+    },
+    /// Event: the line carries no `:` splitting header from body.
+    EventNoColon {
+        /// Message index.
+        line: usize,
+    },
+    /// Event: the header is shorter than the minimal `_e{1,0}`.
+    EventHeaderTooShort {
+        /// Message index.
+        line: usize,
+    },
+    /// Event: the header carries no `,` between the two lengths.
+    EventNoLengthComma {
+        /// Message index.
+        line: usize,
+    },
+    /// Event: the title length is not a non-negative integer.
+    EventBadTitleLen {
+        /// Message index.
+        line: usize,
+    },
+    /// Event: the title length is zero.
+    EventEmptyTitle {
+        /// Message index.
+        line: usize,
+    },
+    /// Event: the text length is not a non-negative integer.
+    EventBadTextLen {
+        /// Message index.
+        line: usize,
+    },
+    /// Event: `title_len + 1 + text_len` overflows.
+    EventLengthOverflow {
+        /// Message index.
+        line: usize,
+    },
+    /// Event: the body is shorter than the declared `title_len + 1 + text_len`.
+    EventBodyTooShort {
+        /// Message index.
+        line: usize,
+    },
+    /// Service check: fewer than two `|`.
+    ServiceCheckTooFewPipes {
+        /// Message index.
+        line: usize,
+    },
+    /// Service check: shorter than the four-byte `_sc|` header.
+    ServiceCheckTooShort {
+        /// Message index.
+        line: usize,
+    },
+    /// Service check: the name is empty.
+    ServiceCheckEmptyName {
+        /// Message index.
+        line: usize,
+    },
+    /// Service check: the status is not byte-exactly one of `0` `1` `2` `3`.
+    ServiceCheckBadStatus {
+        /// Message index.
+        line: usize,
+    },
+}
+
+/// Whether the Datadog Agent would forward the whole serialized `DogStatsD` payload.
+///
+/// Frames the payload like the Agent's `server.go` `scanLines`, `nextMessage`, and `dropCR`. It
+/// splits on `\n`, drops a single trailing `\r` from each segment so `\r\n` and `\n` both work, and
+/// skips empty segments, since a blank line is never malformed. The returned index counts every
+/// segment, blanks included. An empty or all-blank payload is `Ok(())`.
+///
+/// The eol-unterminated final-line drop is out of scope: the default `dogstatsd_eol_required=[]`
+/// leaves eol termination off and the generator always `\n`-terminates.
+///
+/// # Errors
+///
+/// Returns the first [`PayloadError`] the Agent would drop on, or `Ok(())` when every message
+/// forwards.
+pub fn is_malformed(payload: &[u8]) -> Result<(), PayloadError> {
+    for (line, segment) in payload.split(|&b| b == b'\n').enumerate() {
+        let segment = segment.strip_suffix(b"\r").unwrap_or(segment);
+        if segment.is_empty() {
+            continue;
+        }
+        if segment.starts_with(b"_e{") {
+            classify_event(line, segment)?;
+        } else if segment.starts_with(b"_sc") {
+            classify_service_check(line, segment)?;
+        } else {
+            classify_metric(line, segment)?;
+        }
+    }
+    Ok(())
+}
+
+/// Apply the Agent `parseMetricSample` M1-M6 drop rules to a single metric line.
+fn classify_metric(line: usize, seg: &[u8]) -> Result<(), PayloadError> {
+    let mut parts = seg.split(|&b| b == b'|');
+    let field0 = parts.next().unwrap_or(&[]);
+    // M1: a metric needs at least one `|`, so a second split part must exist.
+    let Some(type_field) = parts.next() else {
+        return Err(PayloadError::MetricNoPipe { line });
+    };
+    // M2: field-0 must carry a `:` splitting name from value.
+    let Some(colon) = field0.iter().position(|&b| b == b':') else {
+        return Err(PayloadError::MetricNameValueNoColon { line });
+    };
+    let name = &field0[..colon];
+    let value = &field0[colon + 1..];
+    // M3: name and value are both non-empty.
+    if name.is_empty() {
+        return Err(PayloadError::MetricEmptyName { line });
+    }
+    if value.is_empty() {
+        return Err(PayloadError::MetricEmptyValue { line });
+    }
+    // M4 and M5: the type must match exactly, and a non-set value must parse.
+    match type_field {
+        b"s" => {}
+        b"g" | b"c" | b"h" | b"d" | b"ms" => {
+            if value_is_malformed(value) {
+                return Err(PayloadError::MetricUnparseableValue { line });
+            }
+        }
+        _ => return Err(PayloadError::MetricBadType { line }),
+    }
+    // M6: a sample-rate `@` chunk must parse as a Go float. Everything else is skipped.
+    //
+    // The `T` timestamp chunk is deliberately NOT modeled: it drops only when readTimestamps, gated
+    // by `dogstatsd_no_aggregation_pipeline`, is on and the value is not an integer >= 1, a
+    // config-gated surface this generator does not emit. The origin chunks c:/e:/card: never drop.
+    for chunk in parts {
+        if let Some((&first, rest)) = chunk.split_first() {
+            if first == b'@' && !go_parse_float_ok(rest) {
+                return Err(PayloadError::MetricBadRate { line });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Apply the Agent `parseEvent` header drop rules to a single `_e{...}` line. The body and every
+/// optional field forward verbatim, so only the header can drop.
+fn classify_event(line: usize, seg: &[u8]) -> Result<(), PayloadError> {
+    let Some(colon) = seg.iter().position(|&b| b == b':') else {
+        return Err(PayloadError::EventNoColon { line });
+    };
+    let header = &seg[..colon];
+    let body = &seg[colon + 1..];
+    // The minimal header is `_e{1,0}`, seven bytes. `_e{` and the closing byte are stripped by
+    // position. The closing `}` is assumed, never validated.
+    if header.len() < 7 {
+        return Err(PayloadError::EventHeaderTooShort { line });
+    }
+    let raw_lengths = &header[3..header.len() - 1];
+    let Some(comma) = raw_lengths.iter().position(|&b| b == b',') else {
+        return Err(PayloadError::EventNoLengthComma { line });
+    };
+    let raw_title_len = &raw_lengths[..comma];
+    let raw_text_len = &raw_lengths[comma + 1..];
+    let Some(title_len) = atoi(raw_title_len).filter(|&len| len >= 0) else {
+        return Err(PayloadError::EventBadTitleLen { line });
+    };
+    if title_len == 0 {
+        return Err(PayloadError::EventEmptyTitle { line });
+    }
+    let Some(text_len) = atoi(raw_text_len).filter(|&len| len >= 0) else {
+        return Err(PayloadError::EventBadTextLen { line });
+    };
+    // Both lengths are non-negative here, so the magnitude is the value. Go widens them to uint for
+    // the framing math below.
+    let (title_len, text_len) = (title_len.unsigned_abs(), text_len.unsigned_abs());
+    // Go frames the body as title_len + 1, the title/text `|`, plus text_len, computed on uint64.
+    let Some(content_len) = title_len.checked_add(1).and_then(|v| v.checked_add(text_len)) else {
+        return Err(PayloadError::EventLengthOverflow { line });
+    };
+    let Ok(body_len) = u64::try_from(body.len()) else {
+        // A body longer than u64::MAX cannot be too short.
+        return Ok(());
+    };
+    if body_len < content_len {
+        return Err(PayloadError::EventBodyTooShort { line });
+    }
+    Ok(())
+}
+
+/// Parse an event length exactly as Go's `strconv.Atoi` does: an optional leading sign, decimal
+/// digits, no underscores, overflow beyond the 64-bit `int` is a failure. Returns the signed value so
+/// the caller applies the Agent's own `< 0` test rather than treating the sign byte as the verdict.
+/// That is why `-0` parses as a valid zero-length field: Go parses it to zero, and the Agent accepts.
+fn atoi(s: &[u8]) -> Option<i64> {
+    let (neg, digits) = match s.first() {
+        Some(b'+') => (false, &s[1..]),
+        Some(b'-') => (true, &s[1..]),
+        _ => (false, s),
+    };
+    if digits.is_empty() {
+        return None;
+    }
+    let mut acc: i128 = 0;
+    for &c in digits {
+        if !c.is_ascii_digit() {
+            return None;
+        }
+        acc = acc * 10 + i128::from(c - b'0');
+        if acc > i128::from(u64::MAX) {
+            return None;
+        }
+    }
+    let value = if neg { -acc } else { acc };
+    i64::try_from(value).ok()
+}
+
+/// Apply the Agent `parseServiceCheck` drop rules to a single `_sc` line.
+fn classify_service_check(line: usize, seg: &[u8]) -> Result<(), PayloadError> {
+    // The parser needs a name terminator and a status terminator, so at least two `|`.
+    let two_pipes = seg
+        .iter()
+        .position(|&b| b == b'|')
+        .is_some_and(|i| seg[i + 1..].contains(&b'|'));
+    if !two_pipes {
+        return Err(PayloadError::ServiceCheckTooFewPipes { line });
+    }
+    // The parser strips a four-byte `_sc|` header by position.
+    if seg.len() < 4 {
+        return Err(PayloadError::ServiceCheckTooShort { line });
+    }
+    let mut fields = seg[4..].split(|&b| b == b'|');
+    let name = fields.next().unwrap_or(&[]);
+    if name.is_empty() {
+        return Err(PayloadError::ServiceCheckEmptyName { line });
+    }
+    let status = fields.next().unwrap_or(&[]);
+    if !matches!(status, b"0" | b"1" | b"2" | b"3") {
+        return Err(PayloadError::ServiceCheckBadStatus { line });
+    }
+    Ok(())
+}
+
+/// M5 for a non-set type: a value carrying `:` splits into colon segments, empty segments are
+/// discarded, and the value is malformed when any surviving segment fails the Go-float parse or when
+/// no segment survives. A value with no `:` is malformed when the whole value fails the Go-float
+/// parse.
+fn value_is_malformed(value: &[u8]) -> bool {
+    if value.contains(&b':') {
+        let mut survived = 0usize;
+        for seg in value.split(|&b| b == b':') {
+            if seg.is_empty() {
+                continue;
+            }
+            survived += 1;
+            if !go_parse_float_ok(seg) {
+                return true;
+            }
+        }
+        survived == 0
+    } else {
+        !go_parse_float_ok(value)
+    }
+}
+
+/// Whether Go's `strconv.ParseFloat(s, 64)` would accept these bytes without error.
+///
+/// This mirrors Go, not Rust. It accepts hex-floats such as `0x1p-2`, underscore digit separators
+/// such as `1_000`, and the unsigned specials `nan`, `inf`, and `infinity` with an optional sign on
+/// the infinities. It rejects `+nan`/`-nan` and any finite decimal that overflows f64. Underflow to
+/// `0.0` is not an error.
+fn go_parse_float_ok(s: &[u8]) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    if is_special_float(s) {
+        return true;
+    }
+    let Some(scan) = scan_float(s) else {
+        return false;
+    };
+    if scan.hex {
+        !hex_value_overflows(s)
+    } else {
+        decimal_is_finite(s)
+    }
+}
+
+/// Whether the bytes match one of Go's special float tokens: `inf`/`infinity` with an optional sign,
+/// or `nan` with no sign, all case-insensitive. Go rejects `+nan`/`-nan`.
+fn is_special_float(s: &[u8]) -> bool {
+    let (rest, signed) = match s.first() {
+        Some(b'+' | b'-') => (&s[1..], true),
+        _ => (s, false),
+    };
+    let eq_ci = |token: &[u8]| rest.len() == token.len() && rest.iter().zip(token).all(|(&a, &b)| (a | 0x20) == b);
+    if eq_ci(b"inf") || eq_ci(b"infinity") {
+        return true;
+    }
+    !signed && eq_ci(b"nan")
+}
+
+/// Result of a successful Go-float syntax scan.
+#[derive(Clone, Copy, Debug)]
+struct FloatScan {
+    hex: bool,
+}
+
+/// Scan the bytes as a Go decimal or hex float, returning `Some` only when the whole slice is
+/// consumed as a syntactically valid number. This mirrors Go's `readFloat` plus `underscoreOK`. It
+/// does not decide magnitude overflow.
+fn scan_float(s: &[u8]) -> Option<FloatScan> {
+    if !underscore_ok(s) {
+        return None;
+    }
+    let n = s.len();
+    let mut i = 0usize;
+
+    if i < n && (s[i] == b'+' || s[i] == b'-') {
+        i += 1;
+    }
+
+    // Go enters hex mode only when at least one byte follows the `0x` prefix.
+    let mut hex = false;
+    let mut exp_char = b'e';
+    if i + 2 < n && s[i] == b'0' && (s[i + 1] | 0x20) == b'x' {
+        hex = true;
+        exp_char = b'p';
+        i += 2;
+    }
+
+    let mut saw_digits = false;
+    let mut saw_dot = false;
+    while i < n {
+        let c = s[i];
+        if c == b'_' {
+            i += 1;
+            continue;
+        }
+        if c == b'.' {
+            if saw_dot {
+                break;
+            }
+            saw_dot = true;
+            i += 1;
+            continue;
+        }
+        if c.is_ascii_digit() {
+            saw_digits = true;
+            i += 1;
+            continue;
+        }
+        if hex && (b'a'..=b'f').contains(&(c | 0x20)) {
+            saw_digits = true;
+            i += 1;
+            continue;
+        }
+        break;
+    }
+    if !saw_digits {
+        return None;
+    }
+
+    if i < n && (s[i] | 0x20) == exp_char {
+        i += 1;
+        if i < n && (s[i] == b'+' || s[i] == b'-') {
+            i += 1;
+        }
+        if i >= n || !s[i].is_ascii_digit() {
+            return None;
+        }
+        while i < n {
+            let c = s[i];
+            if c == b'_' || c.is_ascii_digit() {
+                i += 1;
+            } else {
+                break;
+            }
+        }
+    } else if hex {
+        // A hex float requires a binary `p` exponent.
+        return None;
+    }
+
+    if i != n {
+        return None;
+    }
+    Some(FloatScan { hex })
+}
+
+/// Whether the underscores in `s` sit only between digits or between a base prefix and a digit,
+/// mirroring Go's `underscoreOK`.
+fn underscore_ok(s: &[u8]) -> bool {
+    if !s.contains(&b'_') {
+        return true;
+    }
+    // States: `^` start, `0` digit or base prefix, `_` underscore, `!` other.
+    let mut saw = b'^';
+    let n = s.len();
+    let mut i = 0usize;
+
+    if n >= 1 && (s[0] == b'-' || s[0] == b'+') {
+        i = 1;
+    }
+
+    let mut hex = false;
+    if n - i >= 2 && s[i] == b'0' {
+        let lc = s[i + 1] | 0x20;
+        if lc == b'b' || lc == b'o' || lc == b'x' {
+            saw = b'0';
+            hex = lc == b'x';
+            i += 2;
+        }
+    }
+
+    while i < n {
+        let c = s[i];
+        if c.is_ascii_digit() || (hex && (b'a'..=b'f').contains(&(c | 0x20))) {
+            saw = b'0';
+        } else if c == b'_' {
+            if saw != b'0' {
+                return false;
+            }
+            saw = b'_';
+        } else {
+            if saw == b'_' {
+                return false;
+            }
+            saw = b'!';
+        }
+        i += 1;
+    }
+    saw != b'_'
+}
+
+/// Whether a Go-syntactically-valid decimal float has finite magnitude. Go returns `ErrRange` when a
+/// finite decimal overflows to infinity. Rust's parser surfaces the same overflow as an infinite
+/// result, so a finite parse means Go accepts it.
+fn decimal_is_finite(s: &[u8]) -> bool {
+    let parsed = if s.contains(&b'_') {
+        let cleaned: Vec<u8> = s.iter().copied().filter(|&b| b != b'_').collect();
+        parse_ascii_f64(&cleaned)
+    } else {
+        parse_ascii_f64(s)
+    };
+    match parsed {
+        Some(v) => v.is_finite(),
+        // Go accepted the syntax. Anything Rust cannot re-parse here is a small-magnitude form such
+        // as a trailing-dot mantissa, never an overflow.
+        None => true,
+    }
+}
+
+/// Parse ASCII bytes as an f64, or `None` when they are not valid UTF-8 or not a Rust float.
+fn parse_ascii_f64(s: &[u8]) -> Option<f64> {
+    simdutf8::basic::from_utf8(s).ok()?.parse::<f64>().ok()
+}
+
+/// Whether a Go-syntactically-valid hex float overflows f64.
+///
+/// This mirrors Go's `readFloat`/`atofHex`. It folds at most 16 significant hex digits, at least 64
+/// bits, into the mantissa and tracks the hex-point position. Integer digits beyond the cap grow the
+/// binary exponent rather than the mantissa, and fractional digits beyond the cap are dropped. The
+/// binary exponent is `(point_digits - mantissa_digits) * 4` plus the `p` exponent, so the bounded
+/// mantissa times `2^exponent` gives the true overflow verdict without relying on f64 saturation.
+/// Underflow to zero is not an overflow.
+fn hex_value_overflows(s: &[u8]) -> bool {
+    const MAX_MANT_HEX_DIGITS: i64 = 16;
+
+    let len = s.len();
+    let mut i = 0usize;
+    if i < len && (s[i] == b'+' || s[i] == b'-') {
+        i += 1;
+    }
+    i += 2; // Skip the validated `0x` prefix.
+
+    let mut mantissa: f64 = 0.0;
+    let mut nd: i64 = 0; // Significant digits seen. Drives the hex-point position.
+    let mut nd_mant: i64 = 0; // Digits folded into the mantissa, capped.
+    let mut dp: i64 = 0; // Significant digits before the hex point.
+    let mut saw_dot = false;
+    while i < len {
+        let byte = s[i];
+        if byte == b'_' {
+            i += 1;
+            continue;
+        }
+        if byte == b'.' {
+            if saw_dot {
+                break;
+            }
+            saw_dot = true;
+            dp = nd;
+            i += 1;
+            continue;
+        }
+        let digit: u8 = if byte.is_ascii_digit() {
+            byte - b'0'
+        } else {
+            let lower = byte | 0x20;
+            if (b'a'..=b'f').contains(&lower) {
+                lower - b'a' + 10
+            } else {
+                break;
+            }
+        };
+        // Leading zeros shift the point but never enter the mantissa.
+        if digit == 0 && nd == 0 {
+            dp -= 1;
+            i += 1;
+            continue;
+        }
+        nd += 1;
+        if nd_mant < MAX_MANT_HEX_DIGITS {
+            mantissa = mantissa * 16.0 + f64::from(digit);
+            nd_mant += 1;
+        }
+        i += 1;
+    }
+    // No digit folded into the mantissa means the value is zero, never an overflow.
+    if nd_mant == 0 {
+        return false;
+    }
+    if !saw_dot {
+        dp = nd;
+    }
+    // Count in bits.
+    dp *= 4;
+    nd_mant *= 4;
+
+    i += 1; // Skip the `p`/`P` exponent marker.
+    let mut esign: i64 = 1;
+    if i < len && (s[i] == b'+' || s[i] == b'-') {
+        if s[i] == b'-' {
+            esign = -1;
+        }
+        i += 1;
+    }
+    let mut exp: i64 = 0;
+    while i < len {
+        let byte = s[i];
+        if byte == b'_' {
+            i += 1;
+        } else if byte.is_ascii_digit() {
+            exp = exp.saturating_mul(10).saturating_add(i64::from(byte - b'0'));
+            i += 1;
+        } else {
+            break;
+        }
+    }
+    dp = dp.saturating_add(esign.saturating_mul(exp));
+
+    let total = dp.saturating_sub(nd_mant);
+    if total > 1100 {
+        return true;
+    }
+    if total < -1200 {
+        return false;
+    }
+    let Ok(total_i32) = i32::try_from(total) else {
+        return true;
+    };
+    (mantissa * 2f64.powi(total_i32)).is_infinite()
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::{is_malformed, PayloadError};
+
+    // --- metrics ---
+
+    #[test]
+    fn metric_well_formed_forwards() {
+        // Covers basic, set with an unparsed value, multi-value packed, special values, @rate, tags
+        // and origin chunks with delimiters, and a non-UTF-8 name. All forward through the lenient
+        // Agent.
+        for line in [
+            &b"m:1|c"[..],
+            b"m:1|g",
+            b"m:1|ms",
+            b"m:1|h",
+            b"m:1|d",
+            b"m:anything goes|s",
+            b"m:1:2:3|d",
+            b"m:nan|g",
+            b"m:inf|g",
+            b"m:-inf|g",
+            b"m:0x1p4|g",
+            b"m:1_000|g",
+            b"m:1.|g",
+            b"m:.5|g",
+            b"m:1|c|@0.5",
+            b"m:1|c|@nan",
+            b"m:1|c|#a:b,c:d",
+            b"m:1|c|c:cid-deadbeef",
+            b"m:1|c|card:high",
+            b"na\xff\x00me:1|c",
+        ] {
+            assert_eq!(is_malformed(line), Ok(()), "expected forward: {line:?}");
+        }
+    }
+
+    #[test]
+    fn metric_drop_rules() {
+        assert_eq!(is_malformed(b"m:1"), Err(PayloadError::MetricNoPipe { line: 0 }));
+        assert_eq!(
+            is_malformed(b"noColon|g"),
+            Err(PayloadError::MetricNameValueNoColon { line: 0 })
+        );
+        assert_eq!(is_malformed(b":1|g"), Err(PayloadError::MetricEmptyName { line: 0 }));
+        assert_eq!(is_malformed(b"m:|g"), Err(PayloadError::MetricEmptyValue { line: 0 }));
+        assert_eq!(is_malformed(b"m:1|gg"), Err(PayloadError::MetricBadType { line: 0 }));
+        assert_eq!(is_malformed(b"m:1|"), Err(PayloadError::MetricBadType { line: 0 }));
+        assert_eq!(
+            is_malformed(b"m:notafloat|g"),
+            Err(PayloadError::MetricUnparseableValue { line: 0 })
+        );
+        assert_eq!(
+            is_malformed(b"m:::|d"),
+            Err(PayloadError::MetricUnparseableValue { line: 0 })
+        );
+        assert_eq!(
+            is_malformed(b"m:1|c|@bad"),
+            Err(PayloadError::MetricBadRate { line: 0 })
+        );
+    }
+
+    // --- events ---
+
+    #[test]
+    fn event_well_formed_forwards() {
+        for line in [
+            &b"_e{1,0}:a|"[..],
+            b"_e{5,4}:title|text",
+            b"_e{5,0}:title|",
+            b"_e{5,4}:title|text|h:host|k:key|p:normal|t:error|s:src|#a:b",
+            b"_e{5,4}:title|text|p:bogus|t:bogus|d:notanint", // bad optional fields still forward
+            b"_e{5,4}:title|text|extra bytes past declared body", // body longer than declared is fine
+            b"_e{5,4}:t\xff\x00le|te\xffxt",                  // non-UTF-8 title/text forward
+        ] {
+            assert_eq!(is_malformed(line), Ok(()), "expected forward: {line:?}");
+        }
+    }
+
+    #[test]
+    fn event_drop_rules() {
+        assert_eq!(
+            is_malformed(b"_e{5,4}title|text"),
+            Err(PayloadError::EventNoColon { line: 0 })
+        );
+        assert_eq!(
+            is_malformed(b"_e{}:x"),
+            Err(PayloadError::EventHeaderTooShort { line: 0 })
+        );
+        assert_eq!(
+            is_malformed(b"_e{500}:title"),
+            Err(PayloadError::EventNoLengthComma { line: 0 })
+        );
+        assert_eq!(
+            is_malformed(b"_e{x,0}:title"),
+            Err(PayloadError::EventBadTitleLen { line: 0 })
+        );
+        assert_eq!(
+            is_malformed(b"_e{0,0}:"),
+            Err(PayloadError::EventEmptyTitle { line: 0 })
+        );
+        assert_eq!(
+            is_malformed(b"_e{5,x}:title"),
+            Err(PayloadError::EventBadTextLen { line: 0 })
+        );
+        assert_eq!(
+            is_malformed(b"_e{5,4}:t"),
+            Err(PayloadError::EventBodyTooShort { line: 0 })
+        );
+    }
+
+    // Go parses the header lengths with `strconv.Atoi` and drops only on `< 0`, so a signed zero is a
+    // valid zero-length field the Agent forwards. Rejecting it would hide an Agent-accepted line from
+    // the state search.
+    #[test]
+    fn event_signed_zero_length_matches_atoi() {
+        assert_eq!(is_malformed(b"_e{1,-0}:a|"), Ok(()));
+        assert_eq!(is_malformed(b"_e{1,-00}:a|"), Ok(()));
+        // A genuinely negative length still drops, as `textLength < 0` does in the Agent.
+        assert_eq!(
+            is_malformed(b"_e{1,-1}:a|"),
+            Err(PayloadError::EventBadTextLen { line: 0 })
+        );
+        // A signed-zero title parses to zero, so the Agent's own empty-title check is what drops it.
+        assert_eq!(
+            is_malformed(b"_e{-0,0}:"),
+            Err(PayloadError::EventEmptyTitle { line: 0 })
+        );
+    }
+
+    // --- service checks ---
+
+    #[test]
+    fn service_check_well_formed_forwards() {
+        for line in [
+            &b"_sc|name|0"[..],
+            b"_sc|name|1",
+            b"_sc|name|2",
+            b"_sc|name|3",
+            b"_sc|name|0|h:host|#a:b|m:message text",
+            b"_sc|na\xffme|0", // non-UTF-8 name forwards
+        ] {
+            assert_eq!(is_malformed(line), Ok(()), "expected forward: {line:?}");
+        }
+    }
+
+    #[test]
+    fn service_check_drop_rules() {
+        assert_eq!(
+            is_malformed(b"_sc|nameonly"),
+            Err(PayloadError::ServiceCheckTooFewPipes { line: 0 })
+        );
+        assert_eq!(
+            is_malformed(b"_sc"),
+            Err(PayloadError::ServiceCheckTooFewPipes { line: 0 })
+        );
+        assert_eq!(
+            is_malformed(b"_sc||0"),
+            Err(PayloadError::ServiceCheckEmptyName { line: 0 })
+        );
+        assert_eq!(
+            is_malformed(b"_sc|name|9"),
+            Err(PayloadError::ServiceCheckBadStatus { line: 0 })
+        );
+        assert_eq!(
+            is_malformed(b"_sc|name|"),
+            Err(PayloadError::ServiceCheckBadStatus { line: 0 })
+        );
+    }
+
+    // --- framing / routing ---
+
+    #[test]
+    fn framing_skips_blanks_and_reports_first_offending_line() {
+        // Blank lines are counted in the index but never malformed. The first bad message wins.
+        let payload = b"m:1|c\n\n\nbad|line\nm:2|c";
+        assert_eq!(
+            is_malformed(payload),
+            Err(PayloadError::MetricNameValueNoColon { line: 3 })
+        );
+    }
+
+    #[test]
+    fn framing_handles_crlf_and_empty_payload() {
+        assert_eq!(is_malformed(b"m:1|c\r\nm:2|g\r\n"), Ok(()));
+        assert_eq!(is_malformed(b""), Ok(()));
+        assert_eq!(is_malformed(b"\n\n"), Ok(()));
+    }
+
+    #[test]
+    fn routing_by_prefix() {
+        // `_e` without `{` and any gibberish route to the metric parser.
+        assert_eq!(is_malformed(b"_e:1|g"), Ok(()));
+        assert_eq!(is_malformed(b"gibberish"), Err(PayloadError::MetricNoPipe { line: 0 }));
+    }
+
+    // --- Go strconv parity port ---
+
+    #[test]
+    fn go_float_accepts_go_specific_forms() {
+        // Each rides in as a metric value: forwarded iff Go ParseFloat accepts it.
+        for value in [
+            &b"0x1p-2"[..],
+            b"1_000",
+            b"nan",
+            b"inf",
+            b"infinity",
+            b"+inf",
+            b"-inf",
+            b"1.",
+            b".5",
+            b"0x1.8p3",
+        ] {
+            let mut line = b"m:".to_vec();
+            line.extend_from_slice(value);
+            line.extend_from_slice(b"|g");
+            assert_eq!(is_malformed(&line), Ok(()), "expected forward for value {value:?}");
+        }
+    }
+
+    #[test]
+    fn go_float_rejects_what_go_rejects() {
+        for value in [
+            &b"+nan"[..],
+            b"-nan",
+            b"0x1",
+            b"_1",
+            b"1_",
+            b"1__0",
+            b"1e",
+            b"1e+",
+            b"abc",
+        ] {
+            let mut line = b"m:".to_vec();
+            line.extend_from_slice(value);
+            line.extend_from_slice(b"|g");
+            assert_eq!(
+                is_malformed(&line),
+                Err(PayloadError::MetricUnparseableValue { line: 0 }),
+                "expected drop for value {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn hex_float_overflow_boundary() {
+        // 0x1p1023 is finite, 0x1p1024 overflows f64.
+        assert_eq!(is_malformed(b"m:0x1p1023|g"), Ok(()));
+        assert_eq!(
+            is_malformed(b"m:0x1p1024|g"),
+            Err(PayloadError::MetricUnparseableValue { line: 0 })
+        );
+    }
+
+    proptest! {
+        // The predicate must be total over arbitrary bytes: never panic, whatever the input.
+        #[test]
+        fn property_test_never_panics(payload in proptest::collection::vec(any::<u8>(), 0..128)) {
+            let _ = is_malformed(&payload);
+        }
+    }
+}

--- a/test/antithesis/harness/src/driver.rs
+++ b/test/antithesis/harness/src/driver.rs
@@ -15,24 +15,15 @@ use std::sync::mpsc::sync_channel;
 use std::thread::{self, sleep};
 use std::time::{Duration, Instant};
 
-use rand::seq::IndexedRandom;
+use antithesis_sdk::prelude::*;
 use rand::Rng;
+use serde_json::json;
 
+use crate::dogstatsd::is_malformed;
 use crate::payload::dogstatsd;
-pub use crate::payload::dogstatsd::Batch;
 
 const SEND_RETRY_BUDGET: Duration = Duration::from_secs(5);
 const SEND_RETRY_BACKOFF: Duration = Duration::from_millis(1);
-
-/// Sample a line composition: half clean, a quarter feral, a quarter mixed.
-#[must_use]
-pub fn sample<R: Rng + ?Sized>(rng: &mut R) -> Batch {
-    match [Batch::Clean, Batch::Clean, Batch::Feral, Batch::Mixed].choose(rng) {
-        Some(Batch::Feral) => Batch::Feral,
-        Some(Batch::Mixed) => Batch::Mixed,
-        _ => Batch::Clean,
-    }
-}
 
 /// A generated payload queued for the sockets: the packed bytes and what they hold.
 struct Datagram {
@@ -72,14 +63,21 @@ pub struct Stats {
 /// Errors if a worker thread panics. Sustained backpressure is reported via
 /// [`Stats::timed_out`], not as an error.
 pub fn run<R: Rng + Send + 'static>(
-    mut rng: R, batch: Batch, limit_bytes: usize, count: usize, sockets: Vec<UnixDatagram>,
+    mut rng: R, limit_bytes: usize, count: usize, sockets: Vec<UnixDatagram>,
 ) -> anyhow::Result<Stats> {
     let (tx, rx) = sync_channel::<Datagram>(2024);
 
     let producer = thread::spawn(move || {
         for _ in 0..count {
             let mut bytes = Vec::new();
-            let payload = dogstatsd::write_payload(&mut rng, &mut bytes, batch, limit_bytes);
+            let payload = dogstatsd::write_payload(&mut rng, &mut bytes, limit_bytes);
+            // Green by construction: write_payload emits only lines the Agent forwards. The anchor
+            // catches any generator drift that would ship a droppable datagram.
+            assert_always!(
+                is_malformed(&bytes).is_ok(),
+                "driver payload is well-formed",
+                &json!({})
+            );
             if tx.send(Datagram { bytes, payload }).is_err() {
                 break;
             }

--- a/test/antithesis/harness/src/lib.rs
+++ b/test/antithesis/harness/src/lib.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 pub mod config;
+pub mod dogstatsd;
 #[cfg(unix)]
 pub mod driver;
 pub mod payload;

--- a/test/antithesis/harness/src/payload/dogstatsd.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd.rs
@@ -1,110 +1,39 @@
 //! `DogStatsD` payload generation.
 //!
-//! Dogstatsd is three message types: metric, event, service check.
-//!
-//! # Metrics
-//!
-//! ```text
-//! <NAME>:<VALUE>|<TYPE>|@<SAMPLE_RATE>|#<TAG>,<TAG>...|c:<CONTAINER>|T<TS>|e:<EXT>|card:<CARD>
-//!
-//! Required: <NAME>:<VALUE>|<TYPE>.
-//!
-//! <NAME>        := [^:|\n]+
-//! <VALUE>       := <NUMBER>(:<NUMBER>)*        ':'-packed multi-value, non-set
-//!                | [^|\n]+                     raw string, set type
-//! <NUMBER>      := [+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)? | [+-]?(inf|infinity|nan)
-//! <TYPE>        := c|g|ms|h|s|d                count gauge timer histogram set distribution
-//! <SAMPLE_RATE> := @<NUMBER>
-//! <TAG>         := [^,|\n]+                    conventionally <KEY>:<VALUE>, the ':' is not required
-//! <CONTAINER>   := c:[^|\n]+                   e.g. ci-<id>, in-<inode>
-//! <TS>          := T\d+                        unix seconds
-//! <EXT>         := e:[^|\n]+                   e.g. it-,cn-,pu-
-//! <CARD>        := card:[^|\n]+                recognized: none|low|orchestrator|high
-//! ```
-//!
-//! # Events
+//! Generation builds three structured message types, metric, event, and service check, then
+//! serializes each to datagram bytes. Every message is checked with [`crate::dogstatsd::is_malformed`]
+//! on its serialized bytes and repaired until the Datadog Agent would forward it. There is no
+//! clean/feral/mixed configuration and no per-line vibe. The legal space is exactly the set of
+//! payloads `is_malformed` accepts. Content fields range over the full forwarded alphabet including
+//! delimiter bytes, and the predicate sorts the delimiter-bearing cases the Agent keeps from the ones
+//! it drops.
 //!
 //! ```text
-//! _e{<TITLE_LEN>,<TEXT_LEN>}:<TITLE>|<TEXT>|d:<TS>|h:<HOST>|k:<AGGKEY>|p:<PRIO>|s:<SRC>|t:<ALERT>|#<TAGS>
-//!
-//! Required: _e{<TITLE_LEN>,<TEXT_LEN>}:<TITLE>|<TEXT>. c: / e: / card: are valid here too.
-//!
-//! <TITLE_LEN>,<TEXT_LEN> := \d+               byte length of TITLE / TEXT
-//! <TITLE>,<TEXT>         := [^\n]{LEN}         length-delimited, so '|' and ':' are allowed
-//! <TS>          := d:\d+                       unix seconds
-//! <HOST>        := h:[^|\n]+
-//! <AGGKEY>      := k:[^|\n]+
-//! <PRIO>        := p:[^|\n]+                   recognized: normal|low (else default)
-//! <SRC>         := s:[^|\n]+
-//! <ALERT>       := t:[^|\n]+                   recognized: error|warning|info|success (else default)
-//! <TAGS>        := #<TAG>(,<TAG>)*
+//! metric:        <NAME>:<VALUE>(:<VALUE>)*|<TYPE>[|@<RATE>][|#<TAGS>][|c:..][|e:..][|card:..]
+//! event:         _e{<TITLE_LEN>,<TEXT_LEN>}:<TITLE>|<TEXT>[|h:..][|k:..][|p:..][|s:..][|t:..][|#<TAGS>]
+//! service check: _sc|<NAME>|<STATUS>[|h:..][|m:..][|#<TAGS>]
 //! ```
-//!
-//! # Service checks
-//!
-//! ```text
-//! _sc|<NAME>|<STATUS>|d:<TS>|h:<HOST>|#<TAG>,<TAG>...|m:<MESSAGE>
-//!
-//! Required: _sc|<NAME>|<STATUS>. c: / e: / card: are valid here too.
-//!
-//! <NAME>        := [^|\n]+
-//! <STATUS>      := [0-3]                       OK warning critical unknown
-//! <TS>          := d:\d+                       unix seconds
-//! <HOST>        := h:[^|\n]+
-//! <TAGS>        := #<TAG>(,<TAG>)*
-//! <MESSAGE>     := m:[^|\n]+
-//! ```
-//!
-//! # Name combinatorics
-//!
-//! A clean name is `c` segments from `COMPLIANT_WORD` (10 words) joined by
-//! `NAME_SEPARATORS` (4). Distinct names at count `c`: `10^c · 4^(c-1)`. `c` is
-//! sampled by vibe: clean draws from `ELEMENT_COUNTS_CLEAN` (a small body, no
-//! boundary cases); feral draws from `ELEMENT_COUNTS_FERAL`, which adds the `0`
-//! and large boundary counts as a tail.
-//!
-//! | `c`   | P(c) clean | P(c) feral | distinct names |
-//! |-------|------------|------------|----------------|
-//! | 0     | —          | 1/12       | 1 (empty)      |
-//! | 1-3   | 6/9        | 6/12       | 10 .. ~16e3    |
-//! | 4-6   | 3/9        | 3/12       | ~640e3 .. ~1e9 |
-//! | 127   | —          | 1/12       | ~10^203        |
-//! | 255   | —          | 1/12       | ~10^408        |
 
 use rand::{Rng, RngExt};
+
+use crate::dogstatsd::is_malformed;
 
 mod common;
 mod events;
 mod metrics;
 mod service_checks;
 
-pub use common::{sample_vibe, Vibe};
+/// How many times to re-sample a message whose serialized bytes the Agent would drop before falling
+/// back to a guaranteed-well-formed line. Construction is mostly-valid, so the fallback is rare.
+const REPAIR_TRIES: usize = 16;
 
-/// The three `DogStatsD` message types.
-#[derive(Clone, Copy)]
-enum Message {
-    Metric,
-    Event,
-    ServiceCheck,
-}
+/// A guaranteed-well-formed metric, used only if repair is exhausted, so the pack loop always
+/// terminates.
+const FALLBACK_LINE: &[u8] = b"harness.fallback:1|c";
 
-/// Sample a message type. The mix is heavily metric-weighted — 98% metric, 1%
-/// event, 1% service check. Metrics drive the aggregate context map and the
-/// sketch bin paths, the invariants worth exercising, so the bulk of load goes
-/// there while events and service checks still fire often enough to keep their
-/// own anchors non-vacuous.
-fn choose_message<R: Rng + ?Sized>(rng: &mut R) -> Message {
-    match rng.random_range(0..100u32) {
-        0 => Message::Event,
-        1 => Message::ServiceCheck,
-        _ => Message::Metric,
-    }
-}
-
-/// Ceiling on a generated datagram, the Datadog Agent's default
-/// `dogstatsd_buffer_size`. A run caps each datagram to the smaller of this and
-/// the SUT's sampled receive buffer, so a packed datagram always fits one read
-/// and the SUT never truncates a line mid-token.
+/// Ceiling on a generated datagram, the Datadog Agent's default `dogstatsd_buffer_size`. A run caps
+/// each datagram to the smaller of this and the SUT's sampled receive buffer, so a packed datagram
+/// always fits one read and the SUT never truncates a line mid-token.
 pub const PAYLOAD_BYTE_LIMIT: usize = 8_192;
 
 /// What a generated payload holds, for anchoring assertions.
@@ -116,80 +45,85 @@ pub struct Payload {
     pub max_packed: usize,
 }
 
-/// Append one `DogStatsD` line of a sampled type to `buf`. When a line would
-/// exceed `limit_bytes`, drop it whole rather than shear it, leaving `buf`
-/// unchanged. A non-empty line always ends in `\n`.
-///
-/// Returns the packed value count when a multi-value metric was emitted, else
-/// `None`.
-pub fn write_line<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe, limit_bytes: usize) -> Option<usize> {
-    let start = buf.len();
-    let packed = match choose_message(rng) {
-        Message::Event => {
-            events::write(rng, buf, vibe);
-            None
+/// One of the three `DogStatsD` message types, structured.
+enum Message {
+    Metric(metrics::Metric),
+    Event(events::Event),
+    ServiceCheck(service_checks::ServiceCheck),
+}
+
+impl Message {
+    /// Sample a message type. The mix is heavily metric-weighted: 98% metric, 1% event, 1% service
+    /// check. Metrics drive the aggregate context and sketch paths, so the bulk of load goes there
+    /// while events and service checks still fire often enough to keep their anchors non-vacuous.
+    fn generate(rng: &mut (impl Rng + ?Sized), budget: usize) -> Option<Self> {
+        match rng.random_range(0..100u32) {
+            0 => events::Event::generate(rng, budget).map(Message::Event),
+            1 => service_checks::ServiceCheck::generate(rng, budget).map(Message::ServiceCheck),
+            _ => metrics::Metric::generate(rng, budget).map(Message::Metric),
         }
-        Message::ServiceCheck => {
-            service_checks::write(rng, buf, vibe);
-            None
-        }
-        Message::Metric => metrics::write(rng, buf, vibe),
-    };
-    if buf.len() - start > limit_bytes {
-        // Drop a whole line that exceeds limit_bytes rather than shear it mid-token.
-        // A sheared fragment is exactly the parse-error spew this generator avoids.
-        buf.truncate(start);
-        return None;
     }
-    packed
-}
 
-/// Per-run line composition: every line clean, every line feral, or a per-line
-/// clean-or-feral mix.
-#[derive(Clone, Copy, Debug)]
-pub enum Batch {
-    /// Every line clean.
-    Clean,
-    /// Every line feral.
-    Feral,
-    /// Each line independently clean or feral.
-    Mixed,
-}
-
-impl Batch {
-    /// The vibe for one line of this batch, sampled per call so `Mixed` interleaves.
-    fn vibe<R: Rng + ?Sized>(self, rng: &mut R) -> Vibe {
+    /// Serialize to datagram bytes, without the trailing `\n`.
+    fn serialize(&self, out: &mut Vec<u8>) {
         match self {
-            Batch::Clean => Vibe::Clean,
-            Batch::Feral => Vibe::Feral,
-            Batch::Mixed => sample_vibe(rng),
+            Message::Metric(m) => m.serialize(out),
+            Message::Event(e) => e.serialize(out),
+            Message::ServiceCheck(s) => s.serialize(out),
+        }
+    }
+
+    /// The packed multi-value run length this message contributes, or zero.
+    fn packed(&self) -> usize {
+        match self {
+            Message::Metric(m) => m.packed(),
+            Message::Event(_) | Message::ServiceCheck(_) => 0,
         }
     }
 }
 
-/// Pack whole `\n`-terminated lines into `buf` until the next sampled line does
-/// not fit the space left under `limit_bytes`. That overflowing line is dropped
-/// whole rather than sheared and ends the payload, so the packed datagram never
-/// exceeds `limit_bytes` and holds only whole lines. Each line takes its vibe
-/// from `batch`, so a `Mixed` payload interleaves clean and feral lines. Clears
-/// `buf` first.
-pub fn write_payload<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, batch: Batch, limit_bytes: usize) -> Payload {
+/// Sample one message and serialize it to bytes the Agent forwards, within `budget` bytes including
+/// the trailing `\n`. Re-samples up to [`REPAIR_TRIES`] times a message the Agent would drop or one
+/// that overruns the budget, then falls back to [`FALLBACK_LINE`]. Returns `None` only when even the
+/// fallback does not fit.
+///
+/// The budget is a construction input, not a filter applied afterwards: a sample that does not fit is
+/// another sample to take, never a reason to end the payload. Ending it would leave the datagram
+/// short, or empty when the very first sample overran, and a short datagram is workload the SUT never
+/// sees while the driver still spends one of its configured sends.
+fn wellformed_line(rng: &mut (impl Rng + ?Sized), budget: usize) -> Option<(Vec<u8>, usize)> {
+    for _ in 0..REPAIR_TRIES {
+        // The message is built against the budget, so it fits by construction. The retry is only for
+        // the Agent's own drop rules, which are about content rather than size.
+        let Some(message) = Message::generate(rng, budget.saturating_sub(1)) else {
+            break;
+        };
+        let mut bytes = Vec::new();
+        message.serialize(&mut bytes);
+        if bytes.len() < budget && is_malformed(&bytes).is_ok() {
+            return Some((bytes, message.packed()));
+        }
+    }
+    (FALLBACK_LINE.len() < budget).then(|| (FALLBACK_LINE.to_vec(), 0))
+}
+
+/// Pack whole `\n`-terminated lines into `buf` until the budget cannot hold another line. Each line is
+/// sampled against the budget still free, so the datagram fills rather than ending on the first
+/// oversized sample, never exceeds `limit_bytes`, and holds only whole lines every one of which the
+/// Agent forwards. Clears `buf` first.
+pub fn write_payload(rng: &mut (impl Rng + ?Sized), buf: &mut Vec<u8>, limit_bytes: usize) -> Payload {
     buf.clear();
     let mut payload = Payload::default();
     loop {
-        let vibe = batch.vibe(rng);
-        let start = buf.len();
-        // Pass the budget still free so an overflowing line is dropped whole, not
-        // sheared, and the total stays within `limit_bytes`.
-        let packed = write_line(rng, buf, vibe, limit_bytes - buf.len());
-        if buf.len() == start {
-            // The line did not fit the space left, so the payload is complete.
+        // The budget left, `\n` included. Every accepted line consumes at least one byte, so the
+        // remaining budget strictly shrinks and the loop ends once nothing fits.
+        let Some((line, packed)) = wellformed_line(rng, limit_bytes - buf.len()) else {
             break;
-        }
+        };
+        buf.extend_from_slice(&line);
+        buf.push(b'\n');
         payload.lines += 1;
-        if let Some(count) = packed {
-            payload.max_packed = payload.max_packed.max(count);
-        }
+        payload.max_packed = payload.max_packed.max(packed);
     }
     payload
 }
@@ -200,51 +134,54 @@ mod test {
     use rand::rngs::SmallRng;
     use rand::SeedableRng;
 
-    use super::{write_line, write_payload, Batch, Vibe};
+    use super::{write_payload, FALLBACK_LINE, PAYLOAD_BYTE_LIMIT};
+    use crate::dogstatsd::is_malformed;
 
-    fn any_vibe() -> impl Strategy<Value = Vibe> {
-        prop_oneof![Just(Vibe::Clean), Just(Vibe::Feral)]
-    }
-
-    fn any_batch() -> impl Strategy<Value = Batch> {
-        prop_oneof![Just(Batch::Clean), Just(Batch::Feral), Just(Batch::Mixed)]
-    }
-
-    /// Lines carry no interior newline and each is `\n`-terminated, so the line
-    /// count equals the newline count.
+    /// Lines carry no interior newline and each is `\n`-terminated, so the line count equals the
+    /// newline count.
     #[allow(clippy::naive_bytecount)]
     fn newline_count(buf: &[u8]) -> usize {
         buf.iter().filter(|&&b| b == b'\n').count()
     }
 
     proptest! {
+        /// Every datagram the generator emits is one the Agent forwards. A packed datagram must be
+        /// entirely well-formed.
         #[test]
-        fn write_line_stays_within_its_limit(seed: u64, limit_bytes: u16, vibe in any_vibe()) {
+        fn property_test_every_payload_is_well_formed(seed: u64) {
             let mut rng = SmallRng::seed_from_u64(seed);
-            let limit_bytes = usize::from(limit_bytes);
             let mut buf = Vec::new();
-            write_line(&mut rng, &mut buf, vibe, limit_bytes);
-
-            prop_assert!(buf.len() <= limit_bytes);
-            if !buf.is_empty() {
-                prop_assert_eq!(buf[buf.len() - 1], b'\n');
-                prop_assert_eq!(newline_count(&buf), 1);
+            for _ in 0..8 {
+                write_payload(&mut rng, &mut buf, PAYLOAD_BYTE_LIMIT);
+                prop_assert_eq!(is_malformed(&buf), Ok(()), "emitted a droppable datagram: {:?}", String::from_utf8_lossy(&buf));
             }
         }
 
         #[test]
-        fn write_payload_stays_within_its_limit(seed: u64, limit_bytes: u16, batch in any_batch()) {
+        fn property_test_payload_stays_within_its_limit(seed: u64, limit_bytes: u16) {
             let mut rng = SmallRng::seed_from_u64(seed);
             let limit_bytes = usize::from(limit_bytes);
             let mut buf = Vec::new();
-            let payload = write_payload(&mut rng, &mut buf, batch, limit_bytes);
+            let payload = write_payload(&mut rng, &mut buf, limit_bytes);
 
             prop_assert!(buf.len() <= limit_bytes);
             prop_assert_eq!(newline_count(&buf), payload.lines);
-            // Whole lines only: a non-empty datagram ends on a line boundary, never a shorn token.
             if !buf.is_empty() {
                 prop_assert_eq!(buf[buf.len() - 1], b'\n');
             }
+        }
+
+        /// A budget that admits any line at all yields load. An empty datagram burns one of the
+        /// driver's configured sends without reaching the SUT, so the generator must fill the budget
+        /// it was given rather than give up on the first oversized sample.
+        #[test]
+        fn property_test_payload_is_never_empty_when_a_line_fits(seed: u64, limit_bytes in (FALLBACK_LINE.len() + 1)..4096usize) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let mut buf = Vec::new();
+            let payload = write_payload(&mut rng, &mut buf, limit_bytes);
+
+            prop_assert!(!buf.is_empty(), "empty datagram at limit {}", limit_bytes);
+            prop_assert!(payload.lines > 0);
         }
     }
 }

--- a/test/antithesis/harness/src/payload/dogstatsd/common.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd/common.rs
@@ -1,33 +1,22 @@
-//! Shared `DogStatsD` payload sampling: vibe, segment and number builders, tags.
+//! Shared `DogStatsD` content sampling: alphabets, field and value builders, tags.
+//!
+//! There is no clean/feral split. Every content field ranges over the full forwarded byte alphabet:
+//! ASCII words, exotic and non-UTF-8 bytes, AND the message delimiters `:` `|` `,` `#` `@`. Including
+//! the delimiters is deliberate. It reaches the context-dependent forwarded cases the Agent keeps,
+//! such as a `:` inside a set value or a `:` in a tag value, and the ones it drops. The generator does
+//! not decide which is which. It serializes and lets [`crate::dogstatsd::is_malformed`] sort and
+//! repair.
 
 use rand::distr::Distribution;
-use rand::seq::IndexedRandom;
 use rand::{Rng, RngExt};
 
-use crate::rand::Boundary;
+use crate::rand::Wide;
 
-/// Clean by-the-book output, or feral.
-#[derive(Clone, Copy, Debug)]
-pub enum Vibe {
-    /// Well-formed.
-    Clean,
-    /// Aberrant.
-    Feral,
-}
-
-/// Sample a per-line vibe, evenly, from `rng`.
-pub fn sample_vibe<R: Rng + ?Sized>(rng: &mut R) -> Vibe {
-    match [Vibe::Clean, Vibe::Feral].choose(rng) {
-        Some(Vibe::Feral) => Vibe::Feral,
-        _ => Vibe::Clean,
-    }
-}
-
-/// The Agent's name-legal separators, for joining name-like segments.
-pub(crate) const NAME_SEPARATORS: &[u8] = b"._- ";
+/// The Agent's name-legal separators, for joining segments.
+const NAME_SEPARATORS: &[u8] = b"._- ";
 
 /// Compliant identifier segments: names, hosts, keys, source types.
-pub(crate) const COMPLIANT_WORD: &[&[u8]] = &[
+const COMPLIANT_WORD: &[&[u8]] = &[
     b"adp",
     b"dogstatsd",
     b"requests",
@@ -40,10 +29,9 @@ pub(crate) const COMPLIANT_WORD: &[&[u8]] = &[
     b"workers",
 ];
 
-/// Aberrant identifier segments: whitespace, NUL, ill-formed and non-conforming
-/// UTF-8, and exotic Unicode. Omits the framing breakers `:` `|` `,` `#` `@`,
-/// the message-type prefixes and the empty segment.
-pub(crate) const ABERRANT_WORD: &[&[u8]] = &[
+/// Aberrant identifier segments: whitespace, NUL, ill-formed and non-conforming UTF-8, and exotic
+/// Unicode. Omits `\n` and `\r`, which are datagram framing rather than content.
+const ABERRANT_WORD: &[&[u8]] = &[
     b" ",
     b"\t",
     b"\0",
@@ -59,11 +47,40 @@ pub(crate) const ABERRANT_WORD: &[&[u8]] = &[
     "a\u{0301}".as_bytes(), // combining acute accent
     "\u{200d}".as_bytes(),  // zero-width joiner
     "\u{202e}".as_bytes(),  // right-to-left override
-    "\u{feff}".as_bytes(),  // byte-order mark / zero-width no-break space
+    "\u{feff}".as_bytes(),  // byte-order mark
 ];
 
-/// Aberrant metric values: confirmed to parse with Go's `ParseFloat`.
-pub(crate) const ABERRANT_VALUE: &[&[u8]] = &[
+/// Message delimiters, mixed into content so the generator explores delimiter-bearing fields. Most
+/// land the message in the drop set and are repaired away. The survivors are the forwarded oddities.
+const DELIMITERS: &[&[u8]] = &[b":", b"|", b",", b"#", b"@"];
+
+/// The full content alphabet for identifier-like fields.
+const WORD_POOLS: &[&[&[u8]]] = &[COMPLIANT_WORD, ABERRANT_WORD, DELIMITERS];
+
+/// Tag keys. `host` is excluded. `DogStatsD` promotes a `host` tag to the metric host resource, and
+/// varying host instances break the intake host-consistency check.
+const COMPLIANT_TAG_KEYS: &[&[u8]] = &[b"env", b"service", b"region", b"version", b"team", b"shard"];
+
+/// Tag values.
+const COMPLIANT_TAG_VALUES: &[&[u8]] = &[
+    b"prod",
+    b"staging",
+    b"adp",
+    b"us-east-1",
+    b"eu-west-1",
+    b"1.2.3",
+    b"web01",
+    b"0",
+];
+
+/// The full content alphabet for tag keys.
+const TAG_KEY_POOLS: &[&[&[u8]]] = &[COMPLIANT_TAG_KEYS, ABERRANT_WORD, DELIMITERS];
+
+/// The full content alphabet for tag values.
+const TAG_VALUE_POOLS: &[&[&[u8]]] = &[COMPLIANT_TAG_VALUES, ABERRANT_WORD, DELIMITERS];
+
+/// Metric values confirmed to parse with Go's `ParseFloat`.
+const SPECIAL_VALUE: &[&[u8]] = &[
     b"0",
     b"-0",
     b"inf",
@@ -79,154 +96,214 @@ pub(crate) const ABERRANT_VALUE: &[&[u8]] = &[
     b"3.141592653589793115997963468544185161590576171875000000000000000000000000",
 ];
 
-// NOTE I have intentionally avoided TS for the time being.
-
-// NOTE `host` is excluded. `DogStatsD` promotes a `host` tag to the metric host
-// resource, emitting varying `host` instances plays hell with Pyld17
-// host-consistency check.
-const COMPLIANT_TAG_KEYS: &[&[u8]] = &[b"env", b"service", b"region", b"version", b"team", b"shard"];
-const ABERRANT_TAG_KEYS: &[&[u8]] = &[b" ", b"\0", b"\x80", b"\xc3", "café".as_bytes(), "🦆".as_bytes()];
-const COMPLIANT_TAG_VALUES: &[&[u8]] = &[
-    b"prod",
-    b"staging",
-    b"adp",
-    b"us-east-1",
-    b"eu-west-1",
-    b"1.2.3",
-    b"web01",
-    b"0",
-];
-const ABERRANT_TAG_VALUES: &[&[u8]] = &[
-    b"",
-    b":",
-    b"\xff",
-    b"\xed\xa0\x80",
-    "café".as_bytes(),
-    "🦆".as_bytes(),
-    "\u{202e}".as_bytes(),
+/// Sample-rate tokens for the `@` field, all Go-`ParseFloat`-able.
+const RATE_TOKEN: &[&[u8]] = &[
+    b"1", b"0.5", b"0.25", b"0.1", b"0.001", b"+0.5", b"1.", b".5", b"0x1p-1", b"1_000", b"2", b"inf", b"+inf",
+    b"-inf", b"nan",
 ];
 
-/// Compact, or a cursed-but-equivalent padded encoding.
-#[derive(Clone, Copy)]
-enum Form {
-    Compact,
-    Expanded,
+/// Segment counts for a required field: at least one, with a large-boundary tail so huge fields stay
+/// in the explored surface.
+const COUNTS_REQUIRED: &[usize] = &[1, 1, 2, 2, 3, 3, 4, 5, 6, 127, 255];
+
+/// Segment counts for an optional field: the required body plus zero.
+const COUNTS_OPTIONAL: &[usize] = &[0, 1, 1, 2, 2, 3, 3, 4, 5, 6, 127, 255];
+
+/// Pick one item from a static, non-empty pool by index.
+fn pick<'a>(rng: &mut (impl Rng + ?Sized), pool: &[&'a [u8]]) -> &'a [u8] {
+    pool[rng.random_range(0..pool.len())]
 }
 
-/// Extend `buf` with one item sampled from `rng`. Clean draws from `compliant`;
-/// feral chooses between compliant and aberrant.
-pub(crate) fn extend_choice<R: Rng + ?Sized>(
-    rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe, compliant: &[&[u8]], aberrant: &[&[u8]],
-) {
-    let pools: &[&[&[u8]]] = match vibe {
-        Vibe::Clean => &[compliant],
-        Vibe::Feral => &[compliant, aberrant],
-    };
-    if let Some(&pool) = pools.choose(rng) {
-        if let Some(&item) = pool.choose(rng) {
-            buf.extend_from_slice(item);
-        }
+/// The shortest item `pools` can yield, which is the floor cost of one more segment.
+pub(crate) fn min_item(pools: &[&[&[u8]]]) -> usize {
+    pools
+        .iter()
+        .flat_map(|pool| pool.iter())
+        .map(|item| item.len())
+        .min()
+        .unwrap_or(0)
+}
+
+/// Pick an item no longer than `budget`, or `None` when the pools hold nothing that small. Counts the
+/// affordable items and walks to the chosen one, so a segment that would not fit is never built.
+fn pick_within<'a>(rng: &mut (impl Rng + ?Sized), pools: &[&[&'a [u8]]], budget: usize) -> Option<&'a [u8]> {
+    let affordable = pools
+        .iter()
+        .flat_map(|pool| pool.iter())
+        .filter(|item| item.len() <= budget)
+        .count();
+    if affordable == 0 {
+        return None;
     }
+    let nth = rng.random_range(0..affordable);
+    pools
+        .iter()
+        .flat_map(|pool| pool.iter())
+        .filter(|item| item.len() <= budget)
+        .nth(nth)
+        .copied()
 }
 
-/// Repeated-element counts (segments, tags) for clean payloads: a small body, no boundary cases.
-const ELEMENT_COUNTS_CLEAN: &[u8] = &[1, 1, 2, 2, 3, 3, 4, 5, 6];
-
-/// Repeated-element counts for feral payloads: the clean body plus a `0`/large boundary tail.
-const ELEMENT_COUNTS_FERAL: &[u8] = &[1, 1, 2, 2, 3, 3, 4, 5, 6, 0, 127, 255];
-
-fn sample_count<R: Rng + ?Sized>(rng: &mut R, vibe: Vibe) -> u8 {
-    let counts = match vibe {
-        Vibe::Clean => ELEMENT_COUNTS_CLEAN,
-        Vibe::Feral => ELEMENT_COUNTS_FERAL,
-    };
-    counts[rng.random_range(0..counts.len())]
-}
-
-/// Sample a count of segments and join them with sampled `separators`. A pool of
-/// `N` segments over a count `c` gives `N^c` results.
-pub(crate) fn write_segments<R: Rng + ?Sized>(
-    rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe, compliant: &[&[u8]], aberrant: &[&[u8]], separators: &[u8],
-) {
-    let count = sample_count(rng, vibe);
+/// Build a field of separator-joined segments within `budget` bytes. The segment count comes from
+/// `counts`, each segment is drawn from the items that still fit, and the run stops once nothing fits.
+/// Sampling against the room left is what keeps the generator from building a field it would have to
+/// throw away.
+fn field_within(rng: &mut (impl Rng + ?Sized), pools: &[&[&[u8]]], counts: &[usize], budget: usize) -> Vec<u8> {
+    let count = counts[rng.random_range(0..counts.len())];
+    let mut out = Vec::new();
     for i in 0..count {
+        let separator = usize::from(i > 0);
+        let room = budget.saturating_sub(out.len() + separator);
+        let Some(item) = pick_within(rng, pools, room) else {
+            break;
+        };
         if i > 0 {
-            if let Some(&sep) = separators.choose(rng) {
-                buf.push(sep);
-            }
+            out.push(NAME_SEPARATORS[rng.random_range(0..NAME_SEPARATORS.len())]);
         }
-        extend_choice(rng, buf, vibe, compliant, aberrant);
+        out.extend_from_slice(item);
     }
+    out
 }
 
-/// An identifier (name, host, key, source) built from word segments. Always at
-/// least one segment: a zero-segment count would yield an empty identifier, and
-/// the Agent rejects an empty metric name.
-pub(crate) fn write_words<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
-    let start = buf.len();
-    write_segments(rng, buf, vibe, COMPLIANT_WORD, ABERRANT_WORD, NAME_SEPARATORS);
-    if buf.len() == start {
-        extend_choice(rng, buf, vibe, COMPLIANT_WORD, ABERRANT_WORD);
+/// A required identifier within `budget`. Empty when the budget cannot hold one segment, which the
+/// caller must treat as "no line fits" rather than emitting an invalid name.
+pub(crate) fn identifier_within(rng: &mut (impl Rng + ?Sized), budget: usize) -> Vec<u8> {
+    field_within(rng, WORD_POOLS, COUNTS_REQUIRED, budget)
+}
+
+/// An optional free-text field within `budget`.
+pub(crate) fn optional_text_within(rng: &mut (impl Rng + ?Sized), budget: usize) -> Vec<u8> {
+    field_within(rng, WORD_POOLS, COUNTS_OPTIONAL, budget)
+}
+
+/// A tag set serialized within `budget` bytes, `|#` and separating commas included. Each tag is built
+/// against the room left, and the run stops when the next one cannot fit.
+pub(crate) fn tags_within(rng: &mut (impl Rng + ?Sized), budget: usize) -> Vec<Vec<u8>> {
+    let count = COUNTS_OPTIONAL[rng.random_range(0..COUNTS_OPTIONAL.len())];
+    // `|#` before the first tag, then a comma before each later one.
+    let Some(mut room) = budget.checked_sub(2) else {
+        return Vec::new();
+    };
+    let mut out: Vec<Vec<u8>> = Vec::new();
+    for _ in 0..count {
+        let separator = usize::from(!out.is_empty());
+        let Some(tag_room) = room.checked_sub(separator) else {
+            break;
+        };
+        // A tag is `key:value` with a required key, so it needs a segment plus the colon.
+        if tag_room < min_item(TAG_KEY_POOLS) + 1 {
+            break;
+        }
+        let key = field_within(rng, TAG_KEY_POOLS, COUNTS_REQUIRED, tag_room - 1);
+        if key.is_empty() {
+            break;
+        }
+        let mut tag = key;
+        tag.push(b':');
+        let value = field_within(rng, TAG_VALUE_POOLS, COUNTS_OPTIONAL, tag_room - tag.len());
+        tag.extend_from_slice(&value);
+        room -= separator + tag.len();
+        out.push(tag);
     }
+    out
 }
 
-/// Append `|<prefix><item>`, the item chosen from `rng` for the vibe.
-pub(crate) fn write_field<R: Rng + ?Sized>(
-    rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe, prefix: &[u8], compliant: &[&[u8]], aberrant: &[&[u8]],
-) {
-    buf.push(b'|');
-    buf.extend_from_slice(prefix);
-    extend_choice(rng, buf, vibe, compliant, aberrant);
-}
-
-/// A vibe-sampled count of `key:value` tags joined by ','. Feral can sample a
-/// count of zero (no tags) or a large boundary count; clean stays in the small
-/// body. Clean draws compliant keys and values; feral mixes aberrant ones in,
-/// key and value independently.
-pub(crate) fn write_tags<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
-    let count = sample_count(rng, vibe);
-    for t in 0..count {
-        if t == 0 {
-            buf.extend_from_slice(b"|#");
+/// Serialize a tag set as `|#key:value,key:value`. An empty set appends nothing.
+pub(crate) fn serialize_tags(tags: &[Vec<u8>], out: &mut Vec<u8>) {
+    for (i, tag) in tags.iter().enumerate() {
+        if i == 0 {
+            out.extend_from_slice(b"|#");
         } else {
-            buf.push(b',');
+            out.push(b',');
         }
-        write_segments(rng, buf, vibe, COMPLIANT_TAG_KEYS, ABERRANT_TAG_KEYS, NAME_SEPARATORS);
-        buf.push(b':');
-        write_segments(
-            rng,
-            buf,
-            vibe,
-            COMPLIANT_TAG_VALUES,
-            ABERRANT_TAG_VALUES,
-            NAME_SEPARATORS,
-        );
+        out.extend_from_slice(tag);
     }
 }
 
-/// Write `digits` to `buf` as-is, or padded with equivalent leading zeros (and
-/// trailing zeros when there is a fractional part). Same value, cursed encoding.
-pub(crate) fn write_number<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, digits: &[u8]) {
-    match [Form::Compact, Form::Expanded].choose(rng) {
-        Some(Form::Expanded) => {
-            let (sign, rest) = match digits.first() {
-                Some(&(b'-' | b'+')) => (&digits[..1], &digits[1..]),
-                _ => (&digits[..0], digits),
-            };
-            buf.extend_from_slice(sign);
-            pad_zeros(rng, buf);
-            buf.extend_from_slice(rest);
-            let fractional = rest.contains(&b'.') && !rest.iter().any(|&c| c == b'e' || c == b'E');
-            if fractional {
-                pad_zeros(rng, buf);
-            }
+/// A metric value token guaranteed to parse with Go's `ParseFloat`: a special literal, or a wide
+/// float or integer rendered compactly or in a cursed-but-equivalent zero-padded form.
+pub(crate) fn float_token(rng: &mut (impl Rng + ?Sized)) -> Vec<u8> {
+    match rng.random_range(0..3u8) {
+        0 => pick(rng, SPECIAL_VALUE).to_vec(),
+        1 => {
+            let v: f64 = Wide.sample(rng);
+            let mut ryu = ryu::Buffer::new();
+            render_number(rng, ryu.format(v).as_bytes())
         }
-        _ => buf.extend_from_slice(digits),
+        _ => {
+            let v: i64 = Wide.sample(rng);
+            let mut itoa = itoa::Buffer::new();
+            render_number(rng, itoa.format(v).as_bytes())
+        }
     }
 }
 
-/// Append a boundary-sampled run of '0' bytes to `buf`.
-fn pad_zeros<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>) {
-    let zeros = usize::from(Boundary::<u8>::new().sample(rng));
-    buf.resize(buf.len() + zeros, b'0');
+/// The floor cost of a value token, the shortest `SPECIAL_VALUE` entry.
+pub(crate) fn min_value_token() -> usize {
+    SPECIAL_VALUE.iter().map(|item| item.len()).min().unwrap_or(1)
+}
+
+/// A float value token within `budget`. Falls back to the shortest affordable literal rather than
+/// rendering a number that would not fit, and is empty only when nothing fits.
+pub(crate) fn float_token_within(rng: &mut (impl Rng + ?Sized), budget: usize) -> Vec<u8> {
+    let token = float_token(rng);
+    if token.len() <= budget {
+        return token;
+    }
+    pick_within(rng, &[SPECIAL_VALUE], budget)
+        .map(<[u8]>::to_vec)
+        .unwrap_or_default()
+}
+
+/// A sample-rate token within `budget`, or `None` when no rate literal fits.
+pub(crate) fn rate_token_within(rng: &mut (impl Rng + ?Sized), budget: usize) -> Option<Vec<u8>> {
+    pick_within(rng, &[RATE_TOKEN], budget).map(<[u8]>::to_vec)
+}
+
+/// A set-type value within `budget`.
+pub(crate) fn opaque_value_within(rng: &mut (impl Rng + ?Sized), budget: usize) -> Vec<u8> {
+    field_within(rng, WORD_POOLS, COUNTS_REQUIRED, budget)
+}
+
+/// The serialized length of a tag set, `|#` and separating commas included.
+pub(crate) fn tags_len(tags: &[Vec<u8>]) -> usize {
+    if tags.is_empty() {
+        0
+    } else {
+        2 + tags.iter().map(Vec::len).sum::<usize>() + tags.len() - 1
+    }
+}
+
+/// Render `digits` as-is, or padded with equivalent leading zeros, and trailing zeros for a
+/// fractional part. Same value, cursed encoding.
+fn render_number(rng: &mut (impl Rng + ?Sized), digits: &[u8]) -> Vec<u8> {
+    if rng.random_range(0..2u8) == 0 {
+        return digits.to_vec();
+    }
+    let (sign, rest) = match digits.first() {
+        Some(&(b'-' | b'+')) => (&digits[..1], &digits[1..]),
+        _ => (&digits[..0], digits),
+    };
+    let mut out = Vec::new();
+    out.extend_from_slice(sign);
+    pad_zeros(rng, &mut out);
+    out.extend_from_slice(rest);
+    let fractional = rest.contains(&b'.') && !rest.iter().any(|&c| c == b'e' || c == b'E');
+    if fractional {
+        pad_zeros(rng, &mut out);
+    }
+    out
+}
+
+/// Append a boundary-sampled run of `0` bytes.
+fn pad_zeros(rng: &mut (impl Rng + ?Sized), out: &mut Vec<u8>) {
+    // A short run of leading/trailing zeros: enough to exercise padded encodings without bloating.
+    let zeros = usize::from(pick_padding_run(rng));
+    out.resize(out.len() + zeros, b'0');
+}
+
+/// A boundary-biased zero-run length.
+fn pick_padding_run(rng: &mut (impl Rng + ?Sized)) -> u8 {
+    const RUNS: &[u8] = &[0, 1, 2, 8, 16, 32, 64, 127];
+    RUNS[rng.random_range(0..RUNS.len())]
 }

--- a/test/antithesis/harness/src/payload/dogstatsd/events.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd/events.rs
@@ -1,72 +1,91 @@
-//! Feral `DogStatsD` event generation.
+//! Structured `DogStatsD` event generation.
 
-use rand::distr::Distribution;
-use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::{Rng, RngExt};
 
-use super::common::{self, Vibe};
-use crate::rand::Boundary;
+use super::common;
 
-/// Priority payloads (the `p:` field).
-const COMPLIANT_PRIO: &[&[u8]] = &[b"normal", b"low"];
+/// Optional-field prefixes: hostname, aggregation key, priority, source type, alert type. Bad
+/// priority and alert values are logged and defaulted by the Agent, never dropped, so any content
+/// forwards.
+const OPT_PREFIXES: &[&[u8]] = &[b"h:", b"k:", b"p:", b"s:", b"t:"];
 
-/// Alert-type payloads (the `t:` field).
-const COMPLIANT_ALERT: &[&[u8]] = &[b"error", b"warning", b"info", b"success"];
+/// Optional-field counts: mostly none, with a boundary tail.
+const OPT_COUNTS: &[usize] = &[0, 0, 0, 0, 1, 1, 2, 3, 127, 255];
 
-/// An event optional field.
-#[derive(Clone, Copy)]
-enum Opt {
-    Hostname,
-    AggKey,
-    Priority,
-    Source,
-    Alert,
+/// A structured event: `_e{title_len,text_len}:title|text[|opt...]`.
+#[derive(Clone, Debug)]
+pub(crate) struct Event {
+    /// Title content, required non-empty.
+    title: Vec<u8>,
+    /// Text content, may be empty.
+    text: Vec<u8>,
+    /// `key:value` tags.
+    tags: Vec<Vec<u8>>,
+    /// Optional chunks, each carrying its own prefix.
+    options: Vec<Vec<u8>>,
 }
 
-/// Append one event `_e{<TLEN>,<XLEN>}:<TITLE>|<TEXT>[|opt...]` to `buf`.
-pub(crate) fn write<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
-    let mut title = Vec::new();
-    common::write_words(rng, &mut title, vibe);
-    let mut text = Vec::new();
-    common::write_words(rng, &mut text, vibe);
-
-    buf.extend_from_slice(b"_e{");
-    write_len(buf, title.len());
-    buf.push(b',');
-    write_len(buf, text.len());
-    buf.extend_from_slice(b"}:");
-    buf.extend_from_slice(&title);
-    buf.push(b'|');
-    buf.extend_from_slice(&text);
-
-    let count = Boundary::<u8>::new().sample(rng);
-    for _ in 0..count {
-        match [Opt::Hostname, Opt::AggKey, Opt::Priority, Opt::Source, Opt::Alert].choose(rng) {
-            Some(Opt::Hostname) => {
-                buf.extend_from_slice(b"|h:");
-                common::write_words(rng, buf, vibe);
-            }
-            Some(Opt::AggKey) => {
-                buf.extend_from_slice(b"|k:");
-                common::write_words(rng, buf, vibe);
-            }
-            Some(Opt::Priority) => common::write_field(rng, buf, vibe, b"p:", COMPLIANT_PRIO, common::ABERRANT_WORD),
-            Some(Opt::Source) => {
-                buf.extend_from_slice(b"|s:");
-                common::write_words(rng, buf, vibe);
-            }
-            _ => common::write_field(rng, buf, vibe, b"t:", COMPLIANT_ALERT, common::ABERRANT_WORD),
+impl Event {
+    /// Sample an event with content over the full forwarded alphabet. The body is length-delimited,
+    /// so title and text carry any bytes including delimiters.
+    pub(crate) fn generate(rng: &mut (impl Rng + ?Sized), budget: usize) -> Option<Self> {
+        // `_e{N,M}:title|text` is the skeleton. The header digits grow with the field lengths, so a
+        // conservative four bytes per length keeps the estimate above what serialization will write for
+        // any field this generator can build.
+        const HEADER: usize = "_e{".len() + 4 + 1 + 4 + "}:".len() + 1;
+        let title_room = budget.checked_sub(HEADER)?;
+        let title = common::identifier_within(rng, title_room);
+        if title.is_empty() {
+            return None;
         }
+        let spent = HEADER + title.len();
+        let text = common::optional_text_within(rng, budget.saturating_sub(spent));
+        let spent = spent + text.len();
+        let tags = common::tags_within(rng, budget.saturating_sub(spent));
+        let spent = spent + common::tags_len(&tags);
+        Some(Self {
+            title,
+            text,
+            tags,
+            options: options(rng, budget.saturating_sub(spent)),
+        })
     }
 
-    common::write_tags(rng, buf, vibe);
-    buf.push(b'\n');
+    /// Serialize the event to datagram bytes, without the trailing `\n`. The header lengths are the
+    /// true byte lengths of the title and text, so the Agent never rejects on a length mismatch.
+    pub(crate) fn serialize(&self, out: &mut Vec<u8>) {
+        let mut itoa = itoa::Buffer::new();
+        out.extend_from_slice(b"_e{");
+        out.extend_from_slice(itoa.format(self.title.len()).as_bytes());
+        out.push(b',');
+        out.extend_from_slice(itoa.format(self.text.len()).as_bytes());
+        out.extend_from_slice(b"}:");
+        out.extend_from_slice(&self.title);
+        out.push(b'|');
+        out.extend_from_slice(&self.text);
+        common::serialize_tags(&self.tags, out);
+        for opt in &self.options {
+            out.push(b'|');
+            out.extend_from_slice(opt);
+        }
+    }
 }
 
-/// The event header length: the true byte length of the title or text. A header
-/// length that disagrees with the payload makes the Agent reject the event, so
-/// the feral strangeness lives in the title and text content, not a lied length.
-fn write_len(buf: &mut Vec<u8>, actual: usize) {
-    let mut itoa = itoa::Buffer::new();
-    buf.extend_from_slice(itoa.format(actual).as_bytes());
+/// Sample a run of optional chunks.
+fn options(rng: &mut (impl Rng + ?Sized), budget: usize) -> Vec<Vec<u8>> {
+    let count = OPT_COUNTS[rng.random_range(0..OPT_COUNTS.len())];
+    let mut out = Vec::new();
+    let mut room = budget;
+    for _ in 0..count {
+        let prefix = OPT_PREFIXES[rng.random_range(0..OPT_PREFIXES.len())];
+        // Each chunk carries a leading `|` on the wire.
+        let Some(body_room) = room.checked_sub(1 + prefix.len()) else {
+            break;
+        };
+        let mut chunk = prefix.to_vec();
+        chunk.extend_from_slice(&common::optional_text_within(rng, body_room));
+        room -= 1 + chunk.len();
+        out.push(chunk);
+    }
+    out
 }

--- a/test/antithesis/harness/src/payload/dogstatsd/metrics.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd/metrics.rs
@@ -1,180 +1,157 @@
-//! Feral `DogStatsD` metric-line generation.
+//! Structured `DogStatsD` metric generation.
 
-use rand::distr::Distribution;
-use rand::seq::IndexedRandom;
 use rand::{Rng, RngExt};
 
-use super::common::{self, Vibe};
-use crate::rand::{Boundary, Wide};
+use super::common;
 
+/// The metric types: count, gauge, timing, histogram, set, distribution.
 const METRIC_TYPES: &[&[u8]] = &[b"c", b"g", b"ms", b"h", b"s", b"d"];
 
-/// Sample-rate payloads (the `@` field).
-const COMPLIANT_RATE: &[&[u8]] = &[b"1", b"0.5", b"0.25", b"0.1", b"0.001"];
+/// Extension-field counts: mostly none, with a boundary tail.
+const EXT_COUNTS: &[usize] = &[0, 0, 0, 0, 1, 1, 2, 3, 127, 255];
 
-const ABERRANT_RATE: &[&[u8]] = &[
-    b"+0.5", b"1.", b".5", b"0x1p-1", b"1_000", b"2", b"inf", b"+inf", b"-inf", b"nan",
-];
-
-/// Container-id payloads (the `c:` field).
-const COMPLIANT_CONTAINER: &[&[u8]] = &[b"ci-0a1b2c3d4e5f", b"cid-deadbeef", b"in-4026531840"];
-
-/// External-data items (the `e:` field), joined by ',' at runtime.
-const COMPLIANT_EXT: &[&[u8]] = &[
-    b"it-true",
-    b"it-false",
-    b"cn-redis",
-    b"cn-web",
-    b"pu-810fe89d",
-    b"pu-abc",
-];
-
-/// Cardinality payloads (the `card:` field).
-const COMPLIANT_CARD: &[&[u8]] = &[b"none", b"low", b"orchestrator", b"high"];
-
-/// The `e:` external-data item separator.
-const EXT_SEPARATORS: &[u8] = b",";
-
-/// How to build a value.
-#[derive(Clone, Copy)]
-enum ValueKind {
-    Aberrant,
-    Int,
-    Wide,
+/// A structured metric: `name:value[:value...]|type[|ext...]`.
+#[derive(Clone, Debug)]
+pub(crate) struct Metric {
+    /// Metric name content.
+    name: Vec<u8>,
+    /// One value for a set, else a `:`-packed run of Go-float tokens.
+    values: Vec<Vec<u8>>,
+    /// The type symbol.
+    kind: &'static [u8],
+    /// `key:value` tags.
+    tags: Vec<Vec<u8>>,
+    /// Extension chunks, each carrying its own prefix: `@`, `c:`, `e:`, or `card:`.
+    extensions: Vec<Vec<u8>>,
 }
 
-/// A metric extension field.
-#[derive(Clone, Copy)]
-enum Ext {
-    Rate,
-    Container,
-    External,
-    Cardinality,
-}
-
-/// Append one metric line `<NAME>:<VALUE>|<TYPE>[|ext...]` to `buf`. Returns
-/// the packed value count when the value is a multi-value run, else `None`.
-pub(crate) fn write<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) -> Option<usize> {
-    common::write_words(rng, buf, vibe);
-    buf.push(b':');
-    let packed = write_value(rng, buf, vibe);
-    buf.push(b'|');
-    if let Some(&t) = METRIC_TYPES.choose(rng) {
-        buf.extend_from_slice(t);
+impl Metric {
+    /// Sample a metric with content over the full forwarded alphabet.
+    pub(crate) fn generate(rng: &mut (impl Rng + ?Sized), budget: usize) -> Option<Self> {
+        let kind = METRIC_TYPES[rng.random_range(0..METRIC_TYPES.len())];
+        // `name:value|kind` is the whole of a valid metric, so the name is built against what is left
+        // once the rest of that skeleton is reserved.
+        let reserved = 1 + common::min_value_token() + 1 + kind.len();
+        let name_room = budget.checked_sub(reserved)?;
+        let name = common::identifier_within(rng, name_room);
+        if name.is_empty() {
+            return None;
+        }
+        let mut spent = name.len() + reserved;
+        let values = if kind == b"s" {
+            vec![common::opaque_value_within(
+                rng,
+                budget - spent + common::min_value_token(),
+            )]
+        } else {
+            // The first value is already reserved. Each extra one costs a `:` and its own bytes.
+            let mut values = vec![common::float_token_within(
+                rng,
+                budget - spent + common::min_value_token(),
+            )];
+            spent = spent - common::min_value_token() + values[0].len();
+            for _ in 1..value_count(rng) {
+                let room = budget.saturating_sub(spent + 1);
+                let value = common::float_token_within(rng, room);
+                if value.is_empty() {
+                    break;
+                }
+                spent += 1 + value.len();
+                values.push(value);
+            }
+            values
+        };
+        if values.iter().any(Vec::is_empty) {
+            return None;
+        }
+        let spent: usize =
+            name.len() + 1 + values.iter().map(Vec::len).sum::<usize>() + values.len() - 1 + 1 + kind.len();
+        let tags = common::tags_within(rng, budget.saturating_sub(spent));
+        let spent = spent + common::tags_len(&tags);
+        Some(Self {
+            name,
+            values,
+            kind,
+            tags,
+            extensions: extensions(rng, budget.saturating_sub(spent)),
+        })
     }
-    common::write_tags(rng, buf, vibe);
-    write_extensions(rng, buf, vibe);
-    buf.push(b'\n');
-    packed
+
+    /// Serialize the metric to datagram bytes, without the trailing `\n`.
+    pub(crate) fn serialize(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.name);
+        out.push(b':');
+        for (i, value) in self.values.iter().enumerate() {
+            if i > 0 {
+                out.push(b':');
+            }
+            out.extend_from_slice(value);
+        }
+        out.push(b'|');
+        out.extend_from_slice(self.kind);
+        common::serialize_tags(&self.tags, out);
+        for ext in &self.extensions {
+            out.push(b'|');
+            out.extend_from_slice(ext);
+        }
+    }
+
+    /// The packed multi-value run length, or zero for a single value or a set.
+    pub(crate) fn packed(&self) -> usize {
+        if self.kind != b"s" && self.values.len() > 1 {
+            self.values.len()
+        } else {
+            0
+        }
+    }
 }
 
-/// The value field: a `:`-packed run of scalars. Run odds:
-///
-/// | run | odds   |
-/// |-----|--------|
-/// | 1   | 99%    |
-/// | 2   | 0.5%   |
-/// | 3   | 0.25%  |
-/// | 4   | 0.125% |
-/// | 5   | 0.125% |
-fn write_value<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) -> Option<usize> {
-    let count: u8 = match rng.random_range(0..800u16) {
+/// The `:`-packed value run length. Overwhelmingly one, with a short tail.
+fn value_count(rng: &mut (impl Rng + ?Sized)) -> usize {
+    match rng.random_range(0..800u16) {
         0..792 => 1,
         792..796 => 2,
         796..798 => 3,
         798 => 4,
-        799..=u16::MAX => 5,
-    };
-    for i in 0..count {
-        if i > 0 {
-            buf.push(b':');
-        }
-        write_scalar(rng, buf, vibe);
-    }
-    (count > 1).then_some(usize::from(count))
-}
-
-/// Write one scalar. Clean: a wide log-uniform value. Feral: an aberrant literal,
-/// a wide integer, or a wide float in a compact or cursed-but-equivalent expanded
-/// encoding.
-fn write_scalar<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
-    let mut ryu = ryu::Buffer::new();
-    match vibe {
-        Vibe::Clean => {
-            let v: f64 = Wide.sample(rng);
-            buf.extend_from_slice(ryu.format(v).as_bytes());
-        }
-        Vibe::Feral => match [ValueKind::Aberrant, ValueKind::Int, ValueKind::Wide].choose(rng) {
-            Some(ValueKind::Aberrant) => {
-                if let Some(&v) = common::ABERRANT_VALUE.choose(rng) {
-                    buf.extend_from_slice(v);
-                }
-            }
-            Some(ValueKind::Wide) => {
-                let v: f64 = Wide.sample(rng);
-                common::write_number(rng, buf, ryu.format(v).as_bytes());
-            }
-            _ => {
-                let mut itoa = itoa::Buffer::new();
-                let v: i64 = Wide.sample(rng);
-                common::write_number(rng, buf, itoa.format(v).as_bytes());
-            }
-        },
+        _ => 5,
     }
 }
 
-/// A boundary-sampled count of extension fields, each a random kind. Repeats and
-/// zero are allowed.
-fn write_extensions<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
-    let count = Boundary::<u8>::new().sample(rng);
+/// Sample a run of extension chunks.
+fn extensions(rng: &mut (impl Rng + ?Sized), budget: usize) -> Vec<Vec<u8>> {
+    let count = EXT_COUNTS[rng.random_range(0..EXT_COUNTS.len())];
+    let mut out = Vec::new();
+    let mut room = budget;
     for _ in 0..count {
-        match [Ext::Rate, Ext::Container, Ext::External, Ext::Cardinality].choose(rng) {
-            Some(Ext::Rate) => common::write_field(rng, buf, vibe, b"@", COMPLIANT_RATE, ABERRANT_RATE),
-            Some(Ext::Container) => {
-                common::write_field(rng, buf, vibe, b"c:", COMPLIANT_CONTAINER, common::ABERRANT_WORD);
-            }
-            Some(Ext::External) => {
-                buf.extend_from_slice(b"|e:");
-                common::write_segments(rng, buf, vibe, COMPLIANT_EXT, common::ABERRANT_WORD, EXT_SEPARATORS);
-            }
-            _ => common::write_field(rng, buf, vibe, b"card:", COMPLIANT_CARD, common::ABERRANT_WORD),
-        }
+        // Each chunk carries a leading `|`.
+        let Some(chunk_room) = room.checked_sub(1) else {
+            break;
+        };
+        let Some(chunk) = ext_chunk(rng, chunk_room) else {
+            break;
+        };
+        room -= 1 + chunk.len();
+        out.push(chunk);
     }
+    out
 }
 
-#[cfg(test)]
-mod test {
-    use proptest::prelude::*;
-    use rand::rngs::SmallRng;
-    use rand::SeedableRng;
-
-    use super::{write_value, Vibe};
-
-    fn any_vibe() -> impl Strategy<Value = Vibe> {
-        prop_oneof![Just(Vibe::Clean), Just(Vibe::Feral)]
-    }
-
-    proptest! {
-        /// A value carrying a `:`-packed run must report its count. The split
-        /// piece count is the run length, so it must equal the returned count.
-        #[test]
-        fn packed_value_reports_its_count(seed: u64, vibe in any_vibe()) {
-            let mut rng = SmallRng::seed_from_u64(seed);
-            for _ in 0..1_000 {
-                let mut buf = Vec::new();
-                let packed = write_value(&mut rng, &mut buf, vibe);
-                let values = buf.split(|&b| b == b':').count();
-                if values > 1 {
-                    prop_assert_eq!(
-                        packed,
-                        Some(values),
-                        "value {:?} packs {} values but write_value returned {:?}",
-                        String::from_utf8_lossy(&buf),
-                        values,
-                        packed
-                    );
-                }
-            }
-        }
-    }
+/// One extension chunk with its prefix. The `@` rate is a parseable token. The origin chunks carry
+/// free content the Agent never drops on.
+fn ext_chunk(rng: &mut (impl Rng + ?Sized), budget: usize) -> Option<Vec<u8>> {
+    let prefix: &[u8] = match rng.random_range(0..4u8) {
+        0 => b"@",
+        1 => b"c:",
+        2 => b"e:",
+        _ => b"card:",
+    };
+    let body_room = budget.checked_sub(prefix.len())?;
+    let body = if prefix == b"@" {
+        common::rate_token_within(rng, body_room)?
+    } else {
+        common::optional_text_within(rng, body_room)
+    };
+    let mut chunk = prefix.to_vec();
+    chunk.extend_from_slice(&body);
+    Some(chunk)
 }

--- a/test/antithesis/harness/src/payload/dogstatsd/service_checks.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd/service_checks.rs
@@ -1,42 +1,81 @@
-//! Feral `DogStatsD` service-check generation.
+//! Structured `DogStatsD` service-check generation.
 
-use rand::distr::Distribution;
-use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::{Rng, RngExt};
 
-use super::common::{self, Vibe};
-use crate::rand::Boundary;
+use super::common;
 
-/// Status payloads: OK, warning, critical, unknown.
-const COMPLIANT_STATUS: &[&[u8]] = &[b"0", b"1", b"2", b"3"];
+/// Status symbols: OK, warning, critical, unknown.
+const STATUS: &[&[u8]] = &[b"0", b"1", b"2", b"3"];
 
-/// A service-check optional field.
-#[derive(Clone, Copy)]
-enum Opt {
-    Hostname,
-    Message,
+/// Optional-field prefixes: hostname, message.
+const OPT_PREFIXES: &[&[u8]] = &[b"h:", b"m:"];
+
+/// Optional-field counts: mostly none, with a boundary tail.
+const OPT_COUNTS: &[usize] = &[0, 0, 0, 0, 1, 1, 2, 3, 127, 255];
+
+/// A structured service check: `_sc|name|status[|opt...]`.
+#[derive(Clone, Debug)]
+pub(crate) struct ServiceCheck {
+    /// Name content, required non-empty.
+    name: Vec<u8>,
+    /// The status symbol, always one of `0` `1` `2` `3`.
+    status: &'static [u8],
+    /// `key:value` tags.
+    tags: Vec<Vec<u8>>,
+    /// Optional chunks, each carrying its own prefix.
+    options: Vec<Vec<u8>>,
 }
 
-/// Append one service check `_sc|<NAME>|<STATUS>[|opt...]` to `buf`.
-pub(crate) fn write<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
-    buf.extend_from_slice(b"_sc|");
-    common::write_words(rng, buf, vibe);
-    buf.push(b'|');
-    // Status grammar is exactly [0-3] with zero slack — any aberrant status rejects
-    // the whole check, so feral strangeness lives in the name and options, not here.
-    common::extend_choice(rng, buf, vibe, COMPLIANT_STATUS, COMPLIANT_STATUS);
-
-    let count = Boundary::<u8>::new().sample(rng);
-    for _ in 0..count {
-        if let Some(Opt::Hostname) = [Opt::Hostname, Opt::Message].choose(rng) {
-            buf.extend_from_slice(b"|h:");
-            common::write_words(rng, buf, vibe);
-        } else {
-            buf.extend_from_slice(b"|m:");
-            common::write_words(rng, buf, vibe);
+impl ServiceCheck {
+    /// Sample a service check with content over the full forwarded alphabet.
+    pub(crate) fn generate(rng: &mut (impl Rng + ?Sized), budget: usize) -> Option<Self> {
+        // `_sc|name|status` is the skeleton, with a one-byte status.
+        const SKELETON: usize = "_sc|".len() + 1 + 1;
+        let name_room = budget.checked_sub(SKELETON)?;
+        let name = common::identifier_within(rng, name_room);
+        if name.is_empty() {
+            return None;
         }
+        let spent = SKELETON + name.len();
+        let tags = common::tags_within(rng, budget.saturating_sub(spent));
+        let spent = spent + common::tags_len(&tags);
+        Some(Self {
+            name,
+            status: STATUS[rng.random_range(0..STATUS.len())],
+            tags,
+            options: options(rng, budget.saturating_sub(spent)),
+        })
     }
 
-    common::write_tags(rng, buf, vibe);
-    buf.push(b'\n');
+    /// Serialize the service check to datagram bytes, without the trailing `\n`.
+    pub(crate) fn serialize(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(b"_sc|");
+        out.extend_from_slice(&self.name);
+        out.push(b'|');
+        out.extend_from_slice(self.status);
+        common::serialize_tags(&self.tags, out);
+        for opt in &self.options {
+            out.push(b'|');
+            out.extend_from_slice(opt);
+        }
+    }
+}
+
+/// Sample a run of optional chunks.
+fn options(rng: &mut (impl Rng + ?Sized), budget: usize) -> Vec<Vec<u8>> {
+    let count = OPT_COUNTS[rng.random_range(0..OPT_COUNTS.len())];
+    let mut out = Vec::new();
+    let mut room = budget;
+    for _ in 0..count {
+        let prefix = OPT_PREFIXES[rng.random_range(0..OPT_PREFIXES.len())];
+        // Each chunk carries a leading `|` on the wire.
+        let Some(body_room) = room.checked_sub(1 + prefix.len()) else {
+            break;
+        };
+        let mut chunk = prefix.to_vec();
+        chunk.extend_from_slice(&common::optional_text_within(rng, body_room));
+        room -= 1 + chunk.len();
+        out.push(chunk);
+    }
+    out
 }

--- a/test/antithesis/scenarios/differential/src/bin/parallel_driver_send_dogstatsd_differential.rs
+++ b/test/antithesis/scenarios/differential/src/bin/parallel_driver_send_dogstatsd_differential.rs
@@ -62,10 +62,8 @@ mod unix_driver {
         // Both targets share one receive buffer, so one payload limit keeps neither from truncating.
         let driver_config = DriverConfig::read(&config.config_dir)?;
         // Agent first, ADP second: `stats.sent` and `stats.max_packed` are indexed in this order.
-        let batch = driver::sample(&mut AntithesisRng);
         let stats = driver::run(
             AntithesisRng,
-            batch,
             driver_config.payload_byte_limit,
             driver_config.datagram_count,
             vec![agent_socket, adp_socket],
@@ -76,7 +74,7 @@ mod unix_driver {
         let multi_value_both = stats.max_packed[0] > 0 && stats.max_packed[1] > 0;
 
         assert_reachable!(
-            "differential workload ran a dogstatsd batch",
+            "differential workload ran a dogstatsd load",
             &json!({
                 "payloads_received": payloads_received,
                 "agent_sent": agent_sent,

--- a/test/antithesis/scenarios/general/src/bin/parallel_driver_send_dogstatsd.rs
+++ b/test/antithesis/scenarios/general/src/bin/parallel_driver_send_dogstatsd.rs
@@ -10,7 +10,7 @@ mod unix_driver {
     use antithesis_sdk::random::AntithesisRng;
     use clap::Parser;
     use harness::config::DriverConfig;
-    use harness::driver::{self, Batch};
+    use harness::driver;
     use serde_json::json;
 
     #[derive(Debug, Parser)]
@@ -39,10 +39,8 @@ mod unix_driver {
         };
 
         let driver_config = DriverConfig::read(&config.config_dir)?;
-        let batch = driver::sample(&mut AntithesisRng);
         let stats = driver::run(
             AntithesisRng,
-            batch,
             driver_config.payload_byte_limit,
             driver_config.datagram_count,
             vec![socket],
@@ -51,7 +49,7 @@ mod unix_driver {
         let max_packed = stats.max_packed[0];
 
         assert_reachable!(
-            "workload ran a dogstatsd batch",
+            "workload ran a dogstatsd load",
             &json!({
                 "sent": sent,
                 "timed_out": stats.timed_out,
@@ -63,21 +61,6 @@ mod unix_driver {
             max_packed > 0,
             "workload emitted a multi-value metric",
             &json!({ "sent": sent, "max_packed_values": max_packed })
-        );
-        assert_sometimes!(
-            sent > 0 && matches!(batch, Batch::Clean),
-            "workload ran a fully clean batch",
-            &json!({ "sent": sent })
-        );
-        assert_sometimes!(
-            sent > 0 && matches!(batch, Batch::Feral),
-            "workload ran a fully feral batch",
-            &json!({ "sent": sent })
-        );
-        assert_sometimes!(
-            sent > 0 && matches!(batch, Batch::Mixed),
-            "workload ran a mixed batch",
-            &json!({ "sent": sent })
         );
 
         Ok(())


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Our previous approach to generating dogstatsd load for use in the
Antithesis rig was very Datadog/lading inspired: generate something
that is correct-by-construction and then bias the result to be
'interesting'. This works well but the biasing systematically avoids
conditions that are not-malformed -- that is, accepted by the SUT --
but are demonstrative of goofy behavior. This commit changes the
generator to be a hybrid of that approach with a state search approach.
We define a predicate `is_malformed` that confirms whether or not
a payload will be accepted by the SUT and then payloads which are not
malformed, however strange, are transmitted.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
