### PR TITLE
chore(antithesis): non-utf8 bytes in datagrams represent ~1% of generation

### DIFF
--- a/test/antithesis/harness/proptest-regressions/payload/dogstatsd.txt
+++ b/test/antithesis/harness/proptest-regressions/payload/dogstatsd.txt
@@ -6,3 +6,7 @@
 # everyone who runs the test benefits from these saved cases.
 cc 377cba92b14295b3fe5c6f2738a398ee042be8e35f529398ecf9e275e6b0a1da # shrinks to seed = 0
 cc 1f807f27fdbf0b983fc773b815b21d6023e1bce87691d07133b438b862edcc5b # shrinks to seed = 6079028945602138863, limit_bytes = 21
+cc 966dfab50a6a0af70bafa9c882cd664e62586012ec563187766e7b07773b588e # shrinks to seed = 816969264511539406, limit_bytes = 9
+cc 4470fd2185844af9954fc8e973eee2ac8f6c939167fb7d950e448a5ca2d2b52a # shrinks to seed = 881271281136835980, limit_bytes = 8
+cc c084e24d26194bedbf39e3055ace5c28a2d3ce2f2b071be7277a18f49e568849 # shrinks to seed = 6133403856440011550
+cc 89407cb915422a73621ab39b63ac3bb99e1a12ebb33825d9f623da074b805f9f # shrinks to seed = 17633913455663304866, limit_bytes = 3

--- a/test/antithesis/harness/src/bin/first_sample_config/main.rs
+++ b/test/antithesis/harness/src/bin/first_sample_config/main.rs
@@ -73,7 +73,7 @@ fn main() -> anyhow::Result<()> {
     let context_source_path = cli.config_dir.join("context_source.yaml");
     fs::write(
         &context_source_path,
-        ContextSourceConfig::sample(&mut rng, driver.payload_byte_limit)
+        ContextSourceConfig::sample(&mut rng, driver.datagram_byte_limit)
             .to_yaml()?
             .as_bytes(),
     )

--- a/test/antithesis/harness/src/config.rs
+++ b/test/antithesis/harness/src/config.rs
@@ -15,7 +15,7 @@ use rand::distr::{Distribution, StandardUniform};
 use rand::{Rng, RngExt};
 use serde::{Deserialize, Serialize};
 
-use crate::payload::dogstatsd::PAYLOAD_BYTE_LIMIT;
+use crate::payload::dogstatsd::DATAGRAM_BYTE_LIMIT;
 use crate::rand::Probe;
 
 /// Agent log level.
@@ -258,9 +258,9 @@ const MAX_CONTEXTS_PER_REQUEST: usize = 65_536;
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct DriverConfig {
     /// Max bytes a generator packs into one datagram, the smaller of the SUT's
-    /// sampled receive buffer and [`PAYLOAD_BYTE_LIMIT`]. A datagram this size
+    /// sampled receive buffer and [`DATAGRAM_BYTE_LIMIT`]. A datagram this size
     /// fits one read, so the SUT never truncates a line mid-token.
-    pub payload_byte_limit: usize,
+    pub datagram_byte_limit: usize,
     /// Datagrams a driver invocation ships this timeline.
     pub datagram_count: usize,
     /// Distinct contexts a driver invocation fetches from the shared pool as its working set.
@@ -268,22 +268,23 @@ pub struct DriverConfig {
     /// Sampled boundary-biased log-uniform in `1..=1_024`. Valid values run `1..=65_536`, the intake's
     /// per-request ceiling. Outside that the intake rejects every `/contexts` request, the driver waits
     /// out its fetch budget and ships nothing, so [`Self::read`] rejects such a config rather than
-    /// letting a timeline generate no load. A larger working set spreads load over more identities and
-    /// so puts fewer points in each, which is the trade against recurrence.
+    /// letting a timeline generate no load. Every context in a pull gets a line in every datagram that
+    /// has room, so a larger pull makes fatter datagrams over more identities rather than thinner
+    /// series, and the trade is against how often any one identity recurs.
     pub context_count: usize,
 }
 
 impl DriverConfig {
     /// Sample the driver knobs for a SUT whose receive buffer is `buffer_size`.
     fn sample<R: Rng + ?Sized>(rng: &mut R, buffer_size: u64) -> Self {
-        // The min is at most PAYLOAD_BYTE_LIMIT, so a buffer wider than usize
+        // The min is at most DATAGRAM_BYTE_LIMIT, so a buffer wider than usize
         // caps to the ceiling like any other oversized buffer.
-        let payload_byte_limit = match usize::try_from(buffer_size.min(PAYLOAD_BYTE_LIMIT as u64)) {
+        let datagram_byte_limit = match usize::try_from(buffer_size.min(DATAGRAM_BYTE_LIMIT as u64)) {
             Ok(bytes) => bytes,
-            Err(_) => PAYLOAD_BYTE_LIMIT,
+            Err(_) => DATAGRAM_BYTE_LIMIT,
         };
         Self {
-            payload_byte_limit,
+            datagram_byte_limit,
             datagram_count: rng.random_range(0..=MAX_DATAGRAMS),
             context_count: usize::try_from(Probe::new(1, MAX_WORKING_SET).sample(rng)).unwrap_or(usize::MAX),
         }
@@ -304,7 +305,7 @@ impl DriverConfig {
     /// # Errors
     ///
     /// Returns an error if the config is unreadable or is not valid YAML with an
-    /// integer `payload_byte_limit`.
+    /// integer `datagram_byte_limit`.
     pub fn read(config_dir: &Path) -> anyhow::Result<Self> {
         let path = config_dir.join("driver.yaml");
         let yaml = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
@@ -328,19 +329,21 @@ const MAX_CONTEXTS_TOTAL: u64 = 1_000_000;
 /// The per-kind caps a timeline's shared context pool fills to before it recurs existing contexts.
 /// `first_sample_config` samples this beside `datadog.yaml` so cardinality varies per timeline. Each
 /// cap is drawn against the budget the earlier draws left, so a kind's cardinality still varies at
-/// random while the three together stay under [`MAX_CONTEXTS_TOTAL`].
+/// random while the three together stay under `MAX_CONTEXTS_TOTAL`.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct ContextSourceConfig {
     /// Bytes a rendered line of any pooled context must fit, this timeline's real datagram budget
     /// rather than the protocol ceiling. Mint builds identities against it, so every served context
-    /// has a rendering the driver can pack. Defaults to the sampled `payload_byte_limit`, which is the
-    /// smaller of the SUT's receive buffer and [`PAYLOAD_BYTE_LIMIT`].
-    pub payload_byte_limit: usize,
+    /// has a rendering the driver can pack. Defaults to the sampled `datagram_byte_limit`, which is the
+    /// smaller of the SUT's receive buffer and [`DATAGRAM_BYTE_LIMIT`].
+    pub datagram_byte_limit: usize,
     /// Distinct metric contexts the pool holds before it recurs the ones it has.
     ///
-    /// Sampled in `1..=MAX_CONTEXTS_TOTAL` minus what the other kinds took. A larger cap explores more
+    /// Sampled in `2..=MAX_CONTEXTS_TOTAL` minus what the other kinds took. A larger cap explores more
     /// identities and puts fewer points in each, and costs memory: the pool retains every context it
-    /// mints for the life of the run. Zero is not sampled and serves nothing for the kind.
+    /// mints for the life of the run. Two is the floor because the pool holds one context carrying an
+    /// invalid UTF-8 byte per kind alongside the rest, and a kind capped at one could hold only one of
+    /// the two.
     pub metric_contexts: usize,
     /// Distinct event contexts the pool holds. Same range and trade as [`Self::metric_contexts`].
     pub event_contexts: usize,
@@ -354,16 +357,16 @@ impl ContextSourceConfig {
     ///
     /// The draws run in order and each spends from one shared ceiling, so the total is bounded by
     /// construction rather than by scaling three independent draws afterwards. Every kind keeps at
-    /// least one context, since a kind capped at zero panics the pool's draw.
+    /// least two contexts, one of which carries an invalid UTF-8 byte.
     #[must_use]
-    pub fn sample<R: Rng + ?Sized>(rng: &mut R, payload_byte_limit: usize) -> Self {
-        // Two contexts held back so the later kinds can each keep their one.
-        let metric_contexts = sample_cap(rng, MAX_CONTEXTS_TOTAL - 2);
+    pub fn sample<R: Rng + ?Sized>(rng: &mut R, datagram_byte_limit: usize) -> Self {
+        // Four contexts held back so the two later kinds can each keep their two.
+        let metric_contexts = sample_cap(rng, MAX_CONTEXTS_TOTAL - 4);
         let free = MAX_CONTEXTS_TOTAL - metric_contexts as u64;
-        let event_contexts = sample_cap(rng, free - 1);
+        let event_contexts = sample_cap(rng, free - 2);
         let free = free - event_contexts as u64;
         Self {
-            payload_byte_limit,
+            datagram_byte_limit,
             metric_contexts,
             event_contexts,
             service_check_contexts: sample_cap(rng, free),
@@ -384,18 +387,38 @@ impl ContextSourceConfig {
     ///
     /// # Errors
     ///
-    /// Returns an error if the config is unreadable or is not valid YAML.
+    /// Returns an error if the config is unreadable, is not valid YAML, or caps a kind below two. The
+    /// pool seeds every kind with one context carrying an invalid UTF-8 byte and one without, so a cap of
+    /// one cannot hold both and the pool would exceed its own cap assertion. [`Self::sample`] never draws
+    /// below two, and this rejects a config that reached the pool by another route rather than letting it
+    /// redden a run.
     pub fn read(config_dir: &Path) -> anyhow::Result<Self> {
         let path = config_dir.join("context_source.yaml");
         let yaml = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
-        serde_yaml::from_str(&yaml).with_context(|| format!("parse context source config from {}", path.display()))
+        let config: Self = serde_yaml::from_str(&yaml)
+            .with_context(|| format!("parse context source config from {}", path.display()))?;
+        for (kind, cap) in [
+            ("metric_contexts", config.metric_contexts),
+            ("event_contexts", config.event_contexts),
+            ("service_check_contexts", config.service_check_contexts),
+        ] {
+            anyhow::ensure!(
+                cap >= MIN_CONTEXTS_PER_KIND,
+                "{kind} is {cap}, which is below the {MIN_CONTEXTS_PER_KIND} the pool seeds"
+            );
+        }
+        Ok(config)
     }
 }
 
-/// A single per-kind cap in `1..=ceiling`. The ceiling is well within `usize` on every supported
+/// The fewest contexts a kind may be capped at. The pool seeds every kind with one context carrying an
+/// invalid UTF-8 byte and one without, and both count against the cap.
+pub const MIN_CONTEXTS_PER_KIND: usize = 2;
+
+/// A single per-kind cap in `2..=ceiling`. The ceiling is well within `usize` on every supported
 /// target, so the saturating conversion is unreachable in practice.
 fn sample_cap<R: Rng + ?Sized>(rng: &mut R, ceiling: u64) -> usize {
-    usize::try_from(Probe::new(1, ceiling.max(1)).sample(rng)).unwrap_or(usize::MAX)
+    usize::try_from(Probe::new(2, ceiling.max(2)).sample(rng)).unwrap_or(usize::MAX)
 }
 
 #[cfg(test)]
@@ -450,14 +473,29 @@ mod tests {
         yaml.lines().any(|line| line.starts_with(&format!("{key}:")))
     }
 
+    // A cap below what the pool seeds would make the pool exceed its own cap assertion and redden the
+    // run on a config value. Rejected at the boundary, as the sibling driver config is.
+    #[test]
+    fn context_source_read_rejects_a_cap_below_the_seeded_minimum() {
+        let dir = std::env::temp_dir().join(format!("ctxcfg-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        std::fs::write(
+            dir.join("context_source.yaml"),
+            "datagram_byte_limit: 8192\nmetric_contexts: 1\nevent_contexts: 4\nservice_check_contexts: 4\n",
+        )
+        .expect("write config");
+        let err = ContextSourceConfig::read(&dir).expect_err("a cap of 1 must be rejected");
+        assert!(err.to_string().contains("metric_contexts"), "{err}");
+    }
+
     #[test]
     fn driver_config_caps_payload_to_the_smaller_bound() {
-        assert_eq!(DriverConfig::sample(&mut SeqRng(0), 512).payload_byte_limit, 512);
+        assert_eq!(DriverConfig::sample(&mut SeqRng(0), 512).datagram_byte_limit, 512);
         assert_eq!(
-            DriverConfig::sample(&mut SeqRng(0), 1 << 30).payload_byte_limit,
-            PAYLOAD_BYTE_LIMIT
+            DriverConfig::sample(&mut SeqRng(0), 1 << 30).datagram_byte_limit,
+            DATAGRAM_BYTE_LIMIT
         );
-        assert_eq!(DriverConfig::sample(&mut SeqRng(0), 0).payload_byte_limit, 0);
+        assert_eq!(DriverConfig::sample(&mut SeqRng(0), 0).datagram_byte_limit, 0);
     }
 
     #[test]
@@ -511,8 +549,14 @@ mod tests {
             let caps = ContextSourceConfig::sample(&mut SeqRng(seed), 8_192);
             let total = (caps.metric_contexts + caps.event_contexts + caps.service_check_contexts) as u64;
             assert!(total <= MAX_CONTEXTS_TOTAL, "seed {seed} sampled {total}");
-            // A kind of zero panics the pool's `random_range(0..0)`, so every kind keeps at least one.
-            assert!(caps.metric_contexts >= 1 && caps.event_contexts >= 1 && caps.service_check_contexts >= 1);
+            // The pool seeds every kind with one context carrying an invalid UTF-8 byte and one without,
+            // and both count against the cap, so a kind capped below two makes the pool exceed its own
+            // cap assertion.
+            assert!(
+                caps.metric_contexts >= MIN_CONTEXTS_PER_KIND
+                    && caps.event_contexts >= MIN_CONTEXTS_PER_KIND
+                    && caps.service_check_contexts >= MIN_CONTEXTS_PER_KIND
+            );
         }
     }
 

--- a/test/antithesis/harness/src/contexts.rs
+++ b/test/antithesis/harness/src/contexts.rs
@@ -1,11 +1,16 @@
 //! The context protocol: reusable `DogStatsD` identities a driver renders load against.
 //!
 //! A [`Context`] is a per-type stable identity — a metric's `(kind, name, tags)`, an event's title +
-//! tags + option fields, a service check's name + tags + host. It is minted over the free generator's
-//! full content alphabet (`payload/dogstatsd/common.rs`) and accepted only when a probe render is
-//! `!is_malformed` (see [`crate::dogstatsd`]) — conforming to the Agent parser and nothing stricter.
-//! The driver varies the per-occurrence payload (value/text/status, extensions, timestamp) each
-//! render, so a pooled identity recurs while its load varies.
+//! tags + option fields, a service check's name + tags + host. It is minted over the content alphabet in
+//! `payload/dogstatsd/common.rs` and accepted only when a probe render is `!is_malformed`, see
+//! [`crate::dogstatsd`], conforming to the Agent parser and nothing stricter. The driver varies the
+//! per-occurrence payload each render, the value, text, status, extensions and timestamp, so a pooled
+//! identity recurs while its load varies.
+//!
+//! [`Context::mint_non_utf8_within`] mints an identity carrying an invalid UTF-8 byte in its name or a
+//! tag. That is the only source of such a byte in generated load, and it lives in the identity so the
+//! pool counts it against a cap. Poisoning a rendered datagram instead would invent an identity the pool
+//! never issued, one per datagram, which is how bounded cardinality leaks.
 //!
 //! A shared intake pool mints identities up to a per-kind cap then recurs them, and serves them to
 //! drivers over the length-prefixed binary codec here ([`encode_response`] / [`decode_response`]),
@@ -14,17 +19,18 @@
 use rand::{Rng, RngExt};
 
 use crate::dogstatsd::is_malformed;
+use crate::payload::dogstatsd::common;
 
 pub mod event;
 pub mod metric;
 pub mod service_check;
 
-/// How many times to re-mint an identity whose probe render the Agent would drop before falling back
-/// to a guaranteed-sound identity. Mint is mostly-valid, so the fallback is rare.
+/// How many times to re-mint an identity whose probe render the Agent would drop before yielding
+/// nothing. Mint is mostly-valid, so an exhausted loop is rare.
 const REMINT_TRIES: usize = 16;
 
 /// How many times to re-render a context whose per-occurrence payload the Agent would drop before
-/// falling back to a guaranteed-well-formed line.
+/// yielding nothing. 2.3% of single renders need a retry and none has yet exhausted the loop.
 const RENDER_TRIES: usize = 8;
 
 /// Digits allowed for a rendered length field, generous so a floor is never an underestimate.
@@ -105,6 +111,82 @@ impl Context {
         }
     }
 
+    /// Replace one byte of this identity with an invalid UTF-8 byte, so the identity itself is the
+    /// corrupt one rather than a datagram being edited after the fact.
+    ///
+    /// The Agent does no charset validation, so the line still forwards and the criterion stays "does
+    /// the Agent discard it". Which identity field takes the byte is what the intake distinguishes: a
+    /// v3 name dictionary rejects the whole payload, a tag dictionary coerces. A delimiter is never
+    /// overwritten, since removing one reshapes the line. Returns whether a byte was replaced.
+    fn poison(&mut self, rng: &mut (impl Rng + ?Sized)) -> bool {
+        let fields: Vec<&mut Vec<u8>> = match self {
+            Context::Metric(c) => std::iter::once(&mut c.name).chain(c.tags.iter_mut()).collect(),
+            Context::Event(c) => std::iter::once(&mut c.title).chain(c.tags.iter_mut()).collect(),
+            Context::ServiceCheck(c) => std::iter::once(&mut c.name).chain(c.tags.iter_mut()).collect(),
+        };
+        let targets: Vec<(usize, usize)> = fields
+            .iter()
+            .enumerate()
+            .flat_map(|(f, bytes)| {
+                bytes
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, &b)| !matches!(b, b':' | b'|' | b',' | b'#' | b'@'))
+                    .map(move |(i, _)| (f, i))
+            })
+            .collect();
+        if targets.is_empty() {
+            return false;
+        }
+        let (field, at) = targets[rng.random_range(0..targets.len())];
+        let mut fields = fields;
+        fields[field][at] = common::invalid_utf8_byte(rng);
+        true
+    }
+
+    /// Mint an identity of `kind` that carries an invalid UTF-8 byte, or `None` when none can be built
+    /// within `budget`. Corrupt identities live in the pool like any other, so they recur across
+    /// datagrams and count against the kind's cap instead of appearing as fresh one-offs.
+    #[must_use]
+    pub fn mint_non_utf8_within(kind: Kind, rng: &mut (impl Rng + ?Sized), budget: usize) -> Option<Context> {
+        for _ in 0..REMINT_TRIES {
+            let mut context = Context::mint_within(kind, rng, budget)?;
+            if !context.poison(rng) {
+                continue;
+            }
+            // A replaced byte does not always invalidate the field. `0x80` is a valid continuation byte,
+            // so poisoning the trailing byte of `café` turns `C3 A9` into the valid `C3 80`. Verify the
+            // field instead of trimming `0x80` from the pool, which would drop it from the byte space the
+            // SUT ever sees. Unverified, 3.4% of corrupt mints carried no invalid byte at all.
+            if !context.has_non_utf8() {
+                continue;
+            }
+            let mut probe = Vec::new();
+            context.render(rng, &mut probe);
+            if is_malformed(&probe).is_ok() {
+                return Some(context);
+            }
+        }
+        None
+    }
+
+    /// Whether this identity carries an invalid UTF-8 byte.
+    #[must_use]
+    pub fn has_non_utf8(&self) -> bool {
+        let fields: Vec<&[u8]> = match self {
+            Context::Metric(c) => std::iter::once(c.name.as_slice())
+                .chain(c.tags.iter().map(Vec::as_slice))
+                .collect(),
+            Context::Event(c) => std::iter::once(c.title.as_slice())
+                .chain(c.tags.iter().map(Vec::as_slice))
+                .collect(),
+            Context::ServiceCheck(c) => std::iter::once(c.name.as_slice())
+                .chain(c.tags.iter().map(Vec::as_slice))
+                .collect(),
+        };
+        fields.iter().any(|f| simdutf8::basic::from_utf8(f).is_err())
+    }
+
     /// Bytes every render of this identity must spend, whatever the per-occurrence payload.
     #[must_use]
     pub fn floor(&self) -> usize {
@@ -131,9 +213,17 @@ impl Context {
     pub fn render_wellformed_within(
         &self, rng: &mut (impl Rng + ?Sized), out: &mut Vec<u8>, budget: usize,
     ) -> Option<usize> {
-        for _ in 0..RENDER_TRIES {
+        for try_index in 0..RENDER_TRIES {
             let start = out.len();
-            let packed = self.render_within(rng, out, budget)?;
+            // The last try renders at the identity's floor, where the occurrence is the shortest the
+            // identity admits and no extension chunk has room. Sampling a wide occurrence one more time
+            // would be hoping again, and a caller has nowhere to go when the tries run out.
+            let attempt = if try_index + 1 == RENDER_TRIES {
+                self.floor().min(budget)
+            } else {
+                budget
+            };
+            let packed = self.render_within(rng, out, attempt)?;
             if is_malformed(&out[start..]).is_ok() {
                 return Some(packed);
             }
@@ -286,6 +376,19 @@ mod tests {
     }
 
     proptest! {
+        /// A corrupt mint always carries an invalid byte. The replacement byte does not guarantee it on
+        /// its own, and an identity that looks corrupt but is not lands in the clean half of the working
+        /// set and quietly thins the non-UTF-8 rate.
+        #[test]
+        fn property_test_a_corrupt_mint_is_corrupt(seed: u64) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            for _ in 0..16 {
+                if let Some(context) = Context::mint_non_utf8_within(Kind::sample(&mut rng), &mut rng, 8_191) {
+                    prop_assert!(context.has_non_utf8(), "a corrupt mint carried no invalid byte: {context:?}");
+                }
+            }
+        }
+
         /// A minted context conforms to is_malformed. Content carries delimiters, so a raw render may
         /// land on the drop side. The repair loop is the sorter, and any line it does yield forwards.
         #[test]
@@ -294,7 +397,10 @@ mod tests {
             let Some(context) = Context::mint_within(kind, &mut rng, 8_192) else { return Ok(()) };
             for _ in 0..8 {
                 let mut line = Vec::new();
-                if context.render_wellformed_within(&mut rng, &mut line, 8_192).is_some() {
+                if context
+                    .render_wellformed_within(&mut rng, &mut line, 8_192)
+                    .is_some()
+                {
                     prop_assert_eq!(is_malformed(&line), Ok(()), "a rendered line was droppable");
                 }
             }

--- a/test/antithesis/harness/src/driver.rs
+++ b/test/antithesis/harness/src/driver.rs
@@ -1,7 +1,7 @@
 //! Shared `DogStatsD` load-driver engine.
 //!
 //! The engine fetches a working set of contexts from the shared intake pool, then a producer thread
-//! renders per-occurrence payloads against them into a bounded channel while a consumer thread fans
+//! renders per-occurrence values against them into a bounded channel while a consumer thread fans
 //! each datagram out to every socket and tallies per-socket sends. Drivers differ only in how many
 //! sockets they target and which anchors they fire, so both the single-socket and differential
 //! drivers run on this one engine.
@@ -34,12 +34,12 @@ const CONTEXT_FETCH_BACKOFF: Duration = Duration::from_millis(250);
 /// Per-request timeout on a single context fetch.
 const CONTEXT_FETCH_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// A generated payload queued for the sockets: the packed bytes and what they hold.
+/// A generated datagram queued for the sockets: the packed bytes and what they hold.
 struct Datagram {
-    /// The `\n`-packed payload bytes to ship over a socket.
+    /// The `\n`-packed bytes of one datagram, shipped in a single send.
     bytes: Vec<u8>,
     /// The lines and largest packed run in `bytes`.
-    payload: dogstatsd::Payload,
+    stats: dogstatsd::DatagramStats,
 }
 
 /// What a driver run shipped, for anchoring assertions.
@@ -47,7 +47,7 @@ struct Datagram {
 pub struct Stats {
     /// Payloads pulled from the channel, whether or not any send succeeded.
     pub received: usize,
-    /// Lines delivered per socket, summed across payloads, indexed as the sockets
+    /// Lines delivered per socket, summed across datagrams, indexed as the sockets
     /// were passed to [`run`].
     pub sent: Vec<usize>,
     /// Largest packed run that reached each socket, indexed likewise. Zero when
@@ -71,28 +71,40 @@ impl Stats {
     }
 }
 
-/// Fetch a working set of `context_count` contexts from the intake pool at `intake_addr`, then drive
-/// `count` datagrams to every socket, each a fresh render of a sampled context packed to at most
-/// `limit_bytes`, blocking through transient backpressure so every datagram reaches every socket.
+/// Pull `context_count` contexts from the intake pool at `intake_addr` once, then drive `count` datagrams
+/// to every socket from that one pull, each datagram a fresh per-occurrence render of every context that
+/// fits under `limit_bytes`, blocking through transient backpressure so every datagram reaches every
+/// socket.
 /// `context_count`, `count`, and `limit_bytes` come from a load generator's
 /// [`crate::config::DriverConfig`], so a datagram never truncates on receive.
 ///
-/// An unreachable pool ends the run with an empty [`Stats`] rather than an error, so a driver started
-/// before the intake serves degrades to a no-op. A peer that leaves mid-batch, or backpressure that
-/// outlasts the retry budget, ends the run early with a partial [`Stats`].
+/// An unreachable pool ends the run with an empty [`Stats`] rather than an error, so a driver that
+/// cannot reach the intake for its whole fetch budget degrades to a no-op. A peer that leaves mid-batch,
+/// or backpressure that outlasts the retry budget, ends the run early with a partial [`Stats`].
 ///
 /// # Errors
 ///
-/// Errors if a worker thread panics. Sustained backpressure is reported via
-/// [`Stats::timed_out`], not as an error.
+/// Errors if a worker thread panics, or if a reachable pool serves no contexts. Sustained backpressure
+/// is reported via [`Stats::timed_out`], not as an error.
 pub fn run<R: Rng + Send + 'static>(
     mut rng: R, intake_addr: &str, context_count: usize, limit_bytes: usize, count: usize, sockets: Vec<UnixDatagram>,
 ) -> anyhow::Result<Stats> {
-    let contexts = match fetch_contexts(intake_addr, context_count) {
-        // Ordered by floor once here, not per datagram: the working set is fixed for the invocation.
-        Some(contexts) if !contexts.is_empty() => dogstatsd::WorkingSet::new(contexts),
-        // Pool unreachable or empty. No load this invocation, not a failure.
-        _ => return Ok(Stats::empty(sockets.len())),
+    // One pull for the whole invocation, reused for every datagram. The pull is what decides whether
+    // this invocation's datagrams carry a non-UTF-8 byte, and a run schedules many invocations, so the
+    // fraction of pulls carrying one is the fraction of datagrams carrying one.
+    let pull = match fetch_contexts(intake_addr, context_count)? {
+        Some(contexts) => {
+            // The pool serves exactly what was asked for or errors, so a body that decodes to no
+            // contexts means the driver and the intake disagree about the request rather than that load
+            // is unavailable. Shipping nothing on it would hide the disagreement.
+            match dogstatsd::Pull::new(contexts) {
+                Some(pull) => pull,
+                None => anyhow::bail!("context pool served nothing for a request of {context_count} contexts"),
+            }
+        }
+        // The intake stayed unreachable for the whole fetch budget, which is what an injected partition
+        // looks like. No load this invocation, not a failure.
+        None => return Ok(Stats::empty(sockets.len())),
     };
 
     let (tx, rx) = sync_channel::<Datagram>(2024);
@@ -100,15 +112,15 @@ pub fn run<R: Rng + Send + 'static>(
     let producer = thread::spawn(move || {
         for _ in 0..count {
             let mut bytes = Vec::new();
-            let payload = dogstatsd::write_payload(&mut rng, &contexts, &mut bytes, limit_bytes);
-            // Green by construction: write_payload packs only rendered lines the Agent forwards. The
+            let stats = dogstatsd::write_datagram(&mut rng, &pull, &mut bytes, limit_bytes);
+            // Green by construction: write_datagram packs only rendered lines the Agent forwards. The
             // anchor catches any drift that would ship a droppable datagram.
             assert_always!(
                 is_malformed(&bytes).is_ok(),
-                "driver payload is well-formed",
+                "driver datagram is well-formed",
                 &json!({})
             );
-            if tx.send(Datagram { bytes, payload }).is_err() {
+            if tx.send(Datagram { bytes, stats }).is_err() {
                 break;
             }
         }
@@ -124,8 +136,8 @@ pub fn run<R: Rng + Send + 'static>(
             for (i, socket) in sockets.iter().enumerate() {
                 match deliver(socket, &datagram.bytes) {
                     Delivery::Sent => {
-                        sent[i] += datagram.payload.lines;
-                        max_packed[i] = max_packed[i].max(datagram.payload.max_packed);
+                        sent[i] += datagram.stats.lines;
+                        max_packed[i] = max_packed[i].max(datagram.stats.max_packed);
                     }
                     // Peer left mid-batch after Antithesis killed the SUT. Stop and
                     // report the partial batch rather than failing the run.
@@ -155,35 +167,64 @@ pub fn run<R: Rng + Send + 'static>(
         .map_err(|_| anyhow::anyhow!("consumer thread panicked"))?
 }
 
-/// Fetch a working set of `n` contexts from the pool at `intake_addr` over blocking HTTP, retrying
-/// through [`CONTEXT_FETCH_BUDGET`]. Returns `None` if the pool never answers or the body does not
-/// decode, so the caller degrades to no load rather than failing.
-fn fetch_contexts(intake_addr: &str, n: usize) -> Option<Vec<Context>> {
+/// What a context fetch attempt came back with.
+enum Fetched {
+    /// The pool answered with contexts.
+    Contexts(Vec<Context>),
+    /// Nothing answered, or the body did not decode. Worth retrying.
+    Unreachable,
+    /// The pool answered and refused. Its own invariant broke, so retrying it is pointless.
+    Refused(reqwest::StatusCode),
+}
+
+/// Fetch a pull of `n` contexts from the pool at `intake_addr` over blocking HTTP, retrying through
+/// [`CONTEXT_FETCH_BUDGET`]. Returns `None` when the pool never answers, so the caller degrades to no
+/// load rather than failing, which is what an injected partition looks like.
+///
+/// # Errors
+///
+/// Errors when the pool answers and refuses. A refusal means the intake decided it could not serve this
+/// timeline's config at all, and shipping no load on it would hide that behind an idle driver.
+fn fetch_contexts(intake_addr: &str, n: usize) -> anyhow::Result<Option<Vec<Context>>> {
     let url = format!("http://{intake_addr}/contexts?n={n}");
     let client = reqwest::blocking::Client::builder()
         .timeout(CONTEXT_FETCH_TIMEOUT)
         .build()
-        .ok()?;
+        .map_err(|e| anyhow::anyhow!("build the context-fetch client: {e}"))?;
     let deadline = Instant::now() + CONTEXT_FETCH_BUDGET;
     loop {
-        if let Some(contexts) = try_fetch_contexts(&client, &url) {
-            return Some(contexts);
+        match try_fetch_contexts(&client, &url) {
+            Fetched::Contexts(contexts) => return Ok(Some(contexts)),
+            Fetched::Refused(status) => {
+                anyhow::bail!("context pool refused a request for {n} contexts with {status}")
+            }
+            Fetched::Unreachable => {}
         }
         if Instant::now() >= deadline {
-            return None;
+            return Ok(None);
         }
         sleep(CONTEXT_FETCH_BACKOFF);
     }
 }
 
-/// One context-fetch attempt: `None` on a transport error, a non-success status, or a body that does
-/// not decode, so a partial or corrupt response is retried rather than trusted.
-fn try_fetch_contexts(client: &reqwest::blocking::Client, url: &str) -> Option<Vec<Context>> {
-    let response = client.get(url).send().ok()?;
-    if !response.status().is_success() {
-        return None;
+/// One context-fetch attempt. A transport error or a body that does not decode is retried. A non-success
+/// status is not: the pool answered, so the fault is in the request or in the pool's own config, and no
+/// amount of waiting fixes either.
+fn try_fetch_contexts(client: &reqwest::blocking::Client, url: &str) -> Fetched {
+    let Ok(response) = client.get(url).send() else {
+        return Fetched::Unreachable;
+    };
+    let status = response.status();
+    if !status.is_success() {
+        return Fetched::Refused(status);
     }
-    decode_response(&response.bytes().ok()?)
+    let Ok(body) = response.bytes() else {
+        return Fetched::Unreachable;
+    };
+    match decode_response(&body) {
+        Some(contexts) => Fetched::Contexts(contexts),
+        None => Fetched::Unreachable,
+    }
 }
 
 /// Outcome of delivering one line to a socket.

--- a/test/antithesis/harness/src/payload/dogstatsd.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd.rs
@@ -1,11 +1,16 @@
-//! `DogStatsD` payload generation from a pooled context working set.
+//! `DogStatsD` datagram packing from one pull of pooled contexts.
 //!
-//! A driver no longer samples a fresh identity per line. It fetches a working set of [`Context`]s
-//! from the shared intake pool, [`crate::contexts`], and renders a fresh per-occurrence payload
-//! against a sampled context each line, so identities recur while their load varies. Every rendered
-//! line is repaired by [`Context::render_wellformed_within`] to one the Datadog Agent forwards, so a packed
-//! datagram holds only whole lines the Agent keeps. There is no clean/feral/mixed configuration. The
-//! legal space is exactly the set of payloads [`crate::dogstatsd::is_malformed`] accepts.
+//! A driver pulls a set of [`Context`]s from the shared intake pool, [`crate::contexts`], once per
+//! invocation and reuses it for every datagram it sends. Each datagram is a fresh per-occurrence render
+//! of as many of those contexts as fit, and the rest are dropped. Identities recur because the pool is
+//! bounded, while their load varies per render. There is no clean/feral/mixed configuration. The legal
+//! space is exactly the set of payloads [`crate::dogstatsd::is_malformed`] accepts.
+//!
+//! Whether a datagram carries a non-UTF-8 byte is settled by the pull, before the driver sees the
+//! contexts. The intake puts such a context in a fixed fraction of pulls, and a pull holding one leads
+//! every datagram with it, so the fraction of datagrams carrying the byte is the fraction of pulls that
+//! do. Nothing here depends on how many contexts a timeline sampled, which is what makes the rate hold
+//! for a pull of one as well as a pull of a thousand.
 //!
 //! ```text
 //! metric:        <NAME>:<VALUE>(:<VALUE>)*|<TYPE>[|@<RATE>][|#<TAGS>][|c:..][|e:..][|card:..]
@@ -22,99 +27,127 @@ pub(crate) mod common;
 /// Ceiling on a generated datagram, the Datadog Agent's default `dogstatsd_buffer_size`. A run caps
 /// each datagram to the smaller of this and the SUT's sampled receive buffer, so a packed datagram
 /// always fits one read and the SUT never truncates a line mid-token.
-pub const PAYLOAD_BYTE_LIMIT: usize = 8_192;
+pub const DATAGRAM_BYTE_LIMIT: usize = 8_192;
 
-/// What a generated payload holds, for anchoring assertions.
+/// What a generated datagram holds, for anchoring assertions.
 #[derive(Clone, Copy, Debug, Default)]
-pub struct Payload {
-    /// Lines packed into the buffer.
+pub struct DatagramStats {
+    /// Lines packed into the datagram.
     pub lines: usize,
     /// Largest packed multi-value run among those lines. Zero when none.
     pub max_packed: usize,
 }
 
-/// How many affordable contexts a line tries before the datagram ends. A context whose occurrence
-/// payloads keep landing on the drop side is one to move past, not a reason to stop packing.
-const RENDER_PICKS: usize = 4;
-
-/// A driver's working set, ordered by how many bytes each identity forces on every render.
-///
-/// The order is computed once per fetch. Packing a line then finds the affordable contexts by
-/// partition point rather than filtering the whole set, which matters because one invocation packs
-/// thousands of datagrams from a set of up to a thousand identities.
+/// One pull of contexts, held for a driver invocation and packed into every datagram it sends.
 #[derive(Clone, Debug)]
-pub struct WorkingSet {
-    /// Contexts by ascending floor.
+pub struct Pull {
+    /// The contexts as served.
     contexts: Vec<Context>,
-    /// `contexts[i].floor()`, same order, so the affordable contexts are a prefix.
-    floors: Vec<usize>,
+    /// The context carrying an invalid UTF-8 byte, if the pull holds one. It leads every datagram, so
+    /// the intake's per-pull decision reaches every datagram the invocation sends rather than a
+    /// sampling-dependent share of them.
+    lead: Option<usize>,
+    /// The smallest floor in the pull. Packing stops once the room left is under it, which is what keeps
+    /// a pull far larger than a datagram from costing a scan per datagram.
+    min_floor: usize,
 }
 
-impl WorkingSet {
-    /// Order `contexts` by floor and record each one.
+impl Pull {
+    /// Take a pull of contexts. Returns `None` for an empty one, which the pool never serves.
     #[must_use]
-    pub fn new(mut contexts: Vec<Context>) -> Self {
-        contexts.sort_by_key(Context::floor);
-        let floors = contexts.iter().map(Context::floor).collect();
-        Self { contexts, floors }
+    pub fn new(contexts: Vec<Context>) -> Option<Self> {
+        let min_floor = contexts.iter().map(Context::floor).min()?;
+        let lead = contexts.iter().position(Context::has_non_utf8);
+        Some(Self {
+            contexts,
+            lead,
+            min_floor,
+        })
     }
 
-    /// Whether the set holds nothing.
+    /// Whether the pull carries a context bearing an invalid UTF-8 byte.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.contexts.is_empty()
-    }
-
-    /// The smallest floor in the set, or `None` when the set is empty.
-    #[must_use]
-    pub fn smallest_floor(&self) -> Option<usize> {
-        self.floors.first().copied()
-    }
-
-    /// Pick uniformly among the contexts whose identity fits `budget`, or `None` when none does.
-    fn pick(&self, rng: &mut (impl Rng + ?Sized), budget: usize) -> Option<&Context> {
-        let affordable = self.floors.partition_point(|&floor| floor <= budget);
-        (affordable > 0).then(|| &self.contexts[rng.random_range(0..affordable)])
+    pub fn carries_non_utf8(&self) -> bool {
+        self.lead.is_some()
     }
 }
 
-/// Pack whole `\n`-terminated lines into `buf`, each a fresh render of a context that fits the room
-/// left under `limit_bytes`. A context is picked from those the remaining budget can hold and rendered
-/// against that budget, so the datagram fills instead of ending on the first oversized render and
-/// nothing is built and thrown away. A context whose occurrence payloads all land on the drop side is
-/// passed over for another, up to [`RENDER_PICKS`], rather than ending the datagram. Clears `buf`
-/// first. An empty working set, or a budget too small for any identity, yields an empty payload.
-pub fn write_payload(
-    rng: &mut (impl Rng + ?Sized), contexts: &WorkingSet, buf: &mut Vec<u8>, limit_bytes: usize,
-) -> Payload {
+/// Pack one `\n`-terminated line per context into `buf`, within `limit_bytes`, until the room left
+/// cannot hold the smallest context in the pull. Each line is a fresh per-occurrence render against the
+/// room left, so nothing is built and then thrown away, and a context whose line will not fit is passed
+/// over. Clears `buf` first.
+///
+/// A pull carrying an invalid UTF-8 byte renders that context first, where the whole budget is free, so
+/// the byte cannot be lost to a full datagram. The rest are walked from a fresh offset each datagram, so
+/// a pull larger than one datagram still puts every context it holds on the wire across the invocation
+/// rather than only the ones that happen to sort first.
+///
+/// # Panics
+///
+/// Panics when a context whose floor fits the room left produces no line the Agent forwards, and when a
+/// pull carrying an invalid UTF-8 byte cannot pack it. Both are generator bugs rather than SUT behaviour,
+/// and a quieter datagram or a thinner non-UTF-8 rate would hide them.
+pub fn write_datagram(
+    rng: &mut (impl Rng + ?Sized), pull: &Pull, buf: &mut Vec<u8>, limit_bytes: usize,
+) -> DatagramStats {
     buf.clear();
-    let mut payload = Payload::default();
+    let mut stats = DatagramStats::default();
     let mut line = Vec::new();
-    loop {
-        // `\n` is part of what a line costs.
-        let Some(budget) = limit_bytes.checked_sub(buf.len() + 1) else {
-            break;
-        };
-        let mut rendered = None;
-        for _ in 0..RENDER_PICKS {
-            let Some(context) = contexts.pick(rng, budget) else {
-                break;
-            };
-            line.clear();
-            if let Some(packed) = context.render_wellformed_within(rng, &mut line, budget) {
-                rendered = Some(packed);
-                break;
-            }
-        }
-        let Some(packed) = rendered else {
-            break;
-        };
-        buf.extend_from_slice(&line);
-        buf.push(b'\n');
-        payload.lines += 1;
-        payload.max_packed = payload.max_packed.max(packed);
+    if let Some(lead) = pull.lead {
+        let context = &pull.contexts[lead];
+        // The pull's decision has to reach this datagram. The pool mints every context against the same
+        // datagram limit less its newline, so the first line of an empty datagram always has room for it.
+        // Skipping it here would drop the run's non-UTF-8 rate below the rate the pool set, silently.
+        assert!(
+            pack(rng, context, buf, &mut line, limit_bytes, &mut stats),
+            "a pull carrying an invalid UTF-8 byte could not pack it into a {limit_bytes}-byte datagram, \
+             so the context was minted against a larger limit than it is packed at: {context:?}"
+        );
     }
-    payload
+    let count = pull.contexts.len();
+    let start = rng.random_range(0..count);
+    for step in 0..count {
+        let index = (start + step) % count;
+        if Some(index) == pull.lead {
+            continue;
+        }
+        // `\n` is part of what a line costs.
+        let Some(room) = limit_bytes.checked_sub(buf.len() + 1) else {
+            break;
+        };
+        if room < pull.min_floor {
+            break;
+        }
+        pack(rng, &pull.contexts[index], buf, &mut line, limit_bytes, &mut stats);
+    }
+    stats
+}
+
+/// Render `context` into `buf` when the room left holds it, and count what it packed. Reports whether a
+/// line was written.
+fn pack(
+    rng: &mut (impl Rng + ?Sized), context: &Context, buf: &mut Vec<u8>, line: &mut Vec<u8>, limit_bytes: usize,
+    stats: &mut DatagramStats,
+) -> bool {
+    let Some(room) = limit_bytes.checked_sub(buf.len() + 1) else {
+        return false;
+    };
+    if context.floor() > room {
+        return false;
+    }
+    line.clear();
+    // A context whose floor fits renders, always: the repair loop retries the per-occurrence content the
+    // Agent would drop, and its last try renders at the floor, where the occurrence is the shortest the
+    // identity admits. Passing over the context instead would hide a generator that builds one it cannot
+    // render, so this fails where it breaks.
+    let Some(packed) = context.render_wellformed_within(rng, line, room) else {
+        panic!("context floor fits the {room}-byte room left but no repaired render forwarded: {context:?}")
+    };
+    buf.extend_from_slice(line);
+    buf.push(b'\n');
+    stats.lines += 1;
+    stats.max_packed = stats.max_packed.max(packed);
+    true
 }
 
 #[cfg(test)]
@@ -123,17 +156,35 @@ mod test {
     use rand::rngs::SmallRng;
     use rand::SeedableRng;
 
-    use super::{write_payload, WorkingSet, PAYLOAD_BYTE_LIMIT};
+    use super::{write_datagram, Pull, DATAGRAM_BYTE_LIMIT};
     use crate::contexts::{Context, Kind};
     use crate::dogstatsd::is_malformed;
 
-    /// A working set of minted contexts across all three kinds.
-    fn pool(rng: &mut SmallRng, n: usize) -> WorkingSet {
-        WorkingSet::new(
-            (0..n)
-                .filter_map(|_| Context::mint_within(Kind::sample(rng), rng, PAYLOAD_BYTE_LIMIT))
-                .collect(),
-        )
+    /// A pull built against the budget it will be packed at, as the intake builds one. The pool mints
+    /// against the timeline's datagram limit less the newline for exactly this reason: a context minted
+    /// against a larger budget may not fit a smaller datagram.
+    fn pull_of(rng: &mut SmallRng, n: usize, datagram_limit: usize, non_utf8: bool) -> Pull {
+        let budget = datagram_limit.saturating_sub(1);
+        let contexts = (0..n)
+            .filter_map(|slot| {
+                let kind = Kind::sample(rng);
+                if non_utf8 && slot == 0 {
+                    Context::mint_non_utf8_within(kind, rng, budget)
+                } else {
+                    Context::mint_within(kind, rng, budget)
+                }
+            })
+            .collect();
+        Pull::new(contexts).expect("minted no context")
+    }
+
+    /// The identity bytes every render of a context puts on the wire, for spotting it in a datagram.
+    fn identity_bytes(context: &Context) -> &[u8] {
+        match context {
+            Context::Metric(c) => &c.name,
+            Context::Event(c) => &c.title,
+            Context::ServiceCheck(c) => &c.name,
+        }
     }
 
     /// Lines carry no interior newline and each is `\n`-terminated, so the line count equals the
@@ -143,7 +194,135 @@ mod test {
         buf.iter().filter(|&&b| b == b'\n').count()
     }
 
+    // The rate is the pull's, so a pull carrying the byte must put it in EVERY datagram it packs. If it
+    // reached only some of them the datagram rate would fall below the pull rate by a factor nobody
+    // configured.
+    #[test]
+    fn a_pull_carrying_non_utf8_puts_it_in_every_datagram() {
+        for seed in 0..8u64 {
+            for limit_bytes in [128usize, 512, 8_192] {
+                let mut rng = SmallRng::seed_from_u64(seed);
+                let pull = pull_of(&mut rng, 8, limit_bytes, true);
+                assert!(pull.carries_non_utf8(), "the pull was expected to carry the byte");
+                let mut buf = Vec::new();
+                for _ in 0..200 {
+                    write_datagram(&mut rng, &pull, &mut buf, limit_bytes);
+                    assert!(
+                        simdutf8::basic::from_utf8(&buf).is_err(),
+                        "a datagram from a non-UTF-8 pull carried no invalid byte at limit {limit_bytes}"
+                    );
+                    assert_eq!(is_malformed(&buf), Ok(()), "the datagram was droppable");
+                }
+            }
+        }
+    }
+
+    // The converse. A pull without the byte must never manufacture one, or the rate exceeds the pull
+    // rate and the intake is no longer the only thing deciding it.
+    #[test]
+    fn a_pull_without_non_utf8_never_emits_it() {
+        for seed in 0..8u64 {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let limit_bytes = 1024;
+            let pull = pull_of(&mut rng, 8, limit_bytes, false);
+            assert!(!pull.carries_non_utf8());
+            let mut buf = Vec::new();
+            for _ in 0..200 {
+                write_datagram(&mut rng, &pull, &mut buf, limit_bytes);
+                assert!(
+                    simdutf8::basic::from_utf8(&buf).is_ok(),
+                    "a datagram from a UTF-8 pull carried an invalid byte"
+                );
+            }
+        }
+    }
+
+    // The byte must reach a metric tag as well as a metric name. The v3 intake splits on exactly that
+    // axis, coercing non-UTF-8 in the tag dictionary and rejecting the whole payload on the name
+    // dictionary, so a byte pinned to one position can only ever drive half of it. Counting any poisoned
+    // event or service-check line as the other side would let a handful of those satisfy this while the
+    // metric tag path stayed unreachable.
+    #[test]
+    fn non_utf8_reaches_more_than_the_metric_name() {
+        let mut in_name = 0;
+        let mut outside_name = 0;
+        for seed in 0..32u64 {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let pull = pull_of(&mut rng, 8, 512, true);
+            let mut buf = Vec::new();
+            for _ in 0..50 {
+                write_datagram(&mut rng, &pull, &mut buf, 512);
+                for line in buf.split(|&b| b == b'\n') {
+                    if line.is_empty() || simdutf8::basic::from_utf8(line).is_ok() {
+                        continue;
+                    }
+                    if line.starts_with(b"_e{") || line.starts_with(b"_sc") {
+                        continue;
+                    }
+                    let field0 = line.split(|&b| b == b'|').next().unwrap_or(line);
+                    let name = field0.split(|&b| b == b':').next().unwrap_or(field0);
+                    if simdutf8::basic::from_utf8(name).is_err() {
+                        in_name += 1;
+                    } else {
+                        outside_name += 1;
+                    }
+                }
+            }
+        }
+        assert!(in_name > 0, "no non-UTF-8 byte ever landed in a metric name");
+        assert!(
+            outside_name > 0,
+            "every non-UTF-8 byte landed in a metric name, so the tag-dictionary path is unreachable"
+        );
+    }
+
+    // A pull far larger than a datagram must still put every context it holds on the wire across the
+    // invocation. Packing from a fixed end would leave the tail of a thousand-context pull unsent, so the
+    // pool would mint identities the SUT never sees.
+    #[test]
+    fn a_pull_larger_than_a_datagram_still_reaches_every_context() {
+        let mut rng = SmallRng::seed_from_u64(13);
+        let limit_bytes = 512;
+        let pull = pull_of(&mut rng, 64, limit_bytes, false);
+        let mut seen = vec![false; pull.contexts.len()];
+        let mut buf = Vec::new();
+        for _ in 0..2_000 {
+            write_datagram(&mut rng, &pull, &mut buf, limit_bytes);
+            for (index, context) in pull.contexts.iter().enumerate() {
+                let name = identity_bytes(context);
+                if !name.is_empty() && buf.windows(name.len()).any(|window| window == name) {
+                    seen[index] = true;
+                }
+            }
+        }
+        let unseen = seen.iter().filter(|&&hit| !hit).count();
+        assert_eq!(
+            unseen,
+            0,
+            "{unseen} of {} contexts never reached a datagram",
+            pull.contexts.len()
+        );
+    }
+
     proptest! {
+        /// Every context the room affords renders a line the Agent forwards. The packer panics rather
+        /// than passing over one, so this is the invariant that keeps it from firing.
+        #[test]
+        fn property_test_an_affordable_identity_always_renders(seed: u64, limit_bytes in 128..=8_192usize) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let pull = pull_of(&mut rng, 8, limit_bytes, seed % 2 == 0);
+            for context in &pull.contexts {
+                for budget in [context.floor(), limit_bytes - 1, limit_bytes / 2] {
+                    if context.floor() > budget {
+                        continue;
+                    }
+                    let mut line = Vec::new();
+                    let rendered = context.render_wellformed_within(&mut rng, &mut line, budget);
+                    prop_assert!(rendered.is_some(), "affordable identity never forwarded: {context:?}");
+                }
+            }
+        }
+
         /// A rendered metric carries exactly the tag set its identity holds. The Agent assigns the tag
         /// set from every `#`-prefixed optional field it sees, last one winning, so a second such field
         /// would swap the identity's tags for whatever an occurrence body happened to contain. That
@@ -153,10 +332,10 @@ mod test {
         #[test]
         fn property_test_metric_carries_one_tag_field(seed: u64) {
             let mut rng = SmallRng::seed_from_u64(seed);
-            let contexts = pool(&mut rng, 8);
+            let pull = pull_of(&mut rng, 8, DATAGRAM_BYTE_LIMIT, seed % 2 == 0);
             let mut buf = Vec::new();
             for _ in 0..4 {
-                write_payload(&mut rng, &contexts, &mut buf, PAYLOAD_BYTE_LIMIT);
+                write_datagram(&mut rng, &pull, &mut buf, DATAGRAM_BYTE_LIMIT);
                 for line in buf.split(|&b| b == b'\n') {
                     if line.is_empty() || line.starts_with(b"_e{") || line.starts_with(b"_sc") {
                         continue;
@@ -178,60 +357,46 @@ mod test {
             }
         }
 
-        /// Every datagram the driver packs from pooled contexts is one the Agent forwards. A packed
-        /// datagram must be entirely well-formed.
+        /// Every datagram the driver packs from a pull is one the Agent forwards.
         #[test]
         fn property_test_every_payload_is_well_formed(seed: u64) {
             let mut rng = SmallRng::seed_from_u64(seed);
-            let contexts = pool(&mut rng, 8);
+            let pull = pull_of(&mut rng, 8, DATAGRAM_BYTE_LIMIT, seed % 2 == 0);
             let mut buf = Vec::new();
             for _ in 0..8 {
-                write_payload(&mut rng, &contexts, &mut buf, PAYLOAD_BYTE_LIMIT);
+                write_datagram(&mut rng, &pull, &mut buf, DATAGRAM_BYTE_LIMIT);
                 prop_assert_eq!(is_malformed(&buf), Ok(()), "emitted a droppable datagram: {:?}", String::from_utf8_lossy(&buf));
             }
         }
 
-        /// A budget that can hold some context's identity yields load. An empty datagram spends one of
-        /// the driver's configured sends without reaching the SUT, so the packer must fill the budget it
-        /// was given rather than give up on the first context that does not fit. The fallback line is
-        /// the floor below which a render that keeps landing on the drop side has nowhere to go.
+        /// A pull whose smallest context fits yields load. An empty datagram spends one of the driver's
+        /// configured sends without reaching the SUT.
         #[test]
-        fn property_test_payload_is_never_empty_when_a_context_fits(seed: u64, limit_bytes in 1..8_192usize) {
+        fn property_test_payload_is_never_empty_when_a_context_fits(seed: u64, limit_bytes in 128..=8_192usize) {
             let mut rng = SmallRng::seed_from_u64(seed);
-            let contexts = pool(&mut rng, 8);
+            let pull = pull_of(&mut rng, 8, limit_bytes, seed % 2 == 0);
             let mut buf = Vec::new();
-            let payload = write_payload(&mut rng, &contexts, &mut buf, limit_bytes);
+            let stats = write_datagram(&mut rng, &pull, &mut buf, limit_bytes);
 
-            let smallest = contexts.smallest_floor().expect("pool is non-empty");
+            let smallest = pull.min_floor;
             if limit_bytes > smallest {
                 prop_assert!(!buf.is_empty(), "empty datagram at limit {limit_bytes}, smallest floor {smallest}");
-                prop_assert!(payload.lines > 0);
+                prop_assert!(stats.lines > 0);
             }
         }
 
         #[test]
-        fn property_test_payload_stays_within_its_limit(seed: u64, limit_bytes: u16) {
+        fn property_test_payload_stays_within_its_limit(seed: u64, limit_bytes in 128..=8_192usize) {
             let mut rng = SmallRng::seed_from_u64(seed);
-            let contexts = pool(&mut rng, 8);
-            let limit_bytes = usize::from(limit_bytes);
+            let pull = pull_of(&mut rng, 8, limit_bytes, seed % 2 == 0);
             let mut buf = Vec::new();
-            let payload = write_payload(&mut rng, &contexts, &mut buf, limit_bytes);
+            let stats = write_datagram(&mut rng, &pull, &mut buf, limit_bytes);
 
             prop_assert!(buf.len() <= limit_bytes);
-            prop_assert_eq!(newline_count(&buf), payload.lines);
+            prop_assert_eq!(newline_count(&buf), stats.lines);
             if !buf.is_empty() {
                 prop_assert_eq!(buf[buf.len() - 1], b'\n');
             }
-        }
-
-        /// An empty working set yields no load, not a panic.
-        #[test]
-        fn property_test_empty_pool_yields_empty_payload(seed: u64) {
-            let mut rng = SmallRng::seed_from_u64(seed);
-            let mut buf = Vec::new();
-            let payload = write_payload(&mut rng, &WorkingSet::new(Vec::new()), &mut buf, PAYLOAD_BYTE_LIMIT);
-            prop_assert_eq!(payload.lines, 0);
-            prop_assert!(buf.is_empty());
         }
     }
 }

--- a/test/antithesis/harness/src/payload/dogstatsd/common.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd/common.rs
@@ -1,11 +1,16 @@
 //! Shared `DogStatsD` content sampling: alphabets, field and value builders, tags.
 //!
-//! There is no clean/feral split. Every content field ranges over the full forwarded byte alphabet:
-//! ASCII words, exotic and non-UTF-8 bytes, AND the message delimiters `:` `|` `,` `#` `@`. Including
-//! the delimiters is deliberate. It reaches the context-dependent forwarded cases the Agent keeps,
-//! such as a `:` inside a set value or a `:` in a tag value, and the ones it drops. The generator does
-//! not decide which is which. It serializes and lets [`crate::dogstatsd::is_malformed`] sort and
-//! repair.
+//! There is no clean/feral split. Every pool here is valid UTF-8, from plain ASCII words to exotic
+//! scripts, and every content field also draws the message delimiters `:` `|` `,` `#` `@`. Including the
+//! delimiters is deliberate. It reaches the context-dependent forwarded cases the Agent keeps, such as a
+//! `:` inside a set value or a `:` in a tag value, and the ones it drops. The generator does not decide
+//! which is which. It serializes and lets [`crate::dogstatsd::is_malformed`] sort and repair. Value
+//! tokens are the one exception and omit `|`, which closes the value field and would drop every line
+//! carrying it.
+//!
+//! An invalid UTF-8 byte never comes from these pools. It is minted into an identity by
+//! [`crate::contexts::Context::mint_non_utf8_within`], which is the only caller of
+//! [`invalid_utf8_byte`].
 
 use rand::distr::Distribution;
 use rand::{Rng, RngExt};
@@ -29,18 +34,17 @@ const COMPLIANT_WORD: &[&[u8]] = &[
     b"workers",
 ];
 
-/// Aberrant identifier segments: whitespace, NUL, ill-formed and non-conforming UTF-8, and exotic
-/// Unicode. Omits `\n` and `\r`, which are datagram framing rather than content.
+/// Aberrant identifier segments: whitespace, NUL, and exotic but valid UTF-8. Invalid-UTF-8 bytes are
+/// deliberately absent. [`crate::contexts::Context::mint_non_utf8_within`] puts one into an identity
+/// instead, for the fraction of pulls the intake picks, so the blast radius stays a budgeted fraction of
+/// datagrams rather than compounding across every minted context into a near-certain whole-payload v3
+/// reject. Editing a rendered datagram would invent an identity the pool never issued, which is how
+/// bounded cardinality leaks. Omits `\n` and `\r`, which are datagram framing rather than content.
 const ABERRANT_WORD: &[&[u8]] = &[
     b" ",
     b"\t",
     b"\0",
-    b"\x80",                // lone continuation byte
-    b"\xc3",                // truncated two-byte lead
-    b"\xed\xa0\x80",        // UTF-16 surrogate, ill-formed UTF-8
-    b"\xc0\x80",            // overlong NUL
-    b"\xff\xfe",            // non-character bytes
-    "café".as_bytes(),      // non-conforming but valid UTF-8
+    "café".as_bytes(),      // non-ASCII but valid UTF-8
     "Ωμέγα".as_bytes(),     // Greek
     "日本語".as_bytes(),    // CJK
     "🦆".as_bytes(),        // emoji, non-ASCII multi-byte
@@ -50,12 +54,30 @@ const ABERRANT_WORD: &[&[u8]] = &[
     "\u{feff}".as_bytes(),  // byte-order mark
 ];
 
+/// Bytes no valid UTF-8 sequence can lead with, for poisoning a minted identity. `0x80` is a valid
+/// continuation byte, so a poisoned field is verified rather than assumed invalid.
+const INVALID_UTF8: &[u8] = &[0x80, 0xC0, 0xC1, 0xF5, 0xFE, 0xFF];
+
+/// One byte that makes any surrounding ASCII field invalid UTF-8.
+pub(crate) fn invalid_utf8_byte(rng: &mut (impl Rng + ?Sized)) -> u8 {
+    INVALID_UTF8[rng.random_range(0..INVALID_UTF8.len())]
+}
+
 /// Message delimiters, mixed into content so the generator explores delimiter-bearing fields. Most
 /// land the message in the drop set and are repaired away. The survivors are the forwarded oddities.
 const DELIMITERS: &[&[u8]] = &[b":", b"|", b",", b"#", b"@"];
 
 /// The full content alphabet for identifier-like fields.
 const WORD_POOLS: &[&[&[u8]]] = &[COMPLIANT_WORD, ABERRANT_WORD, DELIMITERS];
+
+/// Delimiters a value token may carry. `|` is absent: it closes the value field, so the type token
+/// after it becomes value content and the Agent drops the line. A long value drawn from a pool holding
+/// `|` almost always carries one, which is how a set metric exhausted its repair tries at a wide budget.
+/// The byte is not lost to the generator, only to values, and a value bearing it never reached the SUT.
+const VALUE_DELIMITERS: &[&[u8]] = &[b":", b",", b"#", b"@"];
+
+/// Pools a value token is built from.
+const VALUE_POOLS: &[&[&[u8]]] = &[COMPLIANT_WORD, ABERRANT_WORD, VALUE_DELIMITERS];
 
 /// Tag keys. `host` is excluded. `DogStatsD` promotes a `host` tag to the metric host resource, and
 /// varying host instances break the intake host-consistency check.
@@ -314,9 +336,9 @@ pub(crate) fn rate_token(rng: &mut (impl Rng + ?Sized)) -> Vec<u8> {
     pick(rng, RATE_TOKEN).to_vec()
 }
 
-/// A set-type value: an opaque required field over the full alphabet.
+/// A set-type value: an opaque required field over the alphabet a value may carry.
 pub(crate) fn opaque_value(rng: &mut (impl Rng + ?Sized)) -> Vec<u8> {
-    field(rng, WORD_POOLS, COUNTS_REQUIRED)
+    field(rng, VALUE_POOLS, COUNTS_REQUIRED)
 }
 
 /// The floor cost of a value token, the shortest `SPECIAL_VALUE` entry.
@@ -343,7 +365,7 @@ pub(crate) fn rate_token_within(rng: &mut (impl Rng + ?Sized), budget: usize) ->
 
 /// A set-type value within `budget`.
 pub(crate) fn opaque_value_within(rng: &mut (impl Rng + ?Sized), budget: usize) -> Vec<u8> {
-    field_within(rng, WORD_POOLS, COUNTS_REQUIRED, budget)
+    field_within(rng, VALUE_POOLS, COUNTS_REQUIRED, budget)
 }
 
 /// The serialized length of a tag set, `|#` and separating commas included.

--- a/test/antithesis/intake/src/context_pool.rs
+++ b/test/antithesis/intake/src/context_pool.rs
@@ -11,6 +11,21 @@
 //! The caps are read from `context_source.yaml` on the first [`Pool::serve`] call. The intake starts
 //! before `first_sample_config` samples that file, but the first `/contexts` request only ever comes
 //! from a driver, which runs after `first_sample_config` — so the config is present by then.
+//!
+//! A kind serves an existing context for one of two reasons and the pool tells them apart. Reaching the
+//! cap is the configured end state. Spending every mint try on a duplicate is a crowded alphabet, which
+//! is counted per kind and reported so a cap that fills slowly is visible. It is never latched: one
+//! unlucky streak must not pin a kind below its cap for the rest of the run. A budget too small to hold
+//! a kind's smallest identity is neither of those, and errors.
+//!
+//! One pull in `NON_UTF8_PULL_RATE` leads with a context carrying an invalid UTF-8 byte. A driver pulls
+//! once per invocation and leads every datagram it sends with that context, so a carrying pull puts the
+//! byte in all of its datagrams and any other pull in none. How many datagrams an invocation sends is
+//! sampled independently of what its pull holds, so across a run the fraction of datagrams carrying the
+//! byte is the fraction of pulls that do. Deciding it here rather than in the driver is what makes the
+//! rate independent of how many contexts a timeline sampled: a driver holding one context gets the same
+//! 1% as one holding a thousand. Such a context is a pool member like any other, minted against the same
+//! budget, deduplicated, and counted against its kind's cap, so bounded cardinality is unaffected.
 
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
@@ -40,11 +55,14 @@ struct PoolState {
     /// The per-kind caps, resolved from the config on the first serve.
     caps: Option<ContextSourceConfig>,
     /// Minted metric contexts, grown to the metric cap then drawn from.
-    metric: Vec<Context>,
+    metric: KindPool,
     /// Minted event contexts.
-    event: Vec<Context>,
+    event: KindPool,
     /// Minted service-check contexts.
-    service_check: Vec<Context>,
+    service_check: KindPool,
+    /// Requests per kind that spent every mint try on a duplicate, by [`Kind`] order. A streak says the
+    /// budget's alphabet is crowded against the cap, not that it is spent, so the kind keeps minting.
+    collision_streaks: [u64; 3],
     /// Hashes of every context held, so a duplicate mint does not spend a cap slot. Hashes rather
     /// than the contexts themselves, since the pool already holds up to a million of them and a
     /// second copy would double that. A hash collision rejects a distinct identity, which costs one
@@ -52,9 +70,89 @@ struct PoolState {
     seen: HashSet<u64>,
 }
 
+impl PoolState {
+    /// Mint one context of each sort for every kind, before any pull is served. A pull that owes the
+    /// invalid byte must find a context of the right kind carrying it, and a pull that does not must find
+    /// one without it, so neither half may be empty once the cap is spent. Every cap is at least two,
+    /// which is what makes room for both, and these seeds count against the cap like any other context.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the budget cannot hold a kind's smallest identity.
+    fn seed_halves<R: Rng + ?Sized>(&mut self, caps: ContextSourceConfig, rng: &mut R) -> anyhow::Result<()> {
+        let budget = caps.datagram_byte_limit.saturating_sub(1);
+        // Minted into locals and committed only once all six succeed. Pushing as it goes would leave a
+        // half-seeded pool behind on a failure, and the caller retries, so every retry would stack
+        // another partial seeding against the cap.
+        let mut seeded = Vec::with_capacity(6);
+        for kind in [Kind::Metric, Kind::Event, Kind::ServiceCheck] {
+            for non_utf8 in [false, true] {
+                let context = if non_utf8 {
+                    Context::mint_non_utf8_within(kind, rng, budget)
+                } else {
+                    Context::mint_within(kind, rng, budget)
+                }
+                .with_context(|| {
+                    format!(
+                        "no {kind:?} identity could be minted within the datagram budget {budget}, so this \
+                         timeline's context source and datagram limit contradict each other"
+                    )
+                })?;
+                seeded.push((kind, non_utf8, context));
+            }
+        }
+        for (kind, non_utf8, context) in seeded {
+            let pool = match kind {
+                Kind::Metric => &mut self.metric,
+                Kind::Event => &mut self.event,
+                Kind::ServiceCheck => &mut self.service_check,
+            };
+            self.seen.insert(digest(&context));
+            pool.half(non_utf8).push(context);
+        }
+        Ok(())
+    }
+}
+
+/// One kind's minted contexts, split by whether they carry an invalid UTF-8 byte. The split is storage,
+/// not policy: a pull needs to reach one of each without scanning up to a million members.
+#[derive(Debug, Default)]
+struct KindPool {
+    /// Contexts whose every field is valid UTF-8.
+    utf8: Vec<Context>,
+    /// Contexts carrying an invalid UTF-8 byte in a name or a tag.
+    non_utf8: Vec<Context>,
+}
+
+impl KindPool {
+    /// Contexts held, both halves, which is what a cap counts.
+    fn len(&self) -> usize {
+        self.utf8.len() + self.non_utf8.len()
+    }
+
+    /// Every context held, both halves.
+    #[cfg(test)]
+    fn iter(&self) -> impl Iterator<Item = &Context> {
+        self.utf8.iter().chain(self.non_utf8.iter())
+    }
+
+    /// The half a slot of this sort draws from.
+    fn half(&mut self, non_utf8: bool) -> &mut Vec<Context> {
+        if non_utf8 {
+            &mut self.non_utf8
+        } else {
+            &mut self.utf8
+        }
+    }
+}
+
 /// How many times a duplicate mint is retried before the slot is left for a later request. A small
 /// alphabet under a tight budget collides often, and spinning here would stall the serve.
 const MINT_TRIES: usize = 8;
+
+/// One pull in this many leads with a context carrying an invalid UTF-8 byte, which makes one datagram in
+/// this many carry one.
+const NON_UTF8_PULL_RATE: u32 = 100;
 
 /// The hash a pooled identity is deduplicated by.
 fn digest(context: &Context) -> u64 {
@@ -89,55 +187,97 @@ impl Pool {
         } else {
             let resolved =
                 ContextSourceConfig::read(&self.config_dir).context("read context source config for the pool caps")?;
+            state.seed_halves(resolved, rng)?;
             state.caps = Some(resolved);
             resolved
         };
 
         let mut out = Vec::with_capacity(n);
         let mut served_existing = false;
-        for _ in 0..n {
+        // Settled once for the whole pull, and led with, so the byte cannot be lost to a full datagram.
+        let non_utf8_pull = rng.random_range(0..NON_UTF8_PULL_RATE) == 0;
+        for slot in 0..n {
+            let non_utf8 = non_utf8_pull && slot == 0;
             let kind = Kind::sample(rng);
             let PoolState {
                 metric,
                 event,
                 service_check,
                 seen,
+                collision_streaks,
                 ..
             } = &mut *state;
-            let (pool, cap) = match kind {
-                Kind::Metric => (metric, caps.metric_contexts),
-                Kind::Event => (event, caps.event_contexts),
-                Kind::ServiceCheck => (service_check, caps.service_check_contexts),
+            let (pool, cap, streaks) = match kind {
+                Kind::Metric => (metric, caps.metric_contexts, &mut collision_streaks[0]),
+                Kind::Event => (event, caps.event_contexts, &mut collision_streaks[1]),
+                Kind::ServiceCheck => (service_check, caps.service_check_contexts, &mut collision_streaks[2]),
             };
-            // The identity is minted against this timeline's real datagram budget, so every served
-            // context has a rendering the driver can pack. A budget too small for this kind, or an
-            // alphabet that keeps landing on the drop side, yields nothing rather than a context of
-            // another kind, so a kind's working set never fills with identities it did not ask for.
+            // The identity is minted against this timeline's real datagram budget less the newline
+            // every packed line costs, so every served context has a rendering the driver can pack.
             // A duplicate identity would spend a cap slot without adding a distinct context, so the
             // kind would stop minting early and the run would explore fewer identities than configured.
             // Remint on a duplicate instead of pushing it.
-            let mut minted = None;
+            let mut minted: Option<Context> = None;
+            let budget = caps.datagram_byte_limit.saturating_sub(1);
             if pool.len() < cap {
-                for _ in 0..MINT_TRIES {
-                    let Some(context) = Context::mint_within(kind, rng, caps.payload_byte_limit.saturating_sub(1))
-                    else {
+                for try_index in 0..MINT_TRIES {
+                    // The byte is minted into the identity. Editing a rendered datagram instead would
+                    // mint an identity the pool never issued and the cap never counted, one per edited
+                    // datagram, which is how bounded cardinality leaks.
+                    let candidate = if non_utf8 {
+                        Context::mint_non_utf8_within(kind, rng, budget)
+                    } else {
+                        Context::mint_within(kind, rng, budget)
+                    };
+                    // A mint yields nothing either because the budget cannot hold the kind's smallest
+                    // identity, which is a contradiction between this timeline's context source and its
+                    // datagram limit, or because its own probe loop ran out of tries on content. Only the
+                    // first is a config fault. The second is the same bad luck as a duplicate streak and
+                    // gets the same treatment: count it and let the slot recur.
+                    let Some(context) = candidate else {
+                        anyhow::ensure!(
+                            Context::mint_within(kind, rng, budget).is_some(),
+                            "datagram budget {budget} cannot hold the smallest {kind:?} identity, so this \
+                             timeline's context source and datagram limit contradict each other"
+                        );
+                        *streaks += 1;
                         break;
                     };
                     if seen.insert(digest(&context)) {
                         minted = Some(context);
                         break;
                     }
+                    // Every try collided. That is a crowded alphabet, not a spent one, so the kind stays
+                    // free to mint on the next request. Latching it here would let one unlucky streak
+                    // pin a kind below its cap for the rest of the run. Counted so a cap that fills
+                    // slowly is visible rather than a mystery.
+                    if try_index + 1 == MINT_TRIES {
+                        *streaks += 1;
+                    }
                 }
             }
             if let Some(context) = minted {
-                pool.push(context.clone());
+                pool.half(non_utf8).push(context.clone());
                 out.push(context);
-            } else if !pool.is_empty() {
-                let context = pool[rng.random_range(0..pool.len())].clone();
+            } else {
+                // A kind at its cap, or one whose tries all collided, recurs, which is what gives the
+                // oracle its curves. Both halves were seeded when the caps resolved, so neither is ever
+                // empty and a slot owed the byte is never served a context without it.
+                let half = pool.half(non_utf8);
+                let context = half
+                    .get(rng.random_range(0..half.len().max(1)))
+                    .with_context(|| {
+                        format!(
+                            "{kind:?} pool holds no {} context to serve",
+                            if non_utf8 { "non-UTF-8" } else { "UTF-8" }
+                        )
+                    })?
+                    .clone();
                 served_existing = true;
                 out.push(context);
             }
         }
+        let collision_streaks = state.collision_streaks;
         let metric = state.metric.len();
         let event = state.event.len();
         let service_check = state.service_check.len();
@@ -152,7 +292,11 @@ impl Pool {
                 "metric": metric,
                 "event": event,
                 "service_check": service_check,
-                "caps": { "metric": caps.metric_contexts, "event": caps.event_contexts, "service_check": caps.service_check_contexts }
+                "caps": { "metric": caps.metric_contexts, "event": caps.event_contexts, "service_check": caps.service_check_contexts },
+                // Requests that spent every mint try on a duplicate. Reported rather than asserted on: a
+                // cap near what the budget's alphabet can express collides legitimately, so a run that
+                // hits it is not faulty, but a cap that fills slowly has to say why.
+                "collision_streaks": { "metric": collision_streaks[0], "event": collision_streaks[1], "service_check": collision_streaks[2] }
             })
         );
         assert_sometimes!(served_existing, "context source served an existing context", &json!({}));
@@ -176,6 +320,12 @@ mod tests {
 
     /// Write a `context_source.yaml` with the given per-kind caps into a fresh temp dir.
     fn temp_config(metric: usize, event: usize, service_check: usize) -> PathBuf {
+        temp_config_limited(metric, event, service_check, 8_192)
+    }
+
+    /// The same, for a timeline whose datagram limit is `datagram_byte_limit`. A pool mints against that
+    /// limit, so a test that packs must use the same one.
+    fn temp_config_limited(metric: usize, event: usize, service_check: usize, datagram_byte_limit: usize) -> PathBuf {
         static SEQ: AtomicUsize = AtomicUsize::new(0);
         let dir = std::env::temp_dir().join(format!(
             "ctxpool-{}-{}",
@@ -184,7 +334,7 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).expect("create temp config dir");
         let config = ContextSourceConfig {
-            payload_byte_limit: 8_192,
+            datagram_byte_limit,
             metric_contexts: metric,
             event_contexts: event,
             service_check_contexts: service_check,
@@ -237,6 +387,80 @@ mod tests {
         for held in [&state.metric, &state.event, &state.service_check] {
             let distinct: HashSet<&Context> = held.iter().collect();
             assert_eq!(distinct.len(), held.len(), "a kind holds a duplicate identity");
+        }
+    }
+
+    // A collision streak must not pin a kind below its cap. A crowded alphabet collides often, and a
+    // latched flag would stop the kind minting for the rest of the run on one unlucky request.
+    #[test]
+    fn a_collision_streak_does_not_stop_minting() {
+        let mut rng = SmallRng::seed_from_u64(31);
+        let pool = Pool::new(temp_config(4_096, 4_096, 4_096));
+        for _ in 0..40 {
+            pool.serve(64, &mut rng).expect("serve");
+        }
+        let state = pool.state.lock().expect("lock");
+        let streaks: u64 = state.collision_streaks.iter().sum();
+        let minted = state.metric.len() + state.event.len() + state.service_check.len();
+        assert!(
+            minted > 64,
+            "the pool stopped minting after {streaks} collision streaks, holding {minted}"
+        );
+    }
+
+    // The rate the whole design rests on. One pull in a hundred carries a context with an invalid UTF-8
+    // byte, and a pull is one driver invocation, so this is the datagram rate too: the harness pins that
+    // a carrying pull puts the byte in every datagram it packs and a non-carrying one in none.
+    #[test]
+    fn one_pull_in_a_hundred_carries_non_utf8() {
+        use harness::payload::dogstatsd::Pull;
+
+        let mut rng = SmallRng::seed_from_u64(9);
+        let pool = Pool::new(temp_config(1_000_000, 1_000_000, 1_000_000));
+        let pulls = 5_000usize;
+        let mut carrying = 0usize;
+        for _ in 0..pulls {
+            let contexts = pool.serve(1, &mut rng).expect("serve");
+            if Pull::new(contexts).expect("non-empty").carries_non_utf8() {
+                carrying += 1;
+            }
+        }
+        // 0.25% to 1.25%, as integers so the bound carries no rounding of its own.
+        assert!(
+            carrying * 400 >= pulls && carrying * 80 <= pulls,
+            "pulls carrying non-UTF-8 {carrying}/{pulls}, expected ~1%"
+        );
+    }
+
+    // Once a kind is at its cap, every pull recurs rather than mints, and the half selection in that
+    // branch is the only thing that still makes a carrying pull carry. A run spends nearly all of its
+    // life there, so the rate has to survive the cap being spent.
+    #[test]
+    fn the_rate_holds_after_the_caps_fill() {
+        use harness::payload::dogstatsd::Pull;
+
+        let mut rng = SmallRng::seed_from_u64(21);
+        let pool = Pool::new(temp_config(4, 4, 4));
+        // Spend the caps first, so nothing below mints.
+        for _ in 0..50 {
+            pool.serve(8, &mut rng).expect("serve");
+        }
+        let pulls = 5_000usize;
+        let mut carrying = 0usize;
+        for _ in 0..pulls {
+            let contexts = pool.serve(1, &mut rng).expect("serve");
+            if Pull::new(contexts).expect("non-empty").carries_non_utf8() {
+                carrying += 1;
+            }
+        }
+        assert!(
+            carrying * 400 >= pulls && carrying * 80 <= pulls,
+            "after the caps filled, pulls carrying non-UTF-8 {carrying}/{pulls}, expected ~1%"
+        );
+        let state = pool.state.lock().expect("lock");
+        for held in [&state.metric, &state.event, &state.service_check] {
+            assert!(!held.non_utf8.is_empty(), "a kind holds no non-UTF-8 context");
+            assert!(!held.utf8.is_empty(), "a kind holds no UTF-8 context");
         }
     }
 

--- a/test/antithesis/scenarios/differential/src/bin/parallel_driver_send_dogstatsd_differential.rs
+++ b/test/antithesis/scenarios/differential/src/bin/parallel_driver_send_dogstatsd_differential.rs
@@ -70,7 +70,7 @@ mod unix_driver {
             AntithesisRng,
             &config.intake_addr,
             driver_config.context_count,
-            driver_config.payload_byte_limit,
+            driver_config.datagram_byte_limit,
             driver_config.datagram_count,
             vec![agent_socket, adp_socket],
         )?;

--- a/test/antithesis/scenarios/general/src/bin/parallel_driver_send_dogstatsd.rs
+++ b/test/antithesis/scenarios/general/src/bin/parallel_driver_send_dogstatsd.rs
@@ -50,7 +50,7 @@ mod unix_driver {
             AntithesisRng,
             &config.intake_addr,
             driver_config.context_count,
-            driver_config.payload_byte_limit,
+            driver_config.datagram_byte_limit,
             driver_config.datagram_count,
             vec![socket],
         )?;


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

ADP and Datadog Agent deal with non-utf8 bytes differently. The way that
intake accepts non-utf8 bytes varies depending on where in the payload they
appear and for which protocol version. Previously I created datagrams that were
too non-utf8 heavy, meaning _most_ payloads could be rejected by intake. This
commit changes the generator to emit non-utf8 bytes into about 1% of datagrams.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
