### PR TITLE
chore(antithesis): Add provider_kind in sample config

### DIFF
--- a/test/antithesis/harness/src/config.rs
+++ b/test/antithesis/harness/src/config.rs
@@ -162,6 +162,9 @@ pub(crate) struct V3SeriesConfig {
     enabled: &'static str,
 }
 
+/// Cloud provider kinds sampled into `provider_kind`. The empty string emits no tag.
+const PROVIDER_KINDS: &[&str] = &["", "gke-autopilot", "gke-gdc"];
+
 /// Agent-facing config. `hostname`, `api_key`, `dd_url`, and the socket are
 /// supplied by the environment; `log_level`, the series intake API, and the
 /// `DogStatsD` options are sampled per branch. The static flags are appended by
@@ -184,6 +187,21 @@ pub struct DatadogConfig {
     /// ADP's safety gate for authoritative v3 series, which the Agent has no counterpart for.
     /// Sampled with [`Self::use_v3_api`] so ADP and the Agent never split encodings in a timeline.
     data_plane_metrics_v3_series_enabled: bool,
+    /// Cloud provider kind, sampled per timeline from [`PROVIDER_KINDS`].
+    ///
+    /// A non-empty value makes the Agent append `provider_kind:<value>` to every `DogStatsD` metric as a
+    /// static tag, `comp/dogstatsd/server/impl/server.go:263` and `pkg/util/tags/static_tags.go:84`. In a
+    /// v3 payload that tag becomes a shared prefix tagset, and a metric carrying both a prefix tagset and
+    /// its own tags is the only thing that makes the Agent emit the tagset back-reference Pyld54 asserts
+    /// on. Without it the rig never reaches that assertion.
+    ///
+    /// The empty string is one of the three sampled values and emits no tag, matching the Agent's own
+    /// default. So one timeline in three carries no prefix and exercises the back-reference-free path.
+    ///
+    /// This is a test input rather than an operator knob. Widen [`PROVIDER_KINDS`] to cover more prefix
+    /// tagsets.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    provider_kind: String,
     /// `DogStatsD` options, flattened to top-level `dogstatsd_*` keys.
     #[serde(flatten)]
     dogstatsd: DogStatsdConfig,
@@ -210,6 +228,7 @@ impl DatadogConfig {
             },
             serializer_compressor_kind: rng.random(),
             data_plane_metrics_v3_series_enabled: series_v3,
+            provider_kind: PROVIDER_KINDS[rng.random_range(0..PROVIDER_KINDS.len())].to_owned(),
             dogstatsd: DogStatsdConfig::sample(rng, dogstatsd_socket),
         }
     }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Pyld54 asserts a v3 tagset back-reference resolves to an earlier
tagset. Agent emits that back-reference only when a metric carries both
a shared prefix tagset and its own tags. Previously we only ever emitted
load that carried no shared prefix.

This commit adds provider_kind into the sampled datadog.yaml. Agent will
attach this as a global tag which acts as a shared prefix. 1/3 of
configs will not have provider_kind present.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
