### PR TITLE
feat(otlp): added tls server config option for http and grpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5517,6 +5517,7 @@ dependencies = [
  "socket2",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -433,16 +433,12 @@ ways that are not yet fully characterized.
 | `otlp_config.receiver.protocols.grpc.keepalive.server_parameters.timeout`                  | gRPC keepalive: ping timeout           |         |
 | `otlp_config.receiver.protocols.grpc.max_concurrent_streams`                               | gRPC max concurrent streams            |         |
 | `otlp_config.receiver.protocols.grpc.read_buffer_size`                                     | gRPC read buffer size                  |         |
-| `otlp_config.receiver.protocols.grpc.tls.ca_file`                                          | gRPC TLS CA file path                  |         |
 | `otlp_config.receiver.protocols.grpc.tls.ca_pem`                                           | gRPC TLS CA PEM                        |         |
-| `otlp_config.receiver.protocols.grpc.tls.cert_file`                                        | gRPC TLS cert file path                |         |
 | `otlp_config.receiver.protocols.grpc.tls.cert_pem`                                         | gRPC TLS cert PEM                      |         |
 | `otlp_config.receiver.protocols.grpc.tls.cipher_suites`                                    | gRPC TLS cipher suites                 |         |
-| `otlp_config.receiver.protocols.grpc.tls.client_ca_file`                                   | gRPC TLS client CA file                |         |
 | `otlp_config.receiver.protocols.grpc.tls.client_ca_file_reload`                            | gRPC TLS client CA reload              |         |
 | `otlp_config.receiver.protocols.grpc.tls.curve_preferences`                                | gRPC TLS curve preferences             |         |
 | `otlp_config.receiver.protocols.grpc.tls.include_system_ca_certs_pool`                     | gRPC TLS include system CA pool        |         |
-| `otlp_config.receiver.protocols.grpc.tls.key_file`                                         | gRPC TLS key file path                 |         |
 | `otlp_config.receiver.protocols.grpc.tls.key_pem`                                          | gRPC TLS key PEM                       |         |
 | `otlp_config.receiver.protocols.grpc.tls.max_version`                                      | gRPC TLS max version                   |         |
 | `otlp_config.receiver.protocols.grpc.tls.min_version`                                      | gRPC TLS min version                   |         |
@@ -466,16 +462,12 @@ ways that are not yet fully characterized.
 | `otlp_config.receiver.protocols.http.read_header_timeout`                                  | HTTP read header timeout               |         |
 | `otlp_config.receiver.protocols.http.read_timeout`                                         | HTTP read timeout                      |         |
 | `otlp_config.receiver.protocols.http.response_headers`                                     | HTTP response headers                  |         |
-| `otlp_config.receiver.protocols.http.tls.ca_file`                                          | HTTP TLS CA file path                  |         |
 | `otlp_config.receiver.protocols.http.tls.ca_pem`                                           | HTTP TLS CA PEM                        |         |
-| `otlp_config.receiver.protocols.http.tls.cert_file`                                        | HTTP TLS cert file path                |         |
 | `otlp_config.receiver.protocols.http.tls.cert_pem`                                         | HTTP TLS cert PEM                      |         |
 | `otlp_config.receiver.protocols.http.tls.cipher_suites`                                    | HTTP TLS cipher suites                 |         |
-| `otlp_config.receiver.protocols.http.tls.client_ca_file`                                   | HTTP TLS client CA file                |         |
 | `otlp_config.receiver.protocols.http.tls.client_ca_file_reload`                            | HTTP TLS client CA reload              |         |
 | `otlp_config.receiver.protocols.http.tls.curve_preferences`                                | HTTP TLS curve preferences             |         |
 | `otlp_config.receiver.protocols.http.tls.include_system_ca_certs_pool`                     | HTTP TLS include system CA pool        |         |
-| `otlp_config.receiver.protocols.http.tls.key_file`                                         | HTTP TLS key file path                 |         |
 | `otlp_config.receiver.protocols.http.tls.key_pem`                                          | HTTP TLS key PEM                       |         |
 | `otlp_config.receiver.protocols.http.tls.max_version`                                      | HTTP TLS max version                   |         |
 | `otlp_config.receiver.protocols.http.tls.min_version`                                      | HTTP TLS min version                   |         |
@@ -823,8 +815,16 @@ Both commands scrub recognized secret values before writing JSON to standard out
 | `otlp_config.metrics.tags`                                     | Comma-separated tags for all OTLP metrics.         |
 | `otlp_config.receiver.protocols.grpc.endpoint`                 | otlp_config.receiver.protocols.grpc.endpoint       |
 | `otlp_config.receiver.protocols.grpc.max_recv_msg_size_mib`    | Max OTLP inbound gRPC message size (MiB)           |
+| `otlp_config.receiver.protocols.grpc.tls.ca_file`              | gRPC TLS CA file path                              |
+| `otlp_config.receiver.protocols.grpc.tls.cert_file`            | gRPC TLS cert file path                            |
+| `otlp_config.receiver.protocols.grpc.tls.client_ca_file`       | gRPC TLS client CA file                            |
+| `otlp_config.receiver.protocols.grpc.tls.key_file`             | gRPC TLS key file path                             |
 | `otlp_config.receiver.protocols.grpc.transport`                | otlp_config.receiver.protocols.grpc.transport      |
 | `otlp_config.receiver.protocols.http.endpoint`                 | otlp_config.receiver.protocols.http.endpoint       |
+| `otlp_config.receiver.protocols.http.tls.ca_file`              | HTTP TLS CA file path                              |
+| `otlp_config.receiver.protocols.http.tls.cert_file`            | HTTP TLS cert file path                            |
+| `otlp_config.receiver.protocols.http.tls.client_ca_file`       | HTTP TLS client CA file                            |
+| `otlp_config.receiver.protocols.http.tls.key_file`             | HTTP TLS key file path                             |
 | `otlp_config.traces.enabled`                                   | otlp_config.traces.enabled                         |
 | `otlp_config.traces.internal_port`                             | otlp_config.traces.internal_port                   |
 | `otlp_config.traces.probabilistic_sampler.sampling_percentage` | OTLP trace sampling percentage                     |

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -1005,6 +1005,38 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
         self.config.domains.otlp.receiver.http.endpoint = value;
     }
 
+    fn consume_otlp_config_receiver_protocols_grpc_tls_ca_file(&mut self, value: String) {
+        self.config.domains.otlp.receiver.grpc.tls.ca_file = value;
+    }
+
+    fn consume_otlp_config_receiver_protocols_grpc_tls_cert_file(&mut self, value: String) {
+        self.config.domains.otlp.receiver.grpc.tls.cert_file = value;
+    }
+
+    fn consume_otlp_config_receiver_protocols_grpc_tls_key_file(&mut self, value: String) {
+        self.config.domains.otlp.receiver.grpc.tls.key_file = value;
+    }
+
+    fn consume_otlp_config_receiver_protocols_grpc_tls_client_ca_file(&mut self, value: String) {
+        self.config.domains.otlp.receiver.grpc.tls.client_ca_file = value;
+    }
+
+    fn consume_otlp_config_receiver_protocols_http_tls_ca_file(&mut self, value: String) {
+        self.config.domains.otlp.receiver.http.tls.ca_file = value;
+    }
+
+    fn consume_otlp_config_receiver_protocols_http_tls_cert_file(&mut self, value: String) {
+        self.config.domains.otlp.receiver.http.tls.cert_file = value;
+    }
+
+    fn consume_otlp_config_receiver_protocols_http_tls_key_file(&mut self, value: String) {
+        self.config.domains.otlp.receiver.http.tls.key_file = value;
+    }
+
+    fn consume_otlp_config_receiver_protocols_http_tls_client_ca_file(&mut self, value: String) {
+        self.config.domains.otlp.receiver.http.tls.client_ca_file = value;
+    }
+
     fn consume_otlp_config_traces_enabled(&mut self, value: bool) {
         self.config.domains.otlp.traces.enabled = value;
     }

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -92,6 +92,7 @@ impl FromStr for HistogramMode {
 
 /// TLS settings for an inbound OTLP receiver.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(default)]
 pub struct TlsConfig {
     /// Path to PEM-encoded certificate authorities loaded for Collector configuration compatibility.
     ///

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -3,7 +3,7 @@
 
 use std::{num::NonZeroUsize, str::FromStr};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::defaults::DEFAULT_STRING_INTERNER_SIZE_BYTES;
 use crate::{domains::dogstatsd::OriginTagCardinality, Error};
@@ -86,6 +86,54 @@ impl FromStr for HistogramMode {
             other => Err(Error::new_without_source(format!(
                 "unknown histogram mode `{other}`; expected `nobuckets`, `counters`, or `distributions`"
             ))),
+        }
+    }
+}
+
+/// TLS settings for an inbound OTLP receiver.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+pub struct TlsConfig {
+    /// Path to PEM-encoded certificate authorities loaded for Collector configuration compatibility.
+    ///
+    /// For an inbound receiver, this does not affect client authentication. Use [`Self::client_ca_file`] to configure
+    /// mutual TLS.
+    pub ca_file: String,
+
+    /// Path to the PEM-encoded certificate chain the receiver presents to clients.
+    pub cert_file: String,
+
+    /// Path to the PEM-encoded private key matching [`Self::cert_file`].
+    pub key_file: String,
+
+    /// Path to PEM-encoded certificate authorities trusted for client certificates.
+    ///
+    /// When set, the receiver requires and verifies a client certificate, enabling mutual TLS.
+    pub client_ca_file: String,
+}
+
+impl TlsConfig {
+    /// Returns whether TLS is configured for the receiver.
+    ///
+    /// TLS is disabled when no paths are configured. A configured server identity requires both `cert_file` and
+    /// `key_file`; configuring only one, or configuring either CA path without an identity, is an error.
+    pub fn is_configured(&self) -> Result<bool, Error> {
+        match (
+            self.cert_file.is_empty(),
+            self.key_file.is_empty(),
+            self.ca_file.is_empty(),
+            self.client_ca_file.is_empty(),
+        ) {
+            (true, true, true, true) => Ok(false),
+            (false, false, _, _) => Ok(true),
+            (true, true, false, _) => Err(Error::new_without_source(
+                "`otlp_config.receiver.protocols.*.tls.ca_file` requires `cert_file` and `key_file`",
+            )),
+            (true, true, _, false) => Err(Error::new_without_source(
+                "`otlp_config.receiver.protocols.*.tls.client_ca_file` requires `cert_file` and `key_file`",
+            )),
+            _ => Err(Error::new_without_source(
+                "`otlp_config.receiver.protocols.*.tls.cert_file` and `key_file` must be configured together",
+            )),
         }
     }
 }
@@ -229,6 +277,9 @@ pub struct GrpcReceiver {
 
     /// Transport the gRPC receiver binds (for example, `tcp` or `unix`).
     pub transport: String,
+
+    /// TLS settings for this inbound receiver.
+    pub tls: TlsConfig,
 }
 
 /// OTLP HTTP receiver.
@@ -240,6 +291,9 @@ pub struct HttpReceiver {
     /// Transport the HTTP receiver binds (for example, `tcp` or `unix`). (not in Datadog Agent
     /// config schema)
     pub transport: String,
+
+    /// TLS settings for this inbound receiver.
+    pub tls: TlsConfig,
 }
 
 impl Default for HttpReceiver {
@@ -248,6 +302,7 @@ impl Default for HttpReceiver {
             // Witnessed; overwritten during drive.
             endpoint: String::new(),
             transport: "tcp".to_string(),
+            tls: TlsConfig::default(),
         }
     }
 }
@@ -340,7 +395,28 @@ impl Default for Contexts {
 
 #[cfg(test)]
 mod tests {
-    use super::{CumulativeMonotonicMode, InitialCumulativeMonotonicValue};
+    use super::{CumulativeMonotonicMode, InitialCumulativeMonotonicValue, TlsConfig};
+
+    #[test]
+    fn tls_config_requires_a_complete_server_identity() {
+        let mut config = TlsConfig::default();
+        assert!(!config.is_configured().expect("an empty TLS config should disable TLS"));
+
+        config.cert_file = "server.pem".to_string();
+        assert!(config.is_configured().is_err());
+
+        config.key_file = "server.key".to_string();
+        assert!(config.is_configured().expect("a certificate and key should enable TLS"));
+
+        config.cert_file.clear();
+        config.key_file.clear();
+        config.client_ca_file = "clients.pem".to_string();
+        assert!(config.is_configured().is_err());
+
+        config.client_ca_file.clear();
+        config.ca_file = "compatibility-ca.pem".to_string();
+        assert!(config.is_configured().is_err());
+    }
 
     #[test]
     fn cumulative_monotonic_mode_parses_known_values() {

--- a/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
@@ -355,6 +355,94 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
     };
+    /// `otlp_config.receiver.protocols.grpc.tls.ca_file`-gRPC TLS CA file path
+    OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_TLS_CA_FILE = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_TLS_CA_FILE,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
+    /// `otlp_config.receiver.protocols.grpc.tls.cert_file`-gRPC TLS cert file path
+    OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_TLS_CERT_FILE = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_TLS_CERT_FILE,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
+    /// `otlp_config.receiver.protocols.grpc.tls.client_ca_file`-gRPC TLS client CA file
+    OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_TLS_CLIENT_CA_FILE = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_TLS_CLIENT_CA_FILE,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
+    /// `otlp_config.receiver.protocols.grpc.tls.key_file`-gRPC TLS key file path
+    OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_TLS_KEY_FILE = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_TLS_KEY_FILE,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
+    /// `otlp_config.receiver.protocols.http.tls.ca_file`-HTTP TLS CA file path
+    OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_TLS_CA_FILE = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_TLS_CA_FILE,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
+    /// `otlp_config.receiver.protocols.http.tls.cert_file`-HTTP TLS cert file path
+    OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_TLS_CERT_FILE = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_TLS_CERT_FILE,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
+    /// `otlp_config.receiver.protocols.http.tls.client_ca_file`-HTTP TLS client CA file
+    OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_TLS_CLIENT_CA_FILE = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_TLS_CLIENT_CA_FILE,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
+    /// `otlp_config.receiver.protocols.http.tls.key_file`-HTTP TLS key file path
+    OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_TLS_KEY_FILE = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_TLS_KEY_FILE,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
     /// `tags`-Global tags for EKS Fargate OTLP metrics
     TAGS = SalukiAnnotation {
         schema: &schema::TAGS,

--- a/lib/datadog-agent/config/schema/core/core_schema.yaml
+++ b/lib/datadog-agent/config/schema/core/core_schema.yaml
@@ -5432,6 +5432,46 @@ properties:
                     node_type: setting
                     type: integer
                     default: 0
+                  tls:
+                    node_type: section
+                    type: object
+                    visibility: public
+                    description: TLS server configuration for the OTLP/gRPC listener.
+                    tags:
+                    - template_section:CoreAgent
+                    properties:
+                      ca_file:
+                        node_type: setting
+                        type: string
+                        default: ""
+                        visibility: public
+                        description: Path to a CA bundle file used to verify client certificates.
+                        tags:
+                        - template_section:CoreAgent
+                      cert_file:
+                        node_type: setting
+                        type: string
+                        default: ""
+                        visibility: public
+                        description: Path to the TLS certificate file.
+                        tags:
+                        - template_section:CoreAgent
+                      key_file:
+                        node_type: setting
+                        type: string
+                        default: ""
+                        visibility: public
+                        description: Path to the TLS private key file.
+                        tags:
+                        - template_section:CoreAgent
+                      client_ca_file:
+                        node_type: setting
+                        type: string
+                        default: ""
+                        visibility: public
+                        description: Path to a CA certificate file used to verify client certificates for mutual TLS.
+                        tags:
+                        - template_section:CoreAgent
               http:
                 node_type: section
                 type: object
@@ -5476,6 +5516,46 @@ properties:
                     node_type: setting
                     type: integer
                     default: 0
+                  tls:
+                    node_type: section
+                    type: object
+                    visibility: public
+                    description: TLS server configuration for the OTLP/HTTP listener.
+                    tags:
+                    - template_section:CoreAgent
+                    properties:
+                      ca_file:
+                        node_type: setting
+                        type: string
+                        default: ""
+                        visibility: public
+                        description: Path to a CA bundle file used to verify client certificates.
+                        tags:
+                        - template_section:CoreAgent
+                      cert_file:
+                        node_type: setting
+                        type: string
+                        default: ""
+                        visibility: public
+                        description: Path to the TLS certificate file.
+                        tags:
+                        - template_section:CoreAgent
+                      key_file:
+                        node_type: setting
+                        type: string
+                        default: ""
+                        visibility: public
+                        description: Path to the TLS private key file.
+                        tags:
+                        - template_section:CoreAgent
+                      client_ca_file:
+                        node_type: setting
+                        type: string
+                        default: ""
+                        visibility: public
+                        description: Path to a CA certificate file used to verify client certificates for mutual TLS.
+                        tags:
+                        - template_section:CoreAgent
       metrics:
         node_type: section
         type: object

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -2237,16 +2237,26 @@ inventory:
     description: "gRPC read buffer size"
 
   otlp_config.receiver.protocols.grpc.tls.ca_file:
-    support: unknown
+    support: full
+    pipelines: [otlp]
     description: "gRPC TLS CA file path"
+    test_support:
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: otlp.rs
 
   otlp_config.receiver.protocols.grpc.tls.ca_pem:
     support: unknown
     description: "gRPC TLS CA PEM"
 
   otlp_config.receiver.protocols.grpc.tls.cert_file:
-    support: unknown
+    support: full
+    pipelines: [otlp]
     description: "gRPC TLS cert file path"
+    test_support:
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: otlp.rs
 
   otlp_config.receiver.protocols.grpc.tls.cert_pem:
     support: unknown
@@ -2257,8 +2267,13 @@ inventory:
     description: "gRPC TLS cipher suites"
 
   otlp_config.receiver.protocols.grpc.tls.client_ca_file:
-    support: unknown
+    support: full
+    pipelines: [otlp]
     description: "gRPC TLS client CA file"
+    test_support:
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: otlp.rs
 
   otlp_config.receiver.protocols.grpc.tls.client_ca_file_reload:
     support: unknown
@@ -2273,8 +2288,13 @@ inventory:
     description: "gRPC TLS include system CA pool"
 
   otlp_config.receiver.protocols.grpc.tls.key_file:
-    support: unknown
+    support: full
+    pipelines: [otlp]
     description: "gRPC TLS key file path"
+    test_support:
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: otlp.rs
 
   otlp_config.receiver.protocols.grpc.tls.key_pem:
     support: unknown
@@ -2387,16 +2407,26 @@ inventory:
     description: "HTTP response headers"
 
   otlp_config.receiver.protocols.http.tls.ca_file:
-    support: unknown
+    support: full
+    pipelines: [otlp]
     description: "HTTP TLS CA file path"
+    test_support:
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: otlp.rs
 
   otlp_config.receiver.protocols.http.tls.ca_pem:
     support: unknown
     description: "HTTP TLS CA PEM"
 
   otlp_config.receiver.protocols.http.tls.cert_file:
-    support: unknown
+    support: full
+    pipelines: [otlp]
     description: "HTTP TLS cert file path"
+    test_support:
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: otlp.rs
 
   otlp_config.receiver.protocols.http.tls.cert_pem:
     support: unknown
@@ -2407,8 +2437,13 @@ inventory:
     description: "HTTP TLS cipher suites"
 
   otlp_config.receiver.protocols.http.tls.client_ca_file:
-    support: unknown
+    support: full
+    pipelines: [otlp]
     description: "HTTP TLS client CA file"
+    test_support:
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: otlp.rs
 
   otlp_config.receiver.protocols.http.tls.client_ca_file_reload:
     support: unknown
@@ -2423,8 +2458,13 @@ inventory:
     description: "HTTP TLS include system CA pool"
 
   otlp_config.receiver.protocols.http.tls.key_file:
-    support: unknown
+    support: full
+    pipelines: [otlp]
     description: "HTTP TLS key file path"
+    test_support:
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: otlp.rs
 
   otlp_config.receiver.protocols.http.tls.key_pem:
     support: unknown

--- a/lib/datadog-agent/config/src/generated/datadog_configuration.rs
+++ b/lib/datadog-agent/config/src/generated/datadog_configuration.rs
@@ -1610,6 +1610,9 @@ pub struct OtlpConfigReceiverProtocolsGrpc {
     #[serde(deserialize_with = "crate::cast_de::deserialize_i64")]
     pub max_recv_msg_size_mib: i64,
 
+    #[serde(default)]
+    pub tls: OtlpConfigReceiverProtocolsGrpcTls,
+
     #[serde(
         default = "defaults::datadog_configuration_otlp_config_receiver_protocols_grpc_transport"
     )]
@@ -1622,7 +1625,38 @@ impl Default for OtlpConfigReceiverProtocolsGrpc {
         Self {
             endpoint: defaults::datadog_configuration_otlp_config_receiver_protocols_grpc_endpoint(),
             max_recv_msg_size_mib: Default::default(),
+            tls: Default::default(),
             transport: defaults::datadog_configuration_otlp_config_receiver_protocols_grpc_transport(),
+        }
+    }
+}
+
+#[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+pub struct OtlpConfigReceiverProtocolsGrpcTls {
+    #[serde(default)]
+    #[serde(deserialize_with = "crate::cast_de::deserialize_string")]
+    pub ca_file: String,
+
+    #[serde(default)]
+    #[serde(deserialize_with = "crate::cast_de::deserialize_string")]
+    pub cert_file: String,
+
+    #[serde(default)]
+    #[serde(deserialize_with = "crate::cast_de::deserialize_string")]
+    pub client_ca_file: String,
+
+    #[serde(default)]
+    #[serde(deserialize_with = "crate::cast_de::deserialize_string")]
+    pub key_file: String,
+}
+
+impl Default for OtlpConfigReceiverProtocolsGrpcTls {
+    fn default() -> Self {
+        Self {
+            ca_file: Default::default(),
+            cert_file: Default::default(),
+            client_ca_file: Default::default(),
+            key_file: Default::default(),
         }
     }
 }
@@ -1634,12 +1668,46 @@ pub struct OtlpConfigReceiverProtocolsHttp {
     )]
     #[serde(deserialize_with = "crate::cast_de::deserialize_string")]
     pub endpoint: String,
+
+    #[serde(default)]
+    pub tls: OtlpConfigReceiverProtocolsHttpTls,
 }
 
 impl Default for OtlpConfigReceiverProtocolsHttp {
     fn default() -> Self {
         Self {
             endpoint: defaults::datadog_configuration_otlp_config_receiver_protocols_http_endpoint(),
+            tls: Default::default(),
+        }
+    }
+}
+
+#[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+pub struct OtlpConfigReceiverProtocolsHttpTls {
+    #[serde(default)]
+    #[serde(deserialize_with = "crate::cast_de::deserialize_string")]
+    pub ca_file: String,
+
+    #[serde(default)]
+    #[serde(deserialize_with = "crate::cast_de::deserialize_string")]
+    pub cert_file: String,
+
+    #[serde(default)]
+    #[serde(deserialize_with = "crate::cast_de::deserialize_string")]
+    pub client_ca_file: String,
+
+    #[serde(default)]
+    #[serde(deserialize_with = "crate::cast_de::deserialize_string")]
+    pub key_file: String,
+}
+
+impl Default for OtlpConfigReceiverProtocolsHttpTls {
+    fn default() -> Self {
+        Self {
+            ca_file: Default::default(),
+            cert_file: Default::default(),
+            client_ca_file: Default::default(),
+            key_file: Default::default(),
         }
     }
 }

--- a/lib/datadog-agent/config/src/generated/env_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_keys.rs
@@ -831,6 +831,26 @@ pub static DATADOG_ENV_KEYS: &[EnvKey] = &[
         decode: EnvDecode::Integer,
     },
     EnvKey {
+        env_vars: &["DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_TLS_CA_FILE"],
+        path: &["otlp_config", "receiver", "protocols", "grpc", "tls", "ca_file"],
+        decode: EnvDecode::RawString,
+    },
+    EnvKey {
+        env_vars: &["DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_TLS_CERT_FILE"],
+        path: &["otlp_config", "receiver", "protocols", "grpc", "tls", "cert_file"],
+        decode: EnvDecode::RawString,
+    },
+    EnvKey {
+        env_vars: &["DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_TLS_CLIENT_CA_FILE"],
+        path: &["otlp_config", "receiver", "protocols", "grpc", "tls", "client_ca_file"],
+        decode: EnvDecode::RawString,
+    },
+    EnvKey {
+        env_vars: &["DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_TLS_KEY_FILE"],
+        path: &["otlp_config", "receiver", "protocols", "grpc", "tls", "key_file"],
+        decode: EnvDecode::RawString,
+    },
+    EnvKey {
         env_vars: &["DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_TRANSPORT"],
         path: &["otlp_config", "receiver", "protocols", "grpc", "transport"],
         decode: EnvDecode::RawString,
@@ -838,6 +858,26 @@ pub static DATADOG_ENV_KEYS: &[EnvKey] = &[
     EnvKey {
         env_vars: &["DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT"],
         path: &["otlp_config", "receiver", "protocols", "http", "endpoint"],
+        decode: EnvDecode::RawString,
+    },
+    EnvKey {
+        env_vars: &["DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_TLS_CA_FILE"],
+        path: &["otlp_config", "receiver", "protocols", "http", "tls", "ca_file"],
+        decode: EnvDecode::RawString,
+    },
+    EnvKey {
+        env_vars: &["DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_TLS_CERT_FILE"],
+        path: &["otlp_config", "receiver", "protocols", "http", "tls", "cert_file"],
+        decode: EnvDecode::RawString,
+    },
+    EnvKey {
+        env_vars: &["DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_TLS_CLIENT_CA_FILE"],
+        path: &["otlp_config", "receiver", "protocols", "http", "tls", "client_ca_file"],
+        decode: EnvDecode::RawString,
+    },
+    EnvKey {
+        env_vars: &["DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_TLS_KEY_FILE"],
+        path: &["otlp_config", "receiver", "protocols", "http", "tls", "key_file"],
         decode: EnvDecode::RawString,
     },
     EnvKey {

--- a/lib/datadog-agent/config/src/generated/witness.rs
+++ b/lib/datadog-agent/config/src/generated/witness.rs
@@ -176,8 +176,16 @@ pub trait DatadogConfigWitness {
     fn consume_otlp_config_metrics_tags(&mut self, value: String);
     fn consume_otlp_config_receiver_protocols_grpc_endpoint(&mut self, value: String);
     fn consume_otlp_config_receiver_protocols_grpc_max_recv_msg_size_mib(&mut self, value: i64);
+    fn consume_otlp_config_receiver_protocols_grpc_tls_ca_file(&mut self, value: String);
+    fn consume_otlp_config_receiver_protocols_grpc_tls_cert_file(&mut self, value: String);
+    fn consume_otlp_config_receiver_protocols_grpc_tls_client_ca_file(&mut self, value: String);
+    fn consume_otlp_config_receiver_protocols_grpc_tls_key_file(&mut self, value: String);
     fn consume_otlp_config_receiver_protocols_grpc_transport(&mut self, value: String);
     fn consume_otlp_config_receiver_protocols_http_endpoint(&mut self, value: String);
+    fn consume_otlp_config_receiver_protocols_http_tls_ca_file(&mut self, value: String);
+    fn consume_otlp_config_receiver_protocols_http_tls_cert_file(&mut self, value: String);
+    fn consume_otlp_config_receiver_protocols_http_tls_client_ca_file(&mut self, value: String);
+    fn consume_otlp_config_receiver_protocols_http_tls_key_file(&mut self, value: String);
     fn consume_otlp_config_traces_enabled(&mut self, value: bool);
     fn consume_otlp_config_traces_internal_port(&mut self, value: i64);
     fn consume_otlp_config_traces_probabilistic_sampler_sampling_percentage(&mut self, value: f64);
@@ -462,11 +470,35 @@ pub fn drive(config: &DatadogConfiguration, consumer: &mut impl DatadogConfigWit
     consumer.consume_otlp_config_receiver_protocols_grpc_max_recv_msg_size_mib(
         config.otlp_config.receiver.protocols.grpc.max_recv_msg_size_mib.clone(),
     );
+    consumer.consume_otlp_config_receiver_protocols_grpc_tls_ca_file(
+        config.otlp_config.receiver.protocols.grpc.tls.ca_file.clone(),
+    );
+    consumer.consume_otlp_config_receiver_protocols_grpc_tls_cert_file(
+        config.otlp_config.receiver.protocols.grpc.tls.cert_file.clone(),
+    );
+    consumer.consume_otlp_config_receiver_protocols_grpc_tls_client_ca_file(
+        config.otlp_config.receiver.protocols.grpc.tls.client_ca_file.clone(),
+    );
+    consumer.consume_otlp_config_receiver_protocols_grpc_tls_key_file(
+        config.otlp_config.receiver.protocols.grpc.tls.key_file.clone(),
+    );
     consumer.consume_otlp_config_receiver_protocols_grpc_transport(
         config.otlp_config.receiver.protocols.grpc.transport.clone(),
     );
     consumer.consume_otlp_config_receiver_protocols_http_endpoint(
         config.otlp_config.receiver.protocols.http.endpoint.clone(),
+    );
+    consumer.consume_otlp_config_receiver_protocols_http_tls_ca_file(
+        config.otlp_config.receiver.protocols.http.tls.ca_file.clone(),
+    );
+    consumer.consume_otlp_config_receiver_protocols_http_tls_cert_file(
+        config.otlp_config.receiver.protocols.http.tls.cert_file.clone(),
+    );
+    consumer.consume_otlp_config_receiver_protocols_http_tls_client_ca_file(
+        config.otlp_config.receiver.protocols.http.tls.client_ca_file.clone(),
+    );
+    consumer.consume_otlp_config_receiver_protocols_http_tls_key_file(
+        config.otlp_config.receiver.protocols.http.tls.key_file.clone(),
     );
     consumer.consume_otlp_config_traces_enabled(config.otlp_config.traces.enabled.clone());
     consumer.consume_otlp_config_traces_internal_port(config.otlp_config.traces.internal_port.clone());

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -52,6 +52,7 @@ protobuf = { workspace = true }
 rand = { workspace = true, features = ["std", "std_rng"] }
 regex = { workspace = true, features = ["unicode-perl"] }
 rmp-serde = { workspace = true }
+rustls = { workspace = true }
 saluki-antithesis = { workspace = true }
 saluki-api = { workspace = true }
 saluki-common = { workspace = true }
@@ -63,6 +64,7 @@ saluki-error = { workspace = true }
 saluki-io = { workspace = true }
 saluki-metadata = { workspace = true }
 saluki-metrics = { workspace = true }
+saluki-tls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["alloc"] }
@@ -80,7 +82,8 @@ tokio = { workspace = true, features = [
   "signal",
   "sync",
 ] }
-tonic = { workspace = true, features = ["router", "server"] }
+tokio-rustls = { workspace = true }
+tonic = { workspace = true, features = ["router", "server", "tls-connect-info"] }
 tower = { workspace = true, features = ["limit", "retry", "timeout", "util"] }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -8,9 +8,10 @@ pub mod semantics;
 pub mod traces;
 pub mod util;
 
-use std::sync::Arc;
+use std::{io, sync::Arc};
 
 use ::metrics::Counter;
+use agent_data_plane_config::domains::otlp::TlsConfig;
 use async_trait::async_trait;
 use axum::body::Bytes;
 use axum::extract::State;
@@ -28,6 +29,11 @@ use otlp_protos::opentelemetry::proto::collector::metrics::v1::{
 use otlp_protos::opentelemetry::proto::collector::trace::v1::trace_service_server::{TraceService, TraceServiceServer};
 use otlp_protos::opentelemetry::proto::collector::trace::v1::{ExportTraceServiceRequest, ExportTraceServiceResponse};
 use prost::Message;
+use rustls::{
+    pki_types::{pem::PemObject as _, CertificateDer, PrivateKeyDer},
+    server::WebPkiClientVerifier,
+    RootCertStore, ServerConfig,
+};
 use saluki_common::sync::shutdown::ShutdownCoordinator;
 use saluki_common::task::HandleExt as _;
 use saluki_core::accounting::MemoryLimiter;
@@ -39,8 +45,10 @@ use saluki_io::net::server::http::{ErrorHandle, HttpServer};
 use saluki_io::net::util::hyper::TowerToHyperService;
 use saluki_io::net::ListenAddress;
 use saluki_metrics::MetricsBuilder;
+use saluki_tls::ensure_server_config_fips_compliant;
 use stringtheory::MetaString;
 use tokio::runtime::Handle;
+use tokio_rustls::TlsAcceptor;
 use tonic::transport::Server;
 use tonic::{Request as TonicRequest, Response, Status};
 use tracing::error;
@@ -116,6 +124,8 @@ pub trait OtlpHandler: Send + Sync + 'static {
 pub struct OtlpServerBuilder {
     http_endpoint: ListenAddress,
     grpc_endpoint: ListenAddress,
+    http_tls_config: Option<ServerConfig>,
+    grpc_tls_config: Option<ServerConfig>,
     grpc_max_recv_msg_size_bytes: usize,
 }
 
@@ -127,8 +137,19 @@ impl OtlpServerBuilder {
         Self {
             http_endpoint,
             grpc_endpoint,
+            http_tls_config: None,
+            grpc_tls_config: None,
             grpc_max_recv_msg_size_bytes,
         }
+    }
+
+    /// Configures TLS for the OTLP HTTP and gRPC servers.
+    pub fn with_tls_configs(
+        mut self, http_tls_config: Option<ServerConfig>, grpc_tls_config: Option<ServerConfig>,
+    ) -> Self {
+        self.http_tls_config = http_tls_config;
+        self.grpc_tls_config = grpc_tls_config;
+        self
     }
 
     /// Builds and starts the OTLP servers (HTTP and gRPC).
@@ -175,8 +196,30 @@ impl OtlpServerBuilder {
         let grpc_listener = tokio::net::TcpListener::bind(grpc_socket_addr)
             .await
             .map_err(|e| generic_error!("Failed to bind OTLP gRPC listener on '{}': {}", grpc_socket_addr, e))?;
-        let grpc_incoming = tonic::transport::server::TcpIncoming::from(grpc_listener);
-        thread_pool_handle.spawn_traced_named("otlp-grpc-server", grpc_server.serve_with_incoming(grpc_incoming));
+        match self.grpc_tls_config {
+            Some(tls_config) => {
+                let tls_acceptor = TlsAcceptor::from(Arc::new(tls_config));
+                let grpc_incoming =
+                    futures::stream::unfold((grpc_listener, tls_acceptor), |(listener, acceptor)| async move {
+                        loop {
+                            match listener.accept().await {
+                                Ok((stream, _)) => match acceptor.accept(stream).await {
+                                    Ok(stream) => return Some((Ok::<_, io::Error>(stream), (listener, acceptor))),
+                                    Err(error) => error!(%error, "Failed to complete OTLP gRPC TLS handshake."),
+                                },
+                                Err(error) => return Some((Err(error), (listener, acceptor))),
+                            }
+                        }
+                    });
+                thread_pool_handle
+                    .spawn_traced_named("otlp-grpc-server", grpc_server.serve_with_incoming(grpc_incoming));
+            }
+            None => {
+                let grpc_incoming = tonic::transport::server::TcpIncoming::from(grpc_listener);
+                thread_pool_handle
+                    .spawn_traced_named("otlp-grpc-server", grpc_server.serve_with_incoming(grpc_incoming));
+            }
+        }
 
         // Create and spawn the HTTP server.
         let service = TowerToHyperService::new(
@@ -191,12 +234,137 @@ impl OtlpServerBuilder {
             .await
             .map_err(|e| generic_error!("Failed to create OTLP HTTP listener: {}", e))?;
 
-        let (http_shutdown_coordinator, http_error) = HttpServer::from_listener(http_listener, service)
-            .with_executor(thread_pool_handle)
-            .listen();
+        let mut http_server = HttpServer::from_listener(http_listener, service).with_executor(thread_pool_handle);
+        if let Some(tls_config) = self.http_tls_config {
+            http_server = http_server.with_tls_config(tls_config);
+        }
+        let (http_shutdown_coordinator, http_error) = http_server.listen();
 
         Ok((http_shutdown_coordinator, http_error))
     }
+}
+
+/// Builds a server TLS configuration from an OTLP receiver's TLS settings.
+///
+/// An empty configuration leaves TLS disabled. A configured certificate and key enable TLS; an optional client CA file
+/// additionally enables mutual TLS by requiring and verifying client certificates.
+pub async fn build_server_config(tls: &TlsConfig) -> Result<Option<ServerConfig>, GenericError> {
+    if !tls.is_configured()? {
+        return Ok(None);
+    }
+
+    let certificate_pem = tokio::fs::read(&tls.cert_file).await.map_err(|error| {
+        generic_error!(
+            "Failed to read OTLP TLS certificate file '{}': {}",
+            tls.cert_file,
+            error
+        )
+    })?;
+    let private_key_pem = tokio::fs::read(&tls.key_file)
+        .await
+        .map_err(|error| generic_error!("Failed to read OTLP TLS private key file '{}': {}", tls.key_file, error))?;
+
+    let certificate_chain = CertificateDer::pem_slice_iter(&certificate_pem)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+            generic_error!(
+                "Failed to parse OTLP TLS certificate file '{}': {}",
+                tls.cert_file,
+                error
+            )
+        })?;
+    if certificate_chain.is_empty() {
+        return Err(generic_error!(
+            "OTLP TLS certificate file '{}' contains no certificates.",
+            tls.cert_file
+        ));
+    }
+    let private_key = PrivateKeyDer::from_pem_slice(&private_key_pem)
+        .map_err(|error| {
+            generic_error!(
+                "Failed to parse OTLP TLS private key file '{}': {}",
+                tls.key_file,
+                error
+            )
+        })?
+        .clone_key();
+
+    // The Collector loads `ca_file` into `tls.Config.RootCAs`. A pure inbound receiver does not consult those roots,
+    // but loading and validating the file preserves the Collector's configuration behavior.
+    if !tls.ca_file.is_empty() {
+        let ca_pem = tokio::fs::read(&tls.ca_file)
+            .await
+            .map_err(|error| generic_error!("Failed to read OTLP TLS CA file '{}': {}", tls.ca_file, error))?;
+        let ca_certificates = CertificateDer::pem_slice_iter(&ca_pem)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| generic_error!("Failed to parse OTLP TLS CA file '{}': {}", tls.ca_file, error))?;
+        let mut roots = RootCertStore::empty();
+        for certificate in ca_certificates {
+            roots.add(certificate).map_err(|error| {
+                generic_error!(
+                    "Failed to add a certificate from OTLP TLS CA file '{}': {}",
+                    tls.ca_file,
+                    error
+                )
+            })?;
+        }
+        if roots.is_empty() {
+            return Err(generic_error!(
+                "OTLP TLS CA file '{}' contains no certificates.",
+                tls.ca_file
+            ));
+        }
+    }
+
+    let mut config = if tls.client_ca_file.is_empty() {
+        ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(certificate_chain, private_key)
+            .map_err(|error| generic_error!("Failed to build OTLP TLS server configuration: {}", error))?
+    } else {
+        let client_ca_pem = tokio::fs::read(&tls.client_ca_file).await.map_err(|error| {
+            generic_error!(
+                "Failed to read OTLP TLS client CA file '{}': {}",
+                tls.client_ca_file,
+                error
+            )
+        })?;
+        let client_certificates = CertificateDer::pem_slice_iter(&client_ca_pem)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| {
+                generic_error!(
+                    "Failed to parse OTLP TLS client CA file '{}': {}",
+                    tls.client_ca_file,
+                    error
+                )
+            })?;
+        let mut client_roots = RootCertStore::empty();
+        for certificate in client_certificates {
+            client_roots.add(certificate).map_err(|error| {
+                generic_error!(
+                    "Failed to add a certificate from OTLP TLS client CA file '{}': {}",
+                    tls.client_ca_file,
+                    error
+                )
+            })?;
+        }
+        if client_roots.is_empty() {
+            return Err(generic_error!(
+                "OTLP TLS client CA file '{}' contains no certificates.",
+                tls.client_ca_file
+            ));
+        }
+        let client_verifier = WebPkiClientVerifier::builder(Arc::new(client_roots))
+            .build()
+            .map_err(|error| generic_error!("Failed to build OTLP TLS client verifier: {}", error))?;
+        ServerConfig::builder()
+            .with_client_cert_verifier(client_verifier)
+            .with_single_cert(certificate_chain, private_key)
+            .map_err(|error| generic_error!("Failed to build OTLP mutual TLS server configuration: {}", error))?
+    };
+
+    ensure_server_config_fips_compliant(&mut config)?;
+    Ok(Some(config))
 }
 
 /// HTTP handler for OTLP metrics requests.

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -8,7 +8,7 @@ pub mod semantics;
 pub mod traces;
 pub mod util;
 
-use std::{io, sync::Arc};
+use std::{io, sync::Arc, time::Duration};
 
 use ::metrics::Counter;
 use agent_data_plane_config::domains::otlp::TlsConfig;
@@ -48,10 +48,14 @@ use saluki_metrics::MetricsBuilder;
 use saluki_tls::ensure_server_config_fips_compliant;
 use stringtheory::MetaString;
 use tokio::runtime::Handle;
+use tokio::sync::mpsc;
+use tokio::time::timeout;
 use tokio_rustls::TlsAcceptor;
 use tonic::transport::Server;
 use tonic::{Request as TonicRequest, Response, Status};
 use tracing::error;
+
+const OTLP_GRPC_TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub const OTLP_METRICS_GRPC_SERVICE_PATH: MetaString =
     MetaString::from_static("/opentelemetry.proto.collector.metrics.v1.MetricsService/Export");
@@ -197,20 +201,41 @@ impl OtlpServerBuilder {
             .await
             .map_err(|e| generic_error!("Failed to bind OTLP gRPC listener on '{}': {}", grpc_socket_addr, e))?;
         match self.grpc_tls_config {
-            Some(tls_config) => {
+            Some(mut tls_config) => {
+                // gRPC over TLS requires ALPN negotiation of HTTP/2. Tonic configures this when it owns TLS setup;
+                // configure it explicitly because this server accepts Rustls streams directly.
+                tls_config.alpn_protocols = vec![b"h2".to_vec()];
                 let tls_acceptor = TlsAcceptor::from(Arc::new(tls_config));
-                let grpc_incoming =
-                    futures::stream::unfold((grpc_listener, tls_acceptor), |(listener, acceptor)| async move {
-                        loop {
-                            match listener.accept().await {
-                                Ok((stream, _)) => match acceptor.accept(stream).await {
-                                    Ok(stream) => return Some((Ok::<_, io::Error>(stream), (listener, acceptor))),
-                                    Err(error) => error!(%error, "Failed to complete OTLP gRPC TLS handshake."),
-                                },
-                                Err(error) => return Some((Err(error), (listener, acceptor))),
+                let (incoming_tx, incoming_rx) = mpsc::channel(1024);
+                let handshake_executor = thread_pool_handle.clone();
+
+                thread_pool_handle.spawn_traced_named("otlp-grpc-tls-acceptor", async move {
+                    loop {
+                        let (stream, _) = match grpc_listener.accept().await {
+                            Ok(stream) => stream,
+                            Err(error) => {
+                                let _ = incoming_tx.send(Err(error)).await;
+                                break;
                             }
-                        }
-                    });
+                        };
+
+                        let acceptor = tls_acceptor.clone();
+                        let incoming_tx = incoming_tx.clone();
+                        handshake_executor.spawn_traced_named("otlp-grpc-tls-handshake", async move {
+                            match timeout(OTLP_GRPC_TLS_HANDSHAKE_TIMEOUT, acceptor.accept(stream)).await {
+                                Ok(Ok(stream)) => {
+                                    let _ = incoming_tx.send(Ok::<_, io::Error>(stream)).await;
+                                }
+                                Ok(Err(error)) => error!(%error, "Failed to complete OTLP gRPC TLS handshake."),
+                                Err(_) => error!("Timed out completing OTLP gRPC TLS handshake."),
+                            }
+                        });
+                    }
+                });
+
+                let grpc_incoming = futures::stream::unfold(incoming_rx, |mut rx| async {
+                    rx.recv().await.map(|stream| (stream, rx))
+                });
                 thread_pool_handle
                     .spawn_traced_named("otlp-grpc-server", grpc_server.serve_with_incoming(grpc_incoming));
             }

--- a/lib/saluki-components/src/relays/otlp/mod.rs
+++ b/lib/saluki-components/src/relays/otlp/mod.rs
@@ -266,10 +266,12 @@ mod tests {
                 endpoint: "0.0.0.0:4317".to_string(),
                 transport: "tcp".to_string(),
                 max_recv_msg_size_mib: 4,
+                ..Default::default()
             },
             http: domains::otlp::HttpReceiver {
                 endpoint: "0.0.0.0:4318".to_string(),
                 transport: "tcp".to_string(),
+                ..Default::default()
             },
             ..Default::default()
         });

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -38,7 +38,7 @@ use tokio::sync::mpsc;
 use tokio::time::{interval, MissedTickBehavior};
 use tracing::{debug, error};
 
-use crate::common::otlp::{build_metrics, Metrics, OtlpHandler, OtlpServerBuilder};
+use crate::common::otlp::{build_metrics, build_server_config, Metrics, OtlpHandler, OtlpServerBuilder};
 
 mod logs;
 mod metrics;
@@ -169,6 +169,8 @@ impl SourceBuilder for OtlpConfiguration {
         let metric_tags = parse_configured_metric_tags(&self.otlp.metrics.tags);
         let traces_translator = OtlpTracesTranslator::new(self.otlp.traces.clone());
         let grpc_max_recv_msg_size_bytes = self.otlp.receiver.grpc.max_recv_msg_size_mib as usize * 1024 * 1024;
+        let grpc_tls_config = build_server_config(&self.otlp.receiver.grpc.tls).await?;
+        let http_tls_config = build_server_config(&self.otlp.receiver.http.tls).await?;
         let metrics = build_metrics(&context);
 
         Ok(Box::new(Otlp {
@@ -176,6 +178,8 @@ impl SourceBuilder for OtlpConfiguration {
             origin_tag_resolver,
             grpc_endpoint,
             http_endpoint: ListenAddress::Tcp(http_socket_addr),
+            http_tls_config,
+            grpc_tls_config,
             grpc_max_recv_msg_size_bytes,
             metrics_translator_config,
             metric_tags,
@@ -200,6 +204,8 @@ pub struct Otlp {
     origin_tag_resolver: OtlpOriginTagResolver,
     grpc_endpoint: ListenAddress,
     http_endpoint: ListenAddress,
+    http_tls_config: Option<rustls::ServerConfig>,
+    grpc_tls_config: Option<rustls::ServerConfig>,
     grpc_max_recv_msg_size_bytes: usize,
     metrics_translator_config: metrics::config::OtlpMetricsTranslatorConfig,
     metric_tags: SharedTagSet,
@@ -216,6 +222,8 @@ impl Source for Otlp {
             origin_tag_resolver,
             grpc_endpoint,
             http_endpoint,
+            http_tls_config,
+            grpc_tls_config,
             grpc_max_recv_msg_size_bytes,
             metrics_translator_config,
             metric_tags,
@@ -260,7 +268,8 @@ impl Source for Otlp {
         );
 
         let handler = SourceHandler::new(tx);
-        let server_builder = OtlpServerBuilder::new(http_endpoint, grpc_endpoint, grpc_max_recv_msg_size_bytes);
+        let server_builder = OtlpServerBuilder::new(http_endpoint, grpc_endpoint, grpc_max_recv_msg_size_bytes)
+            .with_tls_configs(http_tls_config, grpc_tls_config);
 
         let (http_shutdown, mut http_error) = server_builder
             .build(handler, memory_limiter.clone(), thread_pool_handle, metrics)

--- a/test/integration/cases/otlp-tls-ca-file/config.yaml
+++ b/test/integration/cases/otlp-tls-ca-file/config.yaml
@@ -1,0 +1,58 @@
+type: integration
+name: "otlp-tls-ca-file"
+description: "Verifies OTLP ingest serves TLS with ca_file without requiring a client certificate"
+timeout: 120s
+runtimes: [linux]
+
+env:
+  DD_API_KEY: "test-api-key"
+  DD_HOSTNAME: "integration-test-otlp-tls"
+  DD_DATA_PLANE_ENABLED: "true"
+  DD_DATA_PLANE_STANDALONE_MODE: "true"
+  DD_DATA_PLANE_OTLP_ENABLED: "true"
+  # Bind ADP to framework-isolated addresses reachable through the container port mapping.
+  DD_DATA_PLANE_OTLP_RECEIVER_GRPC_ENDPOINT_TEMPORARY: "0.0.0.0:56317"
+  DD_DATA_PLANE_OTLP_RECEIVER_HTTP_ENDPOINT_TEMPORARY: "0.0.0.0:56318"
+  # The mounted test PEM contains both the certificate and its private key. Supplying it as
+  # ca_file must not enable mTLS.
+  DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_TLS_CA_FILE: "/tmp/otlp-tls/server.pem"
+  DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_TLS_CERT_FILE: "/tmp/otlp-tls/server.pem"
+  DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_TLS_KEY_FILE: "/tmp/otlp-tls/server.pem"
+  DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_TLS_CA_FILE: "/tmp/otlp-tls/server.pem"
+  DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_TLS_CERT_FILE: "/tmp/otlp-tls/server.pem"
+  DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_TLS_KEY_FILE: "/tmp/otlp-tls/server.pem"
+
+container:
+  files:
+    - "../../../smp/regression/adp/shared/cert.pem:/tmp/otlp-tls/server.pem"
+  exposed_ports:
+    - "56317/tcp"
+    - "56318/tcp"
+
+procedure:
+  # HTTP succeeds over TLS. Certificate verification is intentionally skipped because the mounted
+  # test certificate is self-signed.
+  - assertion: http_check
+    endpoint: "https://localhost:56318/v1/traces"
+    status:
+      equal: 405
+    insecure_skip_verify: true
+    timeout: 60s
+  # gRPC completes a TLS handshake without presenting a client certificate. This verifies that
+  # ca_file does not enable mTLS; client_ca_file is required for that behavior.
+  - action: target_exec
+    command:
+      - sh
+      - -c
+      - >-
+        printf '' | openssl s_client -connect 127.0.0.1:56317 -alpn h2
+        -CAfile /tmp/otlp-tls/server.pem -verify_return_error 2>&1 |
+        grep -q 'Verify return code: 0 (ok)'
+    timeout: 30s
+  - parallel:
+      - assertion: process_stable_for
+        duration: 10s
+      - assertion: log_not_contains
+        pattern: "panic|PANIC"
+        regex: true
+        during: 10s


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Adds TLS support for both OTLP HTTP and gRPC servers. 


## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

Unit tests

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

- Closes: https://github.com/DataDog/saluki/issues/2014
<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
