### PR TITLE
docs(test): require production-reachable unit tests

### DIFF
--- a/docs/development/testing-patterns.md
+++ b/docs/development/testing-patterns.md
@@ -98,6 +98,20 @@ a reviewer into thinking the behavior is covered. Watch for these shapes when yo
   percentage, a byte count, a status mapping) throws away the one thing worth testing. If the doc comment gives you an
   exact expected number, assert that number.
 
+### Verify production reachability
+
+Every unit test **MUST** exercise a production behavior or branch. Before accepting a test, identify both the
+production contract it protects and a plausible change to production code that would make the test fail. A test that
+only executes test-local helpers provides no production coverage, regardless of how realistic its setup appears.
+
+Test helpers **MAY** construct inputs, drive production code, or centralize assertions. A test helper **MUST NOT** be the
+sole subject of a test. If a helper itself needs independent behavioral coverage, promote that behavior into production
+code with its own public or crate-private contract before testing it directly.
+
+During self-review, apply a counterfactual check: choose the production line or branch the test claims to protect, then
+consider deleting it or changing its result. If the test would still pass, strengthen the test to observe that
+production behavior or remove the test.
+
 ### Match tests to documented behavior
 
 When a function's doc comment enumerates specific branches, error variants, or worked examples, treat that enumeration


### PR DESCRIPTION
Had the clanker try to self-remediate based on this discussion around some useless tests https://github.com/DataDog/saluki/pull/2185#discussion_r3659971804

## Summary

- Require unit tests to exercise a production behavior or branch.
- Prohibit tests whose sole subject is a test-only helper.
- Add a counterfactual self-review check based on mutating or removing the claimed production behavior.

## Motivation

A review of test-only networking helpers in #2185 showed that realistic setup and strong-looking assertions can still provide no production coverage. These rules make production reachability and mutation sensitivity explicit review requirements.

## Test plan

- `make check-docs`
- Repository pre-commit checks
