### PR TITLE
fix(config): accept human-readable DogStatsD interner sizes

### DIFF
--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -499,6 +499,10 @@ ADP enforces a minimum sample rate on incoming metrics to prevent memory exhaust
 
 By default, ADP parses DogStatsD packets with the same leniency as the core agent, accepting packets that technically violate the spec. Setting this to `false` enables strict mode, which rejects non-conformant packets. Strict mode is not available in the core agent.
 
+### `dogstatsd_string_interner_size_bytes`
+
+Accepts a bare integer number of bytes or a human-readable byte-size string such as `12MiB`. When unset, ADP derives the byte budget from `dogstatsd_string_interner_size`.
+
 ### `memory_limit` / `memory_slop_factor`
 
 ADP uses an explicit process memory limit (`memory_limit`) rather than relying on Go's garbage collector. The `memory_slop_factor` reserves a fraction of the limit to account for allocations not tracked by ADP's internal accounting. When memory usage approaches `memory_limit`, ADP's global limiter begins exerting backpressure (see `enable_global_limiter`).

--- a/lib/agent-data-plane-config-system/src/loaded.rs
+++ b/lib/agent-data-plane-config-system/src/loaded.rs
@@ -197,6 +197,7 @@ fn build_loader(path: &Path, env: EnvPrecedence) -> Result<ConfigurationLoader, 
 
 #[cfg(test)]
 mod tests {
+    use bytesize::ByteSize;
     use serde_json::json;
 
     use super::*;
@@ -275,5 +276,23 @@ mod tests {
         std::env::remove_var("DD_DOGSTATSD_PORT");
         std::fs::remove_file(&path).ok();
         assert!(matches!(result, Err(Error::Base { .. })));
+    }
+
+    #[test]
+    fn build_base_accepts_a_human_readable_dogstatsd_interner_size() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let path = std::env::temp_dir().join(format!("adp_build_base_interner_{}.yaml", std::process::id()));
+        std::fs::write(&path, "{}\n").unwrap();
+        std::env::set_var("DD_DOGSTATSD_STRING_INTERNER_SIZE_BYTES", "12MiB");
+
+        let base = build_base(&path, EnvPrecedence::AfterFile).expect("human-readable byte size builds");
+        let config = translate_strict(&base, EnvOverlayMode::Fallback).expect("human-readable byte size translates");
+
+        std::env::remove_var("DD_DOGSTATSD_STRING_INTERNER_SIZE_BYTES");
+        std::fs::remove_file(&path).ok();
+        assert_eq!(
+            config.domains.dogstatsd.contexts.string_interner_size_bytes,
+            Some(ByteSize::mib(12).as_u64())
+        );
     }
 }

--- a/lib/agent-data-plane-config-system/src/saluki_only.rs
+++ b/lib/agent-data-plane-config-system/src/saluki_only.rs
@@ -120,7 +120,10 @@ pub struct SalukiOnly {
     /// Maximum cached tagsets (`dogstatsd_cached_tagsets_limit`).
     pub dogstatsd_cached_tagsets_limit: Option<usize>,
     /// Explicit byte budget for the context interner (`dogstatsd_string_interner_size_bytes`).
-    pub dogstatsd_string_interner_size_bytes: Option<u64>,
+    ///
+    /// Accepts a bare integer number of bytes or a human-readable byte-size string such as `12MiB`.
+    /// When unset, the runtime derives the budget from `dogstatsd_string_interner_size`.
+    pub dogstatsd_string_interner_size_bytes: Option<ByteSize>,
     /// Whether to allow heap allocations for contexts (`dogstatsd_allow_context_heap_allocs`).
     pub dogstatsd_allow_context_heap_allocs: Option<bool>,
     /// Floor for metric sample rates (`dogstatsd_minimum_sample_rate`).
@@ -469,7 +472,7 @@ impl SalukiOnly {
             dsd.contexts.cached_tagsets_limit = v;
         }
         if let Some(v) = self.dogstatsd_string_interner_size_bytes {
-            dsd.contexts.string_interner_size_bytes = Some(v);
+            dsd.contexts.string_interner_size_bytes = Some(v.as_u64());
         }
         if let Some(v) = self.dogstatsd_allow_context_heap_allocs {
             dsd.contexts.allow_context_heap_allocs = v;
@@ -764,6 +767,31 @@ mod tests {
             let mut config = SalukiConfiguration::default();
             saluki_only.seed(&mut config);
             assert_eq!(config.control.memory_limit, expected);
+        }
+    }
+
+    /// `dogstatsd_string_interner_size_bytes` is a byte size the source may express as a bare
+    /// integer or a suffixed string. Both forms must reach the same runtime byte budget.
+    #[test]
+    fn dogstatsd_string_interner_size_bytes_accepts_a_bare_integer_or_a_string() {
+        for (value, expected) in [
+            (
+                json!({ "dogstatsd_string_interner_size_bytes": 12_582_912 }),
+                12_582_912,
+            ),
+            (
+                json!({ "dogstatsd_string_interner_size_bytes": "12MiB" }),
+                ByteSize::mib(12).as_u64(),
+            ),
+        ] {
+            let saluki_only: SalukiOnly =
+                serde_json::from_value(value).expect("dogstatsd interner byte size deserializes");
+            let mut config = SalukiConfiguration::default();
+            saluki_only.seed(&mut config);
+            assert_eq!(
+                config.domains.dogstatsd.contexts.string_interner_size_bytes,
+                Some(expected)
+            );
         }
     }
 

--- a/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
+++ b/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
@@ -271,7 +271,7 @@ pub static SALUKI_KEYS: &[SalukiKey] = &[
         env_var_override: None,
         additional_yaml_paths: &[],
         used_by: &["DOGSTATSD_CONFIGURATION"],
-        test_json: None,
+        test_json: Some(r#""12MiB""#),
         pipeline_affinity: "PipelineAffinity::Pipelines(&[Pipeline::DogStatsD])",
         filename: "dogstatsd.rs",
     },

--- a/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
+++ b/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
@@ -261,8 +261,11 @@ pub static SALUKI_KEYS: &[SalukiKey] = &[
         yaml_path: "dogstatsd_string_interner_size_bytes",
         description: "Explicit byte budget for context interner",
         default: "",
-        documentation: None,
-        value_type: "ValueType::Integer",
+        documentation: Some(
+            "Accepts a bare integer number of bytes or a human-readable byte-size string such as `12MiB`. \
+             When unset, ADP derives the byte budget from `dogstatsd_string_interner_size`.",
+        ),
+        value_type: "ValueType::String",
         schema_default: None,
         env_vars: &[],
         env_var_override: None,

--- a/lib/datadog-agent/config-testing/src/config_registry/dogstatsd.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/dogstatsd.rs
@@ -478,7 +478,7 @@ crate::declare_annotations! {
         env_var_override: None,
         used_by: &[structs::DOGSTATSD_CONFIGURATION],
         value_type_override: None,
-        test_json: None,
+        test_json: Some(r#""12MiB""#),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
     };
     /// `dogstatsd_tcp_port`

--- a/lib/datadog-agent/config-testing/src/config_registry/dogstatsd.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/dogstatsd.rs
@@ -64,7 +64,7 @@ static DOGSTATSD_STRING_INTERNER_SIZE_BYTES_SCHEMA: SchemaEntry = SchemaEntry {
     schema: Schema::Saluki,
     yaml_path: "dogstatsd_string_interner_size_bytes",
     env_vars: &[],
-    value_type: ValueType::Integer,
+    value_type: ValueType::String,
     default: None,
 };
 


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Fix ADP startup when DD_DOGSTATSD_STRING_INTERNER_SIZE_BYTES uses a human-readable value such as 12MiB.

The typed-config migration modeled this setting as a plain integer, regressing behavior supported by ADP 1.3.1. 

Use ByteSize so both human-readable sizes and numeric byte counts remain supported.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
Unit Test
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
