### PR TITLE
chore(ci): revert change to use `newest` tag for CI images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,10 +49,10 @@ variables:
   # output artifacts like ADP itself.
   SALUKI_IMAGE_REPO_PREFIX: "saluki"
   SALUKI_IMAGE_REPO_BASE: "${IMAGE_REGISTRY}/${SALUKI_IMAGE_REPO_PREFIX}"
-  SALUKI_BUILD_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/build-ci:newest"
-  SALUKI_GENERAL_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/general-ci:newest"
-  SALUKI_SMP_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/smp-ci:newest"
-  SALUKI_BUILDCACHE_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/buildcache-ci:newest"
+  SALUKI_BUILD_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/build-ci:latest"
+  SALUKI_GENERAL_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/general-ci:latest"
+  SALUKI_SMP_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/smp-ci:latest"
+  SALUKI_BUILDCACHE_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/buildcache-ci:latest"
   SPDX_LICENSES_IMAGE: "registry.ddbuild.io/images/spdx-license-list-data:3.28.0"
 
   # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image that we
@@ -93,9 +93,6 @@ variables:
 
 default:
   tags: ["arch:amd64"]
-  image:
-    name: "${SALUKI_BUILD_CI_IMAGE}"
-    pull_policy: always
 
 # Run a job on official releases (i.e. tagged).
 .on_official_release:

--- a/.gitlab/internal.yml
+++ b/.gitlab/internal.yml
@@ -42,7 +42,7 @@
       allow_failure: true
   script:
     - export IMAGE_REF=${SALUKI_IMAGE_REPO_BASE}/${IMAGE_NAME}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
-    - crane tag ${IMAGE_REF} newest
+    - crane tag ${IMAGE_REF} latest
 
 generate-build-ci-image:
   extends: [.generate-ci-image-definition]


### PR DESCRIPTION
## Summary

As stated in the PR title.

Apparently most of our jobs were continuing to run due to a side effect of how Gitlab merges the CI configuration [^1], but `display-image-tags` was broken and we only realized it after having a need to publish internal images for testing a PR.... doh! 😅 

This PR simply reverts those changes, since the original circumstances for switching in the first place should no longer exist (even if they may return 🤷🏻) and this gets us to the desired state of supporting our rebuilt-weekly images _and_ fixing the `display-image-tags` job.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [ ] Ran the internal image publish jobs on this PR and ensured that they ran as expected, including `display-image-tags`.

## References

DADP-2

[^1]: It's not doing it weirdly, but based on how we specify images for jobs, we were overriding the portion of the default configuration that actually specified the pull policy... so basically all jobs other than `display-image-tags` had the overridden pull policy removed which is how they managed to run successfully.