### PR TITLE
chore(config): make Core Agent config authoritative for V3 routing

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -4,6 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use agent_data_plane_config::shared::{Endpoints, MetricsEncoding};
 use agent_data_plane_config_system::{ConfigurationSystem, EnvPrecedence, LoadedConfiguration};
 use argh::FromArgs;
 use datadog_agent_commons::platform::PlatformSettings;
@@ -377,6 +378,9 @@ async fn create_topology(
 ) -> Result<(TopologyBlueprint, TopologyControlSurfaces), GenericError> {
     let mut blueprint = TopologyBlueprint::new("primary", component_registry);
     blueprint.with_shutdown_timeout(dp_config.stop_timeout());
+    let shared_config = config_system.config();
+    let metrics_encoding = shared_config.shared.metrics_encoding.clone();
+    let endpoints = shared_config.shared.endpoints.clone();
 
     let mut control_surfaces = TopologyControlSurfaces::default();
 
@@ -400,14 +404,25 @@ async fn create_topology(
         || dp_config.service_checks_pipeline_required()
         || dp_config.traces_pipeline_required()
     {
-        let dd_forwarder_config = DatadogForwarderConfiguration::from_configuration(&config_system.raw_map())
-            .error_context("Failed to configure Datadog forwarder.")?;
+        let dd_forwarder_config = DatadogForwarderConfiguration::from_configuration_with_metrics_routing(
+            &config_system.raw_map(),
+            &metrics_encoding,
+            &endpoints,
+        )
+        .error_context("Failed to configure Datadog forwarder.")?;
         blueprint.add_forwarder("dd_out", dd_forwarder_config)?;
     }
 
     if dp_config.metrics_pipeline_required() {
-        add_baseline_metrics_pipeline_to_blueprint(&mut blueprint, &config_system.raw_map(), dp_config, env_provider)
-            .await?;
+        add_baseline_metrics_pipeline_to_blueprint(
+            &mut blueprint,
+            &config_system.raw_map(),
+            &metrics_encoding,
+            &endpoints,
+            dp_config,
+            env_provider,
+        )
+        .await?;
     }
 
     if dp_config.logs_pipeline_required() {
@@ -466,8 +481,8 @@ async fn add_checks_pipeline_to_blueprint(
 }
 
 async fn add_baseline_metrics_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration, dp_config: &DataPlaneConfiguration,
-    env_provider: &ADPEnvironmentProvider,
+    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration, metrics: &MetricsEncoding, endpoints: &Endpoints,
+    dp_config: &DataPlaneConfiguration, env_provider: &ADPEnvironmentProvider,
 ) -> Result<(), GenericError> {
     // Create the back half of the metrics processing pipeline.
     let host_enrichment_config = HostEnrichmentConfiguration::from_environment_provider(env_provider.clone());
@@ -481,8 +496,9 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
         }
     }
 
-    let dd_metrics_config = DatadogMetricsConfiguration::from_configuration(config)
-        .error_context("Failed to configure Datadog Metrics encoder.")?;
+    let dd_metrics_config =
+        DatadogMetricsConfiguration::from_configuration_with_metrics_routing(config, metrics, endpoints)
+            .error_context("Failed to configure Datadog Metrics encoder.")?;
 
     blueprint
         // Components.
@@ -491,14 +507,14 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
         // Metrics, then forwarding.
         .connect_components_in_order(["metrics_enrich", "dd_metrics_encode", "dd_out"])?;
 
-    add_mrf_metrics_pipeline_to_blueprint(blueprint, config)?;
-    add_autoscaling_failover_metrics_pipeline_to_blueprint(blueprint, config)?;
+    add_mrf_metrics_pipeline_to_blueprint(blueprint, config, metrics, endpoints)?;
+    add_autoscaling_failover_metrics_pipeline_to_blueprint(blueprint, config, metrics, endpoints)?;
 
     Ok(())
 }
 
 fn add_mrf_metrics_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration,
+    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration, metrics: &MetricsEncoding, endpoints: &Endpoints,
 ) -> Result<(), GenericError> {
     let mrf_config = MrfConfiguration::from_configuration(config)
         .error_context("Failed to configure Multi-Region Failover metrics pipeline.")?;
@@ -517,19 +533,21 @@ fn add_mrf_metrics_pipeline_to_blueprint(
     };
 
     let mrf_gateway_config = MrfMetricsGatewayConfiguration::new(mrf_config.clone(), config.clone());
-    let mrf_metrics_config = DatadogMetricsConfiguration::from_configuration(config)
-        .error_context("Failed to configure Multi-Region Failover Datadog Metrics encoder.")?
-        .with_metrics_endpoint_override(mrf_dd_url.clone());
+    let mrf_metrics_config =
+        DatadogMetricsConfiguration::from_configuration_with_metrics_routing(config, metrics, endpoints)
+            .error_context("Failed to configure Multi-Region Failover Datadog Metrics encoder.")?
+            .with_metrics_endpoint_override(mrf_dd_url.clone());
 
-    let mrf_forwarder_config = DatadogForwarderConfiguration::from_configuration(config)
-        .map(|config| {
-            config.with_endpoint_override_and_api_key_refresh_config_path(
-                mrf_dd_url,
-                mrf_api_key,
-                "multi_region_failover.api_key",
-            )
-        })
-        .error_context("Failed to configure Multi-Region Failover Datadog forwarder.")?;
+    let mrf_forwarder_config =
+        DatadogForwarderConfiguration::from_configuration_with_metrics_routing(config, metrics, endpoints)
+            .map(|config| {
+                config.with_endpoint_override_and_api_key_refresh_config_path(
+                    mrf_dd_url,
+                    mrf_api_key,
+                    "multi_region_failover.api_key",
+                )
+            })
+            .error_context("Failed to configure Multi-Region Failover Datadog forwarder.")?;
 
     blueprint
         .add_transform("mrf_metrics_gateway", mrf_gateway_config)?
@@ -546,7 +564,7 @@ fn add_mrf_metrics_pipeline_to_blueprint(
 }
 
 fn add_autoscaling_failover_metrics_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration,
+    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration, metrics: &MetricsEncoding, endpoints: &Endpoints,
 ) -> Result<(), GenericError> {
     let af_config = AutoscalingFailoverConfiguration::from_configuration(config)
         .error_context("Failed to configure autoscaling failover metrics pipeline.")?;
@@ -571,12 +589,14 @@ fn add_autoscaling_failover_metrics_pipeline_to_blueprint(
     }
 
     let af_gateway_config = AutoscalingFailoverGatewayConfiguration::new(af_config);
-    let af_metrics_config = DatadogMetricsConfiguration::from_configuration(config)
-        .error_context("Failed to configure autoscaling failover metrics encoder.")?
-        .with_v2_series_only();
-    let cluster_agent_forwarder_config =
-        ClusterAgentForwarderConfiguration::from_configuration(config, ca_url, ca_token)
-            .error_context("Failed to configure Cluster Agent forwarder.")?;
+    let af_metrics_config =
+        DatadogMetricsConfiguration::from_configuration_with_metrics_routing(config, metrics, endpoints)
+            .error_context("Failed to configure autoscaling failover metrics encoder.")?
+            .with_v2_series_only();
+    let cluster_agent_forwarder_config = ClusterAgentForwarderConfiguration::from_configuration_with_metrics_routing(
+        config, metrics, endpoints, ca_url, ca_token,
+    )
+    .error_context("Failed to configure Cluster Agent forwarder.")?;
 
     blueprint
         .add_transform("af_metrics_gateway", af_gateway_config)?

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -442,7 +442,6 @@ The following settings are specific to ADP and have no equivalent in the core ag
 | `apm_config.obfuscation.sql.replace_digits`                     | Replace digits in SQL obfuscation          |                |
 | `apm_config.obfuscation.sql.table_names`                        | Collect table names during obfuscation     |                |
 | `counter_expiry_seconds`                                        | Idle counter keep-alive duration           | 300            |
-| `data_plane.metrics.v3.series.enabled`                          | Enable ADP V3 series                       | false          |
 | `data_plane.otlp.receiver_grpc_endpoint_temporary`              | ADP OTLP gRPC listen endpoint              | localhost:6317 |
 | `data_plane.otlp.receiver_http_endpoint_temporary`              | ADP OTLP HTTP listen endpoint              | localhost:6318 |
 | `data_plane.serializer_zstd_compressor_level`                   | ADP zstd compression level                 | 3              |
@@ -470,10 +469,6 @@ The following settings are specific to ADP and have no equivalent in the core ag
 | `otlp_config.traces.string_interner_size`                       | OTLP trace string interner capacity        |                |
 | `otlp_string_interner_size`                                     | OTLP context interner capacity             |                |
 | `serializer_max_metrics_per_payload`                            | Max metrics per payload                    |                |
-
-### `data_plane.metrics.v3.series.enabled`
-
-ADP requires this flag before it generates or forwards authoritative V3 series payloads. This is separate from `use_v3_api.series.*`, which matches the Core Agent V3 routing configuration.
 
 ### `data_plane.otlp.receiver_grpc_endpoint_temporary`
 

--- a/lib/agent-data-plane-config-system/src/saluki_only.rs
+++ b/lib/agent-data-plane-config-system/src/saluki_only.rs
@@ -39,8 +39,7 @@
 //!
 //! - a top-level key (`dogstatsd_tcp_port`, `aggregate_window_duration_seconds`) is a top-level
 //!   field of the same name;
-//! - a nested key (`apm_config.default_env`, `data_plane.metrics.v3.series.enabled`) is a field on
-//!   a matching chain of nested sub-structs.
+//! - a nested key (`apm_config.default_env`) is a field on a matching chain of nested sub-structs.
 //!
 //! A mismatch does not error. The field deserializes to `None`, `seed` skips it, and the model
 //! keeps its default: the value silently fails to transport.
@@ -177,8 +176,6 @@ pub struct DataPlane {
     pub standalone_mode: Option<bool>,
     /// Checks pipeline gate (`data_plane.checks.*`).
     pub checks: DataPlaneChecks,
-    /// Metrics-intake knobs (`data_plane.metrics.*`).
-    pub metrics: DataPlaneMetrics,
     /// Temporary ADP-only OTLP receiver endpoint settings (`data_plane.otlp.*`).
     pub otlp: DataPlaneOtlp,
 }
@@ -213,30 +210,6 @@ pub struct DataPlaneOtlp {
 #[serde(default)]
 pub struct DataPlaneChecks {
     /// Whether the checks pipeline is enabled (`data_plane.checks.enabled`).
-    pub enabled: Option<bool>,
-}
-
-/// `data_plane.metrics.*`.
-#[derive(Clone, Debug, Default, Deserialize)]
-#[serde(default)]
-pub struct DataPlaneMetrics {
-    /// V3 metrics-intake knobs (`data_plane.metrics.v3.*`).
-    pub v3: DataPlaneMetricsV3,
-}
-
-/// `data_plane.metrics.v3.*`.
-#[derive(Clone, Debug, Default, Deserialize)]
-#[serde(default)]
-pub struct DataPlaneMetricsV3 {
-    /// V3 series knobs (`data_plane.metrics.v3.series.*`).
-    pub series: DataPlaneMetricsV3Series,
-}
-
-/// `data_plane.metrics.v3.series.*`.
-#[derive(Clone, Debug, Default, Deserialize)]
-#[serde(default)]
-pub struct DataPlaneMetricsV3Series {
-    /// ADP-only safety gate authorizing V3 series (`data_plane.metrics.v3.series.enabled`).
     pub enabled: Option<bool>,
 }
 
@@ -444,9 +417,6 @@ impl SalukiOnly {
         if let Some(v) = self.serializer_max_metrics_per_payload {
             config.shared.metrics_encoding.max_metrics_per_payload = v;
         }
-        if let Some(v) = self.data_plane.metrics.v3.series.enabled {
-            config.shared.metrics_encoding.v3_series_enabled = v;
-        }
 
         // domains.dogstatsd
         let dsd = &mut config.domains.dogstatsd;
@@ -640,7 +610,6 @@ mod tests {
                 "stop_timeout": 45,
                 "standalone_mode": true,
                 "checks": { "enabled": true },
-                "metrics": { "v3": { "series": { "enabled": true } } },
                 // TODO(#2177): Remove this block and its endpoint assertions when ADP uses the
                 // canonical schema-provided endpoint keys.
                 "otlp": {
@@ -693,7 +662,6 @@ mod tests {
         assert_eq!(config.shared.metrics_level, "debug");
         assert_eq!(config.shared.metrics_encoding.flush_timeout, Duration::from_secs(7));
         assert_eq!(config.shared.metrics_encoding.max_metrics_per_payload, 999);
-        assert!(config.shared.metrics_encoding.v3_series_enabled);
 
         // domains.dogstatsd
         let dsd = &config.domains.dogstatsd;

--- a/lib/agent-data-plane-config-system/src/system.rs
+++ b/lib/agent-data-plane-config-system/src/system.rs
@@ -417,6 +417,96 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn connected_stream_translates_metrics_v3_routing_configuration() {
+        let (system, agent_tx) = connected_system(
+            json!({
+                "data_plane": {
+                    "metrics": {
+                        "v3": {
+                            "series": {
+                                "enabled": true
+                            }
+                        }
+                    }
+                }
+            }),
+            EnvOverlayMode::Fallback,
+        )
+        .await;
+
+        assert_eq!(
+            system.config().shared.metrics_encoding.v3_series_mode.mode,
+            "datadog_only"
+        );
+
+        agent_tx
+            .send(ConfigUpdate::Snapshot(json!({
+                "serializer_compressor_kind": "zstd",
+                "serializer_experimental_use_v3_api": {
+                    "compression_level": 7,
+                    "series": {
+                        "endpoints": ["https://app.us3.datadoghq.com"],
+                        "validate": true,
+                        "use_beta": true,
+                        "beta_route": "/api/intake/metrics/custom/series",
+                        "shadow_sample_rate": 0.25,
+                        "shadow_sites": ["us3.datadoghq.com"]
+                    }
+                },
+                "use_v2_api": {
+                    "series": false
+                },
+                "use_v3_api": {
+                    "series": {
+                        "enabled": "false",
+                        "endpoints": {
+                            "https://app.datadoghq.com": "true"
+                        }
+                    }
+                },
+                "observability_pipelines_worker": {
+                    "metrics": {
+                        "enabled": true,
+                        "url": "https://opw.example.com",
+                        "use_v3_api": {
+                            "series": true
+                        }
+                    }
+                }
+            })))
+            .await
+            .unwrap();
+
+        await_config(&system, "the streamed metrics V3 routing configuration", |config| {
+            config.shared.metrics_encoding.v3_series_mode.mode == "false"
+                && config
+                    .shared
+                    .metrics_encoding
+                    .v3_series_mode
+                    .endpoint_modes
+                    .get("https://app.datadoghq.com")
+                    .is_some_and(|mode| mode == "true")
+        })
+        .await;
+
+        let config = system.config();
+        let metrics = &config.shared.metrics_encoding;
+        assert!(!metrics.use_v2_series_api);
+        assert_eq!(metrics.v3_api.compression_level, 7);
+        assert_eq!(metrics.v3_api.series.endpoints, vec!["https://app.us3.datadoghq.com"]);
+        assert!(metrics.v3_api.series.validate);
+        assert!(metrics.v3_api.series.use_beta);
+        assert_eq!(metrics.v3_api.series.beta_route, "/api/intake/metrics/custom/series");
+        assert_eq!(metrics.v3_api.series.shadow_sample_rate, 0.25);
+        assert_eq!(metrics.v3_api.series.shadow_sites, vec!["us3.datadoghq.com"]);
+
+        let opw = &config.shared.endpoints.opw_intake;
+        assert!(opw.enabled);
+        assert_eq!(opw.url, "https://opw.example.com");
+        assert!(opw.use_v3_series);
+    }
+
+    #[tokio::test]
     async fn flat_env_key_overlays_onto_nested_datadog_slot() {
         // A flat, underscore-joined key (the shape an environment variable produces) is relocated
         // into the nested `autoscaling.failover.*` slot the Datadog deserializer reads. The string

--- a/lib/agent-data-plane-config/src/shared.rs
+++ b/lib/agent-data-plane-config/src/shared.rs
@@ -249,10 +249,6 @@ pub struct MetricsEncoding {
 
     /// Global and per-endpoint V3 series routing mode (`use_v3_api.series.*`).
     pub v3_series_mode: V3SeriesMode,
-
-    /// ADP-only safety gate that authorizes V3 series (`data_plane.metrics.v3.series.enabled`, not
-    /// in the Datadog Agent config schema).
-    pub v3_series_enabled: bool,
 }
 
 /// V3 metrics-intake protocol settings for the series and sketches payloads

--- a/lib/agent-data-plane-config/src/shared.rs
+++ b/lib/agent-data-plane-config/src/shared.rs
@@ -304,7 +304,10 @@ impl Default for V3ApiSettings {
 /// Global and per-endpoint V3 series routing mode (`use_v3_api.series.*`).
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct V3SeriesMode {
-    /// Global V3 series mode. TODO: consider modeling as an enum.
+    /// Global V3 series mode.
+    ///
+    /// Defaults to `datadog_only`, which enables V3 only for configured Datadog intake URLs.
+    /// TODO: consider modeling as an enum.
     pub mode: String,
 
     /// Per-endpoint V3 series mode overrides, keyed by endpoint URL.
@@ -314,7 +317,7 @@ pub struct V3SeriesMode {
 impl Default for V3SeriesMode {
     fn default() -> Self {
         Self {
-            mode: "true".to_string(),
+            mode: "datadog_only".to_string(),
             endpoint_modes: HashMap::new(),
         }
     }

--- a/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
+++ b/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
@@ -24,24 +24,6 @@ pub struct SalukiKey {
 pub static SALUKI_KEYS: &[SalukiKey] = &[
     // ── data_plane.rs ────────────────────────────────────────────────────────
     SalukiKey {
-        yaml_path: "data_plane.metrics.v3.series.enabled",
-        description: "Enable ADP V3 series",
-        default: "false",
-        documentation: Some(
-            "ADP requires this flag before it generates or forwards authoritative V3 series payloads. \
-             This is separate from `use_v3_api.series.*`, which matches the Core Agent V3 routing configuration.",
-        ),
-        value_type: "ValueType::Bool",
-        schema_default: Some("false"),
-        env_vars: &[],
-        env_var_override: None,
-        additional_yaml_paths: &[],
-        used_by: &["DATADOG_METRICS_CONFIGURATION", "FORWARDER_CONFIGURATION"],
-        test_json: None,
-        pipeline_affinity: "PipelineAffinity::Pipelines(&[Pipeline::DogStatsD])",
-        filename: "data_plane.rs",
-    },
-    SalukiKey {
         yaml_path: "data_plane.otlp.receiver_grpc_endpoint_temporary",
         description: "ADP OTLP gRPC listen endpoint",
         default: "localhost:6317",

--- a/lib/datadog-agent/config-testing/src/config_registry/data_plane.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/data_plane.rs
@@ -4,14 +4,6 @@ use super::schema;
 #[allow(unused_imports)]
 use super::*;
 
-static DATA_PLANE_METRICS_V3_SERIES_ENABLED_SCHEMA: SchemaEntry = SchemaEntry {
-    schema: Schema::Saluki,
-    yaml_path: "data_plane.metrics.v3.series.enabled",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: Some("false"),
-};
-
 static DATA_PLANE_OTLP_RECEIVER_GRPC_ENDPOINT_TEMPORARY_SCHEMA: SchemaEntry = SchemaEntry {
     schema: Schema::Saluki,
     yaml_path: "data_plane.otlp.receiver_grpc_endpoint_temporary",
@@ -66,17 +58,6 @@ crate::declare_annotations! {
         value_type_override: None,
         test_json: None,
         pipeline_affinity: PipelineAffinity::CrossCutting,
-    };
-    /// `data_plane.metrics.v3.series.enabled`
-    DATA_PLANE_METRICS_V3_SERIES_ENABLED = SalukiAnnotation {
-        schema: &DATA_PLANE_METRICS_V3_SERIES_ENABLED_SCHEMA,
-        support_level: SupportLevel::Full,
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[structs::DATADOG_METRICS_CONFIGURATION, structs::FORWARDER_CONFIGURATION],
-        value_type_override: None,
-        test_json: None,
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
     };
     /// `data_plane.otlp.proxy.logs.enabled`-Proxy OTLP logs to Core Agent
     DATA_PLANE_OTLP_PROXY_LOGS_ENABLED = SalukiAnnotation {

--- a/lib/datadog-agent/config/schema/core/core_schema.yaml
+++ b/lib/datadog-agent/config/schema/core/core_schema.yaml
@@ -9985,7 +9985,7 @@ properties:
           enabled:
             node_type: setting
             type: string
-            default: 'true'
+            default: datadog_only
           endpoints:
             node_type: setting
             type: object

--- a/lib/datadog-agent/config/src/generated/datadog_configuration.rs
+++ b/lib/datadog-agent/config/src/generated/datadog_configuration.rs
@@ -1844,7 +1844,7 @@ pub mod defaults {
         vec!["datadoghq.com".to_string()]
     }
     pub(super) fn datadog_configuration_use_v3_api_series_enabled() -> String {
-        "true".to_string()
+        "datadog_only".to_string()
     }
 }
 

--- a/lib/datadog-agent/config/src/remapper.rs
+++ b/lib/datadog-agent/config/src/remapper.rs
@@ -170,11 +170,6 @@ pub const KEY_ALIASES: &[(&str, &str)] = &[
     // shared ADP config structs.
     ("use_v3_api.series.enabled", "use_v3_api_series_enabled"),
     ("use_v3_api.series.endpoints", "use_v3_api_series_endpoints"),
-    // ADP-specific safety gate for enabling authoritative V3 series.
-    (
-        "data_plane.metrics.v3.series.enabled",
-        "data_plane_metrics_v3_series_enabled",
-    ),
     // ADP-specific zstd compression level: YAML `data_plane.serializer_zstd_compressor_level` →
     // flat key `data_plane_serializer_zstd_compressor_level`. This lets both YAML and env-var
     // sources feed the shared encoder config structs with correct precedence.

--- a/lib/saluki-components/src/common/datadog/config.rs
+++ b/lib/saluki-components/src/common/datadog/config.rs
@@ -258,13 +258,6 @@ pub struct ForwarderConfiguration {
     #[serde(flatten)]
     use_v3_api_series: UseV3ApiSeriesConfig,
 
-    /// ADP safety gate for authoritative V3 series metrics.
-    ///
-    /// Defaults to `false`. This keeps ADP on V2 unless both Agent-compatible V3 config and this ADP-specific flag
-    /// enable V3.
-    #[serde(default, rename = "data_plane_metrics_v3_series_enabled")]
-    data_plane_metrics_v3_series_enabled: bool,
-
     /// Payload compressor kind used by the metrics serializer.
     ///
     /// V3 metrics intake is incompatible with zlib/deflate, so the forwarder needs this setting to keep endpoint
@@ -477,11 +470,6 @@ impl ForwarderConfiguration {
     /// Returns the Agent-compatible V3 series configuration.
     pub(crate) const fn use_v3_api_series(&self) -> &UseV3ApiSeriesConfig {
         &self.use_v3_api_series
-    }
-
-    /// Returns true when the ADP V3 series safety gate is enabled.
-    pub(crate) const fn data_plane_metrics_v3_series_enabled(&self) -> bool {
-        self.data_plane_metrics_v3_series_enabled
     }
 
     /// Returns the OPW/Vector V3 series override for metrics-primary routing, if configured.
@@ -980,22 +968,12 @@ mod tests {
                             "http://datadog.example.com": false
                         }
                     }
-                },
-                "data_plane": {
-                    "metrics": {
-                        "v3": {
-                            "series": {
-                                "enabled": true
-                            }
-                        }
-                    }
                 }
             })),
             None,
         )
         .await;
 
-        assert!(config.data_plane_metrics_v3_series_enabled());
         assert_eq!(config.use_v3_api_series().enabled, "datadog_only");
         assert_eq!(
             config.use_v3_api_series().endpoints.get(DATADOG_URL),

--- a/lib/saluki-components/src/common/datadog/config.rs
+++ b/lib/saluki-components/src/common/datadog/config.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use agent_data_plane_config::shared::{Endpoints, MetricsEncoding};
 use facet::Facet;
 use saluki_config::GenericConfiguration;
 use saluki_error::GenericError;
@@ -342,6 +343,21 @@ impl ForwarderConfiguration {
         Ok(forwarder_config)
     }
 
+    /// Applies authoritative typed metrics-routing configuration.
+    pub(crate) fn apply_typed_metrics_configuration(&mut self, metrics: &MetricsEncoding, endpoints: &Endpoints) {
+        self.opw_metrics = OpwMetricsConfiguration {
+            observability_pipelines_worker_enabled: endpoints.opw_intake.enabled,
+            observability_pipelines_worker_url: endpoints.opw_intake.url.clone(),
+            observability_pipelines_worker_use_v3_api_series: endpoints.opw_intake.use_v3_series,
+            vector_enabled: endpoints.vector_intake.enabled,
+            vector_url: endpoints.vector_intake.url.clone(),
+            vector_use_v3_api_series: endpoints.vector_intake.use_v3_series,
+        };
+        self.v3_api = (&metrics.v3_api).into();
+        self.use_v3_api_series = (&metrics.v3_series_mode).into();
+        self.serializer_compressor_kind = endpoints.compression.compressor_kind.clone();
+    }
+
     /// Returns the maximum number of concurrent requests for an individual endpoint.
     pub const fn endpoint_concurrency(&self) -> usize {
         let endpoint_concurrency = if self.endpoint_concurrency == 0 {
@@ -390,7 +406,9 @@ impl ForwarderConfiguration {
 
     /// Forces series metrics routing to accept only V2 payloads.
     pub(crate) fn force_v2_series(&mut self) {
-        self.data_plane_metrics_v3_series_enabled = false;
+        self.use_v3_api_series.enabled = "false".to_string();
+        self.use_v3_api_series.endpoints.clear();
+        self.v3_api.series.endpoints.clear();
         self.v3_api.series.shadow_sites.clear();
     }
 
@@ -524,6 +542,8 @@ impl ForwarderConfiguration {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use saluki_config::ConfigurationLoader;
 
     use super::*;
@@ -979,6 +999,46 @@ mod tests {
             config.use_v3_api_series().endpoints.get(DATADOG_URL),
             Some(&"false".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn typed_metrics_routing_is_authoritative() {
+        let mut config = forwarder_config_from(
+            config_with(serde_json::json!({
+                "serializer_compressor_kind": "zlib",
+                "use_v3_api_series_enabled": "true",
+                "observability_pipelines_worker_metrics_enabled": false,
+            })),
+            None,
+        )
+        .await;
+
+        let mut endpoints = Endpoints::default();
+        endpoints.compression.compressor_kind = "zstd".to_string();
+        endpoints.opw_intake.enabled = true;
+        endpoints.opw_intake.url = OPW_URL.to_string();
+        endpoints.opw_intake.use_v3_series = true;
+        let mut metrics = MetricsEncoding::default();
+        metrics.v3_api.compression_level = 7;
+        metrics.v3_api.series.validate = true;
+        metrics.v3_series_mode.mode = "false".to_string();
+        metrics.v3_series_mode.endpoint_modes = HashMap::from([(DATADOG_URL.to_string(), "true".to_string())]);
+
+        config.apply_typed_metrics_configuration(&metrics, &endpoints);
+
+        assert_eq!(config.serializer_compressor_kind, "zstd");
+        assert_eq!(config.v3_api.compression_level, 7);
+        assert!(config.v3_api.series.validate);
+        assert_eq!(config.use_v3_api_series.enabled, "false");
+        assert_eq!(
+            config.use_v3_api_series.endpoints.get(DATADOG_URL),
+            Some(&"true".to_string())
+        );
+        assert_eq!(
+            endpoint_urls_by_route(&config, EndpointRoute::MetricsPrimary),
+            vec![OPW_URI]
+        );
+        assert_eq!(config.opw_metrics_v3_series_override(), Some(true));
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/common/datadog/endpoints.rs
+++ b/lib/saluki-components/src/common/datadog/endpoints.rs
@@ -82,8 +82,6 @@ pub(crate) struct V3EndpointConfig<'a> {
     pub(crate) resolved_endpoint: &'a Url,
     /// Optional primary endpoint name used by serializer V3 endpoint-list matching.
     pub(crate) serializer_v3_configured_endpoint: Option<&'a str>,
-    /// Whether the ADP V3 series safety gate is enabled.
-    pub(crate) data_plane_v3_series_enabled: bool,
     /// Agent-compatible V3 series config.
     pub(crate) series_config: &'a UseV3ApiSeriesConfig,
     /// OPW/Vector route-specific V3 override.
@@ -137,7 +135,7 @@ impl EndpointV3Settings {
         }
     }
 
-    /// Creates V3 settings using Agent-compatible series V3 configuration plus the ADP safety gate.
+    /// Creates V3 settings using Agent-compatible series V3 configuration.
     ///
     /// `V3EndpointConfig::serializer_v3_configured_endpoint` lets metrics-primary OPW/Vector routes match
     /// `serializer_experimental_use_v3_api.series.endpoints` against the normal primary endpoint name, matching the
@@ -148,26 +146,25 @@ impl EndpointV3Settings {
                 || config.serializer_v3_configured_endpoint.is_some_and(|endpoint| {
                     serializer_v3_config_matches_endpoint(endpoint, config.serializer_v3_series_endpoints)
                 });
-        let use_v3_series = config.data_plane_v3_series_enabled
-            && if serializer_use_v3_series {
-                true
-            } else if let Some(metrics_primary_use_v3) = config.metrics_primary_v3_override {
-                metrics_primary_use_v3
-            } else if let Some(endpoint_value) = config.series_config.endpoints.get(config.configured_endpoint) {
-                evaluate_series_v3_mode(
-                    "use_v3_api.series.endpoints",
-                    endpoint_value,
-                    config.configured_endpoint,
-                    Some(config.resolved_endpoint),
-                )
-            } else {
-                evaluate_series_v3_mode(
-                    "use_v3_api.series.enabled",
-                    &config.series_config.enabled,
-                    config.configured_endpoint,
-                    Some(config.resolved_endpoint),
-                )
-            };
+        let use_v3_series = if serializer_use_v3_series {
+            true
+        } else if let Some(metrics_primary_use_v3) = config.metrics_primary_v3_override {
+            metrics_primary_use_v3
+        } else if let Some(endpoint_value) = config.series_config.endpoints.get(config.configured_endpoint) {
+            evaluate_series_v3_mode(
+                "use_v3_api.series.endpoints",
+                endpoint_value,
+                config.configured_endpoint,
+                Some(config.resolved_endpoint),
+            )
+        } else {
+            evaluate_series_v3_mode(
+                "use_v3_api.series.enabled",
+                &config.series_config.enabled,
+                config.configured_endpoint,
+                Some(config.resolved_endpoint),
+            )
+        };
 
         let use_v3_sketches = config
             .serializer_v3_sketches_endpoints
@@ -1435,7 +1432,6 @@ mod tests {
             configured_endpoint: endpoint.configured_endpoint(),
             resolved_endpoint: endpoint.endpoint(),
             serializer_v3_configured_endpoint: None,
-            data_plane_v3_series_enabled: true,
             series_config,
             metrics_primary_v3_override: None,
             serializer_v3_series_endpoints: &[],
@@ -1447,20 +1443,10 @@ mod tests {
     }
 
     #[test]
-    fn agent_v3_default_requires_data_plane_gate() {
+    fn agent_v3_default_enables_authoritative_v3() {
         let resolved = ResolvedEndpoint::from_raw_endpoint("https://app.datadoghq.com", "fake-api-key")
             .expect("endpoint should resolve");
         let series_config = UseV3ApiSeriesConfig::default();
-
-        let settings = EndpointV3Settings::from_v3_config(V3EndpointConfig {
-            data_plane_v3_series_enabled: false,
-            series_shadow_sites: &["datadoghq.com".to_string()],
-            ..v3_endpoint_config(&resolved, &series_config)
-        });
-        assert!(!settings.use_v3_series);
-        assert!(settings.series_shadow_mode);
-        assert!(settings.should_receive_payload(Some(MetricsPayloadInfo::v3_shadow_series())));
-        assert!(!settings.should_receive_payload(Some(MetricsPayloadInfo::v3_series())));
 
         let settings = EndpointV3Settings::from_v3_config(V3EndpointConfig {
             series_shadow_sites: &["datadoghq.com".to_string()],
@@ -1606,7 +1592,7 @@ mod tests {
     }
 
     #[test]
-    fn serializer_v3_endpoint_list_wins_when_data_plane_gate_enabled() {
+    fn serializer_v3_endpoint_list_wins_over_other_agent_settings() {
         let resolved = ResolvedEndpoint::from_raw_endpoint("https://vector.example.com", "fake-api-key")
             .expect("endpoint should resolve");
         let series_config = UseV3ApiSeriesConfig {

--- a/lib/saluki-components/src/common/datadog/endpoints.rs
+++ b/lib/saluki-components/src/common/datadog/endpoints.rs
@@ -18,8 +18,9 @@ use url::Url;
 
 use super::protocol::{MetricsPayloadInfo, MetricsProtocolVersion, UseV3ApiSeriesConfig};
 
-static DD_URL_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^app(\.mrf)?(\.[a-z]{2}\d)?\.(datad(oghq|0g)\.(com|eu)|ddog-gov\.com)$").unwrap());
+static DD_URL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^app(\.mrf)?\.([a-z]{2,}\d{1,2}\.)?(datad(?:oghq|0g)\.(?:com|eu)|ddog-gov\.com)$").unwrap()
+});
 static DD_SITE_FROM_HOSTNAME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?:^|\.)([a-z]{2,}\d{1,2}\.)?(datad(?:oghq|0g)\.(?:com|eu)|ddog-gov\.com)\.?$").unwrap()
 });
@@ -155,14 +156,12 @@ impl EndpointV3Settings {
                 "use_v3_api.series.endpoints",
                 endpoint_value,
                 config.configured_endpoint,
-                Some(config.resolved_endpoint),
             )
         } else {
             evaluate_series_v3_mode(
                 "use_v3_api.series.enabled",
                 &config.series_config.enabled,
                 config.configured_endpoint,
-                Some(config.resolved_endpoint),
             )
         };
 
@@ -289,27 +288,14 @@ fn parse_series_v3_mode(value: &str) -> SeriesV3Mode {
 }
 
 fn configured_endpoint_is_datadog_url(configured_endpoint: &str) -> bool {
-    let endpoint = configured_endpoint.trim();
-    if endpoint.is_empty() {
-        return false;
-    }
-
-    if Url::parse(endpoint).is_ok_and(|url| is_datadog_url(&url)) {
-        return true;
-    }
-
-    Authority::from_str(endpoint).is_ok_and(|authority| is_datadog_host(authority.host()))
+    Url::parse(configured_endpoint.trim()).is_ok_and(|url| is_datadog_url(&url))
 }
 
-pub(crate) fn evaluate_series_v3_mode(
-    config_key: &'static str, value: &str, configured_endpoint: &str, resolved_endpoint: Option<&Url>,
-) -> bool {
+pub(crate) fn evaluate_series_v3_mode(config_key: &'static str, value: &str, configured_endpoint: &str) -> bool {
     match parse_series_v3_mode(value) {
         SeriesV3Mode::Enabled => true,
         SeriesV3Mode::Disabled => false,
-        SeriesV3Mode::DatadogOnly => {
-            configured_endpoint_is_datadog_url(configured_endpoint) || resolved_endpoint.is_some_and(is_datadog_url)
-        }
+        SeriesV3Mode::DatadogOnly => configured_endpoint_is_datadog_url(configured_endpoint),
         SeriesV3Mode::Invalid => {
             warn!(
                 config_key,
@@ -324,7 +310,7 @@ pub(crate) fn series_v3_config_can_enable_v3(series_config: &UseV3ApiSeriesConfi
     if series_config
         .endpoints
         .iter()
-        .any(|(endpoint, value)| evaluate_series_v3_mode("use_v3_api.series.endpoints", value, endpoint, None))
+        .any(|(endpoint, value)| evaluate_series_v3_mode("use_v3_api.series.endpoints", value, endpoint))
     {
         return true;
     }
@@ -1505,41 +1491,30 @@ mod tests {
     }
 
     #[test]
-    fn agent_v3_datadog_only_config_viability_accepts_schemeless_datadog_endpoints() {
+    fn agent_v3_datadog_only_config_viability_matches_core_agent_url_rules() {
         let mut series_config = UseV3ApiSeriesConfig {
             enabled: "false".to_string(),
             endpoints: HashMap::new(),
         };
-        series_config
-            .endpoints
-            .insert("app.datadoghq.com".to_string(), "datadog_only".to_string());
+        for endpoint in [
+            "https://app.datadoghq.com",
+            "https://APP.DATADOGHQ.COM",
+            "https://app.datadoghq.com.:443",
+            "https://app.us12.datadoghq.com",
+            "https://app.apne1.datadoghq.com",
+        ] {
+            series_config.endpoints = HashMap::from([(endpoint.to_string(), "datadog_only".to_string())]);
+            assert!(series_v3_config_can_enable_v3(&series_config), "{endpoint}");
+        }
 
-        assert!(series_v3_config_can_enable_v3(&series_config));
-
-        series_config.endpoints.clear();
-        series_config
-            .endpoints
-            .insert("app.datadoghq.com:443".to_string(), "datadog_only".to_string());
-
-        assert!(series_v3_config_can_enable_v3(&series_config));
-
-        series_config.endpoints.clear();
-        series_config
-            .endpoints
-            .insert("APP.DATADOGHQ.COM".to_string(), "datadog_only".to_string());
-
-        assert!(series_v3_config_can_enable_v3(&series_config));
-
-        series_config.endpoints.clear();
-        series_config
-            .endpoints
-            .insert("example.com".to_string(), "datadog_only".to_string());
-
-        assert!(!series_v3_config_can_enable_v3(&series_config));
+        for endpoint in ["app.datadoghq.com", "app.datadoghq.com:443", "example.com"] {
+            series_config.endpoints = HashMap::from([(endpoint.to_string(), "datadog_only".to_string())]);
+            assert!(!series_v3_config_can_enable_v3(&series_config), "{endpoint}");
+        }
     }
 
     #[test]
-    fn agent_v3_datadog_only_endpoint_override_matches_schemeless_host_port() {
+    fn agent_v3_datadog_only_endpoint_override_rejects_schemeless_host_port() {
         let resolved = ResolvedEndpoint::from_raw_endpoint("app.datadoghq.com:443", "fake-api-key")
             .expect("endpoint should resolve");
         let mut series_config = UseV3ApiSeriesConfig {
@@ -1552,7 +1527,7 @@ mod tests {
 
         let settings = EndpointV3Settings::from_v3_config(v3_endpoint_config(&resolved, &series_config));
 
-        assert!(settings.use_v3_series);
+        assert!(!settings.use_v3_series);
     }
 
     #[test]

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -604,7 +604,6 @@ async fn run_endpoint_io_loop<B>(
             configured_endpoint: &configured_endpoint,
             resolved_endpoint: endpoint.endpoint(),
             serializer_v3_configured_endpoint: serializer_v3_configured_endpoint.as_deref(),
-            data_plane_v3_series_enabled: config.data_plane_metrics_v3_series_enabled(),
             series_config: config.use_v3_api_series(),
             metrics_primary_v3_override,
             serializer_v3_series_endpoints: &v3_api.series.endpoints,

--- a/lib/saluki-components/src/common/datadog/protocol.rs
+++ b/lib/saluki-components/src/common/datadog/protocol.rs
@@ -2,6 +2,9 @@
 
 use std::collections::HashMap;
 
+use agent_data_plane_config::shared::{
+    V3ApiEncoding as TypedV3ApiEncoding, V3ApiSettings as TypedV3ApiSettings, V3SeriesMode as TypedV3SeriesMode,
+};
 use facet::Facet;
 use serde::{Deserialize, Serialize};
 
@@ -20,7 +23,7 @@ fn default_v3_series_shadow_sites() -> Vec<String> {
 }
 
 fn default_use_v3_api_series_enabled() -> String {
-    "true".to_string()
+    "datadog_only".to_string()
 }
 
 #[derive(Deserialize)]
@@ -274,13 +277,36 @@ impl V3ApiConfig {
     }
 }
 
+impl From<&TypedV3ApiSettings> for V3ApiSettings {
+    fn from(settings: &TypedV3ApiSettings) -> Self {
+        Self {
+            endpoints: settings.endpoints.clone(),
+            validate: settings.validate,
+            use_beta: settings.use_beta,
+            beta_route: settings.beta_route.clone(),
+            shadow_sample_rate: settings.shadow_sample_rate,
+            shadow_sites: settings.shadow_sites.clone(),
+        }
+    }
+}
+
+impl From<&TypedV3ApiEncoding> for V3ApiConfig {
+    fn from(config: &TypedV3ApiEncoding) -> Self {
+        Self {
+            series: (&config.series).into(),
+            sketches: (&config.sketches).into(),
+            compression_level: config.compression_level,
+        }
+    }
+}
+
 /// Agent-compatible `use_v3_api.series` configuration.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Facet)]
 pub struct UseV3ApiSeriesConfig {
     /// Global V3 series mode.
     ///
     /// Valid Agent values are truthy strings, falsy strings, and `datadog_only`. Invalid values are treated as false by
-    /// the evaluator.
+    /// the evaluator. Defaults to `datadog_only`, which enables V3 only for configured Datadog intake URLs.
     #[serde(
         default = "default_use_v3_api_series_enabled",
         deserialize_with = "deserialize_v3_series_mode",
@@ -306,11 +332,20 @@ impl Default for UseV3ApiSeriesConfig {
     }
 }
 
+impl From<&TypedV3SeriesMode> for UseV3ApiSeriesConfig {
+    fn from(config: &TypedV3SeriesMode) -> Self {
+        Self {
+            enabled: config.mode.clone(),
+            endpoints: config.endpoint_modes.clone(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use serde::Deserialize;
 
-    use super::deserialize_v3_series_mode;
+    use super::{deserialize_v3_series_mode, UseV3ApiSeriesConfig};
 
     #[derive(Deserialize)]
     struct Wrapper {
@@ -339,5 +374,10 @@ mod tests {
         for (input, expected) in cases {
             assert_eq!(parse_mode(input.clone()), expected, "{input}");
         }
+    }
+
+    #[test]
+    fn v3_series_mode_defaults_to_datadog_only() {
+        assert_eq!(UseV3ApiSeriesConfig::default().enabled, "datadog_only");
     }
 }

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -367,12 +367,6 @@ pub struct DatadogMetricsConfiguration {
     #[serde(flatten)]
     use_v3_api_series: UseV3ApiSeriesConfig,
 
-    /// ADP safety gate for authoritative V3 series metrics.
-    ///
-    /// Defaults to `false`.
-    #[serde(default, rename = "data_plane_metrics_v3_series_enabled")]
-    data_plane_metrics_v3_series_enabled: bool,
-
     /// Enables routing all metrics to Observability Pipelines Worker.
     #[serde(default, rename = "observability_pipelines_worker_metrics_enabled")]
     observability_pipelines_worker_metrics_enabled: bool,
@@ -602,9 +596,8 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
             !self.additional_endpoints.is_empty(),
             &self.use_v3_api_series,
         );
-        let use_v3_series = self.data_plane_metrics_v3_series_enabled && series_v3_can_be_enabled;
         let series_mode = metrics_encoder_mode_for_config(
-            use_v3_series,
+            series_v3_can_be_enabled,
             self.v3_api.series.validate,
             metrics_v3_disabled_by_compressor,
         );

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -1,5 +1,6 @@
 use std::{collections::VecDeque, ops::Range, time::Duration};
 
+use agent_data_plane_config::shared::{Endpoints, MetricsEncoding};
 use async_trait::async_trait;
 use ddsketch::DDSketch;
 use facet::Facet;
@@ -420,6 +421,26 @@ impl DatadogMetricsConfiguration {
         Ok(config.as_typed()?)
     }
 
+    /// Creates a metrics encoder using authoritative typed metrics-routing configuration.
+    pub fn from_configuration_with_metrics_routing(
+        config: &GenericConfiguration, metrics: &MetricsEncoding, endpoints: &Endpoints,
+    ) -> Result<Self, GenericError> {
+        let mut metrics_config = Self::from_configuration(config)?;
+
+        metrics_config.compressor_kind = endpoints.compression.compressor_kind.clone();
+        metrics_config.use_v2_api_series = metrics.use_v2_series_api;
+        metrics_config.v3_api = (&metrics.v3_api).into();
+        metrics_config.use_v3_api_series = (&metrics.v3_series_mode).into();
+        metrics_config.observability_pipelines_worker_metrics_enabled = endpoints.opw_intake.enabled;
+        metrics_config.observability_pipelines_worker_metrics_url = endpoints.opw_intake.url.clone();
+        metrics_config.observability_pipelines_worker_metrics_use_v3_api_series = endpoints.opw_intake.use_v3_series;
+        metrics_config.vector_metrics_enabled = endpoints.vector_intake.enabled;
+        metrics_config.vector_metrics_url = endpoints.vector_intake.url.clone();
+        metrics_config.vector_metrics_use_v3_api_series = endpoints.vector_intake.use_v3_series;
+
+        Ok(metrics_config)
+    }
+
     /// Sets additional tags to be applied uniformly to all metrics forwarded by this destination.
     pub fn with_additional_tags(mut self, additional_tags: SharedTagSet) -> Self {
         self.additional_tags = Some(additional_tags);
@@ -442,8 +463,12 @@ impl DatadogMetricsConfiguration {
     ///
     /// This is used for local destinations that only accept the V2 series protocol, such as the Cluster Agent.
     pub fn with_v2_series_only(mut self) -> Self {
-        self.data_plane_metrics_v3_series_enabled = false;
+        self.use_v3_api_series.enabled = "false".to_string();
+        self.use_v3_api_series.endpoints.clear();
+        self.v3_api.series.endpoints.clear();
         self.v3_api.series.shadow_sample_rate = 0.0;
+        self.observability_pipelines_worker_metrics_use_v3_api_series = false;
+        self.vector_metrics_use_v3_api_series = false;
         self
     }
 
@@ -464,7 +489,6 @@ impl DatadogMetricsConfiguration {
             configured_endpoint: endpoint.configured_endpoint(),
             resolved_endpoint: endpoint.endpoint(),
             serializer_v3_configured_endpoint,
-            data_plane_v3_series_enabled: self.data_plane_metrics_v3_series_enabled,
             series_config: &self.use_v3_api_series,
             metrics_primary_v3_override,
             serializer_v3_series_endpoints: &self.v3_api.series.endpoints,
@@ -488,7 +512,7 @@ impl DatadogMetricsConfiguration {
     }
 
     fn requires_v2_series(&self, metrics_v3_disabled_by_compressor: bool) -> Result<bool, GenericError> {
-        if metrics_v3_disabled_by_compressor || !self.data_plane_metrics_v3_series_enabled {
+        if metrics_v3_disabled_by_compressor {
             return Ok(true);
         }
 
@@ -1921,11 +1945,12 @@ fn content_encoding_for_scheme(compression_scheme: CompressionScheme) -> Option<
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
+    use std::{collections::HashMap, io::Cursor};
 
     use bytes::Bytes;
     use datadog_protos::metrics::v3::MetricData as V3MetricData;
     use protobuf::Message as _;
+    use saluki_config::ConfigurationLoader;
     use saluki_context::{
         tags::{Tag, TagSet},
         Context,
@@ -1976,6 +2001,55 @@ serializer_experimental_use_v3_api:
             Some("https://app.datadoghq.eu"),
             config.v3_api.sketches.endpoints.first().map(String::as_str)
         );
+    }
+
+    #[tokio::test]
+    async fn typed_metrics_routing_is_authoritative() {
+        let (raw, _) = ConfigurationLoader::for_tests(
+            Some(serde_json::json!({
+                "serializer_compressor_kind": "zlib",
+                "use_v2_api_series": true,
+                "use_v3_api_series_enabled": "true",
+                "observability_pipelines_worker_metrics_enabled": false,
+            })),
+            None,
+            false,
+        )
+        .await;
+
+        let mut endpoints = Endpoints::default();
+        endpoints.compression.compressor_kind = "zstd".to_string();
+        endpoints.opw_intake.enabled = true;
+        endpoints.opw_intake.url = "https://opw.example.com".to_string();
+        endpoints.opw_intake.use_v3_series = true;
+        let mut metrics = MetricsEncoding {
+            use_v2_series_api: false,
+            ..Default::default()
+        };
+        metrics.v3_api.compression_level = 7;
+        metrics.v3_api.series.validate = true;
+        metrics.v3_series_mode.mode = "false".to_string();
+        metrics.v3_series_mode.endpoint_modes =
+            HashMap::from([("https://app.datadoghq.com".to_string(), "true".to_string())]);
+
+        let config = DatadogMetricsConfiguration::from_configuration_with_metrics_routing(&raw, &metrics, &endpoints)
+            .expect("configuration should deserialize");
+
+        assert_eq!(config.compressor_kind, "zstd");
+        assert!(!config.use_v2_api_series);
+        assert_eq!(config.v3_api.compression_level, 7);
+        assert!(config.v3_api.series.validate);
+        assert_eq!(config.use_v3_api_series.enabled, "false");
+        assert_eq!(
+            config.use_v3_api_series.endpoints.get("https://app.datadoghq.com"),
+            Some(&"true".to_string())
+        );
+        assert!(config.observability_pipelines_worker_metrics_enabled);
+        assert_eq!(
+            config.observability_pipelines_worker_metrics_url,
+            "https://opw.example.com"
+        );
+        assert!(config.observability_pipelines_worker_metrics_use_v3_api_series);
     }
 
     #[test]
@@ -2029,7 +2103,6 @@ serializer_experimental_use_v3_api:
     fn mixed_v2_and_v3_endpoints_require_v2_series() {
         let config = v3_series_config(
             r#"
-data_plane_metrics_v3_series_enabled: true
 use_v3_api_series_enabled: "datadog_only"
 additional_endpoints:
   https://custom.example.com:
@@ -2044,7 +2117,6 @@ additional_endpoints:
     fn validation_requires_v2_series() {
         let config = v3_series_config(
             r#"
-data_plane_metrics_v3_series_enabled: true
 use_v3_api_series_enabled: "true"
 serializer_experimental_use_v3_api:
   series:
@@ -2060,7 +2132,6 @@ serializer_experimental_use_v3_api:
         let config = v3_series_config(
             r#"
 dd_url: https://agent.datad0g.com.
-data_plane_metrics_v3_series_enabled: true
 use_v3_api_series_enabled: "false"
 additional_endpoints:
   https://agent.datadoghq.com.:
@@ -2081,7 +2152,6 @@ serializer_experimental_use_v3_api:
         let config = v3_series_config(
             r#"
 dd_url: https://primary.example.com
-data_plane_metrics_v3_series_enabled: true
 use_v3_api_series_enabled: "false"
 serializer_experimental_use_v3_api:
   series:
@@ -2108,7 +2178,6 @@ serializer_experimental_use_v3_api:
     fn v2_series_only_override_keeps_v2_and_disables_shadowing() {
         let config = v3_series_config(
             r#"
-data_plane_metrics_v3_series_enabled: true
 use_v3_api_series_enabled: "true"
 serializer_experimental_use_v3_api:
   series:
@@ -2117,7 +2186,9 @@ serializer_experimental_use_v3_api:
         )
         .with_v2_series_only();
 
-        assert!(!config.data_plane_metrics_v3_series_enabled);
+        assert_eq!("false", config.use_v3_api_series.enabled);
+        assert!(config.use_v3_api_series.endpoints.is_empty());
+        assert!(config.v3_api.series.endpoints.is_empty());
         assert_eq!(0.0, config.v3_api.series.shadow_sample_rate);
         assert!(config.requires_v2_series(false).expect("endpoint should resolve"));
     }

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -204,13 +204,14 @@ fn metrics_primary_url_can_resolve(url: &str) -> bool {
 }
 
 fn series_v3_can_be_enabled_for_config(
-    serializer_use_v3_series: bool, metrics_primary_v3_override: Option<bool>, has_additional_endpoints: bool,
-    series_config: &UseV3ApiSeriesConfig,
+    use_v2_api_series: bool, serializer_use_v3_series: bool, metrics_primary_v3_override: Option<bool>,
+    has_additional_endpoints: bool, series_config: &UseV3ApiSeriesConfig,
 ) -> bool {
-    serializer_use_v3_series
-        || metrics_primary_v3_override == Some(true)
-        || ((metrics_primary_v3_override != Some(false) || has_additional_endpoints)
-            && series_v3_config_can_enable_v3(series_config))
+    use_v2_api_series
+        && (serializer_use_v3_series
+            || metrics_primary_v3_override == Some(true)
+            || ((metrics_primary_v3_override != Some(false) || has_additional_endpoints)
+                && series_v3_config_can_enable_v3(series_config)))
 }
 
 /// Datadog Metrics encoder.
@@ -512,7 +513,7 @@ impl DatadogMetricsConfiguration {
     }
 
     fn requires_v2_series(&self, metrics_v3_disabled_by_compressor: bool) -> Result<bool, GenericError> {
-        if metrics_v3_disabled_by_compressor {
+        if !self.use_v2_api_series || metrics_v3_disabled_by_compressor {
             return Ok(true);
         }
 
@@ -615,6 +616,7 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
             self.vector_metrics_use_v3_api_series,
         );
         let series_v3_can_be_enabled = series_v3_can_be_enabled_for_config(
+            self.use_v2_api_series,
             self.v3_api.use_v3_series(),
             metrics_primary_v3_override,
             !self.additional_endpoints.is_empty(),
@@ -2128,6 +2130,36 @@ serializer_experimental_use_v3_api:
     }
 
     #[test]
+    fn v1_series_configuration_takes_precedence_over_v3() {
+        let config = v3_series_config(
+            r#"
+use_v2_api_series: false
+use_v3_api_series_enabled: "true"
+"#,
+        );
+
+        let series_v3_can_be_enabled = series_v3_can_be_enabled_for_config(
+            config.use_v2_api_series,
+            false,
+            None,
+            false,
+            &config.use_v3_api_series,
+        );
+
+        assert!(!series_v3_can_be_enabled);
+
+        assert_eq!(
+            MetricsEncoderMode::V2Only,
+            metrics_encoder_mode_for_config(series_v3_can_be_enabled, false, false)
+        );
+
+        assert!(
+            config.requires_v2_series(false).expect("endpoint should resolve"),
+            "V1 configuration must retain the legacy series builder even when V3 is enabled"
+        );
+    }
+
+    #[test]
     fn all_v3_serializer_endpoints_do_not_require_v2_series() {
         let config = v3_series_config(
             r#"
@@ -2200,24 +2232,28 @@ serializer_experimental_use_v3_api:
             selected_metrics_primary_v3_override(true, "http://[::1", false, true, "http://vector.example.com", false);
 
         assert!(!series_v3_can_be_enabled_for_config(
+            true,
             false,
             Some(false),
             false,
             &series_config
         ));
         assert!(series_v3_can_be_enabled_for_config(
+            true,
             false,
             Some(true),
             false,
             &series_config
         ));
         assert!(series_v3_can_be_enabled_for_config(
+            true,
             false,
             Some(false),
             true,
             &series_config
         ));
         assert!(series_v3_can_be_enabled_for_config(
+            true,
             true,
             Some(false),
             false,
@@ -2225,6 +2261,7 @@ serializer_experimental_use_v3_api:
         ));
         assert_eq!(None, invalid_metrics_primary_override);
         assert!(series_v3_can_be_enabled_for_config(
+            true,
             false,
             invalid_metrics_primary_override,
             false,

--- a/lib/saluki-components/src/forwarders/cluster_agent/mod.rs
+++ b/lib/saluki-components/src/forwarders/cluster_agent/mod.rs
@@ -1,5 +1,6 @@
 //! Cluster Agent forwarder.
 
+use agent_data_plane_config::shared::{Endpoints, MetricsEncoding};
 use async_trait::async_trait;
 use http::{
     header::AUTHORIZATION,
@@ -61,6 +62,20 @@ impl ClusterAgentForwarderConfiguration {
             forwarder_config,
             auth_header_value,
         })
+    }
+
+    /// Creates a Cluster Agent forwarder using authoritative typed metrics-routing configuration.
+    pub fn from_configuration_with_metrics_routing(
+        config: &GenericConfiguration, metrics: &MetricsEncoding, endpoints: &Endpoints, endpoint_url: String,
+        auth_token: String,
+    ) -> Result<Self, GenericError> {
+        let mut config = Self::from_configuration(config, endpoint_url, auth_token)?;
+        config
+            .forwarder_config
+            .apply_typed_metrics_configuration(metrics, endpoints);
+        config.forwarder_config.clear_opw_metrics_endpoint();
+        config.forwarder_config.force_v2_series();
+        Ok(config)
     }
 }
 
@@ -252,12 +267,7 @@ mod tests {
                         "url": "https://opw.example.com"
                     }
                 },
-                "data_plane_metrics_v3_series_enabled": true,
-                "use_v3_api": {
-                    "series": {
-                        "enabled": "true"
-                    }
-                },
+                "use_v3_api_series_enabled": "true",
                 "serializer_experimental_use_v3_api": {
                     "series": {
                         "shadow_sites": ["example.com"]
@@ -271,14 +281,19 @@ mod tests {
 
         let unmodified_forwarder =
             ForwarderConfiguration::from_configuration(&config).expect("forwarder configuration should parse");
-        assert!(unmodified_forwarder.data_plane_metrics_v3_series_enabled());
+        assert_eq!("true", unmodified_forwarder.use_v3_api_series().enabled);
         assert_eq!(
             &["example.com".to_string()],
             unmodified_forwarder.v3_api().series.shadow_sites.as_slice()
         );
 
-        let config = ClusterAgentForwarderConfiguration::from_configuration(
+        let mut metrics = MetricsEncoding::default();
+        metrics.v3_series_mode.mode = "true".to_string();
+        metrics.v3_api.series.shadow_sites = vec!["example.com".to_string()];
+        let config = ClusterAgentForwarderConfiguration::from_configuration_with_metrics_routing(
             &config,
+            &metrics,
+            &Endpoints::default(),
             "https://cluster-agent.example.com".to_string(),
             "secret-token".to_string(),
         )
@@ -295,7 +310,9 @@ mod tests {
             "https://cluster-agent.example.com/"
         );
         assert_eq!(endpoints[0].endpoint().cached_api_key(), "secret-token");
-        assert!(!config.forwarder_config.data_plane_metrics_v3_series_enabled());
+        assert_eq!("false", config.forwarder_config.use_v3_api_series().enabled);
+        assert!(config.forwarder_config.use_v3_api_series().endpoints.is_empty());
+        assert!(config.forwarder_config.v3_api().series.endpoints.is_empty());
         assert!(config.forwarder_config.v3_api().series.shadow_sites.is_empty());
     }
 }

--- a/lib/saluki-components/src/forwarders/datadog/mod.rs
+++ b/lib/saluki-components/src/forwarders/datadog/mod.rs
@@ -1,3 +1,4 @@
+use agent_data_plane_config::shared::{Endpoints, MetricsEncoding};
 use async_trait::async_trait;
 use http::Uri;
 use saluki_common::buf::FrozenChunkedBytesBuffer;
@@ -47,6 +48,17 @@ impl DatadogForwarderConfiguration {
             forwarder_config,
             configuration: Some(config.clone()),
         })
+    }
+
+    /// Creates a forwarder using authoritative typed metrics-routing configuration.
+    pub fn from_configuration_with_metrics_routing(
+        config: &GenericConfiguration, metrics: &MetricsEncoding, endpoints: &Endpoints,
+    ) -> Result<Self, GenericError> {
+        let mut config = Self::from_configuration(config)?;
+        config
+            .forwarder_config
+            .apply_typed_metrics_configuration(metrics, endpoints);
+        Ok(config)
     }
 
     /// Overrides the default endpoint and refreshes its API key from the given config path.


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

- Remove the ADP-specific `data_plane.metrics.v3.series.enabled` gate.
- Use the authoritative typed Agent configuration for metrics protocol and endpoint routing.
- Match Core Agent behavior for `use_v3_api.series.*`, including the `datadog_only` default, per-endpoint overrides, and Datadog URL recognition.
- Apply the same routing configuration across primary, OPW/Vector, MRF, and autoscaling metrics paths.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
