### PR TITLE
fix(tls): ignore permission denied errors when loading individual TLS certs from root store

### DIFF
--- a/lib/saluki-tls/src/lib.rs
+++ b/lib/saluki-tls/src/lib.rs
@@ -524,8 +524,9 @@ fn default_crypto_provider() -> CryptoProvider {
 /// ## Errors
 ///
 /// If errors occur during certificate loading and no certificates were ultimately added to the store, an error is
-/// returned. Missing files or directories referenced by `SSL_CERT_FILE`/`SSL_CERT_DIR` are tolerated and treated as
-/// "no certificates available" rather than as a load failure.
+/// returned. Missing or unreadable files and directories referenced by `SSL_CERT_FILE`/`SSL_CERT_DIR` are tolerated and
+/// treated as "no certificates available" rather than as a load failure; only certificate-content errors (such as
+/// malformed PEM) or other IO failures can fail the load.
 ///
 /// [c_rehash]: https://www.openssl.org/docs/manmaster/man1/c_rehash.html
 pub fn load_platform_root_certificates() -> Result<(), GenericError> {
@@ -558,21 +559,34 @@ pub fn load_platform_root_certificates() -> Result<(), GenericError> {
 ///
 /// If errors occur during certificate loading and no certificates were ultimately added to the store, an error is
 /// returned. Otherwise, even if some certificates failed to parse, the store is returned with whatever certificates were
-/// successfully added. Missing files or directories referenced by `SSL_CERT_FILE`/`SSL_CERT_DIR` are tolerated and do
-/// not produce an error.
+/// successfully added. Missing or unreadable files and directories referenced by `SSL_CERT_FILE`/`SSL_CERT_DIR` are
+/// tolerated and do not produce an error.
 pub fn load_platform_root_certificates_inner() -> Result<RootCertStore, GenericError> {
     let mut root_cert_store = RootCertStore::empty();
 
     let mut result = rustls_native_certs::load_native_certs();
 
-    // Drop "not found" IO errors before evaluating success or failure: a missing `SSL_CERT_FILE` or `SSL_CERT_DIR`
-    // should look like "no certificates available" rather than a load failure, since callers may simply not have set
-    // those env vars on this host.
-    result.errors.retain(|err| {
-        !matches!(
-            &err.kind,
-            rustls_native_certs::ErrorKind::Io { inner, .. } if inner.kind() == std::io::ErrorKind::NotFound,
-        )
+    // Drop tolerable filesystem-access IO errors before evaluating success or failure. A missing (`NotFound`) or
+    // unreadable (`PermissionDenied`) `SSL_CERT_FILE`/`SSL_CERT_DIR` entry should look like "no certificates available"
+    // rather than a load failure: callers may simply not have set those env vars on this host, and a host's cert store
+    // may reference files this process can't read. This mirrors Go's TLS stack (and thus the Datadog Agent), which
+    // skips cert files it can't read. Other IO errors and all certificate-content errors (PEM parse / OS store) are
+    // retained and can still fail the load below when nothing was added.
+    result.errors.retain(|err| match &err.kind {
+        rustls_native_certs::ErrorKind::Io { inner, path }
+            if matches!(
+                inner.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied
+            ) =>
+        {
+            debug!(
+                error = %inner,
+                path = %path.display(),
+                "Skipping missing or unreadable certificate source while loading platform root certificates."
+            );
+            false
+        }
+        _ => true,
     });
 
     // For whatever certificates we _did_ get back, try and add them to the root certificate store.

--- a/lib/saluki-tls/tests/permission_denied_cert_is_tolerated.rs
+++ b/lib/saluki-tls/tests/permission_denied_cert_is_tolerated.rs
@@ -1,0 +1,32 @@
+//! Integration test: an unreadable certificate file in the cert directory is tolerated. The loader skips it (logging at
+//! debug level) and returns an empty store rather than failing bootstrap, mirroring Go's TLS stack (and thus the
+//! Datadog Agent), which skips cert files it can't read.
+#![cfg(unix)]
+
+mod common;
+
+use std::{fs, os::unix::fs::PermissionsExt};
+
+use tempfile::TempDir;
+
+#[test]
+fn permission_denied_cert_is_tolerated() {
+    let temp_dir = TempDir::new().expect("should create temp dir");
+    let cert_path = temp_dir.path().join("unreadable.pem");
+    common::write_self_signed_cert(&cert_path);
+    fs::set_permissions(&cert_path, fs::Permissions::from_mode(0o000)).expect("should chmod cert file");
+
+    // Running as root bypasses filesystem permission checks, so the file would still be readable and the scenario under
+    // test can't be reproduced. Skip in that case rather than assert something untrue.
+    if fs::read(&cert_path).is_ok() {
+        eprintln!("skipping: process can read a mode-0000 file (likely running as root)");
+        return;
+    }
+
+    common::use_cert_dir(temp_dir.path());
+
+    let store =
+        saluki_tls::load_platform_root_certificates_inner().expect("expected unreadable certificate to be tolerated");
+
+    assert!(store.is_empty());
+}


### PR DESCRIPTION
## Summary

This PR updates the root store certificate loading logic in `saluki-tls` to ignore `PermissionDenied` errors when loading individual certificate files found in the certificate directory.

Prior to this PR, we only ignored `NotFound` errors, which silenced errors for improperly set values of `SSL_CERT_FILE` and `SSL_CERT_DIR`, but did nothing if those files existed _but_ had improper permissions such that ADP could not read them.

As part of reasonably matching the behavior of Datadog Agent (but, really, in this case, the behavior of Go, in terms of loading the root trust store), we now ignore `PermissionDenied` errors as well. This ensures that if there are SSL certificate directories without _any_ readable certificate files (permissions-wise), we don't throw an unrecoverable error, but simply proceed with an empty root trust store.

All other errors -- actual failures to parse certificates we _can_ load, etc -- are still collected and surfaced to the caller.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing unit/integration tests and a new integration test that exercises an SSL cert directory with only a single certificate file that has improper permissions.

## References

DADP-2

Closes #2107 
