### PR TITLE
fix(config): isolate tests from ambient proxy variables

### DIFF
--- a/bin/agent-data-plane/src/components/dogstatsd_prefix_filter/mod.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_prefix_filter/mod.rs
@@ -744,7 +744,7 @@ mod config_smoke {
                     .expect("DogStatsDPrefixFilterConfiguration should deserialize")
             },
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await
     }

--- a/lib/datadog-agent/config-testing/src/smoke_test.rs
+++ b/lib/datadog-agent/config-testing/src/smoke_test.rs
@@ -109,7 +109,7 @@ async fn make_config_from_file<P, F>(
 ) -> GenericConfiguration
 where
     P: Provider + Send + Sync + 'static,
-    F: FnOnce() -> P,
+    F: FnOnce(Vec<(String, String)>) -> P,
 {
     let (cfg, _) = ConfigurationLoader::for_tests_with_provider_factory(
         Some(file_values),
@@ -128,7 +128,7 @@ async fn make_config_from_env<P, F>(
 ) -> GenericConfiguration
 where
     P: Provider + Send + Sync + 'static,
-    F: FnOnce() -> P,
+    F: FnOnce(Vec<(String, String)>) -> P,
 {
     let (cfg, _) = ConfigurationLoader::for_tests_with_provider_factory(
         Some(base_file_values.clone()),
@@ -155,8 +155,8 @@ where
 /// **Full field coverage**: loading the struct with all supported keys set simultaneously must
 /// produce a struct where every serialized leaf field differs from the default.
 ///
-/// `key_aliases` and `provider_factory` configure the test config loader. Pass the same aliases and
-/// remapper factory used in production config loading.
+/// `key_aliases` and `provider_factory` configure the test config loader. The provider factory receives the
+/// environment pairs configured for each test case, so it can avoid reading unrelated ambient process variables.
 pub async fn run_config_smoke_tests<T, Factory, P, PF>(
     struct_name: &'static str, non_config_fields: &[&str], base_config: serde_json::Value, config_factory: Factory,
     key_aliases: &'static [(&'static str, &'static str)], provider_factory: PF,
@@ -164,7 +164,7 @@ pub async fn run_config_smoke_tests<T, Factory, P, PF>(
     T: PartialEq + Serialize,
     Factory: Fn(GenericConfiguration) -> T,
     P: Provider + Send + Sync + 'static,
-    PF: Fn() -> P,
+    PF: Fn(Vec<(String, String)>) -> P,
 {
     let keys: Vec<&'static SalukiAnnotation> = SUPPORTED_ANNOTATIONS
         .iter()
@@ -323,7 +323,7 @@ mod tests {
     /// Struct name that no annotation's `used_by` references, so every registered key is "foreign" to it.
     const UNREGISTERED_STRUCT: &str = "NonExistentConfiguration";
 
-    fn empty_provider() -> figment::providers::Serialized<serde_json::Value> {
+    fn empty_provider(_env_vars: Vec<(String, String)>) -> figment::providers::Serialized<serde_json::Value> {
         figment::providers::Serialized::defaults(json!({}))
     }
 

--- a/lib/datadog-agent/config/src/env_reader.rs
+++ b/lib/datadog-agent/config/src/env_reader.rs
@@ -308,14 +308,9 @@ mod tests {
 
     #[test]
     fn lowercase_proxy_env_is_honored() {
-        let _guard = ENV_MUTEX.lock().unwrap();
-
-        // The common lowercase Unix convention must fill the proxy slot, matching the legacy
-        // case-insensitive remapper.
-        std::env::set_var("http_proxy", "http://lower:3128");
+        let env = EnvSnapshot::from_vars([("http_proxy".to_string(), "http://lower:3128".to_string())]);
         let mut base = json!({});
-        apply_datadog_env(&mut base, true).unwrap();
-        std::env::remove_var("http_proxy");
+        apply_proxy_env(base.as_object_mut().unwrap(), &env, true);
 
         assert_eq!(at(&base, &["proxy", "http"]), Some(&json!("http://lower:3128")));
     }

--- a/lib/datadog-agent/config/src/remapper.rs
+++ b/lib/datadog-agent/config/src/remapper.rs
@@ -208,15 +208,19 @@ impl DatadogRemapper {
     /// Constructs a `DatadogRemapper` by eagerly snapshotting env var remappings from the current process
     /// environment.
     pub fn new() -> Self {
-        Self::from_env_vars(std::env::vars())
+        Self::from_env_iter(std::env::vars())
     }
 
-    /// Constructs a `DatadogRemapper` from an explicit set of environment variable name/value pairs.
+    /// Constructs a `DatadogRemapper` from explicitly provided environment variable name/value pairs.
     ///
-    /// Names are matched case-insensitively against [`ENV_REMAPPINGS`]. When more than one name maps to the same
+    /// Names are matched case-insensitively against `ENV_REMAPPINGS`. When more than one name maps to the same
     /// canonical key (for example, both `HTTP_PROXY` and `http_proxy` map to `proxy_http`), the first matching name
     /// encountered wins and later matches are ignored.
-    fn from_env_vars<I>(env_vars: I) -> Self
+    pub fn from_env_vars(env_vars: Vec<(String, String)>) -> Self {
+        Self::from_env_iter(env_vars)
+    }
+
+    fn from_env_iter<I>(env_vars: I) -> Self
     where
         I: IntoIterator<Item = (String, String)>,
     {
@@ -295,7 +299,7 @@ mod tests {
         // guard means the first matching name encountered wins and any later match is ignored. Feeding an
         // explicitly-ordered iterator makes this deterministic, independent of `std::env::vars` ordering (and so
         // this case needs no process-env mutation or lock).
-        let remapper = DatadogRemapper::from_env_vars([
+        let remapper = DatadogRemapper::from_env_vars(vec![
             ("HTTP_PROXY".to_string(), "http://first.example.com".to_string()),
             ("http_proxy".to_string(), "http://second.example.com".to_string()),
         ]);

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -350,7 +350,7 @@ mod tests {
             env_vars,
             false,
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await;
         ApmConfig::from_configuration(&cfg).expect("ApmConfig should deserialize")

--- a/lib/saluki-components/src/common/datadog/config.rs
+++ b/lib/saluki-components/src/common/datadog/config.rs
@@ -571,7 +571,7 @@ mod tests {
             env_vars,
             false,
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await;
         ForwarderConfiguration::from_configuration(&cfg).expect("ForwarderConfiguration should deserialize")
@@ -585,7 +585,7 @@ mod tests {
             env_vars,
             false,
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await;
         cfg
@@ -1202,7 +1202,7 @@ mod config_smoke {
             json!({ "api_key": "smoke-test-api-key" }),
             |cfg| ForwarderConfiguration::from_configuration(&cfg).expect("ForwarderConfiguration should deserialize"),
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await
     }

--- a/lib/saluki-components/src/common/datadog/proxy.rs
+++ b/lib/saluki-components/src/common/datadog/proxy.rs
@@ -320,7 +320,7 @@ mod config_smoke {
                     .expect("ProxyConfiguration should deserialize")
             },
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await
     }

--- a/lib/saluki-components/src/destinations/dsd_debug_log/mod.rs
+++ b/lib/saluki-components/src/destinations/dsd_debug_log/mod.rs
@@ -439,7 +439,7 @@ mod tests {
                     .expect("DogStatsDDebugLogConfiguration should deserialize")
             },
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await
     }

--- a/lib/saluki-components/src/encoders/datadog/events/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/events/mod.rs
@@ -425,7 +425,7 @@ mod config_smoke {
                     .expect("DatadogEventsConfiguration should deserialize")
             },
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await
     }

--- a/lib/saluki-components/src/encoders/datadog/logs/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/logs/mod.rs
@@ -400,7 +400,7 @@ mod config_smoke {
                     .expect("DatadogLogsConfiguration should deserialize")
             },
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await
     }

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -3095,7 +3095,7 @@ mod config_smoke {
                     .expect("DatadogMetricsConfiguration should deserialize")
             },
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await
     }

--- a/lib/saluki-components/src/encoders/datadog/service_checks/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/service_checks/mod.rs
@@ -299,7 +299,7 @@ mod config_smoke {
                     .expect("DatadogServiceChecksConfiguration should deserialize")
             },
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await
     }

--- a/lib/saluki-components/src/encoders/datadog/stats/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/stats/mod.rs
@@ -487,7 +487,7 @@ mod config_smoke {
                     .expect("DatadogApmStatsEncoderConfiguration should deserialize")
             },
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await
     }

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -865,7 +865,7 @@ mod tests {
             Some(&env_vars),
             false,
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await;
         let apm_config = ApmConfig::from_configuration(&cfg).expect("ApmConfig should deserialize");
@@ -985,9 +985,14 @@ mod tests {
     async fn sampling_rate_clamps_percentage_to_unit_interval() {
         // `sampling_percentage` is a 0..100 percentage; only strictly in-range values map to a fractional rate, and
         // anything <= 0 or >= 100 collapses to 1.0 (sample everything).
-        let (cfg, _) =
-            ConfigurationLoader::for_tests_with_provider_factory(None, None, false, KEY_ALIASES, DatadogRemapper::new)
-                .await;
+        let (cfg, _) = ConfigurationLoader::for_tests_with_provider_factory(
+            None,
+            None,
+            false,
+            KEY_ALIASES,
+            DatadogRemapper::from_env_vars,
+        )
+        .await;
         let apm_config = ApmConfig::from_configuration(&cfg).expect("ApmConfig should deserialize");
 
         let cases = [
@@ -1161,7 +1166,7 @@ mod config_smoke {
                     .expect("DatadogTraceConfiguration should deserialize")
             },
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await
     }

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -3267,7 +3267,7 @@ mod config_smoke {
                     .expect("DogStatsDConfiguration should deserialize")
             },
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await
     }

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -1585,7 +1585,7 @@ mod config_smoke {
                     .expect("AggregateConfiguration should deserialize")
             },
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await
     }

--- a/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
@@ -1096,7 +1096,7 @@ mod config_smoke {
                     .expect("DogStatsDMapperConfiguration should deserialize")
             },
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await
     }

--- a/lib/saluki-components/src/transforms/trace_obfuscation/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_obfuscation/mod.rs
@@ -327,7 +327,7 @@ mod config_smoke {
                     .expect("TraceObfuscationConfiguration should deserialize")
             },
             KEY_ALIASES,
-            DatadogRemapper::new,
+            DatadogRemapper::from_env_vars,
         )
         .await
     }

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -412,7 +412,7 @@ impl ConfigurationLoader {
         file_values: Option<serde_json::Value>, env_vars: Option<&[(String, String)]>,
         enable_dynamic_configuration: bool,
     ) -> (GenericConfiguration, Option<tokio::sync::mpsc::Sender<ConfigUpdate>>) {
-        Self::for_tests_with_provider_factory(file_values, env_vars, enable_dynamic_configuration, &[], || {
+        Self::for_tests_with_provider_factory(file_values, env_vars, enable_dynamic_configuration, &[], |_| {
             Serialized::defaults(serde_json::json!({}))
         })
         .await
@@ -422,8 +422,9 @@ impl ConfigurationLoader {
     /// `provider_factory` to build an additional provider inserted between the file provider and the
     /// environment provider.
     ///
-    /// The factory is called after test environment variables have been set, so any env var reads it performs
-    /// (for example, in `DatadogRemapper`) are consistent with the test's env setup.
+    /// The factory receives an owned copy of the explicitly configured test environment variables. Providers can use
+    /// this input instead of reading unrelated variables from the ambient process environment. The factory is called
+    /// after the test environment variables have been set for providers that still require process environment access.
     ///
     /// This is generally only useful for testing purposes, and is exposed publicly in order to be used in cross-crate testing scenarios.
     #[cfg(any(test, feature = "test-util"))]
@@ -433,7 +434,7 @@ impl ConfigurationLoader {
     ) -> (GenericConfiguration, Option<tokio::sync::mpsc::Sender<ConfigUpdate>>)
     where
         P: Provider + Send + Sync + 'static,
-        F: FnOnce() -> P,
+        F: FnOnce(Vec<(String, String)>) -> P,
     {
         let json_file = tempfile::NamedTempFile::new().expect("should not fail to create temp file.");
         let path = &json_file.path();
@@ -466,7 +467,8 @@ impl ConfigurationLoader {
         }
 
         // Build and insert the extra provider while env vars are set so it can snapshot them.
-        let loader = loader.add_providers([provider_factory()]);
+        let provider_env_vars = env_vars.unwrap_or_default().to_vec();
+        let loader = loader.add_providers([provider_factory(provider_env_vars)]);
 
         // Add environment provider last so it has the highest precedence.
         let loader = loader
@@ -496,11 +498,10 @@ impl ConfigurationLoader {
 /// configuration, returning the held guard.
 ///
 /// [`ConfigurationLoader::for_tests`] and [`ConfigurationLoader::for_tests_with_provider_factory`] set and unset
-/// process-wide environment variables to simulate `DD_`-prefixed configuration, and providers such as the Datadog
-/// environment-variable remapper read those same variables via [`std::env::vars`]. Because the process environment
-/// is global mutable state, any test in any crate that reads or writes environment variables relevant to
-/// configuration loading MUST hold this lock for the duration of that access, so that all such tests serialize
-/// against each other rather than racing.
+/// process-wide environment variables to simulate `DD_`-prefixed configuration. Because the process environment is
+/// global mutable state, any test in any crate that reads or writes environment variables relevant to configuration
+/// loading MUST hold this lock for the duration of that access, so that all such tests serialize against each other
+/// rather than racing.
 ///
 /// This is exposed publicly so that tests in downstream crates can serialize against the same single lock that the
 /// loader itself uses, instead of each hand-rolling an independent (and therefore non-serializing) mutex.


### PR DESCRIPTION
## Summary

- Pass each test case's explicit environment variables to test-only provider factories.
- Add `DatadogRemapper::from_env_vars` and use it throughout configuration and smoke tests.
- Keep production behavior unchanged: `DatadogRemapper::new` still snapshots the process environment.

## Problem

Linux CI jobs picked up the ambient proxy value `http://127.0.0.1:15002`. Configuration tests supplied
their own environment inputs, but `DatadogRemapper::new` independently captured the runner's environment.
The proxy therefore overrode YAML fixtures and caused four tests to fail on an otherwise unchanged `main`.

This was initially observed on #2234 and reproduced by this PR before applying the fix.

## Evidence

The same runner [passed at 11:04 AM EDT](https://app.datadoghq.com/logs?from_ts=1785283200000&live=false&query=%22lowercase_proxy_env_is_honored%22+%22PASS%22+ci-job-name%3A%28unit-tests-linux-amd64+OR+unit-tests-linux-arm64%29&storage=flex_tier&stream_sort=desc&to_ts=1785338237000), then [failed at 11:17 AM EDT](https://app.datadoghq.com/logs?from_ts=1785196800000&live=false&query=%22lowercase_proxy_env_is_honored%22+%22FAIL%22&storage=flex_tier&stream_sort=asc&to_ts=1785369600000). [AMD64 and ARM64 failures received the same proxy value](https://app.datadoghq.com/logs?from_ts=1785337200000&live=false&query=ci-project-name%3Asaluki+%22127.0.0.1%3A15002%22&storage=flex_tier&stream_sort=asc&to_ts=1785339000000). This points to a CI environment change rather than a Saluki code change.

## Original failures

- `datadog-agent-config env_reader::tests::lowercase_proxy_env_is_honored`

  ```text
  assertion `left == right` failed
    left: Some(String("http://127.0.0.1:15002"))
   right: Some(String("http://lower:3128"))
  ```

- `saluki-components common::datadog::config::tests::proxy_set_via_yaml_nested_config`

  ```text
  assertion `left == right` failed
    left: "http://127.0.0.1:15002/"
   right: "http://proxy-a.example.com:3128/"
  ```

- `saluki-components common::datadog::proxy::config_smoke::proxy_configuration_smoke_test`

  ```text
  config smoke tests for 'ProxyConfiguration' failed with 3 error(s):
    [1] yaml_path 'proxy.http': struct did not change from its default
    [2] yaml_path 'proxy.https': struct did not change from its default
    [3] 2 serialized field(s) are never changed by any registered config key: [proxy_http, proxy_https]
  ```

- `saluki-components common::datadog::config::config_smoke::smoke_test`

  ```text
  config smoke tests for 'ForwarderConfiguration' failed with 3 error(s):
    [1] yaml_path 'proxy.http': struct did not change from its default
    [2] yaml_path 'proxy.https': struct did not change from its default
    [3] 2 serialized field(s) are never changed by any registered config key: [proxy_http, proxy_https]
  ```

## Fix

`ConfigurationLoader::for_tests_with_provider_factory` now transfers an owned copy of the test's
environment pairs to its provider factory. Test providers construct `DatadogRemapper` from those pairs,
fully isolating them from unrelated process variables without changing production precedence behavior.

The lowercase proxy test also uses an explicit `EnvSnapshot` instead of mutating the process environment.

## Testing

- Re-ran the four original failures with `HTTP_PROXY` and `HTTPS_PROXY` set to
  `http://127.0.0.1:15002`: all passed.
- Ran the affected package suites under the same injected proxy environment: 1,176 passed, 1 skipped.
- `cargo check --workspace`
- `cargo check --workspace --tests`
- `make fmt`
