### PR TITLE
feat(correctness): inventory ADP expvar differences

### DIFF
--- a/bin/correctness/panoramic/src/correctness/analysis/expvars.rs
+++ b/bin/correctness/panoramic/src/correctness/analysis/expvars.rs
@@ -1,0 +1,506 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+
+use serde_json::Value;
+
+/// A pair of Core Agent `/debug/vars` snapshots surrounding the test workload.
+pub struct ExpvarSnapshots {
+    pub before: Value,
+    pub after: Value,
+}
+
+#[derive(Clone, Copy)]
+enum NumericValue {
+    Integer(i128),
+    Float(f64),
+}
+
+impl PartialEq for NumericValue {
+    fn eq(&self, other: &Self) -> bool {
+        match (*self, *other) {
+            (Self::Integer(value), Self::Integer(other)) => value == other,
+            (Self::Float(value), Self::Float(other)) => value == other,
+            (Self::Integer(value), Self::Float(other)) | (Self::Float(other), Self::Integer(value)) => {
+                other.is_finite() && other.fract() == 0.0 && other as i128 == value && value as f64 == other
+            }
+        }
+    }
+}
+
+impl NumericValue {
+    fn subtract(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Integer(value), Self::Integer(other)) => Self::Integer(value - other),
+            (value, other) => Self::Float(value.as_f64() - other.as_f64()),
+        }
+    }
+
+    fn as_f64(self) -> f64 {
+        match self {
+            Self::Integer(value) => value as f64,
+            Self::Float(value) => value,
+        }
+    }
+
+    fn is_zero(self) -> bool {
+        match self {
+            Self::Integer(value) => value == 0,
+            Self::Float(value) => value == 0.0,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Observation {
+    Missing,
+    Number(NumericValue),
+    Other,
+}
+
+#[derive(Clone, Copy)]
+struct Activity {
+    delta: Option<NumericValue>,
+    appeared: bool,
+    disappeared: bool,
+    shape_mismatch: bool,
+}
+
+impl Activity {
+    fn between(before: Observation, after: Observation) -> Self {
+        match (before, after) {
+            (Observation::Number(before), Observation::Number(after)) => Self {
+                delta: Some(after.subtract(before)),
+                appeared: false,
+                disappeared: false,
+                shape_mismatch: false,
+            },
+            (Observation::Missing, Observation::Number(after)) => Self {
+                delta: Some(after),
+                appeared: true,
+                disappeared: false,
+                shape_mismatch: false,
+            },
+            (Observation::Number(_), Observation::Missing) => Self {
+                delta: None,
+                appeared: false,
+                disappeared: true,
+                shape_mismatch: false,
+            },
+            (Observation::Number(_), Observation::Other) | (Observation::Other, Observation::Number(_)) => Self {
+                delta: None,
+                appeared: false,
+                disappeared: false,
+                shape_mismatch: true,
+            },
+            _ => Self {
+                delta: Some(NumericValue::Integer(0)),
+                appeared: false,
+                disappeared: false,
+                shape_mismatch: false,
+            },
+        }
+    }
+
+    fn is_active(self) -> bool {
+        self.delta.is_some_and(|delta| !delta.is_zero()) || self.appeared || self.disappeared || self.shape_mismatch
+    }
+}
+
+struct PathComparison {
+    path: String,
+    baseline_before: Observation,
+    baseline_after: Observation,
+    baseline_activity: Activity,
+    comparison_before: Observation,
+    comparison_after: Observation,
+    comparison_activity: Activity,
+    classification: &'static str,
+    matches: bool,
+}
+
+/// Comparison of every numeric expvar path observed across two targets.
+pub struct ExpvarComparisonReport {
+    rows: Vec<PathComparison>,
+}
+
+impl ExpvarComparisonReport {
+    /// Returns whether all observed numeric expvar paths have matching workload deltas.
+    pub fn matches(&self) -> bool {
+        self.rows.iter().all(|row| row.matches)
+    }
+
+    /// Returns the number of paths that were numeric in at least one snapshot.
+    pub fn total_numeric_paths(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Returns the number of paths whose value or shape changed during the workload.
+    pub fn active_paths(&self) -> usize {
+        self.rows
+            .iter()
+            .filter(|row| row.baseline_activity.is_active() || row.comparison_activity.is_active())
+            .count()
+    }
+
+    /// Renders a deterministic table of active and incompatible paths.
+    pub fn details(&self) -> String {
+        let mut output = String::from(
+            "path | baseline before | baseline after | baseline delta | comparison before | comparison after | comparison delta | classification\n",
+        );
+
+        for row in self
+            .rows
+            .iter()
+            .filter(|row| row.baseline_activity.is_active() || row.comparison_activity.is_active() || !row.matches)
+        {
+            let _ = writeln!(
+                output,
+                "{} | {} | {} | {} | {} | {} | {} | {}",
+                row.path,
+                format_observation(row.baseline_before),
+                format_observation(row.baseline_after),
+                format_delta(row.baseline_activity.delta),
+                format_observation(row.comparison_before),
+                format_observation(row.comparison_after),
+                format_delta(row.comparison_activity.delta),
+                row.classification,
+            );
+        }
+
+        output
+    }
+
+    /// Returns a compact count of paths in each classification.
+    pub fn summary(&self) -> String {
+        let mut counts = BTreeMap::<&str, usize>::new();
+        for row in &self.rows {
+            *counts.entry(row.classification).or_default() += 1;
+        }
+
+        let classifications = counts
+            .into_iter()
+            .map(|(classification, count)| format!("{classification}={count}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        format!(
+            "Compared {} numeric expvar paths; {} changed during the workload. {}",
+            self.total_numeric_paths(),
+            self.active_paths(),
+            classifications
+        )
+    }
+}
+
+/// Compares all numeric JSON leaves using each target's before/after delta.
+pub fn compare_snapshots(baseline: &ExpvarSnapshots, comparison: &ExpvarSnapshots) -> ExpvarComparisonReport {
+    let baseline_before = flatten_leaves(&baseline.before);
+    let baseline_after = flatten_leaves(&baseline.after);
+    let comparison_before = flatten_leaves(&comparison.before);
+    let comparison_after = flatten_leaves(&comparison.after);
+
+    let paths = baseline_before
+        .keys()
+        .chain(baseline_after.keys())
+        .chain(comparison_before.keys())
+        .chain(comparison_after.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    let rows = paths
+        .into_iter()
+        .filter_map(|path| {
+            let baseline_before_value = observe(&baseline_before, &path);
+            let baseline_after_value = observe(&baseline_after, &path);
+            let comparison_before_value = observe(&comparison_before, &path);
+            let comparison_after_value = observe(&comparison_after, &path);
+
+            if ![
+                baseline_before_value,
+                baseline_after_value,
+                comparison_before_value,
+                comparison_after_value,
+            ]
+            .iter()
+            .any(|value| matches!(value, Observation::Number(_)))
+            {
+                return None;
+            }
+
+            let baseline_activity = Activity::between(baseline_before_value, baseline_after_value);
+            let comparison_activity = Activity::between(comparison_before_value, comparison_after_value);
+            let (classification, matches) = classify(baseline_activity, comparison_activity);
+
+            Some(PathComparison {
+                path,
+                baseline_before: baseline_before_value,
+                baseline_after: baseline_after_value,
+                baseline_activity,
+                comparison_before: comparison_before_value,
+                comparison_after: comparison_after_value,
+                comparison_activity,
+                classification,
+                matches,
+            })
+        })
+        .collect();
+
+    ExpvarComparisonReport { rows }
+}
+
+fn classify(baseline: Activity, comparison: Activity) -> (&'static str, bool) {
+    if baseline.shape_mismatch || comparison.shape_mismatch {
+        return ("shape_mismatch", false);
+    }
+    if baseline.disappeared || comparison.disappeared {
+        let matches = baseline.disappeared == comparison.disappeared;
+        return (if matches { "disappeared_equally" } else { "disappeared" }, matches);
+    }
+    if baseline.appeared || comparison.appeared {
+        let matches = baseline.appeared == comparison.appeared && baseline.delta == comparison.delta;
+        return (
+            if matches {
+                "appeared_equally"
+            } else {
+                "appeared_unequally"
+            },
+            matches,
+        );
+    }
+
+    let baseline = baseline.delta.unwrap_or(NumericValue::Integer(0));
+    let comparison = comparison.delta.unwrap_or(NumericValue::Integer(0));
+    if baseline == comparison {
+        ("equal_activity", true)
+    } else if !baseline.is_zero() && comparison.is_zero() {
+        ("baseline_only_activity", false)
+    } else if baseline.is_zero() && !comparison.is_zero() {
+        ("adp_only_activity", false)
+    } else {
+        ("unequal_activity", false)
+    }
+}
+
+fn observe(values: &BTreeMap<String, Observation>, path: &str) -> Observation {
+    values.get(path).copied().unwrap_or(Observation::Missing)
+}
+
+fn flatten_leaves(value: &Value) -> BTreeMap<String, Observation> {
+    let mut values = BTreeMap::new();
+    flatten_value(value, "", &mut values);
+    values
+}
+
+fn flatten_value(value: &Value, path: &str, values: &mut BTreeMap<String, Observation>) {
+    match value {
+        Value::Object(object) => {
+            for (key, value) in object {
+                let escaped = key.replace('~', "~0").replace('/', "~1");
+                flatten_value(value, &format!("{path}/{escaped}"), values);
+            }
+        }
+        Value::Array(array) => {
+            for (index, value) in array.iter().enumerate() {
+                flatten_value(value, &format!("{path}/{index}"), values);
+            }
+        }
+        Value::Number(number) => {
+            let number = if let Some(value) = number.as_i64() {
+                NumericValue::Integer(i128::from(value))
+            } else if let Some(value) = number.as_u64() {
+                NumericValue::Integer(i128::from(value))
+            } else if let Some(value) = number.as_f64() {
+                NumericValue::Float(value)
+            } else {
+                values.insert(path.to_string(), Observation::Other);
+                return;
+            };
+            values.insert(path.to_string(), Observation::Number(number));
+        }
+        _ => {
+            values.insert(path.to_string(), Observation::Other);
+        }
+    }
+}
+
+fn format_observation(observation: Observation) -> String {
+    match observation {
+        Observation::Missing => "<missing>".to_string(),
+        Observation::Number(value) => format_number(value),
+        Observation::Other => "<non-numeric>".to_string(),
+    }
+}
+
+fn format_delta(delta: Option<NumericValue>) -> String {
+    delta.map(format_number).unwrap_or_else(|| "<n/a>".to_string())
+}
+
+fn format_number(value: NumericValue) -> String {
+    match value {
+        NumericValue::Integer(value) => value.to_string(),
+        NumericValue::Float(value) if value.fract() == 0.0 => format!("{value:.0}"),
+        NumericValue::Float(value) => value.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, Value};
+
+    use super::{compare_snapshots, ExpvarSnapshots};
+    use crate::correctness::analysis::AnalysisRunner;
+
+    fn snapshots(before: Value, after: Value) -> ExpvarSnapshots {
+        ExpvarSnapshots { before, after }
+    }
+
+    #[test]
+    fn compares_before_after_deltas_instead_of_absolute_values() {
+        let baseline = snapshots(
+            json!({"dogstatsd": {"MetricPackets": 10}}),
+            json!({"dogstatsd": {"MetricPackets": 25}}),
+        );
+        let comparison = snapshots(
+            json!({"dogstatsd": {"MetricPackets": 100}}),
+            json!({"dogstatsd": {"MetricPackets": 115}}),
+        );
+
+        let report = compare_snapshots(&baseline, &comparison);
+
+        assert!(report.matches());
+        assert_eq!(report.total_numeric_paths(), 1);
+        assert_eq!(report.active_paths(), 1);
+        assert!(report.summary().contains("equal_activity=1"));
+    }
+
+    #[test]
+    fn reports_every_changed_numeric_path_in_stable_order() {
+        let baseline = snapshots(
+            json!({
+                "dogstatsd": {"MetricPackets": 1},
+                "dogstatsd-udp": {"Packets": 2},
+                "unchanged": 9,
+            }),
+            json!({
+                "dogstatsd": {"MetricPackets": 11},
+                "dogstatsd-udp": {"Packets": 22},
+                "unchanged": 9,
+            }),
+        );
+        let comparison = snapshots(
+            json!({
+                "dogstatsd": {"MetricPackets": 1},
+                "dogstatsd-udp": {"Packets": 2},
+                "unchanged": 9,
+            }),
+            json!({
+                "dogstatsd": {"MetricPackets": 1},
+                "dogstatsd-udp": {"Packets": 7},
+                "unchanged": 9,
+            }),
+        );
+
+        let report = compare_snapshots(&baseline, &comparison);
+        let details = report.details();
+
+        assert!(!report.matches());
+        assert_eq!(report.total_numeric_paths(), 3);
+        assert_eq!(report.active_paths(), 2);
+        assert!(details.contains("/dogstatsd/MetricPackets | 1 | 11 | 10 | 1 | 1 | 0 | baseline_only_activity"));
+        assert!(details.contains("/dogstatsd-udp/Packets | 2 | 22 | 20 | 2 | 7 | 5 | unequal_activity"));
+        assert!(!details.contains("/unchanged"));
+        assert!(
+            details.find("/dogstatsd-udp/Packets").unwrap() < details.find("/dogstatsd/MetricPackets").unwrap(),
+            "paths should be sorted lexicographically"
+        );
+    }
+
+    #[test]
+    fn traverses_arrays_and_escapes_json_pointer_paths() {
+        let baseline = snapshots(
+            json!({"a/b": [{"~count": 1}], "ignored": "1"}),
+            json!({"a/b": [{"~count": 4}], "ignored": "9"}),
+        );
+        let comparison = snapshots(
+            json!({"a/b": [{"~count": 1}], "ignored": true}),
+            json!({"a/b": [{"~count": 4}], "ignored": false}),
+        );
+
+        let report = compare_snapshots(&baseline, &comparison);
+
+        assert!(report.matches());
+        assert_eq!(report.total_numeric_paths(), 1);
+        assert!(report.details().contains("/a~1b/0/~0count"));
+        assert!(!report.details().contains("ignored"));
+    }
+
+    #[test]
+    fn compares_equal_integer_and_floating_point_deltas_numerically() {
+        let baseline = snapshots(json!({"value": 0}), json!({"value": 1}));
+        let comparison = snapshots(json!({"value": 0.5}), json!({"value": 1.5}));
+
+        let report = compare_snapshots(&baseline, &comparison);
+
+        assert!(report.matches());
+        assert!(report.details().contains("equal_activity"));
+    }
+
+    #[test]
+    fn preserves_integer_deltas_larger_than_f64_can_represent_exactly() {
+        let baseline = snapshots(
+            json!({"timestamp": 1_785_359_179_812_154_112_u64}),
+            json!({"timestamp": 1_785_359_179_812_154_113_u64}),
+        );
+        let comparison = snapshots(
+            json!({"timestamp": 1_785_359_179_812_154_112_u64}),
+            json!({"timestamp": 1_785_359_179_812_154_114_u64}),
+        );
+
+        let report = compare_snapshots(&baseline, &comparison);
+
+        assert!(!report.matches());
+        assert!(report.details().contains(
+            "/timestamp | 1785359179812154112 | 1785359179812154113 | 1 | 1785359179812154112 | 1785359179812154114 | 2 | unequal_activity"
+        ));
+    }
+
+    #[test]
+    fn treats_a_numeric_path_that_appears_after_load_as_starting_at_zero() {
+        let baseline = snapshots(json!({}), json!({"lazy": {"counter": 8}}));
+        let comparison = snapshots(json!({}), json!({"lazy": {"counter": 3}}));
+
+        let report = compare_snapshots(&baseline, &comparison);
+
+        assert!(!report.matches());
+        assert!(report
+            .details()
+            .contains("/lazy/counter | <missing> | 8 | 8 | <missing> | 3 | 3 | appeared_unequally"));
+    }
+
+    #[test]
+    fn analysis_runner_returns_the_expvar_inventory_as_failure_details() {
+        let baseline = snapshots(json!({"counter": 0}), json!({"counter": 5}));
+        let comparison = snapshots(json!({"counter": 0}), json!({"counter": 0}));
+
+        let (error, details) = AnalysisRunner::new_expvars(baseline, comparison)
+            .run_analysis()
+            .expect_err("the mismatched expvar delta should fail analysis");
+
+        assert!(error.to_string().contains("numeric expvar paths"));
+        assert_eq!(details.len(), 1);
+        assert!(details[0].contains("/counter"));
+        assert!(details[0].contains("baseline_only_activity"));
+    }
+
+    #[test]
+    fn reports_numeric_shape_changes_without_coercion() {
+        let baseline = snapshots(json!({"value": 1}), json!({"value": "gone"}));
+        let comparison = snapshots(json!({"value": 1}), json!({"value": 2}));
+
+        let report = compare_snapshots(&baseline, &comparison);
+
+        assert!(!report.matches());
+        assert!(report.details().contains("/value"));
+        assert!(report.details().contains("shape_mismatch"));
+    }
+}

--- a/bin/correctness/panoramic/src/correctness/analysis/mod.rs
+++ b/bin/correctness/panoramic/src/correctness/analysis/mod.rs
@@ -6,6 +6,8 @@ pub use self::collected::CollectedData;
 
 mod dogstatsd_forwarding;
 mod events;
+mod expvars;
+pub use self::expvars::ExpvarSnapshots;
 mod metrics;
 mod service_checks;
 mod traces;
@@ -25,6 +27,9 @@ pub enum AnalysisMode {
 
     /// Compares traces between the baseline and comparison targets.
     Traces,
+
+    /// Compares numeric Core Agent expvar deltas between the baseline and comparison targets.
+    Expvars,
 }
 
 /// Options for traces analysis. Used when `AnalysisMode` is `Traces`.
@@ -39,8 +44,9 @@ pub struct TracesAnalysisOptions {
 /// Analysis runner.
 pub struct AnalysisRunner {
     mode: AnalysisMode,
-    baseline_data: CollectedData,
-    comparison_data: CollectedData,
+    baseline_data: Option<CollectedData>,
+    comparison_data: Option<CollectedData>,
+    expvar_snapshots: Option<(ExpvarSnapshots, ExpvarSnapshots)>,
     traces_options: Option<TracesAnalysisOptions>,
     require_dogstatsd_forwarded_packets: bool,
 }
@@ -52,12 +58,31 @@ impl AnalysisRunner {
     pub fn new(
         mode: AnalysisMode, baseline_data: CollectedData, comparison_data: CollectedData,
         traces_options: Option<TracesAnalysisOptions>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, GenericError> {
+        if matches!(mode, AnalysisMode::Expvars) {
+            return Err(saluki_error::generic_error!(
+                "Use AnalysisRunner::new_expvars for expvar analysis."
+            ));
+        }
+
+        Ok(Self {
             mode,
-            baseline_data,
-            comparison_data,
+            baseline_data: Some(baseline_data),
+            comparison_data: Some(comparison_data),
+            expvar_snapshots: None,
             traces_options,
+            require_dogstatsd_forwarded_packets: false,
+        })
+    }
+
+    /// Creates an analysis runner for Core Agent expvar snapshots.
+    pub fn new_expvars(baseline: ExpvarSnapshots, comparison: ExpvarSnapshots) -> Self {
+        Self {
+            mode: AnalysisMode::Expvars,
+            baseline_data: None,
+            comparison_data: None,
+            expvar_snapshots: Some((baseline, comparison)),
+            traces_options: None,
             require_dogstatsd_forwarded_packets: false,
         }
     }
@@ -75,18 +100,39 @@ impl AnalysisRunner {
     /// If the analysis fails, or if the analysis identifies a difference between the baseline and comparison data,
     /// an error is returned alongside the full list of mismatch details (for log output).
     pub fn run_analysis(self) -> Result<(), (GenericError, Vec<String>)> {
+        if let AnalysisMode::Expvars = self.mode {
+            let (baseline, comparison) = self
+                .expvar_snapshots
+                .expect("expvar analysis runner must contain snapshots");
+            let report = expvars::compare_snapshots(&baseline, &comparison);
+            return if report.matches() {
+                Ok(())
+            } else {
+                Err((saluki_error::generic_error!(report.summary()), vec![report.details()]))
+            };
+        }
+
+        let baseline_data = self
+            .baseline_data
+            .as_ref()
+            .expect("telemetry analysis runner must contain baseline data");
+        let comparison_data = self
+            .comparison_data
+            .as_ref()
+            .expect("telemetry analysis runner must contain comparison data");
+
         match self.mode {
             AnalysisMode::Events => {
-                let analyzer = events::EventsAnalyzer::new(&self.baseline_data, &self.comparison_data);
+                let analyzer = events::EventsAnalyzer::new(baseline_data, comparison_data);
                 analyzer.run_analysis()
             }
             AnalysisMode::Metrics => {
-                let analyzer = metrics::MetricsAnalyzer::new(&self.baseline_data, &self.comparison_data)
-                    .map_err(|e| (e, vec![]))?;
+                let analyzer =
+                    metrics::MetricsAnalyzer::new(baseline_data, comparison_data).map_err(|e| (e, vec![]))?;
                 analyzer.run_analysis()
             }
             AnalysisMode::ServiceChecks => {
-                let analyzer = service_checks::ServiceChecksAnalyzer::new(&self.baseline_data, &self.comparison_data);
+                let analyzer = service_checks::ServiceChecksAnalyzer::new(baseline_data, comparison_data);
                 analyzer.run_analysis()
             }
             AnalysisMode::Traces => {
@@ -94,16 +140,29 @@ impl AnalysisRunner {
                     otlp_direct_analysis_mode: false,
                     additional_span_ignore_fields: Vec::new(),
                 });
-                let analyzer = traces::TracesAnalyzer::new(&self.baseline_data, &self.comparison_data, opts)
-                    .map_err(|e| (e, vec![]))?;
+                let analyzer =
+                    traces::TracesAnalyzer::new(baseline_data, comparison_data, opts).map_err(|e| (e, vec![]))?;
                 analyzer.run_analysis()
             }
+            AnalysisMode::Expvars => unreachable!("expvar analysis returns before telemetry analysis"),
         }?;
 
         dogstatsd_forwarding::run_analysis(
-            self.baseline_data.dogstatsd_forwarded_packets(),
-            self.comparison_data.dogstatsd_forwarded_packets(),
+            baseline_data.dogstatsd_forwarded_packets(),
+            comparison_data.dogstatsd_forwarded_packets(),
             self.require_dogstatsd_forwarded_packets,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AnalysisMode;
+
+    #[test]
+    fn expvars_analysis_mode_deserializes() {
+        let mode = serde_yaml::from_str::<AnalysisMode>("expvars").expect("expvars analysis mode should deserialize");
+
+        assert!(matches!(mode, AnalysisMode::Expvars));
     }
 }

--- a/bin/correctness/panoramic/src/correctness/expvars.rs
+++ b/bin/correctness/panoramic/src/correctness/expvars.rs
@@ -1,0 +1,120 @@
+use std::time::Duration;
+
+use airlock::docker;
+use bollard::{
+    container::LogOutput,
+    exec::{CreateExecOptions, StartExecResults},
+};
+use futures::TryStreamExt as _;
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use serde_json::Value;
+use tokio::time::sleep;
+
+const EXPVAR_ENDPOINT: &str = "http://127.0.0.1:5000/debug/vars";
+const SNAPSHOT_ATTEMPTS: usize = 30;
+const SNAPSHOT_RETRY_DELAY: Duration = Duration::from_millis(200);
+
+/// Captures the Core Agent expvar document from inside a Docker target container.
+pub async fn capture_expvars(container_name: &str) -> Result<Value, GenericError> {
+    let mut last_error = None;
+    for _ in 0..SNAPSHOT_ATTEMPTS {
+        match capture_once(container_name).await {
+            Ok(snapshot) => return Ok(snapshot),
+            Err(error) => {
+                last_error = Some(error);
+                sleep(SNAPSHOT_RETRY_DELAY).await;
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| generic_error!("No attempts were made to capture Core Agent expvars.")))
+}
+
+async fn capture_once(container_name: &str) -> Result<Value, GenericError> {
+    let docker = docker::connect().error_context("Failed to connect to Docker for expvar capture.")?;
+    let exec = docker
+        .create_exec(
+            container_name,
+            CreateExecOptions::<String> {
+                cmd: Some(vec![
+                    "curl".to_string(),
+                    "--silent".to_string(),
+                    "--show-error".to_string(),
+                    "--fail".to_string(),
+                    "--connect-timeout".to_string(),
+                    "1".to_string(),
+                    "--max-time".to_string(),
+                    "5".to_string(),
+                    EXPVAR_ENDPOINT.to_string(),
+                ]),
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .error_context("Failed to create expvar capture exec.")?;
+    let exec_id = exec.id.clone();
+    let result = docker
+        .start_exec(&exec_id, None)
+        .await
+        .error_context("Failed to start expvar capture exec.")?;
+
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    if let StartExecResults::Attached { mut output, .. } = result {
+        while let Some(chunk) = output
+            .try_next()
+            .await
+            .error_context("Failed to read expvar capture output.")?
+        {
+            match chunk {
+                LogOutput::StdOut { message } => stdout.push_str(&String::from_utf8_lossy(&message)),
+                LogOutput::StdErr { message } => stderr.push_str(&String::from_utf8_lossy(&message)),
+                _ => {}
+            }
+        }
+    }
+
+    let inspect = docker
+        .inspect_exec(&exec_id)
+        .await
+        .error_context("Failed to inspect expvar capture exec.")?;
+    if inspect.exit_code != Some(0) {
+        return Err(generic_error!(
+            "Expvar capture exited {:?} in container '{}': {}",
+            inspect.exit_code,
+            container_name,
+            stderr
+        ));
+    }
+
+    decode_expvar_output(&stdout)
+}
+
+fn decode_expvar_output(output: &str) -> Result<Value, GenericError> {
+    serde_json::from_str(output).error_context("Failed to decode Core Agent /debug/vars response.")
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::decode_expvar_output;
+
+    #[test]
+    fn decodes_the_core_agent_expvar_document() {
+        let value =
+            decode_expvar_output(r#"{"dogstatsd":{"MetricPackets":12}}"#).expect("valid expvar JSON should decode");
+
+        assert_eq!(value, json!({"dogstatsd": {"MetricPackets": 12}}));
+    }
+
+    #[test]
+    fn rejects_non_json_command_output() {
+        let error = decode_expvar_output("curl: connection refused")
+            .expect_err("invalid command output should not become a snapshot");
+
+        assert!(error.to_string().contains("decode Core Agent /debug/vars"));
+    }
+}

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -338,6 +338,7 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
         _ => None,
     };
     let analysis_runner = AnalysisRunner::new(config.analysis_mode, baseline_data, comparison_data, traces_options)
+        .expect("kind correctness runner does not support expvar analysis")
         .with_dogstatsd_forwarding_requirement(config.require_dogstatsd_forwarded_packets);
     let analysis_result = analysis_runner.run_analysis();
     let analysis_duration = analysis_start.elapsed();

--- a/bin/correctness/panoramic/src/correctness/mod.rs
+++ b/bin/correctness/panoramic/src/correctness/mod.rs
@@ -1,5 +1,6 @@
 pub mod analysis;
 pub mod config;
+mod expvars;
 pub mod k8s;
 pub mod runner;
 pub mod sync;

--- a/bin/correctness/panoramic/src/correctness/runner.rs
+++ b/bin/correctness/panoramic/src/correctness/runner.rs
@@ -14,13 +14,15 @@ use airlock::{
 use rand::{distr::SampleString as _, rng};
 use rand_distr::Alphanumeric;
 use saluki_error::{generic_error, GenericError};
+use serde_json::Value;
 use tokio::{select, task::JoinHandle, time::sleep};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, info_span, Instrument as _, Span};
 
 use crate::correctness::{
-    analysis::{AnalysisMode, AnalysisRunner, CollectedData, TracesAnalysisOptions},
+    analysis::{AnalysisMode, AnalysisRunner, CollectedData, ExpvarSnapshots, TracesAnalysisOptions},
     config::{Config, Runtime},
+    expvars::capture_expvars,
     sync::Coordinator,
 };
 use crate::{
@@ -42,6 +44,15 @@ const FLUSH_WAIT: Duration = Duration::from_secs(32);
 
 /// Run a single correctness test and return a panoramic `TestResult`.
 pub async fn run_correctness_test(name: String, config: Config, tctx: TestContext) -> TestResult {
+    if config.runtime == Runtime::KubernetesInDocker && matches!(config.analysis_mode, AnalysisMode::Expvars) {
+        return make_error_result(
+            name,
+            Instant::now(),
+            "configuration",
+            generic_error!("The expvars correctness analysis mode currently supports only the Docker runtime."),
+        );
+    }
+
     match config.runtime {
         Runtime::Docker => run_docker_correctness_test(name, config, tctx).await,
         Runtime::KubernetesInDocker => crate::correctness::k8s::run_k8s_correctness_test(name, config, tctx).await,
@@ -61,7 +72,7 @@ async fn run_docker_correctness_test(name: String, config: Config, tctx: TestCon
 
     // Phase 2: collect data
     let collect_start = Instant::now();
-    let (baseline_data, comparison_data) = match test_runner.run().await {
+    let run_data = match test_runner.run().await {
         Ok(data) => data,
         Err(e) => return make_error_result(name, started, "collect_data", e),
     };
@@ -74,10 +85,23 @@ async fn run_docker_correctness_test(name: String, config: Config, tctx: TestCon
             otlp_direct_analysis_mode: config.otlp_direct_analysis_mode,
             additional_span_ignore_fields: config.additional_span_ignore_fields.clone(),
         }),
-        AnalysisMode::Events | AnalysisMode::Metrics | AnalysisMode::ServiceChecks => None,
+        AnalysisMode::Events | AnalysisMode::Metrics | AnalysisMode::ServiceChecks | AnalysisMode::Expvars => None,
     };
-    let analysis_runner = AnalysisRunner::new(config.analysis_mode, baseline_data, comparison_data, traces_options)
-        .with_dogstatsd_forwarding_requirement(config.require_dogstatsd_forwarded_packets);
+    let analysis_runner = if matches!(config.analysis_mode, AnalysisMode::Expvars) {
+        let (baseline, comparison) = run_data
+            .expvars
+            .expect("expvars correctness run must capture before and after snapshots");
+        AnalysisRunner::new_expvars(baseline, comparison)
+    } else {
+        AnalysisRunner::new(
+            config.analysis_mode.clone(),
+            run_data.baseline_data,
+            run_data.comparison_data,
+            traces_options,
+        )
+        .expect("non-expvar analysis mode must accept telemetry data")
+        .with_dogstatsd_forwarding_requirement(config.require_dogstatsd_forwarded_packets)
+    };
     let analysis_result = analysis_runner.run_analysis();
     let analysis_duration = analysis_start.elapsed();
 
@@ -98,13 +122,18 @@ async fn run_docker_correctness_test(name: String, config: Config, tctx: TestCon
         },
     ];
 
+    let assertion_name = match config.analysis_mode {
+        AnalysisMode::Expvars => "expvar deltas match",
+        _ => "telemetry matches",
+    };
+
     match analysis_result {
         Ok(()) => TestResult {
             name,
             passed: true,
             duration: total_duration,
             assertion_results: vec![AssertionResult {
-                name: "telemetry matches".to_string(),
+                name: assertion_name.to_string(),
                 passed: true,
                 message: "No difference detected between baseline and comparison.".to_string(),
                 duration: analysis_duration,
@@ -121,7 +150,7 @@ async fn run_docker_correctness_test(name: String, config: Config, tctx: TestCon
                 passed: false,
                 duration: total_duration,
                 assertion_results: vec![AssertionResult {
-                    name: "telemetry matches".to_string(),
+                    name: assertion_name.to_string(),
                     passed: false,
                     message: full_message,
                     duration: analysis_duration,
@@ -177,6 +206,7 @@ pub struct CorrectnessRunner {
     baseline_coordinator: Coordinator,
     comparison_coordinator: Coordinator,
     millstone_coordinator: Coordinator,
+    capture_expvars: bool,
 }
 
 impl CorrectnessRunner {
@@ -194,6 +224,7 @@ impl CorrectnessRunner {
             baseline_coordinator: Coordinator::new(),
             comparison_coordinator: Coordinator::new(),
             millstone_coordinator: Coordinator::new(),
+            capture_expvars: matches!(config.analysis_mode, AnalysisMode::Expvars),
         })
     }
 
@@ -349,7 +380,7 @@ impl CorrectnessRunner {
         }
     }
 
-    pub async fn run(mut self) -> Result<(CollectedData, CollectedData), GenericError> {
+    async fn run(mut self) -> Result<CorrectnessRunData, GenericError> {
         let baseline_isolation_group_id = generate_isolation_group_id();
         let comparison_isolation_group_id = generate_isolation_group_id();
         let millstone_isolation_group_id = generate_isolation_group_id();
@@ -413,6 +444,29 @@ impl CorrectnessRunner {
                 return Err(e);
             }
         };
+        let expvars_before = if self.capture_expvars {
+            match self
+                .capture_expvar_pair(
+                    baseline_collector.target_container_name.clone(),
+                    comparison_collector.target_container_name.clone(),
+                )
+                .await
+            {
+                Ok(pair) => Some(pair),
+                Err(error) => {
+                    cleanup_groups(
+                        &baseline_isolation_group_id,
+                        &comparison_isolation_group_id,
+                        &millstone_isolation_group_id,
+                    )
+                    .await;
+                    return Err(error);
+                }
+            }
+        } else {
+            None
+        };
+
         info!("Agent containers spawned successfully. Starting shared millstone...");
 
         // Phase 4: Spawn the shared millstone container now that both agent volumes exist.
@@ -466,6 +520,29 @@ impl CorrectnessRunner {
         // on flushing like metrics does.
         sleep(FLUSH_WAIT).await;
 
+        let expvars_after = if self.capture_expvars {
+            match self
+                .capture_expvar_pair(
+                    baseline_collector.target_container_name.clone(),
+                    comparison_collector.target_container_name.clone(),
+                )
+                .await
+            {
+                Ok(pair) => Some(pair),
+                Err(error) => {
+                    cleanup_groups(
+                        &baseline_isolation_group_id,
+                        &comparison_isolation_group_id,
+                        &millstone_isolation_group_id,
+                    )
+                    .await;
+                    return Err(error);
+                }
+            }
+        } else {
+            None
+        };
+
         // Phase 7: Collect data from both datadog-intake containers, then shut everything down.
         info!("Collecting data from baseline and comparison intake containers...");
         let maybe_baseline_data = run_in_background(
@@ -510,8 +587,47 @@ impl CorrectnessRunner {
 
         info!("Cleanup complete.");
 
-        Ok((baseline_data, comparison_data))
+        let expvars = match (expvars_before, expvars_after) {
+            (Some((baseline_before, comparison_before)), Some((baseline_after, comparison_after))) => Some((
+                ExpvarSnapshots {
+                    before: baseline_before,
+                    after: baseline_after,
+                },
+                ExpvarSnapshots {
+                    before: comparison_before,
+                    after: comparison_after,
+                },
+            )),
+            (None, None) => None,
+            _ => unreachable!("expvar snapshots must be captured in before/after pairs"),
+        };
+
+        Ok(CorrectnessRunData {
+            baseline_data,
+            comparison_data,
+            expvars,
+        })
     }
+
+    async fn capture_expvar_pair(
+        &mut self, baseline_container_name: String, comparison_container_name: String,
+    ) -> Result<(Value, Value), GenericError> {
+        let baseline = run_in_background(&Span::current(), async move {
+            capture_expvars(&baseline_container_name).await
+        });
+        let comparison = run_in_background(&Span::current(), async move {
+            capture_expvars(&comparison_container_name).await
+        });
+
+        self.unwrap_or_shutdown("capture_expvars", baseline.await, comparison.await)
+            .await
+    }
+}
+
+struct CorrectnessRunData {
+    baseline_data: CollectedData,
+    comparison_data: CollectedData,
+    expvars: Option<(ExpvarSnapshots, ExpvarSnapshots)>,
 }
 
 fn run_in_background<F, T>(span: &Span, f: F) -> SpawnedResult<T>
@@ -666,6 +782,7 @@ impl DriverResults {
 /// port needed to collect data from `datadog-intake`.
 struct AgentGroupCollector {
     datadog_intake_port: u16,
+    target_container_name: String,
 }
 
 impl AgentGroupCollector {
@@ -675,7 +792,15 @@ impl AgentGroupCollector {
             .and_then(|details| details.try_get_exposed_port("tcp", 2049))
             .ok_or_else(|| generic_error!("Failed to get exposed port details for datadog-intake container."))?;
 
-        Ok(Self { datadog_intake_port })
+        let target_container_name = spawned_drivers
+            .get_driver_details("target")
+            .map(|details| details.container_name().to_string())
+            .ok_or_else(|| generic_error!("Failed to get target container details."))?;
+
+        Ok(Self {
+            datadog_intake_port,
+            target_container_name,
+        })
     }
 }
 

--- a/test/correctness/cases/dsd-expvars/config.yaml
+++ b/test/correctness/cases/dsd-expvars/config.yaml
@@ -1,0 +1,20 @@
+type: correctness
+runtime: docker
+analysis_mode: expvars
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=false
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=true
+    - DD_DATA_PLANE_REMOTE_AGENT_ENABLED=true
+    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/cases/dsd-expvars/datadog.yaml
+++ b/test/correctness/cases/dsd-expvars/datadog.yaml
@@ -1,0 +1,21 @@
+hostname: "correctness-testing"
+api_key: dummy-api-key-correctness-testing
+health_port: 5555
+
+apm_config:
+  enabled: false
+
+process_config:
+  process_collection:
+    enabled: false
+  container_collection:
+    enabled: false
+
+dd_url: "http://datadog-intake:2049"
+
+dogstatsd_port: 8125
+dogstatsd_non_local_traffic: true
+dogstatsd_socket: ""
+dogstatsd_stream_socket: ""
+dogstatsd_origin_detection: false
+dogstatsd_workers_count: 1

--- a/test/correctness/cases/dsd-expvars/millstone.yaml
+++ b/test/correctness/cases/dsd-expvars/millstone.yaml
@@ -1,0 +1,45 @@
+seed: [3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137]
+target: "udp://$GROUP:8125"
+aggregation_bucket_width_secs: 10
+volume: 5000
+send_delay_us: 1000
+corpus:
+  size: 5000
+  payload:
+    dogstatsd:
+      contexts:
+        constant: 500
+      name_length:
+        inclusive:
+          min: 1
+          max: 32
+      tag_length:
+        inclusive:
+          min: 3
+          max: 16
+      tags_per_msg:
+        inclusive:
+          min: 2
+          max: 8
+      value:
+        float_probability: 0.5
+        range:
+          inclusive:
+            min: -9999999
+            max: 9999999
+      multivalue_count:
+        inclusive:
+          min: 2
+          max: 32
+      multivalue_pack_probability: 0.08
+      kind_weights:
+        metric: 80
+        event: 10
+        service_check: 10
+      metric_weights:
+        count: 208
+        gauge: 66
+        timer: 0
+        distribution: 72
+        set: 0
+        histogram: 1


### PR DESCRIPTION
## Summary

Adds a Docker-only `expvars` correctness analysis mode to panoramic. It snapshots every numeric Core Agent `/debug/vars` leaf before and after an identical workload, compares baseline and ADP deltas, and writes a deterministic path-level inventory to the test result artifact.

Adds an intentionally failing `dsd-expvars` case for DADP-160. The failure is the deliverable for this exploratory draft: it establishes the current compatibility gap and gives us evidence for choosing the eventual bridge allowlist.

An observed run compared 1,445 numeric paths and found 256 active paths. The stable ADP-relevant gaps include:

- `dogstatsd/{MetricPackets,EventPackets,ServiceCheckPackets}`
- `dogstatsd-udp/{Packets,Bytes}`
- DogStatsD aggregator context/sample/event/service-check/sketch counters and flush data
- Forwarder transaction input/success counters and bytes for payloads handled by ADP

The case explicitly runs ADP in connected/RAR mode.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- `cargo nextest run -p panoramic` — 51 passed
- `cargo clippy -p panoramic --tests -- -D warnings` — passed
- `cargo check -p panoramic --tests` — passed
- `make fmt` — passed
- Panoramic `dsd-expvars` live run — failed as intended at `expvar deltas match`, with the complete before/after/delta inventory in `result.log`
- `make check-all` progressed through the relevant checks but could not complete locally because `cmake` is not installed for the unrelated FIPS feature build

## References

- DADP-160: Expose ADP telemetry in Core Agent go_expvars
