### PR TITLE
feat(dogstatsd): mirror client telemetry to COAT

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -16,7 +16,9 @@ use saluki_app::{
 use saluki_components::{
     config::{AutoscalingFailoverConfiguration, ClusterAgentConfiguration, MrfConfiguration},
     decoders::otlp::OtlpDecoderConfiguration,
-    destinations::{DogStatsDDebugLogConfiguration, DogStatsDStatisticsConfiguration},
+    destinations::{
+        DogStatsDClientTelemetryConfiguration, DogStatsDDebugLogConfiguration, DogStatsDStatisticsConfiguration,
+    },
     encoders::{
         BufferedIncrementalConfiguration, DatadogApmStatsEncoderConfiguration, DatadogEventsConfiguration,
         DatadogLogsConfiguration, DatadogMetricsConfiguration, DatadogServiceChecksConfiguration,
@@ -771,6 +773,7 @@ async fn add_dsd_pipeline_to_blueprint(
         .add_transform("events_enrich", events_enrich_config)?
         .add_transform("service_checks_enrich", service_checks_enrich_config)?
         .add_destination("dsd_stats_out", dsd_stats_config)?
+        .add_destination("dsd_client_telemetry_out", DogStatsDClientTelemetryConfiguration)?
         // Metrics.
         .connect_components_in_order([
             "dsd_in.metrics",
@@ -790,7 +793,9 @@ async fn add_dsd_pipeline_to_blueprint(
             "dd_service_checks_encode",
         ])?
         // DogStatsD Stats.
-        .connect_components("dsd_in.metrics", "dsd_stats_out")?;
+        .connect_components("dsd_in.metrics", "dsd_stats_out")?
+        // Post-aggregation client telemetry for RAR/COAT.
+        .connect_components("dsd_post_agg_filter", "dsd_client_telemetry_out")?;
 
     if dsd_debug_log_config.enabled() {
         blueprint

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -568,4 +568,104 @@ mod tests {
         assert_eq!(find("transactions.retries"), Some("Transaction retry count"));
         assert_eq!(find("transactions.requeued"), Some("Transaction requeue count"));
     }
+
+    #[test]
+    fn rar_telemetry_remaps_supported_dogstatsd_client_telemetry_metrics_as_gauges() {
+        let metrics = [
+            (
+                "adp.dogstatsd_client_telemetry_metrics",
+                "datadog.dogstatsd.client.metrics",
+            ),
+            (
+                "adp.dogstatsd_client_telemetry_metrics_by_type",
+                "datadog.dogstatsd.client.metrics_by_type",
+            ),
+            (
+                "adp.dogstatsd_client_telemetry_events",
+                "datadog.dogstatsd.client.events",
+            ),
+            (
+                "adp.dogstatsd_client_telemetry_service_checks",
+                "datadog.dogstatsd.client.service_checks",
+            ),
+            (
+                "adp.dogstatsd_client_telemetry_metric_dropped_on_receive",
+                "datadog.dogstatsd.client.metric_dropped_on_receive",
+            ),
+            (
+                "adp.dogstatsd_client_telemetry_bytes_sent",
+                "datadog.dogstatsd.client.bytes_sent",
+            ),
+            (
+                "adp.dogstatsd_client_telemetry_bytes_dropped",
+                "datadog.dogstatsd.client.bytes_dropped",
+            ),
+            (
+                "adp.dogstatsd_client_telemetry_bytes_dropped_queue",
+                "datadog.dogstatsd.client.bytes_dropped_queue",
+            ),
+            (
+                "adp.dogstatsd_client_telemetry_bytes_dropped_writer",
+                "datadog.dogstatsd.client.bytes_dropped_writer",
+            ),
+            (
+                "adp.dogstatsd_client_telemetry_packets_sent",
+                "datadog.dogstatsd.client.packets_sent",
+            ),
+            (
+                "adp.dogstatsd_client_telemetry_packets_dropped",
+                "datadog.dogstatsd.client.packets_dropped",
+            ),
+            (
+                "adp.dogstatsd_client_telemetry_packets_dropped_queue",
+                "datadog.dogstatsd.client.packets_dropped_queue",
+            ),
+            (
+                "adp.dogstatsd_client_telemetry_packets_dropped_writer",
+                "datadog.dogstatsd.client.packets_dropped_writer",
+            ),
+            (
+                "adp.dogstatsd_client_telemetry_aggregated_context",
+                "datadog.dogstatsd.client.aggregated_context",
+            ),
+            (
+                "adp.dogstatsd_client_telemetry_aggregated_context_by_type",
+                "datadog.dogstatsd.client.aggregated_context_by_type",
+            ),
+        ]
+        .into_iter()
+        .map(|(internal_name, _)| {
+            Event::Metric(Metric::gauge(
+                Context::from_static_parts(
+                    internal_name,
+                    &["component_id:dsd_client_telemetry_out", "component_type:destination"],
+                ),
+                7.0,
+            ))
+        })
+        .collect();
+
+        let output = render_with(get_datadog_agent_remappings(), metrics);
+
+        for exported_name in [
+            "datadog__dogstatsd__client__metrics",
+            "datadog__dogstatsd__client__metrics_by_type",
+            "datadog__dogstatsd__client__events",
+            "datadog__dogstatsd__client__service_checks",
+            "datadog__dogstatsd__client__metric_dropped_on_receive",
+            "datadog__dogstatsd__client__bytes_sent",
+            "datadog__dogstatsd__client__bytes_dropped",
+            "datadog__dogstatsd__client__bytes_dropped_queue",
+            "datadog__dogstatsd__client__bytes_dropped_writer",
+            "datadog__dogstatsd__client__packets_sent",
+            "datadog__dogstatsd__client__packets_dropped",
+            "datadog__dogstatsd__client__packets_dropped_queue",
+            "datadog__dogstatsd__client__packets_dropped_writer",
+            "datadog__dogstatsd__client__aggregated_context",
+            "datadog__dogstatsd__client__aggregated_context_by_type",
+        ] {
+            assert!(output.contains(&format!("# TYPE {exported_name} gauge")), "{output}");
+            assert!(output.contains(&format!("{exported_name} 7")), "{output}");
+        }
+    }
 }

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -570,71 +570,16 @@ mod tests {
     }
 
     #[test]
-    fn rar_telemetry_remaps_supported_dogstatsd_client_telemetry_metrics_as_gauges() {
+    fn rar_telemetry_remaps_supported_dogstatsd_client_byte_telemetry_as_gauges() {
         let metrics = [
-            (
-                "adp.dogstatsd_client_telemetry_metrics",
-                "datadog.dogstatsd.client.metrics",
-            ),
-            (
-                "adp.dogstatsd_client_telemetry_metrics_by_type",
-                "datadog.dogstatsd.client.metrics_by_type",
-            ),
-            (
-                "adp.dogstatsd_client_telemetry_events",
-                "datadog.dogstatsd.client.events",
-            ),
-            (
-                "adp.dogstatsd_client_telemetry_service_checks",
-                "datadog.dogstatsd.client.service_checks",
-            ),
-            (
-                "adp.dogstatsd_client_telemetry_metric_dropped_on_receive",
-                "datadog.dogstatsd.client.metric_dropped_on_receive",
-            ),
-            (
-                "adp.dogstatsd_client_telemetry_bytes_sent",
-                "datadog.dogstatsd.client.bytes_sent",
-            ),
-            (
-                "adp.dogstatsd_client_telemetry_bytes_dropped",
-                "datadog.dogstatsd.client.bytes_dropped",
-            ),
-            (
-                "adp.dogstatsd_client_telemetry_bytes_dropped_queue",
-                "datadog.dogstatsd.client.bytes_dropped_queue",
-            ),
-            (
-                "adp.dogstatsd_client_telemetry_bytes_dropped_writer",
-                "datadog.dogstatsd.client.bytes_dropped_writer",
-            ),
-            (
-                "adp.dogstatsd_client_telemetry_packets_sent",
-                "datadog.dogstatsd.client.packets_sent",
-            ),
-            (
-                "adp.dogstatsd_client_telemetry_packets_dropped",
-                "datadog.dogstatsd.client.packets_dropped",
-            ),
-            (
-                "adp.dogstatsd_client_telemetry_packets_dropped_queue",
-                "datadog.dogstatsd.client.packets_dropped_queue",
-            ),
-            (
-                "adp.dogstatsd_client_telemetry_packets_dropped_writer",
-                "datadog.dogstatsd.client.packets_dropped_writer",
-            ),
-            (
-                "adp.dogstatsd_client_telemetry_aggregated_context",
-                "datadog.dogstatsd.client.aggregated_context",
-            ),
-            (
-                "adp.dogstatsd_client_telemetry_aggregated_context_by_type",
-                "datadog.dogstatsd.client.aggregated_context_by_type",
-            ),
+            "adp.dogstatsd_client_telemetry_bytes_sent",
+            "adp.dogstatsd_client_telemetry_bytes_dropped",
+            "adp.dogstatsd_client_telemetry_bytes_dropped_queue",
+            "adp.dogstatsd_client_telemetry_bytes_dropped_writer",
+            "adp.dogstatsd_client_telemetry_metrics",
         ]
         .into_iter()
-        .map(|(internal_name, _)| {
+        .map(|internal_name| {
             Event::Metric(Metric::gauge(
                 Context::from_static_parts(
                     internal_name,
@@ -648,24 +593,14 @@ mod tests {
         let output = render_with(get_datadog_agent_remappings(), metrics);
 
         for exported_name in [
-            "datadog__dogstatsd__client__metrics",
-            "datadog__dogstatsd__client__metrics_by_type",
-            "datadog__dogstatsd__client__events",
-            "datadog__dogstatsd__client__service_checks",
-            "datadog__dogstatsd__client__metric_dropped_on_receive",
-            "datadog__dogstatsd__client__bytes_sent",
-            "datadog__dogstatsd__client__bytes_dropped",
-            "datadog__dogstatsd__client__bytes_dropped_queue",
-            "datadog__dogstatsd__client__bytes_dropped_writer",
-            "datadog__dogstatsd__client__packets_sent",
-            "datadog__dogstatsd__client__packets_dropped",
-            "datadog__dogstatsd__client__packets_dropped_queue",
-            "datadog__dogstatsd__client__packets_dropped_writer",
-            "datadog__dogstatsd__client__aggregated_context",
-            "datadog__dogstatsd__client__aggregated_context_by_type",
+            "dogstatsd_client__bytes_sent",
+            "dogstatsd_client__bytes_dropped",
+            "dogstatsd_client__bytes_dropped_queue",
+            "dogstatsd_client__bytes_dropped_writer",
         ] {
             assert!(output.contains(&format!("# TYPE {exported_name} gauge")), "{output}");
             assert!(output.contains(&format!("{exported_name} 7")), "{output}");
         }
+        assert!(!output.contains("dogstatsd_client__metrics"), "{output}");
     }
 }

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -570,7 +570,7 @@ mod tests {
     }
 
     #[test]
-    fn rar_telemetry_remaps_supported_dogstatsd_client_byte_telemetry_as_gauges() {
+    fn rar_telemetry_remaps_supported_dogstatsd_client_byte_telemetry_as_counters() {
         let metrics = [
             "adp.dogstatsd_client_telemetry_bytes_sent",
             "adp.dogstatsd_client_telemetry_bytes_dropped",
@@ -579,7 +579,7 @@ mod tests {
         ]
         .into_iter()
         .map(|internal_name| {
-            Event::Metric(Metric::gauge(
+            Event::Metric(Metric::counter(
                 Context::from_static_parts(
                     internal_name,
                     &["component_id:dsd_client_telemetry_out", "component_type:destination"],
@@ -597,7 +597,7 @@ mod tests {
             "dogstatsd_client__bytes_dropped_queue",
             "dogstatsd_client__bytes_dropped_writer",
         ] {
-            assert!(output.contains(&format!("# TYPE {exported_name} gauge")), "{output}");
+            assert!(output.contains(&format!("# TYPE {exported_name} counter")), "{output}");
             assert!(output.contains(&format!("{exported_name} 7")), "{output}");
         }
     }

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -576,7 +576,6 @@ mod tests {
             "adp.dogstatsd_client_telemetry_bytes_dropped",
             "adp.dogstatsd_client_telemetry_bytes_dropped_queue",
             "adp.dogstatsd_client_telemetry_bytes_dropped_writer",
-            "adp.dogstatsd_client_telemetry_metrics",
         ]
         .into_iter()
         .map(|internal_name| {
@@ -601,6 +600,20 @@ mod tests {
             assert!(output.contains(&format!("# TYPE {exported_name} gauge")), "{output}");
             assert!(output.contains(&format!("{exported_name} 7")), "{output}");
         }
+    }
+
+    #[test]
+    fn rar_telemetry_omits_unsupported_dogstatsd_client_metrics() {
+        let metrics = vec![Event::Metric(Metric::gauge(
+            Context::from_static_parts(
+                "adp.dogstatsd_client_telemetry_metrics",
+                &["component_id:dsd_client_telemetry_out", "component_type:destination"],
+            ),
+            7.0,
+        ))];
+
+        let output = render_with(get_datadog_agent_remappings(), metrics);
+
         assert!(!output.contains("dogstatsd_client__metrics"), "{output}");
     }
 }

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -140,5 +140,68 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
         .with_original_tags(["message_type", "origin"])
         .with_additional_tags(["state:error"])
         .with_help_text("Count of service checks/events/metrics processed by dogstatsd"),
+        // DogStatsD client telemetry. These gauges mirror the post-aggregation metric stream without client-provided
+        // dimensions, so COAT receives the same values that ADP sends to customer intake while retaining bounded
+        // cardinality.
+        RemapperRule::by_name(
+            "adp.dogstatsd_client_telemetry_metrics",
+            "datadog.dogstatsd.client.metrics",
+        ),
+        RemapperRule::by_name(
+            "adp.dogstatsd_client_telemetry_metrics_by_type",
+            "datadog.dogstatsd.client.metrics_by_type",
+        ),
+        RemapperRule::by_name(
+            "adp.dogstatsd_client_telemetry_events",
+            "datadog.dogstatsd.client.events",
+        ),
+        RemapperRule::by_name(
+            "adp.dogstatsd_client_telemetry_service_checks",
+            "datadog.dogstatsd.client.service_checks",
+        ),
+        RemapperRule::by_name(
+            "adp.dogstatsd_client_telemetry_metric_dropped_on_receive",
+            "datadog.dogstatsd.client.metric_dropped_on_receive",
+        ),
+        RemapperRule::by_name(
+            "adp.dogstatsd_client_telemetry_bytes_sent",
+            "datadog.dogstatsd.client.bytes_sent",
+        ),
+        RemapperRule::by_name(
+            "adp.dogstatsd_client_telemetry_bytes_dropped",
+            "datadog.dogstatsd.client.bytes_dropped",
+        ),
+        RemapperRule::by_name(
+            "adp.dogstatsd_client_telemetry_bytes_dropped_queue",
+            "datadog.dogstatsd.client.bytes_dropped_queue",
+        ),
+        RemapperRule::by_name(
+            "adp.dogstatsd_client_telemetry_bytes_dropped_writer",
+            "datadog.dogstatsd.client.bytes_dropped_writer",
+        ),
+        RemapperRule::by_name(
+            "adp.dogstatsd_client_telemetry_packets_sent",
+            "datadog.dogstatsd.client.packets_sent",
+        ),
+        RemapperRule::by_name(
+            "adp.dogstatsd_client_telemetry_packets_dropped",
+            "datadog.dogstatsd.client.packets_dropped",
+        ),
+        RemapperRule::by_name(
+            "adp.dogstatsd_client_telemetry_packets_dropped_queue",
+            "datadog.dogstatsd.client.packets_dropped_queue",
+        ),
+        RemapperRule::by_name(
+            "adp.dogstatsd_client_telemetry_packets_dropped_writer",
+            "datadog.dogstatsd.client.packets_dropped_writer",
+        ),
+        RemapperRule::by_name(
+            "adp.dogstatsd_client_telemetry_aggregated_context",
+            "datadog.dogstatsd.client.aggregated_context",
+        ),
+        RemapperRule::by_name(
+            "adp.dogstatsd_client_telemetry_aggregated_context_by_type",
+            "datadog.dogstatsd.client.aggregated_context_by_type",
+        ),
     ]
 }

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -140,68 +140,24 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
         .with_original_tags(["message_type", "origin"])
         .with_additional_tags(["state:error"])
         .with_help_text("Count of service checks/events/metrics processed by dogstatsd"),
-        // DogStatsD client telemetry. These gauges mirror the post-aggregation metric stream without client-provided
-        // dimensions, so COAT receives the same values that ADP sends to customer intake while retaining bounded
-        // cardinality.
-        RemapperRule::by_name(
-            "adp.dogstatsd_client_telemetry_metrics",
-            "datadog.dogstatsd.client.metrics",
-        ),
-        RemapperRule::by_name(
-            "adp.dogstatsd_client_telemetry_metrics_by_type",
-            "datadog.dogstatsd.client.metrics_by_type",
-        ),
-        RemapperRule::by_name(
-            "adp.dogstatsd_client_telemetry_events",
-            "datadog.dogstatsd.client.events",
-        ),
-        RemapperRule::by_name(
-            "adp.dogstatsd_client_telemetry_service_checks",
-            "datadog.dogstatsd.client.service_checks",
-        ),
-        RemapperRule::by_name(
-            "adp.dogstatsd_client_telemetry_metric_dropped_on_receive",
-            "datadog.dogstatsd.client.metric_dropped_on_receive",
-        ),
+        // DogStatsD client byte telemetry. These gauges mirror the post-aggregation metric stream without
+        // client-provided dimensions, so COAT receives the same values that ADP sends to customer intake while
+        // retaining bounded cardinality.
         RemapperRule::by_name(
             "adp.dogstatsd_client_telemetry_bytes_sent",
-            "datadog.dogstatsd.client.bytes_sent",
+            "dogstatsd_client.bytes_sent",
         ),
         RemapperRule::by_name(
             "adp.dogstatsd_client_telemetry_bytes_dropped",
-            "datadog.dogstatsd.client.bytes_dropped",
+            "dogstatsd_client.bytes_dropped",
         ),
         RemapperRule::by_name(
             "adp.dogstatsd_client_telemetry_bytes_dropped_queue",
-            "datadog.dogstatsd.client.bytes_dropped_queue",
+            "dogstatsd_client.bytes_dropped_queue",
         ),
         RemapperRule::by_name(
             "adp.dogstatsd_client_telemetry_bytes_dropped_writer",
-            "datadog.dogstatsd.client.bytes_dropped_writer",
-        ),
-        RemapperRule::by_name(
-            "adp.dogstatsd_client_telemetry_packets_sent",
-            "datadog.dogstatsd.client.packets_sent",
-        ),
-        RemapperRule::by_name(
-            "adp.dogstatsd_client_telemetry_packets_dropped",
-            "datadog.dogstatsd.client.packets_dropped",
-        ),
-        RemapperRule::by_name(
-            "adp.dogstatsd_client_telemetry_packets_dropped_queue",
-            "datadog.dogstatsd.client.packets_dropped_queue",
-        ),
-        RemapperRule::by_name(
-            "adp.dogstatsd_client_telemetry_packets_dropped_writer",
-            "datadog.dogstatsd.client.packets_dropped_writer",
-        ),
-        RemapperRule::by_name(
-            "adp.dogstatsd_client_telemetry_aggregated_context",
-            "datadog.dogstatsd.client.aggregated_context",
-        ),
-        RemapperRule::by_name(
-            "adp.dogstatsd_client_telemetry_aggregated_context_by_type",
-            "datadog.dogstatsd.client.aggregated_context_by_type",
+            "dogstatsd_client.bytes_dropped_writer",
         ),
     ]
 }

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -140,8 +140,8 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
         .with_original_tags(["message_type", "origin"])
         .with_additional_tags(["state:error"])
         .with_help_text("Count of service checks/events/metrics processed by dogstatsd"),
-        // DogStatsD client byte telemetry. These gauges mirror the post-aggregation metric stream without
-        // client-provided dimensions, so COAT receives the same values that ADP sends to customer intake while
+        // DogStatsD client byte telemetry. These counters mirror the post-aggregation metric stream without
+        // client-provided dimensions, so COAT receives the same byte totals that ADP sends to customer intake while
         // retaining bounded cardinality.
         RemapperRule::by_name(
             "adp.dogstatsd_client_telemetry_bytes_sent",

--- a/lib/saluki-components/src/destinations/dogstatsd_client_telemetry.rs
+++ b/lib/saluki-components/src/destinations/dogstatsd_client_telemetry.rs
@@ -1,0 +1,138 @@
+use async_trait::async_trait;
+use metrics::Gauge;
+use saluki_core::{
+    accounting::{MemoryBounds, MemoryBoundsBuilder},
+    components::{destinations::*, ComponentContext},
+    data_model::event::{
+        metric::{Metric, MetricValues},
+        Event, EventType,
+    },
+    observability::ComponentMetricsExt as _,
+};
+use saluki_error::GenericError;
+use saluki_metrics::MetricsBuilder;
+use tokio::select;
+use tracing::debug;
+
+/// Configuration for the DogStatsD client telemetry destination.
+#[derive(Default)]
+pub struct DogStatsDClientTelemetryConfiguration;
+
+#[async_trait]
+impl DestinationBuilder for DogStatsDClientTelemetryConfiguration {
+    fn input_event_type(&self) -> EventType {
+        EventType::Metric
+    }
+
+    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
+        Ok(Box::new(DogStatsDClientTelemetry::new(
+            MetricsBuilder::from_component_context(&context),
+        )))
+    }
+}
+
+impl MemoryBounds for DogStatsDClientTelemetryConfiguration {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        builder
+            .minimum()
+            .with_single_value::<DogStatsDClientTelemetry>("destination struct");
+    }
+}
+
+/// Mirrors supported DogStatsD client telemetry metrics into ADP internal telemetry.
+pub struct DogStatsDClientTelemetry {
+    metrics: Gauge,
+    metrics_by_type: Gauge,
+    events: Gauge,
+    service_checks: Gauge,
+    metric_dropped_on_receive: Gauge,
+    bytes_sent: Gauge,
+    bytes_dropped: Gauge,
+    bytes_dropped_queue: Gauge,
+    bytes_dropped_writer: Gauge,
+    packets_sent: Gauge,
+    packets_dropped: Gauge,
+    packets_dropped_queue: Gauge,
+    packets_dropped_writer: Gauge,
+    aggregated_context: Gauge,
+    aggregated_context_by_type: Gauge,
+}
+
+impl DogStatsDClientTelemetry {
+    pub(super) fn new(metrics_builder: MetricsBuilder) -> Self {
+        Self {
+            metrics: metrics_builder.register_gauge("dogstatsd_client_telemetry_metrics"),
+            metrics_by_type: metrics_builder.register_gauge("dogstatsd_client_telemetry_metrics_by_type"),
+            events: metrics_builder.register_gauge("dogstatsd_client_telemetry_events"),
+            service_checks: metrics_builder.register_gauge("dogstatsd_client_telemetry_service_checks"),
+            metric_dropped_on_receive: metrics_builder
+                .register_gauge("dogstatsd_client_telemetry_metric_dropped_on_receive"),
+            bytes_sent: metrics_builder.register_gauge("dogstatsd_client_telemetry_bytes_sent"),
+            bytes_dropped: metrics_builder.register_gauge("dogstatsd_client_telemetry_bytes_dropped"),
+            bytes_dropped_queue: metrics_builder.register_gauge("dogstatsd_client_telemetry_bytes_dropped_queue"),
+            bytes_dropped_writer: metrics_builder.register_gauge("dogstatsd_client_telemetry_bytes_dropped_writer"),
+            packets_sent: metrics_builder.register_gauge("dogstatsd_client_telemetry_packets_sent"),
+            packets_dropped: metrics_builder.register_gauge("dogstatsd_client_telemetry_packets_dropped"),
+            packets_dropped_queue: metrics_builder.register_gauge("dogstatsd_client_telemetry_packets_dropped_queue"),
+            packets_dropped_writer: metrics_builder.register_gauge("dogstatsd_client_telemetry_packets_dropped_writer"),
+            aggregated_context: metrics_builder.register_gauge("dogstatsd_client_telemetry_aggregated_context"),
+            aggregated_context_by_type: metrics_builder
+                .register_gauge("dogstatsd_client_telemetry_aggregated_context_by_type"),
+        }
+    }
+
+    pub(super) fn record_metric(&self, metric: &Metric) {
+        let gauge = match metric.context().name().as_ref() {
+            "datadog.dogstatsd.client.metrics" => &self.metrics,
+            "datadog.dogstatsd.client.metrics_by_type" => &self.metrics_by_type,
+            "datadog.dogstatsd.client.events" => &self.events,
+            "datadog.dogstatsd.client.service_checks" => &self.service_checks,
+            "datadog.dogstatsd.client.metric_dropped_on_receive" => &self.metric_dropped_on_receive,
+            "datadog.dogstatsd.client.bytes_sent" => &self.bytes_sent,
+            "datadog.dogstatsd.client.bytes_dropped" => &self.bytes_dropped,
+            "datadog.dogstatsd.client.bytes_dropped_queue" => &self.bytes_dropped_queue,
+            "datadog.dogstatsd.client.bytes_dropped_writer" => &self.bytes_dropped_writer,
+            "datadog.dogstatsd.client.packets_sent" => &self.packets_sent,
+            "datadog.dogstatsd.client.packets_dropped" => &self.packets_dropped,
+            "datadog.dogstatsd.client.packets_dropped_queue" => &self.packets_dropped_queue,
+            "datadog.dogstatsd.client.packets_dropped_writer" => &self.packets_dropped_writer,
+            "datadog.dogstatsd.client.aggregated_context" => &self.aggregated_context,
+            "datadog.dogstatsd.client.aggregated_context_by_type" => &self.aggregated_context_by_type,
+            _ => return,
+        };
+
+        if let MetricValues::Rate(values, _) = metric.values() {
+            for (_, value) in values {
+                gauge.increment(value);
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl Destination for DogStatsDClientTelemetry {
+    async fn run(self: Box<Self>, mut context: DestinationContext) -> Result<(), GenericError> {
+        let mut health = context.take_health_handle();
+        health.mark_ready();
+        debug!("DogStatsD client telemetry destination started.");
+
+        loop {
+            select! {
+                _ = health.live() => continue,
+                maybe_events = context.events().next() => match maybe_events {
+                    Some(events) => {
+                        for event in events {
+                            if let Event::Metric(metric) = event {
+                                self.record_metric(&metric);
+                            }
+                        }
+                    },
+                    None => break,
+                },
+            }
+        }
+
+        debug!("DogStatsD client telemetry destination stopped.");
+        Ok(())
+    }
+}

--- a/lib/saluki-components/src/destinations/dogstatsd_client_telemetry.rs
+++ b/lib/saluki-components/src/destinations/dogstatsd_client_telemetry.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use metrics::Gauge;
+use metrics::Counter;
 use saluki_core::{
     accounting::{MemoryBounds, MemoryBoundsBuilder},
     components::{destinations::*, ComponentContext},
@@ -41,24 +41,24 @@ impl MemoryBounds for DogStatsDClientTelemetryConfiguration {
 
 /// Mirrors supported DogStatsD client telemetry metrics into ADP internal telemetry.
 pub struct DogStatsDClientTelemetry {
-    bytes_sent: Gauge,
-    bytes_dropped: Gauge,
-    bytes_dropped_queue: Gauge,
-    bytes_dropped_writer: Gauge,
+    bytes_sent: Counter,
+    bytes_dropped: Counter,
+    bytes_dropped_queue: Counter,
+    bytes_dropped_writer: Counter,
 }
 
 impl DogStatsDClientTelemetry {
     pub(super) fn new(metrics_builder: MetricsBuilder) -> Self {
         Self {
-            bytes_sent: metrics_builder.register_gauge("dogstatsd_client_telemetry_bytes_sent"),
-            bytes_dropped: metrics_builder.register_gauge("dogstatsd_client_telemetry_bytes_dropped"),
-            bytes_dropped_queue: metrics_builder.register_gauge("dogstatsd_client_telemetry_bytes_dropped_queue"),
-            bytes_dropped_writer: metrics_builder.register_gauge("dogstatsd_client_telemetry_bytes_dropped_writer"),
+            bytes_sent: metrics_builder.register_counter("dogstatsd_client_telemetry_bytes_sent"),
+            bytes_dropped: metrics_builder.register_counter("dogstatsd_client_telemetry_bytes_dropped"),
+            bytes_dropped_queue: metrics_builder.register_counter("dogstatsd_client_telemetry_bytes_dropped_queue"),
+            bytes_dropped_writer: metrics_builder.register_counter("dogstatsd_client_telemetry_bytes_dropped_writer"),
         }
     }
 
     pub(super) fn record_metric(&self, metric: &Metric) {
-        let gauge = match metric.context().name().as_ref() {
+        let counter = match metric.context().name().as_ref() {
             "datadog.dogstatsd.client.bytes_sent" => &self.bytes_sent,
             "datadog.dogstatsd.client.bytes_dropped" => &self.bytes_dropped,
             "datadog.dogstatsd.client.bytes_dropped_queue" => &self.bytes_dropped_queue,
@@ -68,9 +68,11 @@ impl DogStatsDClientTelemetry {
 
         if let MetricValues::Rate(values, _) = metric.values() {
             // A delayed aggregate flush can contain several closed time buckets in one metric. Separate tag contexts
-            // arrive as separate metrics and intentionally accumulate into this dimensionless COAT gauge.
+            // arrive as separate metrics and intentionally accumulate into this dimensionless COAT counter.
             for (_, value) in values {
-                gauge.increment(value);
+                if value.is_finite() && value >= 0.0 && value.fract() == 0.0 && value <= u64::MAX as f64 {
+                    counter.increment(value as u64);
+                }
             }
         }
     }

--- a/lib/saluki-components/src/destinations/dogstatsd_client_telemetry.rs
+++ b/lib/saluki-components/src/destinations/dogstatsd_client_telemetry.rs
@@ -41,63 +41,28 @@ impl MemoryBounds for DogStatsDClientTelemetryConfiguration {
 
 /// Mirrors supported DogStatsD client telemetry metrics into ADP internal telemetry.
 pub struct DogStatsDClientTelemetry {
-    metrics: Gauge,
-    metrics_by_type: Gauge,
-    events: Gauge,
-    service_checks: Gauge,
-    metric_dropped_on_receive: Gauge,
     bytes_sent: Gauge,
     bytes_dropped: Gauge,
     bytes_dropped_queue: Gauge,
     bytes_dropped_writer: Gauge,
-    packets_sent: Gauge,
-    packets_dropped: Gauge,
-    packets_dropped_queue: Gauge,
-    packets_dropped_writer: Gauge,
-    aggregated_context: Gauge,
-    aggregated_context_by_type: Gauge,
 }
 
 impl DogStatsDClientTelemetry {
     pub(super) fn new(metrics_builder: MetricsBuilder) -> Self {
         Self {
-            metrics: metrics_builder.register_gauge("dogstatsd_client_telemetry_metrics"),
-            metrics_by_type: metrics_builder.register_gauge("dogstatsd_client_telemetry_metrics_by_type"),
-            events: metrics_builder.register_gauge("dogstatsd_client_telemetry_events"),
-            service_checks: metrics_builder.register_gauge("dogstatsd_client_telemetry_service_checks"),
-            metric_dropped_on_receive: metrics_builder
-                .register_gauge("dogstatsd_client_telemetry_metric_dropped_on_receive"),
             bytes_sent: metrics_builder.register_gauge("dogstatsd_client_telemetry_bytes_sent"),
             bytes_dropped: metrics_builder.register_gauge("dogstatsd_client_telemetry_bytes_dropped"),
             bytes_dropped_queue: metrics_builder.register_gauge("dogstatsd_client_telemetry_bytes_dropped_queue"),
             bytes_dropped_writer: metrics_builder.register_gauge("dogstatsd_client_telemetry_bytes_dropped_writer"),
-            packets_sent: metrics_builder.register_gauge("dogstatsd_client_telemetry_packets_sent"),
-            packets_dropped: metrics_builder.register_gauge("dogstatsd_client_telemetry_packets_dropped"),
-            packets_dropped_queue: metrics_builder.register_gauge("dogstatsd_client_telemetry_packets_dropped_queue"),
-            packets_dropped_writer: metrics_builder.register_gauge("dogstatsd_client_telemetry_packets_dropped_writer"),
-            aggregated_context: metrics_builder.register_gauge("dogstatsd_client_telemetry_aggregated_context"),
-            aggregated_context_by_type: metrics_builder
-                .register_gauge("dogstatsd_client_telemetry_aggregated_context_by_type"),
         }
     }
 
     pub(super) fn record_metric(&self, metric: &Metric) {
         let gauge = match metric.context().name().as_ref() {
-            "datadog.dogstatsd.client.metrics" => &self.metrics,
-            "datadog.dogstatsd.client.metrics_by_type" => &self.metrics_by_type,
-            "datadog.dogstatsd.client.events" => &self.events,
-            "datadog.dogstatsd.client.service_checks" => &self.service_checks,
-            "datadog.dogstatsd.client.metric_dropped_on_receive" => &self.metric_dropped_on_receive,
             "datadog.dogstatsd.client.bytes_sent" => &self.bytes_sent,
             "datadog.dogstatsd.client.bytes_dropped" => &self.bytes_dropped,
             "datadog.dogstatsd.client.bytes_dropped_queue" => &self.bytes_dropped_queue,
             "datadog.dogstatsd.client.bytes_dropped_writer" => &self.bytes_dropped_writer,
-            "datadog.dogstatsd.client.packets_sent" => &self.packets_sent,
-            "datadog.dogstatsd.client.packets_dropped" => &self.packets_dropped,
-            "datadog.dogstatsd.client.packets_dropped_queue" => &self.packets_dropped_queue,
-            "datadog.dogstatsd.client.packets_dropped_writer" => &self.packets_dropped_writer,
-            "datadog.dogstatsd.client.aggregated_context" => &self.aggregated_context,
-            "datadog.dogstatsd.client.aggregated_context_by_type" => &self.aggregated_context_by_type,
             _ => return,
         };
 

--- a/lib/saluki-components/src/destinations/dogstatsd_client_telemetry.rs
+++ b/lib/saluki-components/src/destinations/dogstatsd_client_telemetry.rs
@@ -67,6 +67,8 @@ impl DogStatsDClientTelemetry {
         };
 
         if let MetricValues::Rate(values, _) = metric.values() {
+            // A delayed aggregate flush can contain several closed time buckets in one metric. Separate tag contexts
+            // arrive as separate metrics and intentionally accumulate into this dimensionless COAT gauge.
             for (_, value) in values {
                 gauge.increment(value);
             }

--- a/lib/saluki-components/src/destinations/dogstatsd_client_telemetry_tests.rs
+++ b/lib/saluki-components/src/destinations/dogstatsd_client_telemetry_tests.rs
@@ -1,0 +1,92 @@
+use std::time::Duration;
+
+use metrics::set_default_local_recorder;
+use saluki_core::data_model::event::metric::Metric;
+use saluki_metrics::{test::TestRecorder, MetricsBuilder};
+
+use super::dogstatsd_client_telemetry::DogStatsDClientTelemetry;
+
+#[test]
+fn records_all_supported_client_telemetry_rates_without_client_dimensions() {
+    let recorder = TestRecorder::default();
+    let _recorder_guard = set_default_local_recorder(&recorder);
+    let telemetry = DogStatsDClientTelemetry::new(MetricsBuilder::default());
+
+    for (metric_name, telemetry_name) in [
+        ("datadog.dogstatsd.client.metrics", "dogstatsd_client_telemetry_metrics"),
+        (
+            "datadog.dogstatsd.client.metrics_by_type",
+            "dogstatsd_client_telemetry_metrics_by_type",
+        ),
+        ("datadog.dogstatsd.client.events", "dogstatsd_client_telemetry_events"),
+        (
+            "datadog.dogstatsd.client.service_checks",
+            "dogstatsd_client_telemetry_service_checks",
+        ),
+        (
+            "datadog.dogstatsd.client.metric_dropped_on_receive",
+            "dogstatsd_client_telemetry_metric_dropped_on_receive",
+        ),
+        (
+            "datadog.dogstatsd.client.bytes_sent",
+            "dogstatsd_client_telemetry_bytes_sent",
+        ),
+        (
+            "datadog.dogstatsd.client.bytes_dropped",
+            "dogstatsd_client_telemetry_bytes_dropped",
+        ),
+        (
+            "datadog.dogstatsd.client.bytes_dropped_queue",
+            "dogstatsd_client_telemetry_bytes_dropped_queue",
+        ),
+        (
+            "datadog.dogstatsd.client.bytes_dropped_writer",
+            "dogstatsd_client_telemetry_bytes_dropped_writer",
+        ),
+        (
+            "datadog.dogstatsd.client.packets_sent",
+            "dogstatsd_client_telemetry_packets_sent",
+        ),
+        (
+            "datadog.dogstatsd.client.packets_dropped",
+            "dogstatsd_client_telemetry_packets_dropped",
+        ),
+        (
+            "datadog.dogstatsd.client.packets_dropped_queue",
+            "dogstatsd_client_telemetry_packets_dropped_queue",
+        ),
+        (
+            "datadog.dogstatsd.client.packets_dropped_writer",
+            "dogstatsd_client_telemetry_packets_dropped_writer",
+        ),
+        (
+            "datadog.dogstatsd.client.aggregated_context",
+            "dogstatsd_client_telemetry_aggregated_context",
+        ),
+        (
+            "datadog.dogstatsd.client.aggregated_context_by_type",
+            "dogstatsd_client_telemetry_aggregated_context_by_type",
+        ),
+    ] {
+        let metric = Metric::rate(metric_name, [(100, 7.0)], Duration::from_secs(10));
+        telemetry.record_metric(&metric);
+
+        assert_eq!(recorder.gauge(telemetry_name), Some(7.0), "{metric_name}");
+    }
+}
+
+#[test]
+fn ignores_unknown_client_telemetry_names_and_non_rate_values() {
+    let recorder = TestRecorder::default();
+    let _recorder_guard = set_default_local_recorder(&recorder);
+    let telemetry = DogStatsDClientTelemetry::new(MetricsBuilder::default());
+
+    telemetry.record_metric(&Metric::rate(
+        "datadog.dogstatsd.client.unrecognized",
+        [(100, 7.0)],
+        Duration::from_secs(10),
+    ));
+    telemetry.record_metric(&Metric::counter("datadog.dogstatsd.client.bytes_sent", 11.0));
+
+    assert_eq!(recorder.gauge("dogstatsd_client_telemetry_bytes_sent"), Some(0.0));
+}

--- a/lib/saluki-components/src/destinations/dogstatsd_client_telemetry_tests.rs
+++ b/lib/saluki-components/src/destinations/dogstatsd_client_telemetry_tests.rs
@@ -33,7 +33,7 @@ fn records_all_supported_client_telemetry_rates_without_client_dimensions() {
         let metric = Metric::rate(metric_name, [(100, 7.0)], Duration::from_secs(10));
         telemetry.record_metric(&metric);
 
-        assert_eq!(recorder.gauge(telemetry_name), Some(7.0), "{metric_name}");
+        assert_eq!(recorder.counter(telemetry_name), Some(7), "{metric_name}");
     }
 }
 
@@ -50,11 +50,31 @@ fn ignores_unknown_client_telemetry_names_and_non_rate_values() {
     ));
     telemetry.record_metric(&Metric::counter("datadog.dogstatsd.client.bytes_sent", 11.0));
     telemetry.record_metric(&Metric::rate(
+        "datadog.dogstatsd.client.bytes_sent",
+        [(100, 1.5)],
+        Duration::from_secs(10),
+    ));
+    telemetry.record_metric(&Metric::rate(
         "datadog.dogstatsd.client.metrics",
         [(100, 11.0)],
         Duration::from_secs(10),
     ));
 
-    assert_eq!(recorder.gauge("dogstatsd_client_telemetry_bytes_sent"), Some(0.0));
-    assert_eq!(recorder.gauge("dogstatsd_client_telemetry_metrics"), None);
+    assert_eq!(recorder.counter("dogstatsd_client_telemetry_bytes_sent"), Some(0));
+    assert_eq!(recorder.counter("dogstatsd_client_telemetry_metrics"), None);
+}
+
+#[test]
+fn accumulates_client_telemetry_rate_buckets_as_counter_deltas() {
+    let recorder = TestRecorder::default();
+    let _recorder_guard = set_default_local_recorder(&recorder);
+    let telemetry = DogStatsDClientTelemetry::new(MetricsBuilder::default());
+
+    telemetry.record_metric(&Metric::rate(
+        "datadog.dogstatsd.client.bytes_sent",
+        [(100, 7.0), (110, 3.0)],
+        Duration::from_secs(10),
+    ));
+
+    assert_eq!(recorder.counter("dogstatsd_client_telemetry_bytes_sent"), Some(10));
 }

--- a/lib/saluki-components/src/destinations/dogstatsd_client_telemetry_tests.rs
+++ b/lib/saluki-components/src/destinations/dogstatsd_client_telemetry_tests.rs
@@ -13,20 +13,6 @@ fn records_all_supported_client_telemetry_rates_without_client_dimensions() {
     let telemetry = DogStatsDClientTelemetry::new(MetricsBuilder::default());
 
     for (metric_name, telemetry_name) in [
-        ("datadog.dogstatsd.client.metrics", "dogstatsd_client_telemetry_metrics"),
-        (
-            "datadog.dogstatsd.client.metrics_by_type",
-            "dogstatsd_client_telemetry_metrics_by_type",
-        ),
-        ("datadog.dogstatsd.client.events", "dogstatsd_client_telemetry_events"),
-        (
-            "datadog.dogstatsd.client.service_checks",
-            "dogstatsd_client_telemetry_service_checks",
-        ),
-        (
-            "datadog.dogstatsd.client.metric_dropped_on_receive",
-            "dogstatsd_client_telemetry_metric_dropped_on_receive",
-        ),
         (
             "datadog.dogstatsd.client.bytes_sent",
             "dogstatsd_client_telemetry_bytes_sent",
@@ -42,30 +28,6 @@ fn records_all_supported_client_telemetry_rates_without_client_dimensions() {
         (
             "datadog.dogstatsd.client.bytes_dropped_writer",
             "dogstatsd_client_telemetry_bytes_dropped_writer",
-        ),
-        (
-            "datadog.dogstatsd.client.packets_sent",
-            "dogstatsd_client_telemetry_packets_sent",
-        ),
-        (
-            "datadog.dogstatsd.client.packets_dropped",
-            "dogstatsd_client_telemetry_packets_dropped",
-        ),
-        (
-            "datadog.dogstatsd.client.packets_dropped_queue",
-            "dogstatsd_client_telemetry_packets_dropped_queue",
-        ),
-        (
-            "datadog.dogstatsd.client.packets_dropped_writer",
-            "dogstatsd_client_telemetry_packets_dropped_writer",
-        ),
-        (
-            "datadog.dogstatsd.client.aggregated_context",
-            "dogstatsd_client_telemetry_aggregated_context",
-        ),
-        (
-            "datadog.dogstatsd.client.aggregated_context_by_type",
-            "dogstatsd_client_telemetry_aggregated_context_by_type",
         ),
     ] {
         let metric = Metric::rate(metric_name, [(100, 7.0)], Duration::from_secs(10));
@@ -87,6 +49,12 @@ fn ignores_unknown_client_telemetry_names_and_non_rate_values() {
         Duration::from_secs(10),
     ));
     telemetry.record_metric(&Metric::counter("datadog.dogstatsd.client.bytes_sent", 11.0));
+    telemetry.record_metric(&Metric::rate(
+        "datadog.dogstatsd.client.metrics",
+        [(100, 11.0)],
+        Duration::from_secs(10),
+    ));
 
     assert_eq!(recorder.gauge("dogstatsd_client_telemetry_bytes_sent"), Some(0.0));
+    assert_eq!(recorder.gauge("dogstatsd_client_telemetry_metrics"), None);
 }

--- a/lib/saluki-components/src/destinations/mod.rs
+++ b/lib/saluki-components/src/destinations/mod.rs
@@ -9,5 +9,11 @@ pub use self::dsd_stats::{DogStatsDStatisticsConfiguration, DogStatsDStatsAPIHan
 mod dsd_debug_log;
 pub use self::dsd_debug_log::DogStatsDDebugLogConfiguration;
 
+mod dogstatsd_client_telemetry;
+pub use self::dogstatsd_client_telemetry::DogStatsDClientTelemetryConfiguration;
+
+#[cfg(test)]
+mod dogstatsd_client_telemetry_tests;
+
 mod prometheus;
 pub use self::prometheus::{PrometheusConfiguration, PrometheusPayloadProvider};


### PR DESCRIPTION
## Tracking

[DADP-162](https://datadoghq.atlassian.net/browse/DADP-162) · [ASUP-79 metric specification](https://datadoghq.atlassian.net/browse/ASUP-79) · [Core Agent profile enrollment #54316](https://github.com/DataDog/datadog-agent/pull/54316)

## Summary

- tap the DogStatsD metrics stream after aggregation and post-aggregate filtering
- mirror an explicit four-metric client-byte-telemetry allowlist into dimensionless ADP counters
- expose cumulative counters through existing RAR remappings under the shared `dogstatsd_client.*` COAT namespace

The paired Core Agent work must register the same counter names, add them to its Agent Telemetry profile, and handle independent RAR counter resets by remote-agent session epoch.

## Test plan

- `cargo nextest run -p saluki-components`
- `cargo nextest run -p agent-data-plane`
- `cargo check --workspace && cargo check --workspace --tests`
- temporary socket → ADP → RAR → Core Agent telemetry verification
- pre-commit checks (format, clippy, docs, licenses, dependency checks)

[DADP-162]: https://datadoghq.atlassian.net/browse/DADP-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ