### PR TITLE
chore(ci): add support for publishing dev images + clean up jobs in release stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,12 +29,14 @@ workflow:
     - if: $CI_COMMIT_TAG == null
       variables:
         BASE_ADP_IMAGE_VERSION: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+        BASE_ADP_PUBLIC_IMAGE_REPO_NAME: "${ADP_DEV_PUBLIC_IMAGE_REPO_NAME}"
         APP_DEV_BUILD: "true"
         BUILD_PROFILE: "release"
 
     - if: $CI_COMMIT_TAG
       variables:
         BASE_ADP_IMAGE_VERSION: ${CI_COMMIT_TAG}
+        BASE_ADP_PUBLIC_IMAGE_REPO_NAME: "${ADP_RELEASE_PUBLIC_IMAGE_REPO_NAME}"
         APP_DEV_BUILD: "false"
         BUILD_PROFILE: "optimized-release"
 
@@ -78,12 +80,30 @@ variables:
   ADP_IMAGE_VERSION: "${BASE_ADP_IMAGE_VERSION}"
   ADP_IMAGE_VERSION_FIPS: "${BASE_ADP_IMAGE_VERSION}-fips"
 
-  # The tagged image, minus the registry portion.
+  # The tagged internal image, minus the registry portion.
+  #
+  # This is where `publish-adp-image-internal*` lands the GBI-based images, and so is always the real
+  # `agent-data-plane` repository: internal images are already versioned per-pipeline and are not
+  # something we hand to customers.
+  ADP_INTERNAL_IMAGE_TAG: "agent-data-plane:${ADP_IMAGE_VERSION}"
+  ADP_INTERNAL_IMAGE_TAG_FIPS: "agent-data-plane:${ADP_IMAGE_VERSION_FIPS}"
+
+  # The public image repository we publish to, minus the registry portion.
+  #
+  # Official (tagged) releases go to the real repository that customers pull from; every other
+  # pipeline goes to the dedicated dev repository, so that ad-hoc dev publishes can never pollute the
+  # release repository. `publish-standalone-adp-image-linux*` re-checks this at runtime, so treat both
+  # names as load-bearing rather than cosmetic.
+  ADP_RELEASE_PUBLIC_IMAGE_REPO_NAME: "agent-data-plane"
+  ADP_DEV_PUBLIC_IMAGE_REPO_NAME: "agent-data-plane-dev"
+  ADP_PUBLIC_IMAGE_REPO_NAME: "${BASE_ADP_PUBLIC_IMAGE_REPO_NAME}"
+
+  # The tagged public image, minus the registry portion.
   #
   # Used for specifying the image repository to use when publishing the ADP container images, as the registry will be
   # varied depending on where it's being pushed.
-  ADP_IMAGE_TAG: "agent-data-plane:${ADP_IMAGE_VERSION}"
-  ADP_IMAGE_TAG_FIPS: "agent-data-plane:${ADP_IMAGE_VERSION_FIPS}"
+  ADP_PUBLIC_IMAGE_TAG: "${ADP_PUBLIC_IMAGE_REPO_NAME}:${ADP_IMAGE_VERSION}"
+  ADP_PUBLIC_IMAGE_TAG_FIPS: "${ADP_PUBLIC_IMAGE_REPO_NAME}:${ADP_IMAGE_VERSION_FIPS}"
 
   # The full image path.
   #

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -273,8 +273,8 @@ display-image-tags:
       # Image Tags
 
       ## Agent Data Plane (suitable for internal deployments, GBI-based, Nydus-compatible)
-      Non-FIPS: ${IMAGE_REGISTRY}/${ADP_IMAGE_TAG}
-      FIPS:     ${IMAGE_REGISTRY}/${ADP_IMAGE_TAG_FIPS}
+      Non-FIPS: ${IMAGE_REGISTRY}/${ADP_INTERNAL_IMAGE_TAG}
+      FIPS:     ${IMAGE_REGISTRY}/${ADP_INTERNAL_IMAGE_TAG_FIPS}
       EOF
 
 # Builds the darwin release tarball natively on a macOS runner and exposes it as a GitLab job

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -1,3 +1,48 @@
+# Mixins for defining which jobs must be passing before release artifacts can be pushed.
+#
+# We deliberately take a union of all relevant jobs for a given platform -- different architectures, FIPS vs non-FIPS, etc --
+# as we don't want to allow partially publishing release artifacts for a given platform: it should be all or nothing.
+.release-gating-linux:
+  needs:
+    - build-adp-image
+    - build-adp-image-fips
+    - unit-tests-linux-amd64
+    - unit-tests-miri-linux-amd64
+    - unit-tests-linux-arm64
+    - unit-tests-miri-linux-arm64
+    - check-deny
+    - check-licenses
+    - test-integration
+    - run-correctness-tests
+
+.release-gating-darwin:
+  needs:
+    - job: build-release-tarball-darwin-amd64
+      artifacts: true
+    - job: build-release-tarball-darwin-arm64
+      artifacts: true
+    - unit-tests-macos-amd64
+    - unit-tests-miri-macos-amd64
+    - unit-tests-macos-arm64
+    - unit-tests-miri-macos-arm64
+    - check-deny
+    - check-licenses
+    - test-integration-macos-amd64
+    - test-integration-macos-arm64
+    - run-correctness-tests
+
+.release-gating-windows:
+  needs:
+    - job: build-release-zip-windows-amd64
+      artifacts: true
+    - job: build-release-zip-windows-amd64-fips
+      artifacts: true
+    - unit-tests-windows-amd64
+    - test-integration-windows-amd64
+    - check-deny
+    - check-licenses
+    - run-correctness-tests
+
 .docker_publish_job_definition:
   image: registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0
   variables:
@@ -21,40 +66,46 @@
   extends: .docker_publish_job_definition
   stage: release
   rules:
+    - if: !reference [.on_mq_branch, rules, if]
+      when: never
     - if: !reference [.on_official_release, rules, if]
       when: manual
-  needs:
-    - unit-tests-linux-amd64
-    - unit-tests-miri-linux-amd64
-    - unit-tests-linux-arm64
-    - unit-tests-miri-linux-arm64
-    - check-deny
-    - check-licenses
-    - test-correctness-dsd-events
-    - test-correctness-dsd-plain
+    - when: manual
+      allow_failure: true
+  before_script:
+    # Defensive pre-flight check to ensure we aren't publishing a dev build to the non-dev image repository,
+    # since the variables used to determine the image repository to use could technically be overridden
+    # when triggering the pipeline.
+    - |
+      set -euo pipefail
+      if [[ -z "${CI_COMMIT_TAG:-}" && "${IMG_DESTINATIONS}" != "${ADP_DEV_PUBLIC_IMAGE_REPO_NAME}:"* ]]; then
+        echo "ERROR: refusing to publish '${IMG_DESTINATIONS}' from a non-tagged pipeline."
+        echo "Dev pipelines may only publish to the '${ADP_DEV_PUBLIC_IMAGE_REPO_NAME}' repository."
+        echo "To publish to '${ADP_RELEASE_PUBLIC_IMAGE_REPO_NAME}', run the pipeline for a release tag."
+        exit 1
+      fi
   variables:
     IMG_REGISTRIES: public
     IMG_SOURCES: ${SOURCE_IMAGE}
     IMG_DESTINATIONS: ${TARGET_IMAGE}
     IMG_SIGNING: "false"
 
-.push-release-tarball-definition:
+.push-release-tarball-linux-definition:
   stage: release
   rules:
+    - if: !reference [.on_mq_branch, rules, if]
+      when: never
     - if: !reference [.on_official_release, rules, if]
       when: manual
-  needs:
-    - unit-tests-linux-amd64
-    - unit-tests-miri-linux-amd64
-    - unit-tests-linux-arm64
-    - unit-tests-miri-linux-arm64
-    - check-deny
-    - check-licenses
-    - test-correctness-dsd-events
-    - test-correctness-dsd-plain
+      variables:
+        TARGET_BUCKET_PATH: "s3://binaries-ddbuild-io-prod/saluki/"
+    - when: manual
+      allow_failure: true
+      variables:
+        TARGET_BUCKET_PATH: "s3://binaries-ddbuild-io-prod/saluki/dev/"
   image: ${DOCKER_BUILD_IMAGE}
   variables:
-    TARGET_BUCKET_PATH: "s3://binaries-ddbuild-io-prod/saluki/"
+    TARBALL_NAME: "agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz"
   script:
     - apt-get update && DEBIAN_FRONTEND=noninteractive apt install -yy --no-install-recommends awscli >/dev/null
     - mkdir /tmp/image && mkdir /tmp/tarball
@@ -62,31 +113,25 @@
     - mkdir -p /tmp/tarball/opt/datadog /tmp/tarball/opt/datadog-agent/embedded/bin
     - cp /tmp/image/usr/local/bin/agent-data-plane /tmp/tarball/opt/datadog-agent/embedded/bin
     - cp -R /tmp/image/opt/datadog/agent-data-plane /tmp/tarball/opt/datadog/agent-data-plane
-    - tar -C /tmp/tarball -czf /tmp/agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz .
-    - aws s3 cp /tmp/agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz ${TARGET_BUCKET_PATH}
-    - sha256sum /tmp/agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz
+    - tar -C /tmp/tarball -czf /tmp/${TARBALL_NAME} .
+    - sha256sum /tmp/${TARBALL_NAME}
+    - aws s3 cp /tmp/${TARBALL_NAME} ${TARGET_BUCKET_PATH}
 
-# Publish our standalone ADP images,
+# Publish our standalone ADP images and tarballs.
 publish-standalone-adp-image-linux:
-  extends: [.build-common-variables, .publish-image-linux-definition]
-  needs:
-    - build-adp-image
+  extends: [.publish-image-linux-definition, .release-gating-linux]
   variables:
     SOURCE_IMAGE: ${ADP_FULL_IMAGE_TAG}
-    TARGET_IMAGE: ${ADP_IMAGE_TAG}
+    TARGET_IMAGE: ${ADP_PUBLIC_IMAGE_TAG}
 
 publish-standalone-adp-image-linux-fips:
-  extends: [.build-common-variables, .publish-image-linux-definition]
-  needs:
-    - build-adp-image-fips
+  extends: [.publish-image-linux-definition, .release-gating-linux]
   variables:
     SOURCE_IMAGE: ${ADP_FULL_IMAGE_TAG_FIPS}
-    TARGET_IMAGE: ${ADP_IMAGE_TAG_FIPS}
+    TARGET_IMAGE: ${ADP_PUBLIC_IMAGE_TAG_FIPS}
 
 push-release-tarball-linux-amd64:
-  extends: [.build-common-variables, .push-release-tarball-definition]
-  needs:
-    - build-adp-image
+  extends: [.push-release-tarball-linux-definition, .release-gating-linux]
   variables:
     TARGET_OS: "linux"
     TARGET_ARCH: "amd64"
@@ -94,9 +139,7 @@ push-release-tarball-linux-amd64:
     SOURCE_IMAGE_VERSION: ${ADP_IMAGE_VERSION}
 
 push-release-tarball-linux-arm64:
-  extends: [.build-common-variables, .push-release-tarball-definition]
-  needs:
-    - build-adp-image
+  extends: [.push-release-tarball-linux-definition, .release-gating-linux]
   variables:
     TARGET_OS: "linux"
     TARGET_ARCH: "arm64"
@@ -104,9 +147,7 @@ push-release-tarball-linux-arm64:
     SOURCE_IMAGE_VERSION: ${ADP_IMAGE_VERSION}
 
 push-release-tarball-linux-amd64-fips:
-  extends: [.build-common-variables, .push-release-tarball-definition]
-  needs:
-    - build-adp-image-fips
+  extends: [.push-release-tarball-linux-definition, .release-gating-linux]
   variables:
     TARGET_OS: "linux"
     TARGET_ARCH: "amd64"
@@ -114,23 +155,13 @@ push-release-tarball-linux-amd64-fips:
     SOURCE_IMAGE_VERSION: ${ADP_IMAGE_VERSION_FIPS}
 
 push-release-tarball-linux-arm64-fips:
-  extends: [.build-common-variables, .push-release-tarball-definition]
-  needs:
-    - build-adp-image-fips
+  extends: [.push-release-tarball-linux-definition, .release-gating-linux]
   variables:
     TARGET_OS: "linux"
     TARGET_ARCH: "arm64"
     SOURCE_IMAGE: ${ADP_FULL_IMAGE_TAG_FIPS}
     SOURCE_IMAGE_VERSION: ${ADP_IMAGE_VERSION_FIPS}
 
-# Pushes the prebuilt darwin tarball (from `build-release-tarball-darwin-*` in .gitlab/build.yml)
-# to s3. Mirrors the linux `_internal` pattern (build-adp-image-internal-* /
-# publish-adp-image-internal*): manual, with the bucket prefix selected by rule — canonical path
-# on tagged releases, an `internal/` subkey on dev pipelines so we exercise credentials and the
-# artifact handoff end-to-end on every PR without polluting the release path. The mq-working
-# branch guard mirrors the same one the linux `_internal` jobs use. Test gating matches the
-# linux push (.push-release-tarball-definition); attaching it here rather than to the build job
-# keeps the build runnable in parallel with the test stage.
 .push-release-tarball-darwin-definition:
   stage: release
   rules:
@@ -143,52 +174,25 @@ push-release-tarball-linux-arm64-fips:
     - when: manual
       allow_failure: true
       variables:
-        TARGET_BUCKET_PATH: "s3://binaries-ddbuild-io-prod/saluki/internal/"
+        TARGET_BUCKET_PATH: "s3://binaries-ddbuild-io-prod/saluki/dev/"
   image: ${DOCKER_BUILD_IMAGE}
   variables:
     TARBALL_NAME: "agent-data-plane-${ADP_IMAGE_VERSION}-darwin-${TARGET_ARCH}.tar.gz"
   script:
     - apt-get update && DEBIAN_FRONTEND=noninteractive apt install -yy --no-install-recommends awscli >/dev/null
-    # Log the digest before the upload so it lands in the job log even if `aws s3 cp` fails.
     - sha256sum ${TARBALL_NAME}
     - aws s3 cp ${TARBALL_NAME} ${TARGET_BUCKET_PATH}
 
 push-release-tarball-darwin-amd64:
-  extends: [.build-common-variables, .push-release-tarball-darwin-definition]
-  needs:
-    - job: build-release-tarball-darwin-amd64
-      artifacts: true
-    - unit-tests-macos-amd64
-    - unit-tests-miri-macos-amd64
-    - check-deny
-    - check-licenses
-    - test-integration-macos-amd64
+  extends: [.push-release-tarball-darwin-definition, .release-gating-darwin]
   variables:
     TARGET_ARCH: "amd64"
 
 push-release-tarball-darwin-arm64:
-  extends: [.build-common-variables, .push-release-tarball-darwin-definition]
-  needs:
-    - job: build-release-tarball-darwin-arm64
-      artifacts: true
-    - unit-tests-macos-arm64
-    - unit-tests-miri-macos-arm64
-    - check-deny
-    - check-licenses
-    - test-integration-macos-arm64
+  extends: [.push-release-tarball-darwin-definition, .release-gating-darwin]
   variables:
     TARGET_ARCH: "arm64"
 
-# Pushes the prebuilt Windows zip (from `build-release-zip-windows-*` in .gitlab/windows.yml)
-# to s3. Mirrors the linux `_internal` pattern and the darwin push above: manual on every
-# pipeline, with the bucket prefix selected by rule — canonical path on tagged releases, an
-# `internal/` subkey on dev pipelines so credentials and artifact handoff are exercised on
-# every PR without polluting the release path. The mq-working-branch guard matches the linux
-# `_internal` jobs.
-#
-# The upload itself runs in the linux `${DOCKER_BUILD_IMAGE}`, not on a Windows runner, just
-# like the darwin push: keeps Windows runner usage limited to the build itself, with the same
-# IAM-role-driven `aws s3 cp` flow that's already known to work for the linux push jobs.
 .push-release-zip-windows-definition:
   stage: release
   rules:
@@ -201,7 +205,7 @@ push-release-tarball-darwin-arm64:
     - when: manual
       allow_failure: true
       variables:
-        TARGET_BUCKET_PATH: "s3://binaries-ddbuild-io-prod/saluki/internal/"
+        TARGET_BUCKET_PATH: "s3://binaries-ddbuild-io-prod/saluki/dev/"
   image: ${DOCKER_BUILD_IMAGE}
   variables:
     TARGET_ARCH: "amd64"
@@ -209,33 +213,16 @@ push-release-tarball-darwin-arm64:
     ZIP_NAME: "agent-data-plane-${ADP_IMAGE_VERSION}-windows-${TARGET_ARCH}${FIPS_SUFFIX}.zip"
   script:
     - apt-get update && DEBIAN_FRONTEND=noninteractive apt install -yy --no-install-recommends awscli >/dev/null
-    # Log the digest before the upload so it lands in the job log even if `aws s3 cp` fails.
     - sha256sum ${ZIP_NAME}
     - aws s3 cp ${ZIP_NAME} ${TARGET_BUCKET_PATH}
 
-# Test gating mirrors the linux/darwin push jobs: unit + check-deny + check-licenses, plus the
-# windows integration tests at the e2e stage. Attaching the gating to the push job rather than
-# the build job lets the build run in parallel with the test stage.
 push-release-zip-windows-amd64:
-  extends: [.build-common-variables, .push-release-zip-windows-definition]
-  needs:
-    - job: build-release-zip-windows-amd64
-      artifacts: true
-    - unit-tests-windows-amd64
-    - test-integration-windows-amd64
-    - check-deny
-    - check-licenses
+  extends: [.push-release-zip-windows-definition, .release-gating-windows]
 
 push-release-zip-windows-amd64-fips:
-  extends: [.build-common-variables, .push-release-zip-windows-definition]
-  needs:
-    - job: build-release-zip-windows-amd64-fips
-      artifacts: true
-    - unit-tests-windows-amd64
-    - test-integration-windows-amd64
-    - check-deny
-    - check-licenses
+  extends: [.push-release-zip-windows-definition, .release-gating-windows]
   variables:
-    # Only FIPS_SUFFIX is read by the push script (via ZIP_NAME); BUILD_FEATURES has no
-    # effect here since the push job doesn't recompile anything.
+    # FIPS_SUFFIX is the only thing that distinguishes this from the non-FIPS push: it selects the
+    # zip name (via ZIP_NAME), which has to match what the FIPS build job produced. Nothing here
+    # recompiles, so no build settings are needed.
     FIPS_SUFFIX: "-fips"

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -72,18 +72,6 @@
       when: manual
     - when: manual
       allow_failure: true
-  before_script:
-    # Defensive pre-flight check to ensure we aren't publishing a dev build to the non-dev image repository,
-    # since the variables used to determine the image repository to use could technically be overridden
-    # when triggering the pipeline.
-    - |
-      set -euo pipefail
-      if [[ -z "${CI_COMMIT_TAG:-}" && "${IMG_DESTINATIONS}" != "${ADP_DEV_PUBLIC_IMAGE_REPO_NAME}:"* ]]; then
-        echo "ERROR: refusing to publish '${IMG_DESTINATIONS}' from a non-tagged pipeline."
-        echo "Dev pipelines may only publish to the '${ADP_DEV_PUBLIC_IMAGE_REPO_NAME}' repository."
-        echo "To publish to '${ADP_RELEASE_PUBLIC_IMAGE_REPO_NAME}', run the pipeline for a release tag."
-        exit 1
-      fi
   variables:
     IMG_REGISTRIES: public
     IMG_SOURCES: ${SOURCE_IMAGE}


### PR DESCRIPTION
## Summary

This PR adds support for safely publishing release artifacts from dev pipelines, and cleans up some of the pre-requisites for publishing artifacts in the first place.

The primary change is that for dev pipelines (any pipeline not triggered by a Git tag push), we now allow publishing release artifacts (container images, tarballs, ZIP files, etc) but we do so to locations that are isolated from "official" releases: we publish to the `agent-data-plane-dev` image repo, or a new `dev` subpath of our S3 bucket for tarballs/ZIP files, etc. This allows us to test changes to the overall release process (or, at least test _some_ parts that we couldn't previously test) without having to do a full release.

The secondary change is that we cleaned up how we define our publishing jobs so that they all contain the relevant pre-requisite jobs -- tests passing, etc -- relevant to the given platform. This was _mostly_ in place, but was inconsistent between platforms.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [x] Ran the publish jobs on the CI pipeline for _this_ PR and observed that they properly published to the relevant dev-only image repo, bucket path, etc.

## References

DADP-2