### PR TITLE
fix(integration): uncouple from the agent docker api version

### DIFF
--- a/test/integration/cases/liveness-container-tags/run_liveness_test.py
+++ b/test/integration/cases/liveness-container-tags/run_liveness_test.py
@@ -43,11 +43,15 @@ UP_MARKER = "/tmp/adp-liveness-up-validated"
 REQUESTS_PATH = "/tmp/adp-liveness-intake-requests.jsonl"
 ERROR_PATH = "/tmp/adp-liveness-intake-error"
 DOCKER_SOCKET_PATH = "/tmp/adp-liveness-docker.sock"
-DOCKER_API_PREFIX = "/v1.54"
-DOCKER_IMAGES_PATH = DOCKER_API_PREFIX + "/images/json"
-DOCKER_CONTAINERS_PATH = DOCKER_API_PREFIX + "/containers/json"
-DOCKER_EVENTS_PATH = DOCKER_API_PREFIX + "/events"
-DOCKER_INFO_PATH = DOCKER_API_PREFIX + "/info"
+# Routes are matched without the API version the Docker client prefixes them with, so an Agent
+# upgrade that raises the client's version cannot 404 the fixture.
+DOCKER_API_VERSION_PREFIX_REGEX = re.compile(r"^/v[0-9]+\.[0-9]+")
+# Advertised on `/_ping` so the client negotiates a version instead of falling back to its maximum.
+DOCKER_ADVERTISED_API_VERSION = "1.55"
+DOCKER_IMAGES_PATH = "/images/json"
+DOCKER_CONTAINERS_PATH = "/containers/json"
+DOCKER_EVENTS_PATH = "/events"
+DOCKER_INFO_PATH = "/info"
 EXPECTED_CONTAINER_TAGS = (
     "docker_image:example/adp-liveness:1.0",
     "env:liveness-fake",
@@ -195,10 +199,11 @@ class DockerDiscoveryHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_GET(self):
-        path = self.path.split("?", 1)[0]
+        path = DOCKER_API_VERSION_PREFIX_REGEX.sub("", self.path.split("?", 1)[0])
         expected_container_id = self.server.expected_container_id
         if path == "/_ping":
             self.send_response(200)
+            self.send_header("API-Version", DOCKER_ADVERTISED_API_VERSION)
             self.send_header("Content-Length", "2")
             self.end_headers()
             self.wfile.write(b"OK")
@@ -218,7 +223,7 @@ class DockerDiscoveryHandler(BaseHTTPRequestHandler):
                     }
                 ]
             )
-        elif path == DOCKER_API_PREFIX + "/containers/" + expected_container_id + "/json":
+        elif path == "/containers/" + expected_container_id + "/json":
             self.send_json(
                 {
                     "Id": expected_container_id,

--- a/test/integration/cases/liveness-container-tags/test_run_liveness_test.py
+++ b/test/integration/cases/liveness-container-tags/test_run_liveness_test.py
@@ -9,34 +9,52 @@ from pathlib import Path
 
 FIXTURE_PATH = Path(__file__).with_name("run_liveness_test.py")
 EXPECTED_CONTAINER_ID = "a" * 64
+UNKNOWN_CONTAINER_ID = "b" * 64
 spec = importlib.util.spec_from_file_location("run_liveness_test", FIXTURE_PATH)
 fixture = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(fixture)
 
 
 class DockerDiscoveryHandlerTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        socket_path = str(Path(self.temporary_directory.name) / "docker.sock")
+        self.server = fixture.ThreadingUnixHTTPServer(socket_path, fixture.DockerDiscoveryHandler)
+        self.server.expected_container_id = EXPECTED_CONTAINER_ID
+        server_thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        server_thread.start()
+        self.addCleanup(server_thread.join, 1)
+        self.addCleanup(self.server.server_close)
+        self.addCleanup(self.server.shutdown)
+        self.socket_path = socket_path
+
+    def get(self, path):
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.connect(self.socket_path)
+            request = "GET " + path + " HTTP/1.1\r\nHost: docker\r\nConnection: close\r\n\r\n"
+            client.sendall(request.encode("ascii"))
+            response = http.client.HTTPResponse(client)
+            response.begin()
+            response.read()
+            return response
+
     def test_inspect_for_unknown_container_returns_not_found(self):
-        with tempfile.TemporaryDirectory() as temporary_directory:
-            socket_path = str(Path(temporary_directory) / "docker.sock")
-            server = fixture.ThreadingUnixHTTPServer(socket_path, fixture.DockerDiscoveryHandler)
-            server.expected_container_id = EXPECTED_CONTAINER_ID
-            server_thread = threading.Thread(target=server.serve_forever, daemon=True)
-            server_thread.start()
-            try:
-                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
-                    client.connect(socket_path)
-                    client.sendall(
-                        b"GET /v1.54/containers/"
-                        + b"b" * 64
-                        + b"/json HTTP/1.1\r\nHost: docker\r\nConnection: close\r\n\r\n"
-                    )
-                    response = http.client.HTTPResponse(client)
-                    response.begin()
-                    self.assertEqual(response.status, 404)
-            finally:
-                server.shutdown()
-                server.server_close()
-                server_thread.join(timeout=1)
+        response = self.get("/v1.54/containers/" + UNKNOWN_CONTAINER_ID + "/json")
+        self.assertEqual(response.status, 404)
+
+    def test_routes_ignore_the_client_api_version(self):
+        # The Docker client picks the version prefix, and raises it as the Agent upgrades.
+        for prefix in ("", "/v1.40", "/v1.54", "/v1.55", "/v2.0"):
+            for route in ("/containers/" + EXPECTED_CONTAINER_ID + "/json", "/containers/json", "/images/json"):
+                with self.subTest(prefix=prefix, route=route):
+                    self.assertEqual(self.get(prefix + route).status, 200)
+
+    def test_ping_advertises_an_api_version(self):
+        # Without this header the client skips negotiation and requests its own maximum version.
+        response = self.get("/_ping")
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.getheader("API-Version"), fixture.DOCKER_ADVERTISED_API_VERSION)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Human Summary

Should fix the failure of `liveness-container-tags` on nightly.

## AI Summary

The `liveness-container-tags` integration test fails on the nightly Agent. Its fake Docker daemon
serves every route under a hardcoded `/v1.54` prefix, but the Agent has since moved to the
`moby/moby` split client (`client v0.5.0`, `api v1.55.0`), whose `MaxAPIVersion` is `1.55`. Every
request 404s and the docker workloadmeta collector never starts:

```
workloadmeta collector "docker" could not start. error: unable to list docker images:
request returned 404 Not Found for API route and version
http://%2Ftmp%2Fadp-liveness-docker.sock/v1.55/images/json?all=1
```

Without that collector the Core Agent tagger has no entry for the target container, so ADP's
liveness payloads reach the fake intake without `docker_image:` / `env:` tags. The fixture never
writes its marker files and the assertion times out:

```
- file_contains (60.20s)
  Pattern 'validated' not found in file '/tmp/adp-liveness-running-validated' after 60s.
```

ADP itself is healthy throughout — registered with the Agent, config received, topology healthy in
2352ms.

Two changes to the fixture:

- Match routes with the version prefix stripped (`DOCKER_API_VERSION_PREFIX_REGEX`), so a client
  version bump can no longer 404 the fake daemon.
- Advertise `API-Version` on `/_ping`. The old fixture omitted it, which meant it was never
  actually exercising negotiation: `moby/moby/client` treats a ping with no version as an ancient
  daemon and pins itself to `MaxAPIVersion`. `/v1.54` only ever worked because it happened to match
  the previous client's default.

Only the pinned-release pipeline was green here; the nightly job (`AGENT_NIGHTLY=true`) broke as soon
as Agent master picked up the new client, and the pinned job would have followed at the next Agent
bump.

## Change Type
- [x] Bug fix

## How did you test this PR?

The fixture's own unit tests gained coverage for both mechanisms — a prefix matrix (`""`, `/v1.40`,
`/v1.54`, `/v1.55`, `/v2.0` against three routes) and an assertion that `/_ping` advertises a
version. The existing unknown-container 404 case is unchanged in behavior.

Beyond that, I exercised the fixture with the real client the Agent uses. A small Go probe built
against `moby/moby/client v0.5.0` was pointed at the fixture's Docker server over a unix socket:

```
########## BEFORE (pinned /v1.54) ##########
negotiated version = 1.55
ImageList: request returned 404 Not Found for API route and version .../v1.55/images/json?all=1

########## AFTER (version-agnostic) ##########
negotiated version = 1.55
ImageList ok (0)
ContainerList ok (1)
ContainerInspect ok: name=/adp-liveness-fake image=example/adp-liveness:1.0 labels=map[com.datadoghq.tags.env:liveness-fake]
```

The "before" run reproduces the CI failure verbatim. Lowering the advertised version to `1.44` gives
`negotiated version = 1.44` with all routes still served, confirming the `/_ping` header is honored
and that routing is independent of the version.

## References

Nightly integration failure in `liveness-container-tags`.
