### PR TITLE
fix(dev): defer proxy dumper access check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -487,12 +487,11 @@ endif
 
 .PHONY: check-proxy-dumper-tools
 check-proxy-dumper-tools:
-ifeq ($(shell command -v go >/dev/null || echo not-found), not-found)
-	$(error "Please install Go.")
-endif
-ifeq ($(shell timeout 5s git remote show https://github.com/DataDog/dd-source 2>&1 >/dev/null || echo not-available), not-available)
-	$(error "Please ensure Git is configured correctly to accessing private/internal Datadog repositories.")
-endif
+	@command -v go >/dev/null || { echo "Please install Go." >&2; exit 1; }
+	@timeout 5s git remote show https://github.com/DataDog/dd-source >/dev/null 2>&1 || { \
+		echo "Please ensure Git is configured correctly to access private/internal Datadog repositories." >&2; \
+		exit 1; \
+	}
 
 ##@ Checking
 


### PR DESCRIPTION
## Summary

Move the proxy-dumper tool and repository access checks from Makefile parse-time conditionals into the `check-proxy-dumper-tools` recipe.

The existing `$(shell timeout 5s git remote show ...)` expression runs while Make parses the file, so every target performs a private Git network check, including unrelated targets such as `make fmt`. When the timeout terminates the Git/SSH process, Apple GNU Make 3.81 can leave the shell process defunct and wait indefinitely.

With this change, the network check runs only for targets that depend on `check-proxy-dumper-tools`, and failures return a normal actionable error.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- `make -n fmt` completes without performing the proxy-dumper access check.
- `make fmt` completes normally.
- `make check-proxy-dumper-tools` exits cleanly with an actionable error when the private repository is unavailable.
- `git diff --check`

## References

N/A
