### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
       # `make generate-api-docs` installs and pins the nightly toolchain it needs (see
       # RUST_NIGHTLY_VERSION in the Makefile); this step just provides Rust 1.94 and rustup/cargo.
       - name: Set up Rust 1.94
-        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: 1.94.0
           cache: false

--- a/.github/workflows/renovate-sync-licenses.yml
+++ b/.github/workflows/renovate-sync-licenses.yml
@@ -65,7 +65,7 @@ jobs:
       # rustflags cleared to suppress the action's default
       # -D warnings.
       - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
           rustflags: ""


### PR DESCRIPTION
Mechanical rewrite of every `uses:` reference to a full-length commit SHA, produced by [pinact](https://github.com/suzuki-shunsuke/pinact). An unpinned reference resolves to a mutable ref, so a compromise of the upstream action becomes code execution in this repository's CI.

The trailing `# vX.Y.Z` comment is what lets Renovate and Dependabot keep these bumped, so please keep it.

**One thing to check:** references that tracked `@main` or `@master` were resolved to the latest stable tag. If any of them floated deliberately and that behaviour was load-bearing here, say so on the PR and we will revert that line.

ACIX-1926
