### PR TITLE
fix(agent-data-plane): add help text to DSD client telemetry sent over RAR

### DIFF
--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -146,18 +146,22 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
         RemapperRule::by_name(
             "adp.dogstatsd_client_telemetry_bytes_sent",
             "dogstatsd_client.bytes_sent",
-        ),
+        )
+        .with_help_text("Total bytes sent by DogStatsD clients"),
         RemapperRule::by_name(
             "adp.dogstatsd_client_telemetry_bytes_dropped",
             "dogstatsd_client.bytes_dropped",
-        ),
+        )
+        .with_help_text("Total bytes dropped by DogStatsD clients"),
         RemapperRule::by_name(
             "adp.dogstatsd_client_telemetry_bytes_dropped_queue",
             "dogstatsd_client.bytes_dropped_queue",
-        ),
+        )
+        .with_help_text("Total bytes dropped because the DogStatsD client sender queue is full"),
         RemapperRule::by_name(
             "adp.dogstatsd_client_telemetry_bytes_dropped_writer",
             "dogstatsd_client.bytes_dropped_writer",
-        ),
+        )
+        .with_help_text("Total bytes dropped because the DogStatsD client writer cannot send"),
     ]
 }


### PR DESCRIPTION
## Summary

This PR adds the missing help text from the recently introduced DogStatsD client telemetry that we capture and send to the Core Agent via RAR.

In the Core Agent, specifically in the Prometheus library it uses, the help text for a metric cannot be changed at runtime... so once the Core Agent registers a metric, any other usages of that metric must match the help text, including when we capture/collect the same exact metrics from Remote Agents via RAR.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [ ] Build dev artifacts and test them in an Agent PR, running the full Agent CI pipeline, to ensure the E2E tests that caught that breakage show it passing.

## References

DADP-2
