### PR TITLE
feat(otlp): infra-attribute host and entity tag enrichment

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -908,9 +908,8 @@ async fn add_otlp_pipeline_to_blueprint(
             .await
             .error_context("Failed to get default hostname for OTLP source.")?;
         let config = config_system.config();
-        let otlp_config = OtlpConfiguration::from_configuration(&config.domains.otlp)
-            .with_default_hostname(default_hostname)
-            .with_workload_provider(env_provider.workload().clone());
+        let otlp_config = OtlpConfiguration::from_configuration(&config.domains.otlp, env_provider.workload().clone())
+            .with_default_hostname(default_hostname);
 
         blueprint
             // Components.

--- a/bin/agent-data-plane/src/internal/env/workload/collectors/tagger.rs
+++ b/bin/agent-data-plane/src/internal/env/workload/collectors/tagger.rs
@@ -236,7 +236,7 @@ fn remote_entity_id_to_entity_id(remote_entity_id: RemoteEntityId) -> Option<Ent
                 None
             }
         },
-        // GPU entity tags are not used by the OTLP metrics entity resolver.
+        // We don't care about this, so we just ignore it.
         "gpu" => None,
         prefix => {
             warn!("Unhandled entity ID prefix: {}://{}", prefix, remote_entity_id.uid);

--- a/bin/agent-data-plane/src/internal/env/workload/collectors/tagger.rs
+++ b/bin/agent-data-plane/src/internal/env/workload/collectors/tagger.rs
@@ -222,7 +222,13 @@ fn remote_entity_id_to_entity_id(remote_entity_id: RemoteEntityId) -> Option<Ent
     // convert the owned `String`s to `MetaString`s so it's not a huge deal.
     match remote_entity_id.prefix.as_str() {
         "container_id" => Some(EntityId::Container(remote_entity_id.uid.into())),
+        "container_image_metadata" => Some(EntityId::ContainerImageMetadata(remote_entity_id.uid.into())),
+        "ecs_task" => Some(EntityId::EcsTask(remote_entity_id.uid.into())),
+        "deployment" => Some(EntityId::KubernetesDeployment(remote_entity_id.uid.into())),
+        "kubernetes_metadata" => Some(EntityId::KubernetesMetadata(remote_entity_id.uid.into())),
+        "kubernetes_node" => Some(EntityId::KubernetesNode(remote_entity_id.uid.into())),
         "kubernetes_pod_uid" => Some(EntityId::PodUid(remote_entity_id.uid.into())),
+        "process" => Some(EntityId::Process(remote_entity_id.uid.into())),
         "internal" => match remote_entity_id.uid.as_str() {
             "global-entity-id" => Some(EntityId::Global),
             uid => {
@@ -230,11 +236,53 @@ fn remote_entity_id_to_entity_id(remote_entity_id: RemoteEntityId) -> Option<Ent
                 None
             }
         },
-        // We don't care about these, so we just ignore them.
-        "container_image_metadata" | "process" | "gpu" => None,
+        // GPU entity tags are not used by the OTLP metrics entity resolver.
+        "gpu" => None,
         prefix => {
             warn!("Unhandled entity ID prefix: {}://{}", prefix, remote_entity_id.uid);
             None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_all_otlp_metric_entity_prefixes_from_the_remote_tagger() {
+        let cases = [
+            ("container_id", "container", EntityId::Container("container".into())),
+            (
+                "container_image_metadata",
+                "sha256:image",
+                EntityId::ContainerImageMetadata("sha256:image".into()),
+            ),
+            ("ecs_task", "task", EntityId::EcsTask("task".into())),
+            (
+                "deployment",
+                "default/api",
+                EntityId::KubernetesDeployment("default/api".into()),
+            ),
+            (
+                "kubernetes_metadata",
+                "/namespaces//default",
+                EntityId::KubernetesMetadata("/namespaces//default".into()),
+            ),
+            ("kubernetes_node", "node", EntityId::KubernetesNode("node".into())),
+            ("kubernetes_pod_uid", "pod", EntityId::PodUid("pod".into())),
+            ("process", "42", EntityId::Process("42".into())),
+        ];
+
+        for (prefix, uid, expected) in cases {
+            assert_eq!(
+                remote_entity_id_to_entity_id(RemoteEntityId {
+                    prefix: prefix.to_owned(),
+                    uid: uid.to_owned(),
+                }),
+                Some(expected),
+                "{prefix}://{uid}"
+            );
         }
     }
 }

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -752,6 +752,7 @@ Both commands scrub recognized secret values before writing JSON to standard out
 | `otlp_config.metrics.summaries.mode`                           | OTLP summary quantile reporting mode.              |
 | `otlp_config.metrics.sums.cumulative_monotonic_mode`           | Cumulative monotonic sum reporting mode.           |
 | `otlp_config.metrics.sums.initial_cumulative_monotonic_value`  | Initial cumulative sum reporting behavior.         |
+| `otlp_config.metrics.tag_cardinality`                          | Tag cardinality for OTLP metric entity enrichment. |
 | `otlp_config.metrics.tags`                                     | Comma-separated tags for all OTLP metrics.         |
 | `otlp_config.receiver.protocols.grpc.endpoint`                 | otlp_config.receiver.protocols.grpc.endpoint       |
 | `otlp_config.receiver.protocols.grpc.max_recv_msg_size_mib`    | Max OTLP inbound gRPC message size (MiB)           |

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -936,6 +936,24 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
         }
     }
 
+    fn consume_otlp_config_metrics_tag_cardinality(&mut self, value: String) {
+        let cardinality = match value.to_ascii_lowercase().as_str() {
+            "low" => OriginTagCardinality::Low,
+            "orchestrator" => OriginTagCardinality::Orchestrator,
+            "high" => OriginTagCardinality::High,
+            "none" => OriginTagCardinality::None,
+            _ => {
+                self.record_error(TranslateError::new(
+                    "otlp_config.metrics.tag_cardinality",
+                    format!("unknown OTLP tag cardinality `{value}`; expected low, orchestrator, high, or none"),
+                ));
+                return;
+            }
+        };
+
+        self.config.domains.otlp.metrics.tag_cardinality = cardinality;
+    }
+
     fn consume_otlp_config_metrics_tags(&mut self, value: String) {
         self.config.domains.otlp.metrics.tags = value;
     }
@@ -1190,6 +1208,7 @@ mod tests {
             "dd_url": "https://custom.example.com",
             "dogstatsd_port": 9125,
             "dogstatsd_tag_cardinality": "high",
+            "otlp_config": { "metrics": { "tag_cardinality": "orchestrator" } },
             "expected_tags_duration": "15s",
             "telemetry": { "dogstatsd_origin": true },
         }))
@@ -1211,6 +1230,11 @@ mod tests {
         assert_eq!(
             config.domains.dogstatsd.origin.tag_cardinality,
             OriginTagCardinality::High
+        );
+        // The OTLP metrics cardinality uses the same source values but remains scoped to the OTLP metrics domain.
+        assert_eq!(
+            config.domains.otlp.metrics.tag_cardinality,
+            OriginTagCardinality::Orchestrator
         );
         // Driven `format: duration` parse: a Go duration string becomes a `Duration`.
         assert_eq!(config.shared.tags.expected_tags_duration, Duration::from_secs(15));

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -605,21 +605,10 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_dogstatsd_tag_cardinality(&mut self, value: String) {
-        // TODO: consider moving the enum to agent-data-plane-config
-        let cardinality = match value.to_ascii_lowercase().as_str() {
-            "low" => OriginTagCardinality::Low,
-            "orchestrator" => OriginTagCardinality::Orchestrator,
-            "high" => OriginTagCardinality::High,
-            "none" => OriginTagCardinality::None,
-            other => {
-                self.record_error(TranslateError::new_with_message(
-                    "dogstatsd_tag_cardinality",
-                    format!("unknown tag cardinality `{other}`"),
-                ));
-                return;
-            }
-        };
-        self.config.domains.dogstatsd.origin.tag_cardinality = cardinality;
+        match value.parse::<OriginTagCardinality>() {
+            Ok(cardinality) => self.config.domains.dogstatsd.origin.tag_cardinality = cardinality,
+            Err(error) => self.record_error(TranslateError::new("dogstatsd_tag_cardinality", error)),
+        }
     }
 
     fn consume_dogstatsd_tags(&mut self, value: Vec<String>) {
@@ -937,21 +926,10 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_otlp_config_metrics_tag_cardinality(&mut self, value: String) {
-        let cardinality = match value.to_ascii_lowercase().as_str() {
-            "low" => OriginTagCardinality::Low,
-            "orchestrator" => OriginTagCardinality::Orchestrator,
-            "high" => OriginTagCardinality::High,
-            "none" => OriginTagCardinality::None,
-            _ => {
-                self.record_error(TranslateError::new(
-                    "otlp_config.metrics.tag_cardinality",
-                    format!("unknown OTLP tag cardinality `{value}`; expected low, orchestrator, high, or none"),
-                ));
-                return;
-            }
-        };
-
-        self.config.domains.otlp.metrics.tag_cardinality = cardinality;
+        match value.parse::<OriginTagCardinality>() {
+            Ok(cardinality) => self.config.domains.otlp.metrics.tag_cardinality = cardinality,
+            Err(error) => self.record_error(TranslateError::new("otlp_config.metrics.tag_cardinality", error)),
+        }
     }
 
     fn consume_otlp_config_metrics_tags(&mut self, value: String) {

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -1231,7 +1231,6 @@ mod tests {
             config.domains.dogstatsd.origin.tag_cardinality,
             OriginTagCardinality::High
         );
-        // The OTLP metrics cardinality uses the same source values but remains scoped to the OTLP metrics domain.
         assert_eq!(
             config.domains.otlp.metrics.tag_cardinality,
             OriginTagCardinality::Orchestrator

--- a/lib/agent-data-plane-config/src/domains/dogstatsd.rs
+++ b/lib/agent-data-plane-config/src/domains/dogstatsd.rs
@@ -3,9 +3,12 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::time::Duration;
 
 use serde::Serialize;
+
+use crate::Error;
 
 // TODO: better name than Domain? Pipeline? Topology? BlueprintConfig?
 /// Resolved DogStatsD configuration.
@@ -144,6 +147,22 @@ pub enum OriginTagCardinality {
     Orchestrator,
     High,
     None,
+}
+
+impl FromStr for OriginTagCardinality {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_ascii_lowercase().as_str() {
+            "low" => Ok(Self::Low),
+            "orchestrator" => Ok(Self::Orchestrator),
+            "high" => Ok(Self::High),
+            "none" => Ok(Self::None),
+            other => Err(Error::new_without_source(format!(
+                "unknown tag cardinality `{other}`; expected low, orchestrator, high, or none"
+            ))),
+        }
+    }
 }
 
 /// Telemetry emitted by the DogStatsD source.

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -6,7 +6,7 @@ use std::{num::NonZeroUsize, str::FromStr};
 use serde::Serialize;
 
 use crate::defaults::DEFAULT_STRING_INTERNER_SIZE_BYTES;
-use crate::Error;
+use crate::{domains::dogstatsd::OriginTagCardinality, Error};
 
 /// Resolved OTLP configuration.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
@@ -30,6 +30,12 @@ pub struct Domain {
 /// OTLP metrics translation settings.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct Metrics {
+    /// Tag cardinality applied to entity and global tags enriched onto OTLP metrics.
+    ///
+    /// Defaults to `low`. Set this to `orchestrator` or `high` when the additional series cardinality is acceptable.
+    /// `none` disables entity and global tag enrichment.
+    pub tag_cardinality: OriginTagCardinality,
+
     /// How explicit histogram buckets are reported.
     pub histogram_mode: HistogramMode,
 

--- a/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
@@ -322,6 +322,17 @@ crate::declare_annotations! {
         test_json: Some(r#""drop""#),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
     };
+    /// `otlp_config.metrics.tag_cardinality`-Tag cardinality for OTLP metric entity enrichment.
+    OTLP_CONFIG_METRICS_TAG_CARDINALITY = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_METRICS_TAG_CARDINALITY,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: Some(r#""high""#),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
     /// `otlp_config.metrics.tags`-Comma-separated tags for all OTLP metrics.
     OTLP_CONFIG_METRICS_TAGS = SalukiAnnotation {
         schema: &schema::OTLP_CONFIG_METRICS_TAGS,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -2122,6 +2122,20 @@ inventory:
       additional_attributes:
         config_registry_filename: otlp.rs
 
+  otlp_config.metrics.tag_cardinality:
+    support: full
+    pipelines: [otlp]
+    description: "Tag cardinality for OTLP metric entity enrichment."
+    documentation: |-
+      Controls the cardinality of entity and global tags added to OTLP metrics. The default `low` adds
+      low-cardinality workload tags. Set this to `orchestrator` or `high` only when the resulting additional metric
+      series are acceptable. Set it to `none` to disable entity and global tag enrichment.
+    test_support:
+      used_by: [TypedConfigSystem]
+      test_json: '"high"'
+      additional_attributes:
+        config_registry_filename: otlp.rs
+
   otlp_config.metrics.tags:
     support: full
     pipelines: [otlp]
@@ -4003,7 +4017,6 @@ excluded:
   otlp_config.metrics.delta_ttl: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.histograms.send_count_sum_metrics: "deprecated; ADP supports only send_aggregation_metrics"
   otlp_config.metrics.instrumentation_scope_metadata_as_tags: "ignored in initial audit 2026-04-23"
-  otlp_config.metrics.tag_cardinality: "ignored in initial audit 2026-04-23"
   otlp_config.receiver.protocols.grpc.include_metadata: "ignored in initial audit 2026-04-23"
   otlp_config.receiver.protocols.grpc.keepalive.enforcement_policy.min_time: "ignored in initial audit 2026-04-23"
   otlp_config.receiver.protocols.grpc.max_concurrent_streams: "ignored in initial audit 2026-04-23"

--- a/lib/datadog-agent/config/src/generated/datadog_configuration.rs
+++ b/lib/datadog-agent/config/src/generated/datadog_configuration.rs
@@ -1293,6 +1293,11 @@ pub struct OtlpConfigMetrics {
     #[serde(default)]
     pub sums: OtlpConfigMetricsSums,
 
+    #[serde(
+        default = "defaults::datadog_configuration_otlp_config_metrics_tag_cardinality"
+    )]
+    pub tag_cardinality: String,
+
     #[serde(default)]
     pub tags: String,
 }
@@ -1305,6 +1310,7 @@ impl Default for OtlpConfigMetrics {
             resource_attributes_as_tags: Default::default(),
             summaries: Default::default(),
             sums: Default::default(),
+            tag_cardinality: defaults::datadog_configuration_otlp_config_metrics_tag_cardinality(),
             tags: Default::default(),
         }
     }
@@ -1811,6 +1817,9 @@ pub mod defaults {
     }
     pub(super) fn datadog_configuration_data_plane_otlp_proxy_receiver_protocols_grpc_endpoint() -> String {
         "127.0.0.1:4319".to_string()
+    }
+    pub(super) fn datadog_configuration_otlp_config_metrics_tag_cardinality() -> String {
+        "low".to_string()
     }
     pub(super) fn datadog_configuration_otlp_config_metrics_histograms_mode() -> String {
         "distributions".to_string()

--- a/lib/datadog-agent/config/src/generated/env_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_keys.rs
@@ -786,6 +786,11 @@ pub static DATADOG_ENV_KEYS: &[EnvKey] = &[
         decode: EnvDecode::RawString,
     },
     EnvKey {
+        env_vars: &["DD_OTLP_CONFIG_METRICS_TAG_CARDINALITY", "DD_OTLP_TAG_CARDINALITY"],
+        path: &["otlp_config", "metrics", "tag_cardinality"],
+        decode: EnvDecode::RawString,
+    },
+    EnvKey {
         env_vars: &["DD_OTLP_CONFIG_METRICS_TAGS"],
         path: &["otlp_config", "metrics", "tags"],
         decode: EnvDecode::RawString,

--- a/lib/datadog-agent/config/src/generated/witness.rs
+++ b/lib/datadog-agent/config/src/generated/witness.rs
@@ -167,6 +167,7 @@ pub trait DatadogConfigWitness {
     fn consume_otlp_config_metrics_summaries_mode(&mut self, value: String);
     fn consume_otlp_config_metrics_sums_cumulative_monotonic_mode(&mut self, value: String);
     fn consume_otlp_config_metrics_sums_initial_cumulative_monotonic_value(&mut self, value: String);
+    fn consume_otlp_config_metrics_tag_cardinality(&mut self, value: String);
     fn consume_otlp_config_metrics_tags(&mut self, value: String);
     fn consume_otlp_config_receiver_protocols_grpc_endpoint(&mut self, value: String);
     fn consume_otlp_config_receiver_protocols_grpc_max_recv_msg_size_mib(&mut self, value: i64);
@@ -441,6 +442,7 @@ pub fn drive(config: &DatadogConfiguration, consumer: &mut impl DatadogConfigWit
             .initial_cumulative_monotonic_value
             .clone(),
     );
+    consumer.consume_otlp_config_metrics_tag_cardinality(config.otlp_config.metrics.tag_cardinality.clone());
     consumer.consume_otlp_config_metrics_tags(config.otlp_config.metrics.tags.clone());
     consumer.consume_otlp_config_receiver_protocols_grpc_endpoint(
         config.otlp_config.receiver.protocols.grpc.endpoint.clone(),

--- a/lib/saluki-components/src/common/otlp/origin.rs
+++ b/lib/saluki-components/src/common/otlp/origin.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use agent_data_plane_config::domains::dogstatsd::OriginTagCardinality as ConfigOriginTagCardinality;
 use otlp_protos::opentelemetry::proto::common::v1::{self as otlp_common, any_value::Value};
 use saluki_common::collections::FastHashSet;
 use saluki_context::{
@@ -22,6 +23,7 @@ const PROCESS_PID: &str = "process.pid";
 const CGROUP_INODE: &str = "datadog.container.cgroup_inode";
 const INIT_CONTAINER: &str = "datadog.container.is_init";
 
+/// Recognized OTLP resource attributes used for entity tag resolution.
 #[derive(Default)]
 struct OtlpResourceAttributes<'a> {
     container_id: Option<&'a str>,
@@ -78,11 +80,14 @@ impl OtlpOriginTagResolver {
 
     /// Resolves entity and global tags for one OTLP metrics resource by entity precedence.
     pub fn resolve_resource_tags(
-        &self, attributes: &[otlp_common::KeyValue], tag_cardinality: OriginTagCardinality,
+        &self, attributes: &[otlp_common::KeyValue], tag_cardinality: ConfigOriginTagCardinality,
     ) -> SharedTagSet {
-        if tag_cardinality == OriginTagCardinality::None {
-            return SharedTagSet::default();
-        }
+        let tag_cardinality = match tag_cardinality {
+            ConfigOriginTagCardinality::Low => OriginTagCardinality::Low,
+            ConfigOriginTagCardinality::Orchestrator => OriginTagCardinality::Orchestrator,
+            ConfigOriginTagCardinality::High => OriginTagCardinality::High,
+            ConfigOriginTagCardinality::None => return SharedTagSet::default(),
+        };
 
         let attributes = OtlpResourceAttributes::from_attributes(attributes);
         let mut tags = TagSet::default();
@@ -334,7 +339,7 @@ mod tests {
         ];
 
         assert_eq!(
-            tags(resolver.resolve_resource_tags(&resource, OriginTagCardinality::Low)),
+            tags(resolver.resolve_resource_tags(&resource, ConfigOriginTagCardinality::Low)),
             vec![
                 "container:present",
                 "deployment:present",
@@ -360,7 +365,7 @@ mod tests {
         let resource = vec![attribute(PROCESS_PID, Value::IntValue(42))];
 
         assert_eq!(
-            tags(resolver.resolve_resource_tags(&resource, OriginTagCardinality::Low)),
+            tags(resolver.resolve_resource_tags(&resource, ConfigOriginTagCardinality::Low)),
             vec!["container:present", "process:present", "service:container"]
         );
     }
@@ -375,7 +380,7 @@ mod tests {
         let resource = vec![attribute(CGROUP_INODE, Value::IntValue(123))];
 
         assert_eq!(
-            tags(resolver.resolve_resource_tags(&resource, OriginTagCardinality::Low)),
+            tags(resolver.resolve_resource_tags(&resource, ConfigOriginTagCardinality::Low)),
             vec!["container:present", "service:container"]
         );
     }
@@ -395,7 +400,7 @@ mod tests {
         ];
 
         assert_eq!(
-            tags(resolver.resolve_resource_tags(&resource, OriginTagCardinality::Low)),
+            tags(resolver.resolve_resource_tags(&resource, ConfigOriginTagCardinality::Low)),
             vec!["container:present", "service:container"]
         );
     }
@@ -411,15 +416,15 @@ mod tests {
         let resolver = OtlpOriginTagResolver::new(Arc::new(provider));
 
         assert_eq!(
-            tags(resolver.resolve_resource_tags(&[], OriginTagCardinality::Low)),
+            tags(resolver.resolve_resource_tags(&[], ConfigOriginTagCardinality::Low)),
             vec!["low:present"]
         );
         assert_eq!(
-            tags(resolver.resolve_resource_tags(&[], OriginTagCardinality::High)),
+            tags(resolver.resolve_resource_tags(&[], ConfigOriginTagCardinality::High)),
             vec!["high:present", "low:present", "orchestrator:present"]
         );
         assert!(resolver
-            .resolve_resource_tags(&[], OriginTagCardinality::None)
+            .resolve_resource_tags(&[], ConfigOriginTagCardinality::None)
             .is_empty());
     }
 }

--- a/lib/saluki-components/src/common/otlp/origin.rs
+++ b/lib/saluki-components/src/common/otlp/origin.rs
@@ -1,11 +1,26 @@
 use std::sync::Arc;
 
+use otlp_protos::opentelemetry::proto::common::v1::{self as otlp_common, any_value::Value};
+use saluki_common::collections::FastHashSet;
 use saluki_context::{
     origin::{OriginTagCardinality, OriginTagsResolver, RawOrigin},
-    tags::SharedTagSet,
+    tags::{SharedTagSet, TagSet},
 };
-use saluki_env::WorkloadProvider;
+use saluki_env::{workload::EntityId, WorkloadProvider};
+use stringtheory::MetaString;
 use tracing::trace;
+
+const CONTAINER_ID: &str = "container.id";
+const OCI_MANIFEST_DIGEST: &str = "oci.manifest.digest";
+const ECS_TASK_ARN: &str = "aws.ecs.task.arn";
+const K8S_CONTAINER_NAME: &str = "k8s.container.name";
+const K8S_DEPLOYMENT_NAME: &str = "k8s.deployment.name";
+const K8S_NAMESPACE_NAME: &str = "k8s.namespace.name";
+const K8S_NODE_NAME: &str = "k8s.node.name";
+const K8S_POD_UID: &str = "k8s.pod.uid";
+const PROCESS_PID: &str = "process.pid";
+const CGROUP_INODE: &str = "datadog.container.cgroup_inode";
+const INIT_CONTAINER: &str = "datadog.container.is_init";
 
 #[derive(Clone)]
 pub struct OtlpOriginTagResolver {
@@ -17,12 +32,113 @@ impl OtlpOriginTagResolver {
         Self { workload_provider }
     }
 
+    /// Resolves all entity and global tags for one OTLP metrics resource.
+    ///
+    /// The entity order mirrors the Core Agent's infra-attributes processor. The synthetic container candidate is
+    /// resolved first: direct container ID, process ID, cgroup inode, then pod UID plus container name. The first
+    /// fallback that returns tags stands in for the container ID that the Core Agent synthesizes before it evaluates
+    /// the remaining resource entities.
+    pub fn resolve_resource_tags(
+        &self, attributes: &[otlp_common::KeyValue], tag_cardinality: OriginTagCardinality,
+    ) -> SharedTagSet {
+        if tag_cardinality == OriginTagCardinality::None {
+            return SharedTagSet::default();
+        }
+
+        let mut tags = TagSet::default();
+        let mut written_keys = FastHashSet::default();
+
+        if let Some(container_entity) = self.container_entity_from_attributes(attributes, tag_cardinality) {
+            self.collect_tags_for_entity(container_entity, tag_cardinality, &mut written_keys, &mut tags);
+        }
+
+        for entity_id in entity_ids_from_attributes(attributes) {
+            self.collect_tags_for_entity(entity_id, tag_cardinality, &mut written_keys, &mut tags);
+        }
+
+        self.collect_tags_for_entity(EntityId::Global, tag_cardinality, &mut written_keys, &mut tags);
+        tags.into_shared()
+    }
+
+    fn container_entity_from_attributes(
+        &self, attributes: &[otlp_common::KeyValue], tag_cardinality: OriginTagCardinality,
+    ) -> Option<EntityId> {
+        if let Some(container_id) = get_string_attribute(attributes, CONTAINER_ID).filter(|value| !value.is_empty()) {
+            return Some(EntityId::Container(container_id.into()));
+        }
+
+        let mut fallback_entities = Vec::with_capacity(3);
+        if let Some(process_id) = get_integer_attribute(attributes, PROCESS_PID)
+            .and_then(|value| u32::try_from(value).ok())
+            .filter(|value| *value != 0)
+        {
+            fallback_entities.push(EntityId::ContainerPid(process_id));
+        }
+        if let Some(cgroup_inode) = get_integer_attribute(attributes, CGROUP_INODE)
+            .and_then(|value| u64::try_from(value).ok())
+            .filter(|value| *value != 0)
+        {
+            fallback_entities.push(EntityId::ContainerInode(cgroup_inode));
+        }
+        if let Some(container_entity) = self.container_entity_from_external_data(attributes) {
+            fallback_entities.push(container_entity);
+        }
+
+        // `get_tags_for_entity` follows local PID and inode aliases to a canonical container ID. Selecting the first
+        // entity with tags therefore matches the Core Agent's first successful container-ID fallback without exposing
+        // a container-ID resolution API from the workload provider.
+        fallback_entities.into_iter().find(|entity_id| {
+            self.workload_provider
+                .get_tags_for_entity(entity_id, tag_cardinality)
+                .is_some_and(|tags| !tags.is_empty())
+        })
+    }
+
+    fn container_entity_from_external_data(&self, attributes: &[otlp_common::KeyValue]) -> Option<EntityId> {
+        let pod_uid = get_string_attribute(attributes, K8S_POD_UID)?;
+        let container_name = get_string_attribute(attributes, K8S_CONTAINER_NAME)?;
+        let init_container = get_bool_attribute(attributes, INIT_CONTAINER).unwrap_or(false);
+        let external_data = format!("pu-{pod_uid},cn-{container_name},it-{init_container}");
+
+        let mut origin = RawOrigin::default();
+        origin.set_external_data(external_data.as_str());
+        self.workload_provider.get_resolved_origin(origin).and_then(|origin| {
+            origin
+                .resolved_external_data()
+                .map(|external_data| external_data.container_entity_id().clone())
+        })
+    }
+
+    fn collect_tags_for_entity(
+        &self, entity_id: EntityId, tag_cardinality: OriginTagCardinality, written_keys: &mut FastHashSet<String>,
+        tags: &mut TagSet,
+    ) {
+        let Some(entity_tags) = self.workload_provider.get_tags_for_entity(&entity_id, tag_cardinality) else {
+            trace!(
+                ?entity_id,
+                cardinality = tag_cardinality.as_str(),
+                "No tags found for entity."
+            );
+            return;
+        };
+
+        for tag in &entity_tags {
+            let Some((key, value)) = tag.as_str().split_once(':') else {
+                continue;
+            };
+            if key.is_empty() || value.is_empty() || !written_keys.insert(key.to_owned()) {
+                continue;
+            }
+            tags.insert_tag(tag.clone());
+        }
+    }
+
     fn collect_origin_tags(&self, resolved_origin: &saluki_env::workload::origin::ResolvedOrigin) -> SharedTagSet {
         let mut collected_tags = SharedTagSet::default();
         let tag_cardinality = resolved_origin.cardinality().unwrap_or(OriginTagCardinality::Low);
 
-        // TODO: Add additional entity IDs that are specific to OTLP.
-        // https://github.com/DataDog/datadog-agent/blob/main/comp/otelcol/otlp/components/processor/infraattributesprocessor/common.go#L158
+        // Logs retain their existing origin-only behavior. Metrics use `resolve_resource_tags` above to include the
+        // full OTLP entity list and global tags.
         let entity_ids = [
             resolved_origin.local_data(),
             resolved_origin.pod_uid(),
@@ -56,5 +172,254 @@ impl OriginTagsResolver for OtlpOriginTagResolver {
                 SharedTagSet::default()
             }
         }
+    }
+}
+
+fn entity_ids_from_attributes(attributes: &[otlp_common::KeyValue]) -> Vec<EntityId> {
+    let mut entity_ids = Vec::with_capacity(7);
+
+    if let Some(oci_manifest_digest) = get_string_attribute(attributes, OCI_MANIFEST_DIGEST) {
+        if let Some((_, digest)) = oci_manifest_digest.split_once("@sha256:") {
+            entity_ids.push(EntityId::ContainerImageMetadata(format!("sha256:{digest}").into()));
+        }
+    }
+    if let Some(ecs_task_arn) = get_string_attribute(attributes, ECS_TASK_ARN) {
+        entity_ids.push(EntityId::EcsTask(ecs_task_arn.into()));
+    }
+    if let (Some(deployment), Some(namespace)) = (
+        get_string_attribute(attributes, K8S_DEPLOYMENT_NAME),
+        get_string_attribute(attributes, K8S_NAMESPACE_NAME),
+    ) {
+        entity_ids.push(EntityId::KubernetesDeployment(
+            format!("{namespace}/{deployment}").into(),
+        ));
+    }
+    if let Some(namespace) = get_string_attribute(attributes, K8S_NAMESPACE_NAME) {
+        entity_ids.push(EntityId::KubernetesMetadata(format!("/namespaces//{namespace}").into()));
+    }
+    if let Some(node_name) = get_string_attribute(attributes, K8S_NODE_NAME) {
+        entity_ids.push(EntityId::KubernetesNode(node_name.into()));
+    }
+    if let Some(pod_uid) = get_string_attribute(attributes, K8S_POD_UID) {
+        if let Some(entity_id) = EntityId::from_pod_uid(pod_uid) {
+            entity_ids.push(entity_id);
+        }
+    }
+    if let Some(process_id) = get_integer_attribute(attributes, PROCESS_PID) {
+        entity_ids.push(EntityId::Process(MetaString::from(process_id.to_string())));
+    }
+
+    entity_ids
+}
+
+fn get_string_attribute<'a>(attributes: &'a [otlp_common::KeyValue], key: &str) -> Option<&'a str> {
+    attributes.iter().find_map(|attribute| {
+        (attribute.key == key)
+            .then(|| attribute.value.as_ref().and_then(|value| value.value.as_ref()))
+            .flatten()
+            .and_then(|value| match value {
+                Value::StringValue(value) => Some(value.as_str()),
+                _ => None,
+            })
+    })
+}
+
+fn get_integer_attribute(attributes: &[otlp_common::KeyValue], key: &str) -> Option<i64> {
+    attributes.iter().find_map(|attribute| {
+        (attribute.key == key)
+            .then(|| attribute.value.as_ref().and_then(|value| value.value.as_ref()))
+            .flatten()
+            .and_then(|value| match value {
+                Value::IntValue(value) => Some(*value),
+                _ => None,
+            })
+    })
+}
+
+fn get_bool_attribute(attributes: &[otlp_common::KeyValue], key: &str) -> Option<bool> {
+    attributes.iter().find_map(|attribute| {
+        (attribute.key == key)
+            .then(|| attribute.value.as_ref().and_then(|value| value.value.as_ref()))
+            .flatten()
+            .and_then(|value| match value {
+                Value::BoolValue(value) => Some(*value),
+                _ => None,
+            })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use otlp_common::{any_value::Value, AnyValue, KeyValue};
+    use saluki_env::workload::providers::TestWorkloadProvider;
+
+    use super::*;
+
+    fn attribute(key: &str, value: Value) -> KeyValue {
+        KeyValue {
+            key: key.to_owned(),
+            value: Some(AnyValue { value: Some(value) }),
+        }
+    }
+
+    fn tags(tags: SharedTagSet) -> Vec<String> {
+        let mut tags = tags.into_iter().map(|tag| tag.as_str().to_owned()).collect::<Vec<_>>();
+        tags.sort();
+        tags
+    }
+
+    struct ExternalDataWorkloadProvider {
+        tags: TestWorkloadProvider,
+    }
+
+    impl WorkloadProvider for ExternalDataWorkloadProvider {
+        fn get_tags_for_entity(&self, entity_id: &EntityId, cardinality: OriginTagCardinality) -> Option<SharedTagSet> {
+            self.tags.get_tags_for_entity(entity_id, cardinality)
+        }
+
+        fn get_resolved_origin(&self, origin: RawOrigin<'_>) -> Option<saluki_env::workload::origin::ResolvedOrigin> {
+            (!origin.is_empty()).then(|| {
+                saluki_env::workload::origin::ResolvedOrigin::from_parts(
+                    origin.cardinality(),
+                    origin.process_id().map(EntityId::ContainerPid),
+                    origin.local_data().and_then(EntityId::from_local_data),
+                    origin.pod_uid().and_then(EntityId::from_pod_uid),
+                    Some(saluki_env::workload::origin::ResolvedExternalData::new(
+                        EntityId::PodUid("pod-1".into()),
+                        EntityId::Container("external-container".into()),
+                    )),
+                )
+            })
+        }
+    }
+
+    #[test]
+    fn resolves_all_resource_entities_in_core_order_and_merges_global_tags_last() {
+        let mut provider = TestWorkloadProvider::new();
+        provider
+            .add_entity(
+                EntityId::Container("container-id".into()),
+                &["service:container", "container:present"],
+            )
+            .add_entity(
+                EntityId::ContainerImageMetadata("sha256:digest".into()),
+                &["service:image", "image:present"],
+            )
+            .add_entity(EntityId::EcsTask("task-arn".into()), &["task:present"])
+            .add_entity(
+                EntityId::KubernetesDeployment("default/api".into()),
+                &["deployment:present"],
+            )
+            .add_entity(
+                EntityId::KubernetesMetadata("/namespaces//default".into()),
+                &["namespace:present"],
+            )
+            .add_entity(EntityId::KubernetesNode("node-1".into()), &["node:present"])
+            .add_entity(EntityId::PodUid("pod-1".into()), &["pod:present"])
+            .add_entity(EntityId::Process("42".into()), &["process:present"])
+            .add_entity(EntityId::Global, &["service:global", "global:present"]);
+        let resolver = OtlpOriginTagResolver::new(Arc::new(provider));
+
+        let resource = vec![
+            attribute(CONTAINER_ID, Value::StringValue("container-id".into())),
+            attribute(OCI_MANIFEST_DIGEST, Value::StringValue("image@sha256:digest".into())),
+            attribute(ECS_TASK_ARN, Value::StringValue("task-arn".into())),
+            attribute(K8S_DEPLOYMENT_NAME, Value::StringValue("api".into())),
+            attribute(K8S_NAMESPACE_NAME, Value::StringValue("default".into())),
+            attribute(K8S_NODE_NAME, Value::StringValue("node-1".into())),
+            attribute(K8S_POD_UID, Value::StringValue("pod-1".into())),
+            attribute(PROCESS_PID, Value::IntValue(42)),
+        ];
+
+        assert_eq!(
+            tags(resolver.resolve_resource_tags(&resource, OriginTagCardinality::Low)),
+            vec![
+                "container:present",
+                "deployment:present",
+                "global:present",
+                "image:present",
+                "namespace:present",
+                "node:present",
+                "pod:present",
+                "process:present",
+                "service:container",
+                "task:present",
+            ]
+        );
+    }
+
+    #[test]
+    fn falls_back_from_process_id_to_container_tags_before_other_entities() {
+        let mut provider = TestWorkloadProvider::new();
+        provider
+            .add_entity(EntityId::ContainerPid(42), &["service:container", "container:present"])
+            .add_entity(EntityId::Process("42".into()), &["service:process", "process:present"]);
+        let resolver = OtlpOriginTagResolver::new(Arc::new(provider));
+        let resource = vec![attribute(PROCESS_PID, Value::IntValue(42))];
+
+        assert_eq!(
+            tags(resolver.resolve_resource_tags(&resource, OriginTagCardinality::Low)),
+            vec!["container:present", "process:present", "service:container"]
+        );
+    }
+
+    #[test]
+    fn falls_back_from_cgroup_inode_to_container_tags() {
+        let provider = TestWorkloadProvider::with_entity(
+            EntityId::ContainerInode(123),
+            &["service:container", "container:present"],
+        );
+        let resolver = OtlpOriginTagResolver::new(Arc::new(provider));
+        let resource = vec![attribute(CGROUP_INODE, Value::IntValue(123))];
+
+        assert_eq!(
+            tags(resolver.resolve_resource_tags(&resource, OriginTagCardinality::Low)),
+            vec!["container:present", "service:container"]
+        );
+    }
+
+    #[test]
+    fn falls_back_from_pod_uid_and_container_name_to_container_tags() {
+        let provider = ExternalDataWorkloadProvider {
+            tags: TestWorkloadProvider::with_entity(
+                EntityId::Container("external-container".into()),
+                &["service:container", "container:present"],
+            ),
+        };
+        let resolver = OtlpOriginTagResolver::new(Arc::new(provider));
+        let resource = vec![
+            attribute(K8S_POD_UID, Value::StringValue("pod-1".into())),
+            attribute(K8S_CONTAINER_NAME, Value::StringValue("app".into())),
+        ];
+
+        assert_eq!(
+            tags(resolver.resolve_resource_tags(&resource, OriginTagCardinality::Low)),
+            vec!["container:present", "service:container"]
+        );
+    }
+
+    #[test]
+    fn uses_the_requested_tag_cardinality() {
+        let provider = TestWorkloadProvider::with_entity_cardinalities(
+            EntityId::Global,
+            &["low:present"],
+            &["orchestrator:present"],
+            &["high:present"],
+        );
+        let resolver = OtlpOriginTagResolver::new(Arc::new(provider));
+
+        assert_eq!(
+            tags(resolver.resolve_resource_tags(&[], OriginTagCardinality::Low)),
+            vec!["low:present"]
+        );
+        assert_eq!(
+            tags(resolver.resolve_resource_tags(&[], OriginTagCardinality::High)),
+            vec!["high:present", "low:present", "orchestrator:present"]
+        );
+        assert!(resolver
+            .resolve_resource_tags(&[], OriginTagCardinality::None)
+            .is_empty());
     }
 }

--- a/lib/saluki-components/src/common/otlp/origin.rs
+++ b/lib/saluki-components/src/common/otlp/origin.rs
@@ -22,6 +22,50 @@ const PROCESS_PID: &str = "process.pid";
 const CGROUP_INODE: &str = "datadog.container.cgroup_inode";
 const INIT_CONTAINER: &str = "datadog.container.is_init";
 
+#[derive(Default)]
+struct OtlpResourceAttributes<'a> {
+    container_id: Option<&'a str>,
+    oci_manifest_digest: Option<&'a str>,
+    ecs_task_arn: Option<&'a str>,
+    k8s_container_name: Option<&'a str>,
+    k8s_deployment_name: Option<&'a str>,
+    k8s_namespace_name: Option<&'a str>,
+    k8s_node_name: Option<&'a str>,
+    k8s_pod_uid: Option<&'a str>,
+    process_pid: Option<i64>,
+    cgroup_inode: Option<i64>,
+    init_container: Option<bool>,
+}
+
+impl<'a> OtlpResourceAttributes<'a> {
+    fn from_attributes(attributes: &'a [otlp_common::KeyValue]) -> Self {
+        let mut extracted = Self::default();
+
+        for attribute in attributes {
+            let Some(value) = attribute.value.as_ref().and_then(|value| value.value.as_ref()) else {
+                continue;
+            };
+
+            match (attribute.key.as_str(), value) {
+                (CONTAINER_ID, Value::StringValue(value)) => extracted.container_id = Some(value),
+                (OCI_MANIFEST_DIGEST, Value::StringValue(value)) => extracted.oci_manifest_digest = Some(value),
+                (ECS_TASK_ARN, Value::StringValue(value)) => extracted.ecs_task_arn = Some(value),
+                (K8S_CONTAINER_NAME, Value::StringValue(value)) => extracted.k8s_container_name = Some(value),
+                (K8S_DEPLOYMENT_NAME, Value::StringValue(value)) => extracted.k8s_deployment_name = Some(value),
+                (K8S_NAMESPACE_NAME, Value::StringValue(value)) => extracted.k8s_namespace_name = Some(value),
+                (K8S_NODE_NAME, Value::StringValue(value)) => extracted.k8s_node_name = Some(value),
+                (K8S_POD_UID, Value::StringValue(value)) => extracted.k8s_pod_uid = Some(value),
+                (PROCESS_PID, Value::IntValue(value)) => extracted.process_pid = Some(*value),
+                (CGROUP_INODE, Value::IntValue(value)) => extracted.cgroup_inode = Some(*value),
+                (INIT_CONTAINER, Value::BoolValue(value)) => extracted.init_container = Some(*value),
+                _ => {}
+            }
+        }
+
+        extracted
+    }
+}
+
 #[derive(Clone)]
 pub struct OtlpOriginTagResolver {
     workload_provider: Arc<dyn WorkloadProvider + Send + Sync>,
@@ -32,12 +76,7 @@ impl OtlpOriginTagResolver {
         Self { workload_provider }
     }
 
-    /// Resolves all entity and global tags for one OTLP metrics resource.
-    ///
-    /// The entity order mirrors the Core Agent's infra-attributes processor. The synthetic container candidate is
-    /// resolved first: direct container ID, process ID, cgroup inode, then pod UID plus container name. The first
-    /// fallback that returns tags stands in for the container ID that the Core Agent synthesizes before it evaluates
-    /// the remaining resource entities.
+    /// Resolves entity and global tags for one OTLP metrics resource by entity precedence.
     pub fn resolve_resource_tags(
         &self, attributes: &[otlp_common::KeyValue], tag_cardinality: OriginTagCardinality,
     ) -> SharedTagSet {
@@ -45,14 +84,15 @@ impl OtlpOriginTagResolver {
             return SharedTagSet::default();
         }
 
+        let attributes = OtlpResourceAttributes::from_attributes(attributes);
         let mut tags = TagSet::default();
         let mut written_keys = FastHashSet::default();
 
-        if let Some(container_entity) = self.container_entity_from_attributes(attributes, tag_cardinality) {
+        if let Some(container_entity) = self.container_entity_from_attributes(&attributes, tag_cardinality) {
             self.collect_tags_for_entity(container_entity, tag_cardinality, &mut written_keys, &mut tags);
         }
 
-        for entity_id in entity_ids_from_attributes(attributes) {
+        for entity_id in entity_ids_from_attributes(&attributes) {
             self.collect_tags_for_entity(entity_id, tag_cardinality, &mut written_keys, &mut tags);
         }
 
@@ -61,20 +101,22 @@ impl OtlpOriginTagResolver {
     }
 
     fn container_entity_from_attributes(
-        &self, attributes: &[otlp_common::KeyValue], tag_cardinality: OriginTagCardinality,
+        &self, attributes: &OtlpResourceAttributes<'_>, tag_cardinality: OriginTagCardinality,
     ) -> Option<EntityId> {
-        if let Some(container_id) = get_string_attribute(attributes, CONTAINER_ID).filter(|value| !value.is_empty()) {
+        if let Some(container_id) = attributes.container_id.filter(|value| !value.is_empty()) {
             return Some(EntityId::Container(container_id.into()));
         }
 
         let mut fallback_entities = Vec::with_capacity(3);
-        if let Some(process_id) = get_integer_attribute(attributes, PROCESS_PID)
+        if let Some(process_id) = attributes
+            .process_pid
             .and_then(|value| u32::try_from(value).ok())
             .filter(|value| *value != 0)
         {
             fallback_entities.push(EntityId::ContainerPid(process_id));
         }
-        if let Some(cgroup_inode) = get_integer_attribute(attributes, CGROUP_INODE)
+        if let Some(cgroup_inode) = attributes
+            .cgroup_inode
             .and_then(|value| u64::try_from(value).ok())
             .filter(|value| *value != 0)
         {
@@ -84,9 +126,6 @@ impl OtlpOriginTagResolver {
             fallback_entities.push(container_entity);
         }
 
-        // `get_tags_for_entity` follows local PID and inode aliases to a canonical container ID. Selecting the first
-        // entity with tags therefore matches the Core Agent's first successful container-ID fallback without exposing
-        // a container-ID resolution API from the workload provider.
         fallback_entities.into_iter().find(|entity_id| {
             self.workload_provider
                 .get_tags_for_entity(entity_id, tag_cardinality)
@@ -94,10 +133,10 @@ impl OtlpOriginTagResolver {
         })
     }
 
-    fn container_entity_from_external_data(&self, attributes: &[otlp_common::KeyValue]) -> Option<EntityId> {
-        let pod_uid = get_string_attribute(attributes, K8S_POD_UID)?;
-        let container_name = get_string_attribute(attributes, K8S_CONTAINER_NAME)?;
-        let init_container = get_bool_attribute(attributes, INIT_CONTAINER).unwrap_or(false);
+    fn container_entity_from_external_data(&self, attributes: &OtlpResourceAttributes<'_>) -> Option<EntityId> {
+        let pod_uid = attributes.k8s_pod_uid?;
+        let container_name = attributes.k8s_container_name?;
+        let init_container = attributes.init_container.unwrap_or(false);
         let external_data = format!("pu-{pod_uid},cn-{container_name},it-{init_container}");
 
         let mut origin = RawOrigin::default();
@@ -175,77 +214,38 @@ impl OriginTagsResolver for OtlpOriginTagResolver {
     }
 }
 
-fn entity_ids_from_attributes(attributes: &[otlp_common::KeyValue]) -> Vec<EntityId> {
+fn entity_ids_from_attributes(attributes: &OtlpResourceAttributes<'_>) -> Vec<EntityId> {
     let mut entity_ids = Vec::with_capacity(7);
 
-    if let Some(oci_manifest_digest) = get_string_attribute(attributes, OCI_MANIFEST_DIGEST) {
+    if let Some(oci_manifest_digest) = attributes.oci_manifest_digest {
         if let Some((_, digest)) = oci_manifest_digest.split_once("@sha256:") {
             entity_ids.push(EntityId::ContainerImageMetadata(format!("sha256:{digest}").into()));
         }
     }
-    if let Some(ecs_task_arn) = get_string_attribute(attributes, ECS_TASK_ARN) {
+    if let Some(ecs_task_arn) = attributes.ecs_task_arn {
         entity_ids.push(EntityId::EcsTask(ecs_task_arn.into()));
     }
-    if let (Some(deployment), Some(namespace)) = (
-        get_string_attribute(attributes, K8S_DEPLOYMENT_NAME),
-        get_string_attribute(attributes, K8S_NAMESPACE_NAME),
-    ) {
+    if let (Some(deployment), Some(namespace)) = (attributes.k8s_deployment_name, attributes.k8s_namespace_name) {
         entity_ids.push(EntityId::KubernetesDeployment(
             format!("{namespace}/{deployment}").into(),
         ));
     }
-    if let Some(namespace) = get_string_attribute(attributes, K8S_NAMESPACE_NAME) {
+    if let Some(namespace) = attributes.k8s_namespace_name {
         entity_ids.push(EntityId::KubernetesMetadata(format!("/namespaces//{namespace}").into()));
     }
-    if let Some(node_name) = get_string_attribute(attributes, K8S_NODE_NAME) {
+    if let Some(node_name) = attributes.k8s_node_name {
         entity_ids.push(EntityId::KubernetesNode(node_name.into()));
     }
-    if let Some(pod_uid) = get_string_attribute(attributes, K8S_POD_UID) {
+    if let Some(pod_uid) = attributes.k8s_pod_uid {
         if let Some(entity_id) = EntityId::from_pod_uid(pod_uid) {
             entity_ids.push(entity_id);
         }
     }
-    if let Some(process_id) = get_integer_attribute(attributes, PROCESS_PID) {
+    if let Some(process_id) = attributes.process_pid {
         entity_ids.push(EntityId::Process(MetaString::from(process_id.to_string())));
     }
 
     entity_ids
-}
-
-fn get_string_attribute<'a>(attributes: &'a [otlp_common::KeyValue], key: &str) -> Option<&'a str> {
-    attributes.iter().find_map(|attribute| {
-        (attribute.key == key)
-            .then(|| attribute.value.as_ref().and_then(|value| value.value.as_ref()))
-            .flatten()
-            .and_then(|value| match value {
-                Value::StringValue(value) => Some(value.as_str()),
-                _ => None,
-            })
-    })
-}
-
-fn get_integer_attribute(attributes: &[otlp_common::KeyValue], key: &str) -> Option<i64> {
-    attributes.iter().find_map(|attribute| {
-        (attribute.key == key)
-            .then(|| attribute.value.as_ref().and_then(|value| value.value.as_ref()))
-            .flatten()
-            .and_then(|value| match value {
-                Value::IntValue(value) => Some(*value),
-                _ => None,
-            })
-    })
-}
-
-fn get_bool_attribute(attributes: &[otlp_common::KeyValue], key: &str) -> Option<bool> {
-    attributes.iter().find_map(|attribute| {
-        (attribute.key == key)
-            .then(|| attribute.value.as_ref().and_then(|value| value.value.as_ref()))
-            .flatten()
-            .and_then(|value| match value {
-                Value::BoolValue(value) => Some(*value),
-                _ => None,
-            })
-    })
 }
 
 #[cfg(test)]

--- a/lib/saluki-components/src/sources/dogstatsd/replay/writer.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/replay/writer.rs
@@ -461,6 +461,26 @@ fn entity_id_to_remote_entity_id(entity_id: &EntityId) -> RemoteEntityId {
             prefix: "container_id".to_string(),
             uid: container_id.to_string(),
         },
+        EntityId::ContainerImageMetadata(digest) => RemoteEntityId {
+            prefix: "container_image_metadata".to_string(),
+            uid: digest.to_string(),
+        },
+        EntityId::EcsTask(task_arn) => RemoteEntityId {
+            prefix: "ecs_task".to_string(),
+            uid: task_arn.to_string(),
+        },
+        EntityId::KubernetesDeployment(deployment) => RemoteEntityId {
+            prefix: "deployment".to_string(),
+            uid: deployment.to_string(),
+        },
+        EntityId::KubernetesMetadata(metadata) => RemoteEntityId {
+            prefix: "kubernetes_metadata".to_string(),
+            uid: metadata.to_string(),
+        },
+        EntityId::KubernetesNode(node) => RemoteEntityId {
+            prefix: "kubernetes_node".to_string(),
+            uid: node.to_string(),
+        },
         EntityId::PodUid(pod_uid) => RemoteEntityId {
             prefix: "kubernetes_pod_uid".to_string(),
             uid: pod_uid.to_string(),
@@ -468,6 +488,10 @@ fn entity_id_to_remote_entity_id(entity_id: &EntityId) -> RemoteEntityId {
         EntityId::Global => RemoteEntityId {
             prefix: "internal".to_string(),
             uid: "global-entity-id".to_string(),
+        },
+        EntityId::Process(process_id) => RemoteEntityId {
+            prefix: "process".to_string(),
+            uid: process_id.to_string(),
         },
         EntityId::ContainerPid(pid) => RemoteEntityId {
             prefix: "container_pid".to_string(),
@@ -482,14 +506,32 @@ fn entity_id_to_remote_entity_id(entity_id: &EntityId) -> RemoteEntityId {
 
 pub(super) fn parse_entity_id_str(value: &str) -> Option<EntityId> {
     const CONTAINER_ID_PREFIX: &str = "container_id://";
+    const CONTAINER_IMAGE_METADATA_PREFIX: &str = "container_image_metadata://";
+    const ECS_TASK_PREFIX: &str = "ecs_task://";
+    const KUBERNETES_DEPLOYMENT_PREFIX: &str = "deployment://";
+    const KUBERNETES_METADATA_PREFIX: &str = "kubernetes_metadata://";
+    const KUBERNETES_NODE_PREFIX: &str = "kubernetes_node://";
     const POD_UID_PREFIX: &str = "kubernetes_pod_uid://";
+    const PROCESS_PREFIX: &str = "process://";
     const CONTAINER_PID_PREFIX: &str = "container_pid://";
     const CONTAINER_INODE_PREFIX: &str = "container_inode://";
 
     if let Some(container_id) = value.strip_prefix(CONTAINER_ID_PREFIX) {
         Some(EntityId::Container(container_id.into()))
+    } else if let Some(digest) = value.strip_prefix(CONTAINER_IMAGE_METADATA_PREFIX) {
+        Some(EntityId::ContainerImageMetadata(digest.into()))
+    } else if let Some(task_arn) = value.strip_prefix(ECS_TASK_PREFIX) {
+        Some(EntityId::EcsTask(task_arn.into()))
+    } else if let Some(deployment) = value.strip_prefix(KUBERNETES_DEPLOYMENT_PREFIX) {
+        Some(EntityId::KubernetesDeployment(deployment.into()))
+    } else if let Some(metadata) = value.strip_prefix(KUBERNETES_METADATA_PREFIX) {
+        Some(EntityId::KubernetesMetadata(metadata.into()))
+    } else if let Some(node) = value.strip_prefix(KUBERNETES_NODE_PREFIX) {
+        Some(EntityId::KubernetesNode(node.into()))
     } else if let Some(pod_uid) = value.strip_prefix(POD_UID_PREFIX) {
         Some(EntityId::PodUid(pod_uid.into()))
+    } else if let Some(process_id) = value.strip_prefix(PROCESS_PREFIX) {
+        Some(EntityId::Process(process_id.into()))
     } else if let Some(pid) = value.strip_prefix(CONTAINER_PID_PREFIX) {
         pid.parse().ok().map(EntityId::ContainerPid)
     } else if let Some(inode) = value.strip_prefix(CONTAINER_INODE_PREFIX) {

--- a/lib/saluki-components/src/sources/otlp/logs/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/logs/translator.rs
@@ -28,9 +28,7 @@ pub struct OtlpLogsTranslator {
 }
 
 impl OtlpLogsTranslator {
-    pub fn from_resource_logs(
-        resource_logs: OtlpResourceLogs, origin_tag_resolver: Option<&OtlpOriginTagResolver>,
-    ) -> Self {
+    pub fn from_resource_logs(resource_logs: OtlpResourceLogs, origin_tag_resolver: &OtlpOriginTagResolver) -> Self {
         let resource = resource_logs.resource.unwrap_or_default();
         let source = resource_to_source(&resource);
         let host = match &source {
@@ -44,10 +42,8 @@ impl OtlpLogsTranslator {
         let mut attribute_tags = tags_from_attributes(&resource.attributes, ResourceAttributeTagMode::Mapped);
         attribute_tags.insert_tag(OTEL_SOURCE_TAG.clone());
         let origin = raw_origin_from_attributes(&resource.attributes);
-        if let Some(resolver) = origin_tag_resolver {
-            let origin_tags = resolver.resolve_origin_tags(origin);
-            attribute_tags.merge_shared(&origin_tags);
-        }
+        let origin_tags = origin_tag_resolver.resolve_origin_tags(origin);
+        attribute_tags.merge_shared(&origin_tags);
 
         Self {
             resource,
@@ -122,6 +118,7 @@ mod tests {
 
     use super::OtlpLogsTranslator;
     use super::SERVICE_NAME;
+    use crate::common::otlp::origin::OtlpOriginTagResolver;
     use crate::sources::otlp::logs::transform::DDTAGS_ATTR;
 
     const TRACE_ID: [u8; 16] = [
@@ -181,7 +178,12 @@ mod tests {
             schema_url: String::new(),
         };
 
-        let translator = OtlpLogsTranslator::from_resource_logs(resource_logs, None);
+        let translator = OtlpLogsTranslator::from_resource_logs(
+            resource_logs,
+            &OtlpOriginTagResolver::new(std::sync::Arc::new(
+                saluki_env::workload::providers::NoopWorkloadProvider,
+            )),
+        );
 
         let mut events = translator.collect::<Vec<_>>();
         assert_eq!(events.len(), 1);

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -1,8 +1,10 @@
 use std::time::Duration;
 
-use agent_data_plane_config::domains::otlp::{
-    CumulativeMonotonicMode, HistogramMode, InitialCumulativeMonotonicValue, SummaryMode,
+use agent_data_plane_config::domains::{
+    dogstatsd::OriginTagCardinality as ConfigOriginTagCardinality,
+    otlp::{CumulativeMonotonicMode, HistogramMode, InitialCumulativeMonotonicValue, SummaryMode},
 };
+use saluki_context::origin::OriginTagCardinality;
 use saluki_error::{generic_error, GenericError};
 
 const DEFAULT_DELTA_TTL: Duration = Duration::from_secs(3600);
@@ -11,6 +13,8 @@ const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(1800);
 #[derive(Debug, Clone, Copy)]
 #[allow(dead_code)]
 pub struct OtlpMetricsTranslatorConfig {
+    /// Cardinality of entity and global tags resolved from an OTLP resource.
+    pub tag_cardinality: OriginTagCardinality,
     pub hist_mode: HistogramMode,
     pub send_histogram_aggregations: bool,
     pub cumulative_monotonic_mode: CumulativeMonotonicMode,
@@ -42,6 +46,16 @@ impl OtlpMetricsTranslatorConfig {
             return Err(generic_error!("no buckets mode and no send count sum are incompatible"));
         }
         Ok(())
+    }
+
+    pub fn with_tag_cardinality(mut self, tag_cardinality: ConfigOriginTagCardinality) -> Self {
+        self.tag_cardinality = match tag_cardinality {
+            ConfigOriginTagCardinality::Low => OriginTagCardinality::Low,
+            ConfigOriginTagCardinality::Orchestrator => OriginTagCardinality::Orchestrator,
+            ConfigOriginTagCardinality::High => OriginTagCardinality::High,
+            ConfigOriginTagCardinality::None => OriginTagCardinality::None,
+        };
+        self
     }
 
     pub fn with_remapping(mut self, with_remapping: bool) -> Self {
@@ -121,6 +135,7 @@ impl OtlpMetricsTranslatorConfig {
 impl Default for OtlpMetricsTranslatorConfig {
     fn default() -> Self {
         Self {
+            tag_cardinality: OriginTagCardinality::Low,
             hist_mode: HistogramMode::default(),
             send_histogram_aggregations: false,
             cumulative_monotonic_mode: CumulativeMonotonicMode::default(),

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -1,10 +1,9 @@
 use std::time::Duration;
 
 use agent_data_plane_config::domains::{
-    dogstatsd::OriginTagCardinality as ConfigOriginTagCardinality,
+    dogstatsd::OriginTagCardinality,
     otlp::{CumulativeMonotonicMode, HistogramMode, InitialCumulativeMonotonicValue, SummaryMode},
 };
-use saluki_context::origin::OriginTagCardinality;
 use saluki_error::{generic_error, GenericError};
 
 const DEFAULT_DELTA_TTL: Duration = Duration::from_secs(3600);
@@ -46,16 +45,6 @@ impl OtlpMetricsTranslatorConfig {
             return Err(generic_error!("no buckets mode and no send count sum are incompatible"));
         }
         Ok(())
-    }
-
-    pub fn with_tag_cardinality(mut self, tag_cardinality: ConfigOriginTagCardinality) -> Self {
-        self.tag_cardinality = match tag_cardinality {
-            ConfigOriginTagCardinality::Low => OriginTagCardinality::Low,
-            ConfigOriginTagCardinality::Orchestrator => OriginTagCardinality::Orchestrator,
-            ConfigOriginTagCardinality::High => OriginTagCardinality::High,
-            ConfigOriginTagCardinality::None => OriginTagCardinality::None,
-        };
-        self
     }
 
     pub fn with_remapping(mut self, with_remapping: bool) -> Self {

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -80,7 +80,7 @@ pub struct OtlpMetricsTranslator {
     config: OtlpMetricsTranslatorConfig,
     default_hostname: MetaString,
     context_resolver: ContextResolver,
-    origin_tag_resolver: Option<OtlpOriginTagResolver>,
+    origin_tag_resolver: OtlpOriginTagResolver,
     resolved_origin_tags: SharedTagSet,
     prev_pts: PointsCache,
     process_start_time_ns: u64, // Used for initial value consumption.
@@ -427,7 +427,7 @@ impl OtlpMetricsTranslator {
     /// configured metric tags.
     pub fn new(
         config: OtlpMetricsTranslatorConfig, default_hostname: MetaString, context_resolver: ContextResolver,
-        origin_tag_resolver: Option<OtlpOriginTagResolver>, metric_tags: SharedTagSet,
+        origin_tag_resolver: OtlpOriginTagResolver, metric_tags: SharedTagSet,
     ) -> Result<Self, GenericError> {
         config
             .validate()
@@ -468,9 +468,7 @@ impl OtlpMetricsTranslator {
             .into_shared();
         self.resolved_origin_tags = self
             .origin_tag_resolver
-            .as_ref()
-            .map(|resolver| resolver.resolve_resource_tags(&resource.attributes, self.config.tag_cardinality))
-            .unwrap_or_default();
+            .resolve_resource_tags(&resource.attributes, self.config.tag_cardinality);
 
         // Combine configured and resource-derived tags once per resource, then reuse them for every
         // instrumentation scope.
@@ -581,7 +579,9 @@ impl OtlpMetricsTranslator {
             config: Default::default(),
             default_hostname: MetaString::from_static("default-host"),
             context_resolver: ContextResolverBuilder::for_tests().build(),
-            origin_tag_resolver: None,
+            origin_tag_resolver: OtlpOriginTagResolver::new(std::sync::Arc::new(
+                saluki_env::workload::providers::NoopWorkloadProvider,
+            )),
             resolved_origin_tags: SharedTagSet::default(),
             prev_pts: PointsCache::for_tests(),
             process_start_time_ns,

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -38,7 +38,8 @@ use super::internal::{instrumentationlibrary, instrumentationscope};
 use super::remap;
 use super::runtime_metrics::{RuntimeMetricMapping, RUNTIME_METRICS_MAPPINGS};
 use crate::common::otlp::attributes::translator::AttributeTranslator;
-use crate::common::otlp::attributes::{raw_origin_from_attributes, ResourceAttributeTagMode};
+use crate::common::otlp::attributes::ResourceAttributeTagMode;
+use crate::common::otlp::origin::OtlpOriginTagResolver;
 use crate::common::otlp::util::{Source, SourceKind};
 use crate::sources::otlp::Metrics;
 
@@ -79,6 +80,8 @@ pub struct OtlpMetricsTranslator {
     config: OtlpMetricsTranslatorConfig,
     default_hostname: MetaString,
     context_resolver: ContextResolver,
+    origin_tag_resolver: Option<OtlpOriginTagResolver>,
+    resolved_origin_tags: SharedTagSet,
     prev_pts: PointsCache,
     process_start_time_ns: u64, // Used for initial value consumption.
     attribute_translator: AttributeTranslator,
@@ -424,7 +427,7 @@ impl OtlpMetricsTranslator {
     /// configured metric tags.
     pub fn new(
         config: OtlpMetricsTranslatorConfig, default_hostname: MetaString, context_resolver: ContextResolver,
-        metric_tags: SharedTagSet,
+        origin_tag_resolver: Option<OtlpOriginTagResolver>, metric_tags: SharedTagSet,
     ) -> Result<Self, GenericError> {
         config
             .validate()
@@ -436,6 +439,8 @@ impl OtlpMetricsTranslator {
             config,
             default_hostname,
             context_resolver,
+            origin_tag_resolver,
+            resolved_origin_tags: SharedTagSet::default(),
             prev_pts: PointsCache::from_config(config),
             process_start_time_ns,
             attribute_translator: AttributeTranslator::new(),
@@ -461,6 +466,11 @@ impl OtlpMetricsTranslator {
             .attribute_translator
             .tags_from_attributes(&resource.attributes, resource_tag_mode)
             .into_shared();
+        self.resolved_origin_tags = self
+            .origin_tag_resolver
+            .as_ref()
+            .map(|resolver| resolver.resolve_resource_tags(&resource.attributes, self.config.tag_cardinality))
+            .unwrap_or_default();
 
         // Combine configured and resource-derived tags once per resource, then reuse them for every
         // instrumentation scope.
@@ -571,6 +581,8 @@ impl OtlpMetricsTranslator {
             config: Default::default(),
             default_hostname: MetaString::from_static("default-host"),
             context_resolver: ContextResolverBuilder::for_tests().build(),
+            origin_tag_resolver: None,
+            resolved_origin_tags: SharedTagSet::default(),
             prev_pts: PointsCache::for_tests(),
             process_start_time_ns,
             attribute_translator: AttributeTranslator::new(),
@@ -680,12 +692,11 @@ impl OtlpMetricsTranslator {
     ) {
         context.metrics.metrics_received().increment(1);
 
-        let raw_origin = raw_origin_from_attributes(context.resource_attributes);
-        match self.context_resolver.resolve_with_optional_host(
+        match self.context_resolver.resolve_with_optional_host_and_origin_tags(
             &dims.name,
             dims.host.as_deref(),
             &dims.tags,
-            Some(raw_origin),
+            self.resolved_origin_tags.clone(),
         ) {
             Some(resolved_context) => {
                 let timestamp_s = timestamp_ns / 1_000_000_000;
@@ -1009,12 +1020,11 @@ impl OtlpMetricsTranslator {
         context: &TranslationContext, interval: i64,
     ) {
         context.metrics.metrics_received().increment(1);
-        let raw_origin = raw_origin_from_attributes(context.resource_attributes);
-        match self.context_resolver.resolve_with_optional_host(
+        match self.context_resolver.resolve_with_optional_host_and_origin_tags(
             &dims.name,
             dims.host.as_deref(),
             &dims.tags,
-            Some(raw_origin),
+            self.resolved_origin_tags.clone(),
         ) {
             Some(resolved_context) => {
                 if interval != 0 {

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -87,6 +87,7 @@ impl OtlpConfiguration {
 
     fn metrics_translator_config(&self) -> metrics::config::OtlpMetricsTranslatorConfig {
         metrics::config::OtlpMetricsTranslatorConfig::default()
+            .with_tag_cardinality(self.otlp.metrics.tag_cardinality)
             .with_summary_mode(self.otlp.metrics.summaries.mode)
             .with_histogram_mode(self.otlp.metrics.histogram_mode)
             .with_send_histogram_aggregations(self.otlp.metrics.send_histogram_aggregations)
@@ -157,8 +158,9 @@ impl SourceBuilder for OtlpConfiguration {
 
         let maybe_origin_tags_resolver = self.workload_provider.clone().map(OtlpOriginTagResolver::new);
 
-        let context_resolver =
-            build_context_resolver(&self.otlp.contexts, &context, maybe_origin_tags_resolver.clone())?;
+        // Metrics resolve their full OTLP entity list at the resource boundary. Keep the context resolver free of an
+        // origin resolver so it cannot apply the legacy RawOrigin-only lookup a second time. Logs retain that resolver.
+        let context_resolver = build_context_resolver(&self.otlp.contexts, &context, None)?;
         let metrics_translator_config = self.metrics_translator_config();
 
         let metric_tags = parse_configured_metric_tags(&self.otlp.metrics.tags);
@@ -234,6 +236,7 @@ impl Source for Otlp {
             metrics_translator_config,
             default_hostname,
             context_resolver,
+            origin_tag_resolver.clone(),
             metric_tags,
         )?;
 

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -64,7 +64,6 @@ fn parse_configured_metric_tags(raw: &str) -> SharedTagSet {
 }
 
 /// Configuration for the OTLP source.
-#[derive(Default)]
 pub struct OtlpConfiguration {
     default_hostname: MetaString,
 
@@ -72,46 +71,37 @@ pub struct OtlpConfiguration {
     otlp: domains::otlp::Domain,
 
     /// Workload provider to utilize for origin detection/enrichment.
-    workload_provider: Option<Arc<dyn WorkloadProvider + Send + Sync>>,
+    workload_provider: Arc<dyn WorkloadProvider + Send + Sync>,
 }
 
 impl OtlpConfiguration {
-    /// Creates a new `OtlpConfiguration` from the resolved OTLP configuration.
-    pub fn from_configuration(otlp: &domains::otlp::Domain) -> Self {
+    /// Creates a new `OtlpConfiguration` from the resolved OTLP configuration and workload provider.
+    pub fn from_configuration<W>(otlp: &domains::otlp::Domain, workload_provider: W) -> Self
+    where
+        W: WorkloadProvider + Send + Sync + 'static,
+    {
         Self {
             default_hostname: MetaString::default(),
             otlp: otlp.clone(),
-            workload_provider: None,
+            workload_provider: Arc::new(workload_provider),
         }
     }
 
     fn metrics_translator_config(&self) -> metrics::config::OtlpMetricsTranslatorConfig {
-        metrics::config::OtlpMetricsTranslatorConfig::default()
-            .with_tag_cardinality(self.otlp.metrics.tag_cardinality)
+        let mut config = metrics::config::OtlpMetricsTranslatorConfig::default()
             .with_summary_mode(self.otlp.metrics.summaries.mode)
             .with_histogram_mode(self.otlp.metrics.histogram_mode)
             .with_send_histogram_aggregations(self.otlp.metrics.send_histogram_aggregations)
             .with_cumulative_monotonic_mode(self.otlp.metrics.sums.cumulative_monotonic_mode)
             .with_initial_cumulative_monotonic_value(self.otlp.metrics.sums.initial_cumulative_monotonic_value)
-            .with_resource_attributes_as_tags(self.otlp.metrics.resource_attributes_as_tags)
+            .with_resource_attributes_as_tags(self.otlp.metrics.resource_attributes_as_tags);
+        config.tag_cardinality = self.otlp.metrics.tag_cardinality;
+        config
     }
 
     /// Sets the default hostname used when OTLP metrics do not carry a resource hostname.
     pub fn with_default_hostname(mut self, hostname: impl Into<MetaString>) -> Self {
         self.default_hostname = hostname.into();
-        self
-    }
-
-    /// Sets the workload provider to use for configuring origin detection/enrichment.
-    ///
-    /// A workload provider must be set otherwise origin detection/enrichment won't be enabled.
-    ///
-    /// Defaults to unset.
-    pub fn with_workload_provider<W>(mut self, workload_provider: W) -> Self
-    where
-        W: WorkloadProvider + Send + Sync + 'static,
-    {
-        self.workload_provider = Some(Arc::new(workload_provider));
         self
     }
 }
@@ -156,7 +146,7 @@ impl SourceBuilder for OtlpConfiguration {
             .next()
             .ok_or_else(|| generic_error!("No addresses resolved for HTTP endpoint '{}'", http_endpoint_str))?;
 
-        let maybe_origin_tags_resolver = self.workload_provider.clone().map(OtlpOriginTagResolver::new);
+        let origin_tag_resolver = OtlpOriginTagResolver::new(Arc::clone(&self.workload_provider));
 
         // Metrics resolve their full OTLP entity list at the resource boundary. Keep the context resolver free of an
         // origin resolver so it cannot apply the legacy RawOrigin-only lookup a second time. Logs retain that resolver.
@@ -170,7 +160,7 @@ impl SourceBuilder for OtlpConfiguration {
 
         Ok(Box::new(Otlp {
             context_resolver,
-            origin_tag_resolver: maybe_origin_tags_resolver,
+            origin_tag_resolver,
             grpc_endpoint,
             http_endpoint: ListenAddress::Tcp(http_socket_addr),
             grpc_max_recv_msg_size_bytes,
@@ -194,7 +184,7 @@ impl MemoryBounds for OtlpConfiguration {
 
 pub struct Otlp {
     context_resolver: ContextResolver,
-    origin_tag_resolver: Option<OtlpOriginTagResolver>,
+    origin_tag_resolver: OtlpOriginTagResolver,
     grpc_endpoint: ListenAddress,
     http_endpoint: ListenAddress,
     grpc_max_recv_msg_size_bytes: usize,
@@ -354,7 +344,7 @@ impl OtlpHandler for SourceHandler {
 
 async fn run_converter(
     mut receiver: mpsc::Receiver<OtlpResource>, source_context: SourceContext,
-    origin_tag_resolver: Option<OtlpOriginTagResolver>, shutdown_handle: ShutdownHandle,
+    origin_tag_resolver: OtlpOriginTagResolver, shutdown_handle: ShutdownHandle,
     mut metrics_translator: OtlpMetricsTranslator, metrics: Metrics, mut traces_translator: OtlpTracesTranslator,
 ) {
     pin!(shutdown_handle);
@@ -395,7 +385,7 @@ async fn run_converter(
                         }
                     }
                     OtlpResource::Logs(resource_logs) => {
-                        let translator = OtlpLogsTranslator::from_resource_logs(resource_logs, origin_tag_resolver.as_ref());
+                        let translator = OtlpLogsTranslator::from_resource_logs(resource_logs, &origin_tag_resolver);
                         for log_event in translator {
                             metrics.logs_received().increment(1);
 
@@ -489,7 +479,7 @@ mod tests {
             metrics,
             ..Default::default()
         };
-        OtlpConfiguration::from_configuration(&otlp)
+        OtlpConfiguration::from_configuration(&otlp, saluki_env::workload::providers::NoopWorkloadProvider)
     }
 
     #[test]
@@ -559,7 +549,7 @@ mod tests {
     #[test]
     fn cumulative_monotonic_sum_mode_defaults_to_delta_conversion() {
         assert_eq!(
-            OtlpConfiguration::default()
+            config_with_metrics(domains::otlp::Metrics::default())
                 .metrics_translator_config()
                 .cumulative_monotonic_mode,
             CumulativeMonotonicMode::ToDelta

--- a/lib/saluki-env/src/workload/entity.rs
+++ b/lib/saluki-env/src/workload/entity.rs
@@ -5,8 +5,14 @@ use std::{cmp::Ordering, fmt};
 use stringtheory::MetaString;
 use tracing::warn;
 
-const ENTITY_PREFIX_POD_UID: &str = "kubernetes_pod_uid://";
 const ENTITY_PREFIX_CONTAINER_ID: &str = "container_id://";
+const ENTITY_PREFIX_CONTAINER_IMAGE_METADATA: &str = "container_image_metadata://";
+const ENTITY_PREFIX_ECS_TASK: &str = "ecs_task://";
+const ENTITY_PREFIX_KUBERNETES_DEPLOYMENT: &str = "deployment://";
+const ENTITY_PREFIX_KUBERNETES_METADATA: &str = "kubernetes_metadata://";
+const ENTITY_PREFIX_KUBERNETES_NODE: &str = "kubernetes_node://";
+const ENTITY_PREFIX_POD_UID: &str = "kubernetes_pod_uid://";
+const ENTITY_PREFIX_PROCESS: &str = "process://";
 const ENTITY_PREFIX_CONTAINER_INODE: &str = "container_inode://";
 const ENTITY_PREFIX_CONTAINER_PID: &str = "container_pid://";
 
@@ -24,15 +30,33 @@ pub enum EntityId {
     /// anything within the workload, such as host or cluster tags.
     Global,
 
+    /// A container ID.
+    ///
+    /// This is generally a long hexadecimal string, as generally used by container runtimes like `containerd`.
+    Container(MetaString),
+
+    /// An OCI image manifest digest.
+    ContainerImageMetadata(MetaString),
+
+    /// An ECS task ARN.
+    EcsTask(MetaString),
+
+    /// A Kubernetes deployment, identified by `<namespace>/<name>`.
+    KubernetesDeployment(MetaString),
+
+    /// Kubernetes metadata, such as a namespace path.
+    KubernetesMetadata(MetaString),
+
+    /// A Kubernetes node name.
+    KubernetesNode(MetaString),
+
     /// A Kubernetes pod UID.
     ///
     /// Represents the UUID of a specific Kubernetes pod.
     PodUid(MetaString),
 
-    /// A container ID.
-    ///
-    /// This is generally a long hexadecimal string, as generally used by container runtimes like `containerd`.
-    Container(MetaString),
+    /// A process identifier reported by the remote tagger.
+    Process(MetaString),
 
     /// A container inode.
     ///
@@ -133,10 +157,17 @@ impl EntityId {
     fn precedence_value(&self) -> usize {
         match self {
             Self::Global => 0,
-            Self::PodUid(_) => 1,
-            Self::Container(_) => 2,
-            Self::ContainerInode(_) => 3,
-            Self::ContainerPid(_) => 4,
+            Self::Container(_) => 1,
+            Self::ContainerImageMetadata(_) => 2,
+            Self::EcsTask(_) => 3,
+            Self::KubernetesDeployment(_) => 4,
+            Self::KubernetesMetadata(_) => 5,
+            Self::KubernetesNode(_) => 6,
+            Self::PodUid(_) => 7,
+            Self::Process(_) => 8,
+            // These are local aliases used to resolve a container before the remote tagger entity lookup.
+            Self::ContainerInode(_) => 9,
+            Self::ContainerPid(_) => 10,
         }
     }
 }
@@ -145,8 +176,16 @@ impl fmt::Display for EntityId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Global => write!(f, "system://global"),
-            Self::PodUid(pod_uid) => write!(f, "{}{}", ENTITY_PREFIX_POD_UID, pod_uid),
             Self::Container(container_id) => write!(f, "{}{}", ENTITY_PREFIX_CONTAINER_ID, container_id),
+            Self::ContainerImageMetadata(digest) => write!(f, "{}{}", ENTITY_PREFIX_CONTAINER_IMAGE_METADATA, digest),
+            Self::EcsTask(task_arn) => write!(f, "{}{}", ENTITY_PREFIX_ECS_TASK, task_arn),
+            Self::KubernetesDeployment(deployment) => {
+                write!(f, "{}{}", ENTITY_PREFIX_KUBERNETES_DEPLOYMENT, deployment)
+            }
+            Self::KubernetesMetadata(metadata) => write!(f, "{}{}", ENTITY_PREFIX_KUBERNETES_METADATA, metadata),
+            Self::KubernetesNode(node) => write!(f, "{}{}", ENTITY_PREFIX_KUBERNETES_NODE, node),
+            Self::PodUid(pod_uid) => write!(f, "{}{}", ENTITY_PREFIX_POD_UID, pod_uid),
+            Self::Process(process_id) => write!(f, "{}{}", ENTITY_PREFIX_PROCESS, process_id),
             Self::ContainerInode(inode) => write!(f, "{}{}", ENTITY_PREFIX_CONTAINER_INODE, inode),
             Self::ContainerPid(pid) => write!(f, "{}{}", ENTITY_PREFIX_CONTAINER_PID, pid),
         }
@@ -169,10 +208,12 @@ impl serde::Serialize for EntityId {
 /// This type establishes a total ordering over entity IDs based on their logical precedence, which is as follows:
 ///
 /// - global (highest precedence)
-/// - pod
 /// - container
-/// - container inode
-/// - container PID (lowest precedence)
+/// - OCI image metadata
+/// - ECS task
+/// - Kubernetes deployment, metadata, node, and pod
+/// - process
+/// - local container inode and PID aliases (lowest precedence)
 ///
 /// Wrapped entity IDs are be sorted highest to lowest precedence. For entity IDs with the same precedence, they're
 /// further ordered by their internal value. For entity IDs with a string identifier, lexicographical ordering is used.
@@ -205,9 +246,23 @@ impl Ord for HighestPrecedenceEntityIdRef<'_> {
         match (self.0, other.0) {
             // Global entities are always equal.
             (EntityId::Global, EntityId::Global) => Ordering::Equal,
-            (EntityId::PodUid(self_pod_uid), EntityId::PodUid(other_pod_uid)) => self_pod_uid.cmp(other_pod_uid),
             (EntityId::Container(self_container_id), EntityId::Container(other_container_id)) => {
                 self_container_id.cmp(other_container_id)
+            }
+            (EntityId::ContainerImageMetadata(self_digest), EntityId::ContainerImageMetadata(other_digest)) => {
+                self_digest.cmp(other_digest)
+            }
+            (EntityId::EcsTask(self_task_arn), EntityId::EcsTask(other_task_arn)) => self_task_arn.cmp(other_task_arn),
+            (EntityId::KubernetesDeployment(self_deployment), EntityId::KubernetesDeployment(other_deployment)) => {
+                self_deployment.cmp(other_deployment)
+            }
+            (EntityId::KubernetesMetadata(self_metadata), EntityId::KubernetesMetadata(other_metadata)) => {
+                self_metadata.cmp(other_metadata)
+            }
+            (EntityId::KubernetesNode(self_node), EntityId::KubernetesNode(other_node)) => self_node.cmp(other_node),
+            (EntityId::PodUid(self_pod_uid), EntityId::PodUid(other_pod_uid)) => self_pod_uid.cmp(other_pod_uid),
+            (EntityId::Process(self_process_id), EntityId::Process(other_process_id)) => {
+                self_process_id.cmp(other_process_id)
             }
             (EntityId::ContainerInode(self_inode), EntityId::ContainerInode(other_inode)) => {
                 self_inode.cmp(other_inode)


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

As part of the ongoing work to reach behavioral parity for the OTLP Ingest metrics pipeline, we need to enrich data with tags from the entities that produced it. 

This PR aims to:

- Expand recognized entity ID types
- Establishes precedence rules 
- Merges tags following a "first-writer-wins" protocol (e.g. `container -> service:x` `pod -> service:y`, `service:x` will be the tag 
- Tag cardinality now recognized

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

Unit tests
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->
- Closes: #2070 
<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
