### PR TITLE
chore(components): remove usages of `facet`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,12 +964,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
-name = "const-fnv1a-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
-
-[[package]]
 name = "const-hex"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,73 +1554,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "facet"
-version = "0.46.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df488bcda61dde160301ee6bce43d42397db599ffc689381a1873b5f035135f9"
-dependencies = [
- "autocfg",
- "facet-core",
- "facet-macros",
-]
-
-[[package]]
-name = "facet-core"
-version = "0.46.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33cf9d80307e9a29f93e5a65ddb65b227b5fa082d649c65d4083345f5d398d0"
-dependencies = [
- "autocfg",
- "const-fnv1a-hash",
- "iddqd",
- "impls",
-]
-
-[[package]]
-name = "facet-macro-parse"
-version = "0.46.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ab349bd1823fbfa129e595a826ef7fb4d1b9c7215428b28de18044d009dbc1"
-dependencies = [
- "facet-macro-types",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "facet-macro-types"
-version = "0.46.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79622a74665b47d1744998dd0d15b73eb0eecdfeb16630b436c5f03365b02e55"
-dependencies = [
- "proc-macro2",
- "quote",
- "unsynn",
-]
-
-[[package]]
-name = "facet-macros"
-version = "0.46.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6656fc7457975f5e1c86791b7a810c40ba53993823ae655f7c331e808c4b5ff"
-dependencies = [
- "facet-macros-impl",
-]
-
-[[package]]
-name = "facet-macros-impl"
-version = "0.46.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f462bad2b5a574b2c94e9ad54162704ceacf3200741b4f0fb88020936b9003ec"
-dependencies = [
- "facet-macro-parse",
- "facet-macro-types",
- "proc-macro2",
- "quote",
- "unsynn",
 ]
 
 [[package]]
@@ -2350,18 +2277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
-name = "iddqd"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fb967ac6b9edb2b5bd91496fc95fdf5eee0772aa31aca370766975f7e57962"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
- "hashbrown 0.16.1",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,12 +2302,6 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
 ]
-
-[[package]]
-name = "impls"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a46645bbd70538861a90d0f26c31537cdf1e44aae99a794fb75a664b70951bc"
 
 [[package]]
 name = "indexmap"
@@ -2935,12 +2844,6 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-
-[[package]]
-name = "mutants"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
 
 [[package]]
 name = "ndarray"
@@ -4350,7 +4253,6 @@ dependencies = [
  "datadog-protos",
  "ddsketch",
  "derive-where",
- "facet",
  "faster-hex",
  "figment",
  "float-cmp",
@@ -5976,17 +5878,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "unsynn"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501a7adf1a4bd9951501e5c66621e972ef8874d787628b7f90e64f936ef7ec0a"
-dependencies = [
- "mutants",
- "proc-macro2",
- "rustc-hash 2.1.2",
-]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,6 @@ async-compression = { version = "0.4.42", default-features = false, features = [
 ] }
 zstd = { version = "0.13.3", default-features = false }
 bitmask-enum = { version = "2.2", default-features = false }
-facet = { version = "0.46.0", default-features = false, features = ["std"] }
 figment = { version = "0.10", default-features = false }
 foldhash = { version = "0.2", default-features = false, features = ["std"] }
 headers = { version = "0.4", default-features = false }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -73,7 +73,6 @@ combine,https://github.com/Marwes/combine,MIT,Markus Westerlind <marwes91@gmail.
 comfy-table,https://github.com/nukesor/comfy-table,MIT,Arne Beer <contact@arne.beer>
 compression-codecs,https://github.com/Nullus157/async-compression,MIT OR Apache-2.0,"Wim Looman <wim@nemo157.com>, Allen Bui <fairingrey@gmail.com>"
 compression-core,https://github.com/Nullus157/async-compression,MIT OR Apache-2.0,"Wim Looman <wim@nemo157.com>, Allen Bui <fairingrey@gmail.com>"
-const-fnv1a-hash,https://github.com/HindrikStegenga/const-fnv1a-hash,MIT,The const-fnv1a-hash Authors
 const-hex,https://github.com/danipopes/const-hex,MIT OR Apache-2.0,DaniPopes <57450786+DaniPopes@users.noreply.github.com>
 const-oid,https://github.com/RustCrypto/formats,Apache-2.0 OR MIT,RustCrypto Developers
 const-oid,https://github.com/RustCrypto/formats/tree/master/const-oid,Apache-2.0 OR MIT,RustCrypto Developers
@@ -112,12 +111,6 @@ encoding_rs_io,https://github.com/BurntSushi/encoding_rs_io,MIT OR Apache-2.0,An
 enum_dispatch,https://gitlab.com/antonok/enum_dispatch,MIT OR Apache-2.0,Anton Lazarev <https://antonok.com>
 equivalent,https://github.com/indexmap-rs/equivalent,Apache-2.0 OR MIT,The equivalent Authors
 errno,https://github.com/lambda-fairy/rust-errno,MIT OR Apache-2.0,"Chris Wong <lambda.fairy@gmail.com>, Dan Gohman <dev@sunfishcode.online>"
-facet,https://github.com/facet-rs/facet,MIT OR Apache-2.0,The facet Authors
-facet-core,https://github.com/facet-rs/facet,MIT OR Apache-2.0,The facet-core Authors
-facet-macro-parse,https://github.com/facet-rs/facet,MIT OR Apache-2.0,The facet-macro-parse Authors
-facet-macro-types,https://github.com/facet-rs/facet,MIT OR Apache-2.0,The facet-macro-types Authors
-facet-macros,https://github.com/facet-rs/facet,MIT OR Apache-2.0,The facet-macros Authors
-facet-macros-impl,https://github.com/facet-rs/facet,MIT OR Apache-2.0,The facet-macros-impl Authors
 faster-hex,https://github.com/NervosFoundation/faster-hex,MIT,zhangsoledad <787953403@qq.com>
 fastrand,https://github.com/smol-rs/fastrand,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 figment,https://github.com/SergioBenitez/Figment,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
@@ -179,11 +172,9 @@ icu_properties,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Projec
 icu_properties_data,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 icu_provider,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 id-arena,https://github.com/fitzgen/id-arena,MIT OR Apache-2.0,"Nick Fitzgerald <fitzgen@gmail.com>, Aleksey Kladov <aleksey.kladov@gmail.com>"
-iddqd,https://github.com/oxidecomputer/iddqd,MIT OR Apache-2.0,The iddqd Authors
 ident_case,https://github.com/TedDriggs/ident_case,MIT OR Apache-2.0,Ted Driggs <ted.driggs@outlook.com>
 idna,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
 idna_adapter,https://github.com/hsivonen/idna_adapter,Apache-2.0 OR MIT,The rust-url developers
-impls,https://github.com/nvzqz/impls,MIT OR Apache-2.0,"Nikolai Vazquez, Nadrieril Feneanar"
 indexmap,https://github.com/indexmap-rs/indexmap,Apache-2.0 OR MIT,The indexmap Authors
 inlinable_string,https://github.com/fitzgen/inlinable_string,Apache-2.0 OR MIT,Nick Fitzgerald <fitzgen@gmail.com>
 ipnet,https://github.com/krisprice/ipnet,MIT OR Apache-2.0,Kris Price <kris@krisprice.nz>
@@ -235,7 +226,6 @@ miniz_oxide,https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide,MIT OR
 mintex,https://github.com/garypen/mintex,Apache-2.0,garypen <garypen@gmail.com>
 mio,https://github.com/tokio-rs/mio,MIT,"Carl Lerche <me@carllerche.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>, Tokio Contributors <team@tokio.rs>"
 multimap,https://github.com/havarnov/multimap,MIT OR Apache-2.0,Håvar Nøvik <havar.novik@gmail.com>
-mutants,https://github.com/sourcefrog/cargo-mutants,MIT,The mutants Authors
 ndarray,https://github.com/rust-ndarray/ndarray,MIT OR Apache-2.0,"Ulrik Sverdrup ""bluss"", Jim Turner"
 nix,https://github.com/nix-rust/nix,MIT,The nix Authors
 nohash-hasher,https://github.com/paritytech/nohash-hasher,Apache-2.0 OR MIT,Parity Technologies <admin@parity.io>
@@ -460,7 +450,6 @@ unicode-segmentation,https://github.com/unicode-rs/unicode-segmentation,MIT OR A
 unicode-width,https://github.com/unicode-rs/unicode-width,MIT OR Apache-2.0,"kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>"
 unicode-xid,https://github.com/unicode-rs/unicode-xid,MIT OR Apache-2.0,"erick.tryzelaar <erick.tryzelaar@gmail.com>, kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>"
 unsafe-libyaml,https://github.com/dtolnay/unsafe-libyaml,MIT,David Tolnay <dtolnay@gmail.com>
-unsynn,https://seed.pipapo.org/nodes/seed.pipapo.org/rad:z39WbeupErKS8TwbDS5yU8eZSa3C,MIT OR Apache-2.0,Christian Thäter <ct@pipapo.org>
 untrusted,https://github.com/briansmith/untrusted,ISC,Brian Smith <brian@briansmith.org>
 url,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
 utf8-width,https://github.com/magiclen/utf8-width,MIT,Magic Len <len@magiclen.org>

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -29,7 +29,6 @@ datadog-agent-config = { workspace = true }
 datadog-agent-metrics-v3 = { workspace = true }
 datadog-protos = { workspace = true }
 ddsketch = { workspace = true }
-facet = { workspace = true }
 faster-hex = { workspace = true }
 figment = { workspace = true }
 float-cmp = { workspace = true, features = ["ratio"] }

--- a/lib/saluki-components/src/common/datadog/config.rs
+++ b/lib/saluki-components/src/common/datadog/config.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use agent_data_plane_config::shared::{Endpoints, MetricsEncoding};
-use facet::Facet;
 use saluki_config::{DurationString, GenericConfiguration};
 use saluki_error::GenericError;
 use saluki_io::net::client::http::{HttpProtocol, TlsMinimumVersion};
@@ -83,7 +82,7 @@ fn min_tls_version_from_config_value(value: &str) -> TlsMinimumVersion {
 
 /// HTTP protocol selection for the Datadog forwarder.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Facet)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(test, derive(serde::Serialize))]
 pub enum ForwarderHttpProtocol {
@@ -109,7 +108,7 @@ impl From<ForwarderHttpProtocol> for HttpProtocol {
 /// The Agent exposes this override under two top-level sections -- `observability_pipelines_worker`
 /// and its deprecated `vector` predecessor -- so this struct is flattened by its owner to read both
 /// from the same root.
-#[derive(Clone, Default, Deserialize, Facet)]
+#[derive(Clone, Default, Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
 pub(crate) struct OpwMetricsConfiguration {
     /// Observability Pipelines Worker routing settings.
@@ -124,7 +123,7 @@ pub(crate) struct OpwMetricsConfiguration {
 }
 
 /// One routing target's `metrics` section.
-#[derive(Clone, Default, Deserialize, Facet)]
+#[derive(Clone, Default, Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
 pub(crate) struct OpwMetricsSection {
     /// Metrics routing settings for this target.
@@ -133,7 +132,7 @@ pub(crate) struct OpwMetricsSection {
 }
 
 /// The routing settings themselves.
-#[derive(Clone, Default, Deserialize, Facet)]
+#[derive(Clone, Default, Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
 pub(crate) struct OpwMetricsSettings {
     /// Enables routing all metrics to this target.
@@ -154,7 +153,7 @@ pub(crate) struct OpwMetricsSettings {
 }
 
 /// The `use_v3_api` sub-section of a routing target's metrics settings.
-#[derive(Clone, Default, Deserialize, Facet)]
+#[derive(Clone, Default, Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
 pub(crate) struct OpwUseV3ApiSettings {
     /// Enables V3 series metrics when routing to this target.
@@ -235,7 +234,7 @@ impl OpwMetricsConfiguration {
 /// This adapter provides a simple way to utilize the existing configuration values that are passed to the Datadog
 /// Agent, which are used to control the behavior of its forwarder, such as retries and concurrency, in conjunction with
 /// with existing primitives, as such retry policies in [`saluki_io::util::retry`].
-#[derive(Clone, Deserialize, Facet)]
+#[derive(Clone, Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
 pub struct ForwarderConfiguration {
     /// Maximum number of concurrent requests for an individual endpoint.
@@ -351,7 +350,6 @@ pub struct ForwarderConfiguration {
 
     /// Parsed minimum TLS protocol version for Datadog intake forwarding.
     #[serde(skip)]
-    #[facet(opaque)]
     parsed_min_tls_version: TlsMinimumVersion,
 
     /// Timeout for completing the TLS handshake after a connection is established, for Datadog intake forwarding.
@@ -360,7 +358,6 @@ pub struct ForwarderConfiguration {
     /// bounds the entire request. A value of `0` disables the handshake deadline entirely, matching the core Agent
     /// convention for this setting.
     #[serde(default = "default_tls_handshake_timeout")]
-    #[facet(opaque)]
     tls_handshake_timeout: DurationString,
 
     /// Whether to signal that the backend should allow arbitrary tag values.

--- a/lib/saluki-components/src/common/datadog/data_plane.rs
+++ b/lib/saluki-components/src/common/datadog/data_plane.rs
@@ -5,11 +5,10 @@
 //! actually reads: a struct that also accepted unrelated `data_plane` keys would silently change
 //! shape when one of them is set, which the configuration smoke tests treat as a defect.
 
-use facet::Facet;
 use serde::Deserialize;
 
 /// The `data_plane` keys read by a payload encoder.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub(crate) struct EncoderDataPlaneConfiguration {
     /// ADP-specific zstd compression level, taking precedence over the Core Agent's

--- a/lib/saluki-components/src/common/datadog/endpoints.rs
+++ b/lib/saluki-components/src/common/datadog/endpoints.rs
@@ -4,7 +4,6 @@ use std::{
     sync::LazyLock,
 };
 
-use facet::Facet;
 use http::uri::Authority;
 use regex::Regex;
 use saluki_config::GenericConfiguration;
@@ -359,11 +358,11 @@ pub(crate) enum EndpointError {
 }
 
 #[serde_as]
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 struct APIKeys(#[serde_as(as = "OneOrMany<_>")] Vec<String>);
 
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 struct MappedAPIKeys(HashMap<String, APIKeys>);
 
@@ -397,7 +396,7 @@ impl std::fmt::Display for MappedAPIKeys {
 ///
 /// Each endpoint can be associated with multiple API keys. Requests will be forwarded to each unique endpoint/API key pair.
 #[serde_as]
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub(crate) struct AdditionalEndpoints(#[serde_as(as = "PickFirst<(DisplayFromStr, _)>")] MappedAPIKeys);
 
@@ -457,7 +456,7 @@ impl AdditionalEndpoints {
 }
 
 /// Endpoint configuration for sending payloads to the Datadog platform.
-#[derive(Clone, Deserialize, Facet)]
+#[derive(Clone, Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
 pub struct EndpointConfiguration {
     /// The API key to use.

--- a/lib/saluki-components/src/common/datadog/obfuscation.rs
+++ b/lib/saluki-components/src/common/datadog/obfuscation.rs
@@ -1,7 +1,6 @@
 //! Obfuscation configuration types.
 
 use agent_data_plane_config::domains::traces;
-use facet::Facet;
 use saluki_config::deserialize_space_separated_or_seq;
 use serde::Deserialize;
 
@@ -9,7 +8,7 @@ use serde::Deserialize;
 ///
 /// This is the Datadog Agent's `apm_config.obfuscation` section: each field is one of its
 /// subsections, named exactly as the Agent names it.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct ObfuscationConfig {
     /// Credit card obfuscation settings.
@@ -100,7 +99,7 @@ impl From<&traces::Obfuscation> for ObfuscationConfig {
 }
 
 /// HTTP URL obfuscation configuration.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct HttpObfuscationConfig {
     /// Whether to remove query strings from HTTP URLs.
@@ -113,7 +112,7 @@ pub struct HttpObfuscationConfig {
 }
 
 /// Memcached obfuscation configuration.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct MemcachedObfuscationConfig {
     /// Whether memcached obfuscation is enabled.
@@ -126,7 +125,7 @@ pub struct MemcachedObfuscationConfig {
 }
 
 /// Credit card obfuscation configuration.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct CreditCardObfuscationConfig {
     /// Whether credit card obfuscation is enabled.
@@ -143,7 +142,7 @@ pub struct CreditCardObfuscationConfig {
 }
 
 /// Redis obfuscation configuration.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct RedisObfuscationConfig {
     /// Whether Redis obfuscation is enabled.
@@ -156,7 +155,7 @@ pub struct RedisObfuscationConfig {
 }
 
 /// Valkey obfuscation configuration.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct ValkeyObfuscationConfig {
     /// Whether Valkey obfuscation is enabled.
@@ -169,7 +168,7 @@ pub struct ValkeyObfuscationConfig {
 }
 
 /// SQL obfuscation configuration.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct SqlObfuscationConfig {
     /// DBMS type (for example, `postgresql`, `mysql`, `mssql`, `sqlite`).
@@ -211,7 +210,7 @@ impl SqlObfuscationConfig {
 }
 
 /// Elasticsearch obfuscation configuration.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct EsObfuscationConfig {
     /// Whether Elasticsearch obfuscation is enabled.
@@ -228,7 +227,7 @@ pub struct EsObfuscationConfig {
 }
 
 /// MongoDB obfuscation configuration.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct MongoObfuscationConfig {
     /// Whether MongoDB obfuscation is enabled.
@@ -245,7 +244,7 @@ pub struct MongoObfuscationConfig {
 }
 
 /// OpenSearch obfuscation configuration.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct OpenSearchObfuscationConfig {
     /// Whether OpenSearch obfuscation is enabled.

--- a/lib/saluki-components/src/common/datadog/protocol.rs
+++ b/lib/saluki-components/src/common/datadog/protocol.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 use agent_data_plane_config::shared::{
     V3ApiEncoding as TypedV3ApiEncoding, V3ApiSettings as TypedV3ApiSettings, V3SeriesMode as TypedV3SeriesMode,
 };
-use facet::Facet;
 use serde::{Deserialize, Serialize};
 
 use super::METRICS_SERIES_V3_BETA_PATH;
@@ -182,7 +181,7 @@ impl MetricsPayloadInfo {
 }
 
 /// V3 API settings for a specific metric type (series or sketches).
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Facet)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct V3ApiSettings {
     /// Endpoints that should receive V3 payloads for this metric type.
     ///
@@ -248,7 +247,7 @@ impl V3ApiSettings {
 }
 
 /// V3 API configuration for per-endpoint V3 support.
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Facet)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct V3ApiConfig {
     /// V3 settings for series metrics (counters, gauges, rates, sets).
     #[serde(default)]
@@ -301,7 +300,7 @@ impl From<&TypedV3ApiEncoding> for V3ApiConfig {
 }
 
 /// The Datadog Agent's `use_v3_api` configuration section.
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Facet)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct UseV3ApiConfig {
     /// Agent-compatible V3 API configuration for series metrics.
     #[serde(default)]
@@ -309,7 +308,7 @@ pub struct UseV3ApiConfig {
 }
 
 /// Agent-compatible `use_v3_api.series` configuration.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Facet)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UseV3ApiSeriesConfig {
     /// Global V3 series mode.
     ///

--- a/lib/saluki-components/src/common/datadog/proxy.rs
+++ b/lib/saluki-components/src/common/datadog/proxy.rs
@@ -1,7 +1,6 @@
 use std::net::IpAddr;
 use std::sync::Arc;
 
-use facet::Facet;
 use headers::Authorization;
 use hyper_http_proxy::{Intercept, Proxy};
 use saluki_common::deser::empty_string_as_none;
@@ -15,7 +14,7 @@ use url::Url;
 /// The proxy servers themselves live in the Datadog Agent's nested `proxy` section, while the two
 /// matching-behavior settings are top-level Agent keys. The nesting is therefore split across two
 /// structs, and this one is flattened by its owner so both levels are read from the same root.
-#[derive(Clone, Deserialize, Facet)]
+#[derive(Clone, Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
 pub struct ProxyConfiguration {
     /// The proxy servers and their bypass list, from the Agent's `proxy` section.
@@ -37,7 +36,7 @@ pub struct ProxyConfiguration {
 }
 
 /// The Datadog Agent's `proxy` configuration section.
-#[derive(Clone, Default, Deserialize, Facet)]
+#[derive(Clone, Default, Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
 struct ProxyServers {
     /// The proxy server for HTTP requests.

--- a/lib/saluki-components/src/common/datadog/retry.rs
+++ b/lib/saluki-components/src/common/datadog/retry.rs
@@ -4,7 +4,6 @@ use std::{
     time::Duration,
 };
 
-use facet::Facet;
 use http::StatusCode;
 use saluki_config::GenericConfiguration;
 use saluki_io::net::util::retry::{
@@ -60,7 +59,7 @@ const fn default_retry_queue_capacity_time_interval_secs() -> u64 {
 }
 
 /// Datadog Agent-specific forwarder retry configuration.
-#[derive(Clone, Deserialize, Facet)]
+#[derive(Clone, Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
 pub struct RetryConfiguration {
     /// The minimum backoff factor to use when retrying requests.

--- a/lib/saluki-components/src/encoders/datadog/events/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/events/mod.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use datadog_protos::events as proto;
-use facet::Facet;
 use http::{uri::PathAndQuery, HeaderValue, Method, Uri};
 use protobuf::{rt::WireType, CodedOutputStream};
 use saluki_common::iter::ReusableDeduplicator;
@@ -58,7 +57,7 @@ const fn default_log_payloads() -> bool {
 /// Datadog Events incremental encoder.
 ///
 /// Generates Datadog Events payloads for the Datadog platform.
-#[derive(Deserialize, Facet)]
+#[derive(Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
 pub struct DatadogEventsConfiguration {
     /// Maximum compressed size, in bytes, of an events payload.

--- a/lib/saluki-components/src/encoders/datadog/logs/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/logs/mod.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use chrono::{SecondsFormat, Utc};
-use facet::Facet;
 use http::{uri::PathAndQuery, HeaderValue, Method, Uri};
 use saluki_common::iter::ReusableDeduplicator;
 use saluki_config::GenericConfiguration;
@@ -41,7 +40,7 @@ fn default_serializer_compressor_kind() -> String {
 }
 
 /// Datadog Logs incremental encoder.
-#[derive(Deserialize, Debug, Facet)]
+#[derive(Deserialize, Debug)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct DatadogLogsConfiguration {
     /// Compression kind for Logs payloads. Defaults to `zstd`.

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -6,7 +6,6 @@ use agent_data_plane_config::{
 };
 use async_trait::async_trait;
 use ddsketch::DDSketch;
-use facet::Facet;
 use http::{HeaderValue, Method, Request};
 use protobuf::{rt::WireType, CodedOutputStream};
 use saluki_common::{
@@ -108,7 +107,7 @@ const fn default_flush_timeout_secs() -> u64 {
 }
 
 /// The Datadog Agent's `use_v2_api` configuration section.
-#[derive(Clone, Deserialize, Facet)]
+#[derive(Clone, Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
 struct UseV2ApiConfig {
     /// Whether to use the V2 API for series metrics.
@@ -227,7 +226,7 @@ fn series_v3_can_be_enabled_for_config(
 /// Datadog Metrics encoder.
 ///
 /// Generates Datadog metrics payloads for the Datadog platform.
-#[derive(Clone, Deserialize, Facet)]
+#[derive(Clone, Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
 pub struct DatadogMetricsConfiguration {
     /// Maximum number of input metrics to encode into a single request payload.
@@ -366,7 +365,6 @@ pub struct DatadogMetricsConfiguration {
 
     /// Additional tags to apply to all forwarded metrics.
     #[serde(default, skip)]
-    #[facet(opaque)]
     additional_tags: Option<SharedTagSet>,
 
     /// V3 API configuration for per-endpoint V3 support.

--- a/lib/saluki-components/src/encoders/datadog/service_checks/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/service_checks/mod.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use facet::Facet;
 use http::{uri::PathAndQuery, HeaderValue, Method, Uri};
 use saluki_config::GenericConfiguration;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
@@ -52,7 +51,7 @@ const fn default_log_payloads() -> bool {
 /// Datadog Service Checks incremental encoder.
 ///
 /// Generates Datadog Service Checks payloads for the Datadog platform.
-#[derive(Deserialize, Facet)]
+#[derive(Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
 pub struct DatadogServiceChecksConfiguration {
     /// Maximum compressed size, in bytes, of a service check payload.


### PR DESCRIPTION
## Summary

As stated in the PR title.

Our original intent for using `facet` was to get around the limitations of `serde` in the context of using it to deal with Agent configuration. Now that we have the full configuration schema for the Agent, however, we can do much more up front at build time, almost entirely obviating the need for a hypothetical and bespoke configuration loading system based on `facet`.

As such, we're removing the code. :)

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing tests, lints, etc etc.

## References

DADP-2