### PR TITLE
fix(agent-data-plane): handle SIGTERM for graceful shutdown

### DIFF
--- a/.vale/styles/config/vocabularies/technical/accept.txt
+++ b/.vale/styles/config/vocabularies/technical/accept.txt
@@ -254,3 +254,6 @@ reimplemented
 hoc
 rss
 waker
+systemd
+rollout(s?)
+subprocess(es)?

--- a/bin/agent-data-plane/src/cli/dogstatsd.rs
+++ b/bin/agent-data-plane/src/cli/dogstatsd.rs
@@ -302,8 +302,12 @@ async fn handle_dogstatsd_replay(
     let cancel_on_signal = tokio::spawn({
         let cancel = cancel.clone();
         async move {
-            if tokio::signal::ctrl_c().await.is_ok() {
-                cancel.cancel();
+            let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                .expect("failed to install SIGTERM handler");
+
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => cancel.cancel(),
+                _ = sigterm.recv() => cancel.cancel(),
             }
         }
     });

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -233,7 +233,7 @@ pub async fn handle_run_command(
     });
 
     info!("Agent Data Plane running.");
-    match root_supervisor.run_with_shutdown(wait_for_sigint()).await {
+    match root_supervisor.run_with_shutdown(wait_for_shutdown_signal()).await {
         Ok(()) => {
             info!("Agent Data Plane shut down successfully.");
             Ok(())
@@ -254,10 +254,31 @@ pub async fn handle_run_command(
     }
 }
 
-async fn wait_for_sigint() {
-    let _ = tokio::signal::ctrl_c().await;
+/// Waits for a shutdown signal.
+///
+/// On Unix, this waits for either `SIGINT` or `SIGTERM`, either of which are used to request a graceful shutdown:
+/// `SIGINT` interactively (`Ctrl+C`), and `SIGTERM` by process supervisors (systemd, container runtimes,
+/// Kubernetes) during rollouts, evictions, node drains, and container shutdown. Other platforms only support
+/// `SIGINT`-equivalent interruption.
+async fn wait_for_shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
 
-    info!("Received SIGINT, shutting down...");
+        let mut sigterm = signal(SignalKind::terminate()).expect("failed to install SIGTERM handler");
+
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => info!("Received SIGINT, shutting down..."),
+            _ = sigterm.recv() => info!("Received SIGTERM, shutting down..."),
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+
+        info!("Received SIGINT, shutting down...");
+    }
 }
 
 /// Check the resolved configuration against the config registry for incompatibilities.

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -258,8 +258,11 @@ pub async fn handle_run_command(
 ///
 /// On Unix, this waits for either `SIGINT` or `SIGTERM`, either of which are used to request a graceful shutdown:
 /// `SIGINT` interactively (`Ctrl+C`), and `SIGTERM` by process supervisors (systemd, container runtimes,
-/// Kubernetes) during rollouts, evictions, node drains, and container shutdown. Other platforms only support
-/// `SIGINT`-equivalent interruption.
+/// Kubernetes) during rollouts, evictions, node drains, and container shutdown.
+///
+/// On Windows, this waits for either `CTRL_C_EVENT` (interactively) or `CTRL_BREAK_EVENT`, the latter being what
+/// `dd-procmgr` (which manages ADP as a subprocess on Windows) sends via `GenerateConsoleCtrlEvent` to request a
+/// graceful stop.
 async fn wait_for_shutdown_signal() {
     #[cfg(unix)]
     {
@@ -273,7 +276,17 @@ async fn wait_for_shutdown_signal() {
         }
     }
 
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        let mut ctrl_break = tokio::signal::windows::ctrl_break().expect("failed to install CTRL_BREAK handler");
+
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => info!("Received CTRL_C, shutting down..."),
+            _ = ctrl_break.recv() => info!("Received CTRL_BREAK, shutting down..."),
+        }
+    }
+
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = tokio::signal::ctrl_c().await;
 


### PR DESCRIPTION
## Human Summary

Adds support for handling SIGTERM on *nix platforms, which we expect to receive when being managed by SystemD or s6, which ADP is packaged with. On Windows, we where we are managed by [procmgr](https://github.com/DataDog/datadog-agent/tree/main/pkg/procmgr) we expect to receive a CTRL_BREAK_EVENT ([ref](https://github.com/DataDog/datadog-agent/blob/eb013ebe547c7eb01868d377e266e47f420ee445/pkg/procmgr/rust/src/platform/windows.rs#L215)) so handle that instead.

For `dogstatsd replay` we currently only support Linux so we only additionally handle SIGTERM. We expect to only be run interactively, but the process may still receive a SIGTERM from out-of-band.

## AI Summary

ADP's production binaries only listened for `SIGINT` when deciding to enter graceful shutdown, but `SIGINT` is not the signal used in any of ADP's real deployment paths — systemd, container runtimes, and Kubernetes all send `SIGTERM` to request shutdown (during service stops/restarts, rollouts, evictions, node drains, and container termination). Since `SIGTERM` used its default disposition, ADP was killed outright instead of draining its topology, so buffered data could be lost and the shutdown-timeout/forceful-abort diagnostics never had a chance to fire. This wires `SIGTERM` into the same graceful-shutdown path already used for `SIGINT`, so the two behave identically. The `dogstatsd replay` debug subcommand gets the same treatment for consistency, since it also has state that should be flushed on interruption. `SIGPIPE` handling is being tracked separately and isn't part of this change.

Verified on a systemd-managed host by installing the current Datadog Agent package and swapping in a build of `agent-data-plane` with this fix:

- Before the fix: `systemctl stop datadog-agent-data-plane` (and `systemctl restart datadog-agent`, which cascades a stop via `BindsTo`) killed the process in single-digit milliseconds with `code=killed, signal=TERM` and no shutdown-path log lines at all.
- After the fix: the same `systemctl stop` produces `Received SIGTERM, shutting down...`, a clean topology drain (listeners and HTTP servers stopping), `Agent Data Plane shut down successfully.`, and the process exits with `status=0/SUCCESS`.

Closes #2319.

## Test plan

- [x] Verified under real systemd: patched `agent-data-plane` binary running as the actual `datadog-agent-data-plane.service` unit now drains and exits cleanly on `systemctl stop` / `systemctl restart datadog-agent`, versus being hard-killed before the fix.
- [x] Verified standalone: direct `SIGTERM` to the binary now triggers the same graceful-shutdown log sequence as `SIGINT`.