### PR TITLE
enhancement(core): add helpers for spawning dynamic workers under component supervisors

### DIFF
--- a/.vale/styles/config/vocabularies/technical/accept.txt
+++ b/.vale/styles/config/vocabularies/technical/accept.txt
@@ -257,3 +257,5 @@ waker
 systemd
 rollout(s?)
 subprocess(es)?
+(non-?)?interruptible
+PR

--- a/.vale/styles/config/vocabularies/technical/accept.txt
+++ b/.vale/styles/config/vocabularies/technical/accept.txt
@@ -259,3 +259,4 @@ rollout(s?)
 subprocess(es)?
 (non-?)?interruptible
 PR
+uninterrupible

--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -354,6 +354,7 @@ mod tests {
         Context, TagSetMutViewState,
     };
     use saluki_core::accounting::{ComponentRegistry, MemoryLimiter};
+    use saluki_core::components::ComponentSpawner;
     use saluki_core::components::{
         transforms::{TransformBuilder, TransformContext},
         ComponentContext,
@@ -1145,7 +1146,11 @@ mod tests {
         let health = HealthRegistry::new()
             .register_component(&saluki_core::support::SubsystemIdentifier::from_dotted("test"))
             .expect("component was not previously registered");
+        // This component doesn't spawn supervised children yet, so a spawner over a never-run supervisor is
+        // sufficient. Anything that does spawn needs `TestComponentSupervisor` (saluki_core::components::test_util)
+        // instead, otherwise the spawn fails with `SupervisorGone`.
         let supervisor_handle = Supervisor::new("test").expect("valid supervisor name").handle();
+        let spawner = ComponentSpawner::new(supervisor_handle, Handle::current());
 
         let context = TransformContext::new(
             &topology_context,
@@ -1154,7 +1159,7 @@ mod tests {
             health,
             dispatcher,
             consumer,
-            supervisor_handle,
+            spawner,
         );
 
         transform.run(context).await.expect("tag filterlist run should succeed");

--- a/lib/saluki-common/src/task/mod.rs
+++ b/lib/saluki-common/src/task/mod.rs
@@ -11,7 +11,7 @@ use tracing::Instrument as _;
 use crate::resource_tracking::Track as _;
 
 mod instrument;
-use self::instrument::TaskInstrument as _;
+pub use self::instrument::{InstrumentedTask, TaskInstrument};
 
 /// Spawns a new asynchronous task, returning a [`JoinHandle`] for it.
 ///

--- a/lib/saluki-components/src/destinations/dsd_stats/mod.rs
+++ b/lib/saluki-components/src/destinations/dsd_stats/mod.rs
@@ -315,6 +315,7 @@ mod tests {
     use std::collections::BTreeSet;
 
     use saluki_context::tags::Tag;
+    use saluki_core::components::ComponentSpawner;
     use serde_json::json;
 
     use super::*;
@@ -419,14 +420,18 @@ mod tests {
         let health = HealthRegistry::new()
             .register_component(&saluki_core::support::SubsystemIdentifier::from_dotted("test"))
             .expect("component was not previously registered");
+        // This component doesn't spawn supervised children yet, so a spawner over a never-run supervisor is
+        // sufficient. Anything that does spawn needs `TestComponentSupervisor` (saluki_core::components::test_util)
+        // instead, otherwise the spawn fails with `SupervisorGone`.
         let supervisor_handle = Supervisor::new("test").expect("valid supervisor name").handle();
+        let spawner = ComponentSpawner::new(supervisor_handle, Handle::current());
         let context = DestinationContext::new(
             &topology_context,
             &component_context,
             ComponentRegistry::default(),
             health,
             consumer,
-            supervisor_handle,
+            spawner,
         );
 
         let run_handle = tokio::spawn(async move { destination.run(context).await });

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -2564,6 +2564,7 @@ mod tests {
     use saluki_config::ConfigurationLoader;
     use saluki_context::{ContextResolverBuilder, TagsResolverBuilder};
     use saluki_core::accounting::{ComponentRegistry, MemoryLimiter};
+    use saluki_core::components::ComponentSpawner;
     use saluki_core::{
         components::{sources::SourceContext, ComponentContext},
         health::HealthRegistry,
@@ -2733,16 +2734,20 @@ mod tests {
         let health = health_registry
             .register_component(&SubsystemIdentifier::from_dotted("test.decoder"))
             .expect("test decoder should have a health handle");
+        // This component doesn't spawn supervised children yet, so a spawner over a never-run supervisor is
+        // sufficient. Anything that does spawn needs `TestComponentSupervisor` (saluki_core::components::test_util)
+        // instead, otherwise the spawn fails with `SupervisorGone`.
         let supervisor_handle = Supervisor::new("dogstatsd-decoder-test")
             .expect("test supervisor name should be valid")
             .handle();
+        let spawner = ComponentSpawner::new(supervisor_handle, Handle::current());
         let source_context = SourceContext::new(
             &topology_context,
             &component_context,
             ComponentRegistry::default(),
             health,
             dispatcher,
-            supervisor_handle,
+            spawner,
         );
 
         (source_context, metrics_rx)

--- a/lib/saluki-core/src/components/decoders/context.rs
+++ b/lib/saluki-core/src/components/decoders/context.rs
@@ -1,8 +1,7 @@
 use crate::accounting::ComponentRegistry;
 use crate::health::Health;
-use crate::runtime::SupervisorHandle;
 use crate::{
-    components::ComponentContext,
+    components::{ComponentContext, ComponentSpawner},
     topology::{EventsDispatcher, PayloadsConsumer, TopologyContext},
 };
 
@@ -14,7 +13,7 @@ pub struct DecoderContext {
     health_handle: Option<Health>,
     dispatcher: EventsDispatcher,
     consumer: PayloadsConsumer,
-    supervisor_handle: SupervisorHandle,
+    spawner: ComponentSpawner,
 }
 
 impl DecoderContext {
@@ -22,7 +21,7 @@ impl DecoderContext {
     pub fn new(
         topology_context: &TopologyContext, component_context: &ComponentContext,
         component_registry: ComponentRegistry, health_handle: Health, dispatcher: EventsDispatcher,
-        consumer: PayloadsConsumer, supervisor_handle: SupervisorHandle,
+        consumer: PayloadsConsumer, spawner: ComponentSpawner,
     ) -> Self {
         Self {
             topology_context: topology_context.clone(),
@@ -31,7 +30,7 @@ impl DecoderContext {
             health_handle: Some(health_handle),
             dispatcher,
             consumer,
-            supervisor_handle,
+            spawner,
         }
     }
 
@@ -69,12 +68,11 @@ impl DecoderContext {
         &mut self.consumer
     }
 
-    /// Returns a handle to the supervisor that this component is spawned on.
+    /// Returns a spawner for supervised child tasks belonging to this component.
     ///
-    /// Dynamic child processes can be spawned via the supervisor handle and thus have their lifecycle
-    /// coupled to the component itself: if the component restarts, or the component's supervisor dies,
-    /// the dynamic child processes will also be terminated automatically as well.
-    pub fn spawn_handle(&self) -> &SupervisorHandle {
-        &self.supervisor_handle
+    /// Children spawned through it have their lifecycle coupled to the component itself: if the
+    /// component restarts, or the component's supervisor dies, its children are terminated too.
+    pub fn spawn_handle(&self) -> &ComponentSpawner {
+        &self.spawner
     }
 }

--- a/lib/saluki-core/src/components/decoders/context.rs
+++ b/lib/saluki-core/src/components/decoders/context.rs
@@ -43,36 +43,36 @@ impl DecoderContext {
         self.health_handle.take().expect("health handle already taken")
     }
 
-    /// Gets a reference to the topology context.
+    /// Returns a reference to the topology context.
     pub fn topology_context(&self) -> &TopologyContext {
         &self.topology_context
     }
 
-    /// Gets a reference to the component context.
+    /// Returns a reference to the component context.
     pub fn component_context(&self) -> &ComponentContext {
         &self.component_context
     }
 
-    /// Gets a reference to the component registry.
+    /// Returns a reference to the component registry.
     pub fn component_registry(&mut self) -> &ComponentRegistry {
         &self.component_registry
     }
 
-    /// Gets a reference to the events dispatcher.
+    /// Returns a reference to the events dispatcher.
     pub fn dispatcher(&self) -> &EventsDispatcher {
         &self.dispatcher
     }
 
-    /// Gets a mutable reference to the payloads consumer.
+    /// Returns a mutable reference to the payloads consumer.
     pub fn payloads(&mut self) -> &mut PayloadsConsumer {
         &mut self.consumer
     }
 
     /// Returns a spawner for supervised child tasks belonging to this component.
     ///
-    /// Children spawned through it have their lifecycle coupled to the component itself: if the
-    /// component restarts, or the component's supervisor dies, its children are terminated too.
-    pub fn spawn_handle(&self) -> &ComponentSpawner {
+    /// All child tasks spawned through this mechanism are tied to the lifecycle of the component itself, such that
+    /// they're automatically shutdown/stopped when the component is stopped during topology shutdown, etc.
+    pub fn spawner(&self) -> &ComponentSpawner {
         &self.spawner
     }
 }

--- a/lib/saluki-core/src/components/destinations/context.rs
+++ b/lib/saluki-core/src/components/destinations/context.rs
@@ -1,8 +1,7 @@
 use crate::accounting::ComponentRegistry;
 use crate::health::Health;
-use crate::runtime::SupervisorHandle;
 use crate::{
-    components::ComponentContext,
+    components::{ComponentContext, ComponentSpawner},
     topology::{EventsConsumer, TopologyContext},
 };
 
@@ -13,7 +12,7 @@ pub struct DestinationContext {
     component_registry: ComponentRegistry,
     health_handle: Option<Health>,
     consumer: EventsConsumer,
-    supervisor_handle: SupervisorHandle,
+    spawner: ComponentSpawner,
 }
 
 impl DestinationContext {
@@ -21,7 +20,7 @@ impl DestinationContext {
     pub fn new(
         topology_context: &TopologyContext, component_context: &ComponentContext,
         component_registry: ComponentRegistry, health_handle: Health, consumer: EventsConsumer,
-        supervisor_handle: SupervisorHandle,
+        spawner: ComponentSpawner,
     ) -> Self {
         Self {
             topology_context: topology_context.clone(),
@@ -29,7 +28,7 @@ impl DestinationContext {
             component_registry,
             health_handle: Some(health_handle),
             consumer,
-            supervisor_handle,
+            spawner,
         }
     }
 
@@ -62,12 +61,11 @@ impl DestinationContext {
         &mut self.consumer
     }
 
-    /// Returns a handle to the supervisor that this component is spawned on.
+    /// Returns a spawner for supervised child tasks belonging to this component.
     ///
-    /// Dynamic child processes can be spawned via the supervisor handle and thus have their lifecycle
-    /// coupled to the component itself: if the component restarts, or the component's supervisor dies,
-    /// the dynamic child processes will also be terminated automatically as well.
-    pub fn spawn_handle(&self) -> &SupervisorHandle {
-        &self.supervisor_handle
+    /// Children spawned through it have their lifecycle coupled to the component itself: if the
+    /// component restarts, or the component's supervisor dies, its children are terminated too.
+    pub fn spawn_handle(&self) -> &ComponentSpawner {
+        &self.spawner
     }
 }

--- a/lib/saluki-core/src/components/destinations/context.rs
+++ b/lib/saluki-core/src/components/destinations/context.rs
@@ -34,38 +34,38 @@ impl DestinationContext {
 
     /// Consumes the health handle of this destination context.
     ///
-    /// ## Panics
+    /// # Panics
     ///
     /// Panics if the health handle has already been taken.
     pub fn take_health_handle(&mut self) -> Health {
         self.health_handle.take().expect("health handle already taken")
     }
 
-    /// Gets a reference to the topology context.
+    /// Returns a reference to the topology context.
     pub fn topology_context(&self) -> &TopologyContext {
         &self.topology_context
     }
 
-    /// Gets a reference to the component context.
+    /// Returns a reference to the component context.
     pub fn component_context(&self) -> &ComponentContext {
         &self.component_context
     }
 
-    /// Gets a reference to the component registry.
+    /// Returns a reference to the component registry.
     pub fn component_registry(&mut self) -> &ComponentRegistry {
         &self.component_registry
     }
 
-    /// Gets a mutable reference to the events consumer.
+    /// Returns a mutable reference to the events consumer.
     pub fn events(&mut self) -> &mut EventsConsumer {
         &mut self.consumer
     }
 
     /// Returns a spawner for supervised child tasks belonging to this component.
     ///
-    /// Children spawned through it have their lifecycle coupled to the component itself: if the
-    /// component restarts, or the component's supervisor dies, its children are terminated too.
-    pub fn spawn_handle(&self) -> &ComponentSpawner {
+    /// All child tasks spawned through this mechanism are tied to the lifecycle of the component itself, such that
+    /// they're automatically shutdown/stopped when the component is stopped during topology shutdown, etc.
+    pub fn spawner(&self) -> &ComponentSpawner {
         &self.spawner
     }
 }

--- a/lib/saluki-core/src/components/encoders/context.rs
+++ b/lib/saluki-core/src/components/encoders/context.rs
@@ -1,8 +1,7 @@
 use crate::accounting::ComponentRegistry;
 use crate::health::Health;
-use crate::runtime::SupervisorHandle;
 use crate::{
-    components::ComponentContext,
+    components::{ComponentContext, ComponentSpawner},
     topology::{EventsConsumer, PayloadsDispatcher, TopologyContext},
 };
 
@@ -14,7 +13,7 @@ pub struct EncoderContext {
     health_handle: Option<Health>,
     dispatcher: PayloadsDispatcher,
     consumer: EventsConsumer,
-    supervisor_handle: SupervisorHandle,
+    spawner: ComponentSpawner,
 }
 
 impl EncoderContext {
@@ -22,7 +21,7 @@ impl EncoderContext {
     pub fn new(
         topology_context: &TopologyContext, component_context: &ComponentContext,
         component_registry: ComponentRegistry, health_handle: Health, dispatcher: PayloadsDispatcher,
-        consumer: EventsConsumer, supervisor_handle: SupervisorHandle,
+        consumer: EventsConsumer, spawner: ComponentSpawner,
     ) -> Self {
         Self {
             topology_context: topology_context.clone(),
@@ -31,7 +30,7 @@ impl EncoderContext {
             health_handle: Some(health_handle),
             dispatcher,
             consumer,
-            supervisor_handle,
+            spawner,
         }
     }
 
@@ -69,12 +68,11 @@ impl EncoderContext {
         &mut self.consumer
     }
 
-    /// Returns a handle to the supervisor that this component is spawned on.
+    /// Returns a spawner for supervised child tasks belonging to this component.
     ///
-    /// Dynamic child processes can be spawned via the supervisor handle and thus have their lifecycle
-    /// coupled to the component itself: if the component restarts, or the component's supervisor dies,
-    /// the dynamic child processes will also be terminated automatically as well.
-    pub fn spawn_handle(&self) -> &SupervisorHandle {
-        &self.supervisor_handle
+    /// Children spawned through it have their lifecycle coupled to the component itself: if the
+    /// component restarts, or the component's supervisor dies, its children are terminated too.
+    pub fn spawn_handle(&self) -> &ComponentSpawner {
+        &self.spawner
     }
 }

--- a/lib/saluki-core/src/components/encoders/context.rs
+++ b/lib/saluki-core/src/components/encoders/context.rs
@@ -43,36 +43,36 @@ impl EncoderContext {
         self.health_handle.take().expect("health handle already taken")
     }
 
-    /// Gets a reference to the topology context.
+    /// Returns a reference to the topology context.
     pub fn topology_context(&self) -> &TopologyContext {
         &self.topology_context
     }
 
-    /// Gets a reference to the component context.
+    /// Returns a reference to the component context.
     pub fn component_context(&self) -> &ComponentContext {
         &self.component_context
     }
 
-    /// Gets a reference to the component registry.
+    /// Returns a reference to the component registry.
     pub fn component_registry(&mut self) -> &ComponentRegistry {
         &self.component_registry
     }
 
-    /// Gets a reference to the payloads dispatcher.
+    /// Returns a reference to the payloads dispatcher.
     pub fn dispatcher(&self) -> &PayloadsDispatcher {
         &self.dispatcher
     }
 
-    /// Gets a mutable reference to the events consumer.
+    /// Returns a mutable reference to the events consumer.
     pub fn events(&mut self) -> &mut EventsConsumer {
         &mut self.consumer
     }
 
     /// Returns a spawner for supervised child tasks belonging to this component.
     ///
-    /// Children spawned through it have their lifecycle coupled to the component itself: if the
-    /// component restarts, or the component's supervisor dies, its children are terminated too.
-    pub fn spawn_handle(&self) -> &ComponentSpawner {
+    /// All child tasks spawned through this mechanism are tied to the lifecycle of the component itself, such that
+    /// they're automatically shutdown/stopped when the component is stopped during topology shutdown, etc.
+    pub fn spawner(&self) -> &ComponentSpawner {
         &self.spawner
     }
 }

--- a/lib/saluki-core/src/components/forwarders/context.rs
+++ b/lib/saluki-core/src/components/forwarders/context.rs
@@ -41,31 +41,31 @@ impl ForwarderContext {
         self.health_handle.take().expect("health handle already taken")
     }
 
-    /// Gets a reference to the topology context.
+    /// Returns a reference to the topology context.
     pub fn topology_context(&self) -> &TopologyContext {
         &self.topology_context
     }
 
-    /// Gets a reference to the component context.
+    /// Returns a reference to the component context.
     pub fn component_context(&self) -> &ComponentContext {
         &self.component_context
     }
 
-    /// Gets a reference to the component registry.
+    /// Returns a reference to the component registry.
     pub fn component_registry(&mut self) -> &ComponentRegistry {
         &self.component_registry
     }
 
-    /// Gets a mutable reference to the payloads consumer.
+    /// Returns a mutable reference to the payloads consumer.
     pub fn payloads(&mut self) -> &mut PayloadsConsumer {
         &mut self.consumer
     }
 
     /// Returns a spawner for supervised child tasks belonging to this component.
     ///
-    /// Children spawned through it have their lifecycle coupled to the component itself: if the
-    /// component restarts, or the component's supervisor dies, its children are terminated too.
-    pub fn spawn_handle(&self) -> &ComponentSpawner {
+    /// All child tasks spawned through this mechanism are tied to the lifecycle of the component itself, such that
+    /// they're automatically shutdown/stopped when the component is stopped during topology shutdown, etc.
+    pub fn spawner(&self) -> &ComponentSpawner {
         &self.spawner
     }
 }

--- a/lib/saluki-core/src/components/forwarders/context.rs
+++ b/lib/saluki-core/src/components/forwarders/context.rs
@@ -1,8 +1,7 @@
 use crate::accounting::ComponentRegistry;
 use crate::health::Health;
-use crate::runtime::SupervisorHandle;
 use crate::{
-    components::ComponentContext,
+    components::{ComponentContext, ComponentSpawner},
     topology::{PayloadsConsumer, TopologyContext},
 };
 
@@ -13,7 +12,7 @@ pub struct ForwarderContext {
     component_registry: ComponentRegistry,
     health_handle: Option<Health>,
     consumer: PayloadsConsumer,
-    supervisor_handle: SupervisorHandle,
+    spawner: ComponentSpawner,
 }
 
 impl ForwarderContext {
@@ -21,7 +20,7 @@ impl ForwarderContext {
     pub fn new(
         topology_context: &TopologyContext, component_context: &ComponentContext,
         component_registry: ComponentRegistry, health_handle: Health, consumer: PayloadsConsumer,
-        supervisor_handle: SupervisorHandle,
+        spawner: ComponentSpawner,
     ) -> Self {
         Self {
             topology_context: topology_context.clone(),
@@ -29,7 +28,7 @@ impl ForwarderContext {
             component_registry,
             health_handle: Some(health_handle),
             consumer,
-            supervisor_handle,
+            spawner,
         }
     }
 
@@ -62,12 +61,11 @@ impl ForwarderContext {
         &mut self.consumer
     }
 
-    /// Returns a handle to the supervisor that this component is spawned on.
+    /// Returns a spawner for supervised child tasks belonging to this component.
     ///
-    /// Dynamic child processes can be spawned via the supervisor handle and thus have their lifecycle
-    /// coupled to the component itself: if the component restarts, or the component's supervisor dies,
-    /// the dynamic child processes will also be terminated automatically as well.
-    pub fn spawn_handle(&self) -> &SupervisorHandle {
-        &self.supervisor_handle
+    /// Children spawned through it have their lifecycle coupled to the component itself: if the
+    /// component restarts, or the component's supervisor dies, its children are terminated too.
+    pub fn spawn_handle(&self) -> &ComponentSpawner {
+        &self.spawner
     }
 }

--- a/lib/saluki-core/src/components/mod.rs
+++ b/lib/saluki-core/src/components/mod.rs
@@ -12,6 +12,12 @@ pub mod relays;
 pub mod sources;
 pub mod transforms;
 
+mod spawner;
+pub use self::spawner::{ChildBuilder, ComponentSpawner};
+
+#[cfg(any(test, feature = "test-util"))]
+pub mod test_util;
+
 /// Component type.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum ComponentType {
@@ -234,9 +240,10 @@ mod tests {
     use super::transforms::TransformContext;
     use super::ComponentContext;
     use crate::accounting::{ComponentRegistry, MemoryLimiter};
+    use crate::components::ComponentSpawner;
     use crate::health::{Health, HealthRegistry};
     use crate::runtime::state::DataspaceRegistry;
-    use crate::runtime::{Supervisor, SupervisorHandle};
+    use crate::runtime::Supervisor;
     use crate::support::SubsystemIdentifier;
     use crate::topology::interconnect::{Consumer, Dispatcher};
     use crate::topology::{
@@ -281,8 +288,15 @@ mod tests {
             .expect("component was not previously registered")
     }
 
-    fn supervisor_handle() -> SupervisorHandle {
-        Supervisor::new("test").expect("valid supervisor name").handle()
+    /// Builds a spawner over a supervisor that is never run.
+    ///
+    /// The tests below only exercise handle-taking, so they never spawn anything -- which is the only reason this is
+    /// adequate. Spawning through this would fail with `SpawnError::SupervisorGone`; a test that needs a component to
+    /// actually spawn children wants
+    /// [`TestComponentSupervisor`][crate::components::test_util::TestComponentSupervisor] instead.
+    fn inert_spawner() -> ComponentSpawner {
+        let handle = Supervisor::new("test").expect("valid supervisor name").handle();
+        ComponentSpawner::new(handle, Handle::current())
     }
 
     fn events_dispatcher(component_context: &ComponentContext) -> EventsDispatcher {
@@ -311,7 +325,7 @@ mod tests {
             ComponentRegistry::default(),
             health_handle(),
             events_dispatcher(&cc),
-            supervisor_handle(),
+            inert_spawner(),
         )
     }
 
@@ -323,7 +337,7 @@ mod tests {
             ComponentRegistry::default(),
             health_handle(),
             payloads_dispatcher(&cc),
-            supervisor_handle(),
+            inert_spawner(),
         )
     }
 
@@ -336,7 +350,7 @@ mod tests {
             health_handle(),
             events_dispatcher(&cc),
             payloads_consumer(&cc),
-            supervisor_handle(),
+            inert_spawner(),
         )
     }
 
@@ -349,7 +363,7 @@ mod tests {
             health_handle(),
             events_dispatcher(&cc),
             events_consumer(&cc),
-            supervisor_handle(),
+            inert_spawner(),
         )
     }
 
@@ -361,7 +375,7 @@ mod tests {
             ComponentRegistry::default(),
             health_handle(),
             events_consumer(&cc),
-            supervisor_handle(),
+            inert_spawner(),
         )
     }
 
@@ -374,7 +388,7 @@ mod tests {
             health_handle(),
             payloads_dispatcher(&cc),
             events_consumer(&cc),
-            supervisor_handle(),
+            inert_spawner(),
         )
     }
 
@@ -386,7 +400,7 @@ mod tests {
             ComponentRegistry::default(),
             health_handle(),
             payloads_consumer(&cc),
-            supervisor_handle(),
+            inert_spawner(),
         )
     }
 

--- a/lib/saluki-core/src/components/relays/context.rs
+++ b/lib/saluki-core/src/components/relays/context.rs
@@ -4,9 +4,8 @@ use saluki_common::sync::shutdown::ShutdownHandle;
 
 use crate::accounting::ComponentRegistry;
 use crate::health::Health;
-use crate::runtime::SupervisorHandle;
 use crate::{
-    components::ComponentContext,
+    components::{ComponentContext, ComponentSpawner},
     topology::{PayloadsDispatcher, TopologyContext},
 };
 
@@ -15,7 +14,7 @@ struct RelayContextInner {
     component_context: ComponentContext,
     component_registry: ComponentRegistry,
     dispatcher: PayloadsDispatcher,
-    supervisor_handle: SupervisorHandle,
+    spawner: ComponentSpawner,
 }
 
 /// Relay context.
@@ -30,7 +29,7 @@ impl RelayContext {
     pub fn new(
         topology_context: &TopologyContext, component_context: &ComponentContext,
         component_registry: ComponentRegistry, health_handle: Health, dispatcher: PayloadsDispatcher,
-        supervisor_handle: SupervisorHandle,
+        spawner: ComponentSpawner,
     ) -> Self {
         Self {
             shutdown_handle: None,
@@ -40,7 +39,7 @@ impl RelayContext {
                 component_context: component_context.clone(),
                 component_registry,
                 dispatcher,
-                supervisor_handle,
+                spawner,
             }),
         }
     }
@@ -91,13 +90,12 @@ impl RelayContext {
         &self.inner.dispatcher
     }
 
-    /// Returns a handle to the supervisor that this component is spawned on.
+    /// Returns a spawner for supervised child tasks belonging to this component.
     ///
-    /// Dynamic child processes can be spawned via the supervisor handle and thus have their lifecycle
-    /// coupled to the component itself: if the component restarts, or the component's supervisor dies,
-    /// the dynamic child processes will also be terminated automatically as well.
-    pub fn spawn_handle(&self) -> &SupervisorHandle {
-        &self.inner.supervisor_handle
+    /// Children spawned through it have their lifecycle coupled to the component itself: if the
+    /// component restarts, or the component's supervisor dies, its children are terminated too.
+    pub fn spawn_handle(&self) -> &ComponentSpawner {
+        &self.inner.spawner
     }
 }
 

--- a/lib/saluki-core/src/components/relays/context.rs
+++ b/lib/saluki-core/src/components/relays/context.rs
@@ -70,31 +70,31 @@ impl RelayContext {
         self.health_handle.take().expect("health handle already taken")
     }
 
-    /// Gets a reference to the topology context.
+    /// Returns a reference to the topology context.
     pub fn topology_context(&self) -> &TopologyContext {
         &self.inner.topology_context
     }
 
-    /// Gets a reference to the component context.
+    /// Returns a reference to the component context.
     pub fn component_context(&self) -> &ComponentContext {
         &self.inner.component_context
     }
 
-    /// Gets a reference to the component registry.
+    /// Returns a reference to the component registry.
     pub fn component_registry(&self) -> &ComponentRegistry {
         &self.inner.component_registry
     }
 
-    /// Gets a reference to the payloads dispatcher.
+    /// Returns a reference to the payloads dispatcher.
     pub fn dispatcher(&self) -> &PayloadsDispatcher {
         &self.inner.dispatcher
     }
 
     /// Returns a spawner for supervised child tasks belonging to this component.
     ///
-    /// Children spawned through it have their lifecycle coupled to the component itself: if the
-    /// component restarts, or the component's supervisor dies, its children are terminated too.
-    pub fn spawn_handle(&self) -> &ComponentSpawner {
+    /// All child tasks spawned through this mechanism are tied to the lifecycle of the component itself, such that
+    /// they're automatically shutdown/stopped when the component is stopped during topology shutdown, etc.
+    pub fn spawner(&self) -> &ComponentSpawner {
         &self.inner.spawner
     }
 }

--- a/lib/saluki-core/src/components/sources/context.rs
+++ b/lib/saluki-core/src/components/sources/context.rs
@@ -46,8 +46,8 @@ impl SourceContext {
 
     /// Installs the shutdown handle for this source context.
     ///
-    /// Called once by the runtime, before the component runs, with the shutdown signal of the
-    /// component's dedicated supervisor.
+    /// Called once by the runtime, before the component runs, with the shutdown signal of the component's dedicated
+    /// supervisor.
     pub(crate) fn set_shutdown_handle(&mut self, shutdown_handle: ShutdownHandle) {
         self.shutdown_handle = Some(shutdown_handle);
     }
@@ -70,31 +70,31 @@ impl SourceContext {
         self.health_handle.take().expect("health handle already taken")
     }
 
-    /// Gets a reference to the topology context.
+    /// Returns a reference to the topology context.
     pub fn topology_context(&self) -> &TopologyContext {
         &self.inner.topology_context
     }
 
-    /// Gets a reference to the component context.
+    /// Returns a reference to the component context.
     pub fn component_context(&self) -> &ComponentContext {
         &self.inner.component_context
     }
 
-    /// Gets a reference to the component registry.
+    /// Returns a reference to the component registry.
     pub fn component_registry(&self) -> &ComponentRegistry {
         &self.inner.component_registry
     }
 
-    /// Gets a reference to the events dispatcher.
+    /// Returns a reference to the events dispatcher.
     pub fn dispatcher(&self) -> &EventsDispatcher {
         &self.inner.dispatcher
     }
 
     /// Returns a spawner for supervised child tasks belonging to this component.
     ///
-    /// Children spawned through it have their lifecycle coupled to the component itself: if the
-    /// component restarts, or the component's supervisor dies, its children are terminated too.
-    pub fn spawn_handle(&self) -> &ComponentSpawner {
+    /// All child tasks spawned through this mechanism are tied to the lifecycle of the component itself, such that
+    /// they're automatically shutdown/stopped when the component is stopped during topology shutdown, etc.
+    pub fn spawner(&self) -> &ComponentSpawner {
         &self.inner.spawner
     }
 }

--- a/lib/saluki-core/src/components/sources/context.rs
+++ b/lib/saluki-core/src/components/sources/context.rs
@@ -4,9 +4,8 @@ use saluki_common::sync::shutdown::ShutdownHandle;
 
 use crate::accounting::ComponentRegistry;
 use crate::health::Health;
-use crate::runtime::SupervisorHandle;
 use crate::{
-    components::ComponentContext,
+    components::{ComponentContext, ComponentSpawner},
     topology::{EventsDispatcher, TopologyContext},
 };
 
@@ -15,7 +14,7 @@ struct SourceContextInner {
     component_context: ComponentContext,
     component_registry: ComponentRegistry,
     dispatcher: EventsDispatcher,
-    supervisor_handle: SupervisorHandle,
+    spawner: ComponentSpawner,
 }
 
 /// Source context.
@@ -30,7 +29,7 @@ impl SourceContext {
     pub fn new(
         topology_context: &TopologyContext, component_context: &ComponentContext,
         component_registry: ComponentRegistry, health_handle: Health, dispatcher: EventsDispatcher,
-        supervisor_handle: SupervisorHandle,
+        spawner: ComponentSpawner,
     ) -> Self {
         Self {
             shutdown_handle: None,
@@ -40,7 +39,7 @@ impl SourceContext {
                 component_context: component_context.clone(),
                 component_registry,
                 dispatcher,
-                supervisor_handle,
+                spawner,
             }),
         }
     }
@@ -91,13 +90,12 @@ impl SourceContext {
         &self.inner.dispatcher
     }
 
-    /// Returns a handle to the supervisor that this component is spawned on.
+    /// Returns a spawner for supervised child tasks belonging to this component.
     ///
-    /// Dynamic child processes can be spawned via the supervisor handle and thus have their lifecycle
-    /// coupled to the component itself: if the component restarts, or the component's supervisor dies,
-    /// the dynamic child processes will also be terminated automatically as well.
-    pub fn spawn_handle(&self) -> &SupervisorHandle {
-        &self.inner.supervisor_handle
+    /// Children spawned through it have their lifecycle coupled to the component itself: if the
+    /// component restarts, or the component's supervisor dies, its children are terminated too.
+    pub fn spawn_handle(&self) -> &ComponentSpawner {
+        &self.inner.spawner
     }
 }
 

--- a/lib/saluki-core/src/components/spawner.rs
+++ b/lib/saluki-core/src/components/spawner.rs
@@ -1,0 +1,453 @@
+//! Utilities for spawning child tasks attached to specific components in a topology.
+use std::{future::Future, time::Duration};
+
+use saluki_common::sync::shutdown::ShutdownHandle;
+use tokio::runtime::Handle;
+
+use crate::runtime::{
+    interruptible_worker, noninterruptible_worker, ChildId, ChildSpecification, FnWorker, IntoWorkerResult,
+    ShutdownStrategy, SpawnError, Supervisable, SupervisorHandle,
+};
+
+/// Component-scoped spawner for child tasks.
+///
+/// Every component in a topology consists of a primary task which runs the "core loop" of the component, and optionally
+/// a number of child tasks that range from handling network connections to processing compute-heavy work in a separate
+/// thread pool.
+///
+/// [`ComponentSpawner`] provides a component-scoped mechanism for spawning those child tasks under supervision. It is
+/// tied specifically to the dedicated per-component supervisor that each component gets, which ensures that child tasks
+/// spawned through this mechanism are properly attributed to the component, and also that their lifecycle is one-to-one
+/// with the component itself.
+///
+/// # Child lifecycle
+///
+/// All child tasks are spawned as [`temporary`][crate::runtime::RestartType::Temporary] and non-significant, which
+/// ensures that the component supervisor does not prematurely exit when they do. This means that, for example, a child
+/// task handling a network error doesn't take down the component if it aborts, which would otherwise be the normal
+/// behavior for a standard child task under supervision.
+///
+/// # Interruptible vs non-interruptible
+///
+/// [`ComponentSpawner`] allows spawning two styles of child task: "interruptible" and "non-interruptible."
+/// Interruptible tasks are wrapped such that when the supervisor signals shutdown, the shutdown signal is
+/// honored/polled despite whatever the logic is in the task itself does. Non-interruptible tasks still received a
+/// shutdown handle, but the task logic itself is responsible for honoring shutdown signals.
+///
+/// Non-interruptible tasks aren't _truly_ uninterrupible: following the normal behavior of async Rust and the behavior
+/// of futures, the future associated with a task can simply be no longer polled or dropped, _effectively_ interrupting
+/// it when considered at the level of "will this task run to completion?"
+///
+/// # Worker pool
+///
+/// [`ComponentSpawner`] is topology-aware, which means callers have the ability to specify a child task runs on the
+/// shared "global" thread pool attached to a given topology. This should be used for compute-heavy tasks, which
+/// otherwise can affect the scheduling latency of I/O-heavy tasks.
+///
+/// # Task naming
+///
+/// Child task names should generally _not_ contain unique patterns/tokens -- such as monotonic IDs or high-cardinality
+/// values -- as they are used for internal telemetry about the task. Generally, task names should be thought of as a
+/// category label: if a component spawns tasks for handling connections, it should prefer to name them like
+/// `conn_handler` instead of `conn_handler_<ID or IP>`.
+///
+/// A child task that must finish draining before the component stops:
+///
+/// ```no_run
+/// # use saluki_core::components::ComponentSpawner;
+/// # async fn drain(shutdown: saluki_common::sync::shutdown::ShutdownHandle) {}
+/// # async fn example(spawner: &ComponentSpawner) -> Result<(), Box<dyn std::error::Error>> {
+/// spawner.spawn_noninterruptible("queue_drainer", |shutdown| drain(shutdown)).await?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// A compute-heavy task that belongs on the shared worker pool, which needs the builder to say so:
+///
+/// ```no_run
+/// # use saluki_core::components::ComponentSpawner;
+/// # async fn encode() {}
+/// # async fn example(spawner: ComponentSpawner) -> Result<(), Box<dyn std::error::Error>> {
+/// spawner.interruptible("encoder", encode()).on_worker_pool().spawn().await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone)]
+pub struct ComponentSpawner {
+    handle: SupervisorHandle,
+    worker_pool: Handle,
+}
+
+impl ComponentSpawner {
+    /// Creates a new `ComponentSpawner`.
+    ///
+    /// `worker_pool` is the shared worker pool owned by the topology, used by children that opt in via
+    /// [`ChildBuilder::on_worker_pool`].
+    ///
+    /// The supervisor behind `handle` **MUST** carry a shutdown budget
+    /// ([`Supervisor::with_shutdown_budget`][crate::runtime::Supervisor::with_shutdown_budget]). Children spawned here
+    /// have no deadline of their own, so without one a child that ignores shutdown stalls the drain indefinitely.
+    pub fn new(handle: SupervisorHandle, worker_pool: Handle) -> Self {
+        Self { handle, worker_pool }
+    }
+
+    /// Spawns a child that observes shutdown itself, on the component's own runtime.
+    ///
+    /// The function receives the supervisor's shutdown signal and decides when it's finished, which makes this the
+    /// right choice for a child that has work to drain.
+    ///
+    /// To place the child on another runtime, or to bound it more tightly than the component as a whole, use
+    /// [`noninterruptible`][Self::noninterruptible] instead.
+    ///
+    /// # Errors
+    ///
+    /// If the component's supervisor isn't running, or the child specification is invalid, an error is returned.
+    pub async fn spawn_noninterruptible<N, F, Fut>(&self, name: N, f: F) -> Result<ChildId, SpawnError>
+    where
+        N: Into<String>,
+        F: FnOnce(ShutdownHandle) -> Fut + Send + 'static,
+        Fut: Future + Send + 'static,
+        Fut::Output: IntoWorkerResult,
+    {
+        self.noninterruptible(name, f).spawn().await
+    }
+
+    /// Spawns a child that runs until it completes or shutdown is signalled, on the component's own runtime.
+    ///
+    /// The future is dropped at whatever await point it's parked on when shutdown fires, so use this only for work
+    /// that is safe to interrupt -- a server accept loop, a connection handler, a periodic refresher.
+    ///
+    /// To place the child on another runtime, or to bound it more tightly than the component as a whole, use
+    /// [`interruptible`][Self::interruptible] instead.
+    ///
+    /// # Errors
+    ///
+    /// If the component's supervisor isn't running, or the child specification is invalid, an error is returned.
+    pub async fn spawn_interruptible<N, Fut>(&self, name: N, fut: Fut) -> Result<ChildId, SpawnError>
+    where
+        N: Into<String>,
+        Fut: Future + Send + 'static,
+        Fut::Output: IntoWorkerResult,
+    {
+        self.interruptible(name, fut).spawn().await
+    }
+
+    /// Describes a child that observes shutdown itself, for configuring before spawning.
+    ///
+    /// Same semantics as [`spawn_noninterruptible`][Self::spawn_noninterruptible]; use this form only when the child
+    /// needs a non-default runtime or grace period. The returned builder does nothing until
+    /// [`spawn`][ChildBuilder::spawn] is called.
+    pub fn noninterruptible<N, F, Fut>(&self, name: N, f: F) -> ChildBuilder<'_>
+    where
+        N: Into<String>,
+        F: FnOnce(ShutdownHandle) -> Fut + Send + 'static,
+        Fut: Future + Send + 'static,
+        Fut::Output: IntoWorkerResult,
+    {
+        ChildBuilder::new(self, noninterruptible_worker(name, f))
+    }
+
+    /// Describes a child that runs until it completes or shutdown is signalled, for configuring before spawning.
+    ///
+    /// Same semantics as [`spawn_interruptible`][Self::spawn_interruptible]; use this form only when the child needs a
+    /// non-default runtime or grace period. The returned builder does nothing until [`spawn`][ChildBuilder::spawn] is
+    /// called.
+    pub fn interruptible<N, Fut>(&self, name: N, fut: Fut) -> ChildBuilder<'_>
+    where
+        N: Into<String>,
+        Fut: Future + Send + 'static,
+        Fut::Output: IntoWorkerResult,
+    {
+        ChildBuilder::new(self, interruptible_worker(name, fut))
+    }
+
+    /// Spawns a child from a hand-written [`Supervisable`].
+    ///
+    /// Use this when a child needs real asynchronous initialization, or state that can't be captured in a closure.
+    ///
+    /// Unlike the other spawn methods, the child's shutdown strategy comes from the worker itself, so a worker that
+    /// reports a finite grace period is held to it in addition to the component's budget -- including the
+    /// [`Supervisable`] default of five seconds, which a worker that doesn't override
+    /// [`shutdown_strategy`][Supervisable::shutdown_strategy] silently inherits. Return
+    /// `ShutdownStrategy::Graceful(Duration::MAX)` from the worker to be bounded by the budget alone, as the other
+    /// spawn methods are.
+    ///
+    /// # Errors
+    ///
+    /// If the component's supervisor isn't running, or the child specification is invalid, an error is returned.
+    pub async fn spawn_supervisable<T>(&self, worker: T) -> Result<ChildId, SpawnError>
+    where
+        T: Supervisable + 'static,
+    {
+        self.handle
+            .spawn_with(ChildSpecification::one_shot_worker(worker))
+            .await
+    }
+
+    /// Returns a handle to the shared worker pool owned by the topology.
+    pub fn worker_pool(&self) -> &Handle {
+        &self.worker_pool
+    }
+
+    /// Returns the underlying supervisor handle.
+    pub fn handle(&self) -> &SupervisorHandle {
+        &self.handle
+    }
+
+    /// Returns the number of children currently running that were spawned through a spawner.
+    ///
+    /// Statically registered children -- the component itself, in a topology -- are not counted.
+    pub fn active_children(&self) -> usize {
+        self.handle.active_children()
+    }
+}
+
+/// A child task that has been described but not yet spawned.
+///
+/// Created by [`ComponentSpawner::noninterruptible` or [`ComponentSpawner::interruptible`], and consumed by
+/// [`spawn`][Self::spawn].
+#[must_use = "a child is only started when `spawn` is called"]
+pub struct ChildBuilder<'a> {
+    spawner: &'a ComponentSpawner,
+    worker: FnWorker,
+    shutdown_timeout: Option<Duration>,
+    runtime: Option<Handle>,
+}
+
+impl<'a> ChildBuilder<'a> {
+    fn new(spawner: &'a ComponentSpawner, worker: FnWorker) -> Self {
+        Self {
+            spawner,
+            worker,
+            shutdown_timeout: None,
+            runtime: None,
+        }
+    }
+
+    /// Runs this child on the shared worker pool owned by the topology, instead of the component's runtime.
+    ///
+    /// Use this for compute-heavy work -- encoding, serialization, protocol servers -- that shouldn't contend with the
+    /// runtime that drives the supervisors and I/O for the topology.
+    pub fn on_worker_pool(mut self) -> Self {
+        self.runtime = Some(self.spawner.worker_pool.clone());
+        self
+    }
+
+    /// Runs this child on a specific runtime.
+    ///
+    /// Prefer [`on_worker_pool`][Self::on_worker_pool] unless the component owns a runtime of its own.
+    pub fn on_runtime(mut self, handle: Handle) -> Self {
+        self.runtime = Some(handle);
+        self
+    }
+
+    /// Bounds this child more tightly than the component as a whole.
+    ///
+    /// By default a child has no deadline of its own and is bounded only by the component's shutdown budget. Set this
+    /// when the component wants a particular child abandoned sooner than that -- a deadline it is deliberately
+    /// imposing, rather than a guess at how long the child ought to take.
+    pub fn with_shutdown_timeout(mut self, timeout: Duration) -> Self {
+        self.shutdown_timeout = Some(timeout);
+        self
+    }
+
+    /// Spawns the child, returning once the supervisor has started it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpawnError::SupervisorGone`] if the component's supervisor isn't running, or [`SpawnError::Rejected`]
+    /// if it rejected the child (for example, an invalid name). A component's supervisor is running for the whole of
+    /// the component's `run`, so `SupervisorGone` in a component indicates that the topology is already being torn
+    /// down.
+    pub async fn spawn(self) -> Result<ChildId, SpawnError> {
+        let Self {
+            spawner,
+            worker,
+            shutdown_timeout,
+            runtime,
+        } = self;
+
+        // `one_shot_worker` registers the child as temporary, which a function-based worker requires: restarting one
+        // re-initializes a body that has already been consumed, failing the child and its supervisor.
+        //
+        // Unless the caller asked for a tighter bound, the child gets no deadline of its own and is bounded solely by
+        // the component supervisor's shutdown budget.
+        let strategy = ShutdownStrategy::Graceful(shutdown_timeout.unwrap_or(Duration::MAX));
+        let mut spec = ChildSpecification::one_shot_worker(worker).with_shutdown_strategy(strategy);
+
+        if let Some(runtime) = runtime {
+            spec = spec.with_runtime(runtime);
+        }
+
+        spawner.handle.spawn_with(spec).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use saluki_metrics::test::TestRecorder;
+    use tokio::sync::oneshot;
+    use tokio::time::timeout;
+
+    use super::*;
+    use crate::components::test_util::TestComponentSupervisor;
+
+    /// How long the drain-participating child in these tests takes to finish after observing shutdown.
+    ///
+    /// Long enough that a child given any short deadline of its own would be aborted before completing, so the tests
+    /// fail if children stop being bounded by the supervisor's budget alone.
+    const DRAIN_DURATION: Duration = Duration::from_millis(300);
+
+    #[tokio::test]
+    async fn noninterruptible_child_observes_shutdown_and_supervisor_exits_cleanly() {
+        // The child holds the component's grace period, observes shutdown, and finishes. A clean supervisor result is
+        // the assertion that matters: `ShutdownTimedOut` would mean the child was aborted rather than draining.
+        let supervisor = TestComponentSupervisor::start("test_component").await;
+        let spawner = supervisor.spawner();
+
+        // The child does real work *after* observing shutdown. Without that, it finishes within any grace period at
+        // all and the test would pass even if children were given a near-zero deadline instead of none.
+        let drained = Arc::new(AtomicUsize::new(0));
+        let child_drained = Arc::clone(&drained);
+
+        spawner
+            .spawn_noninterruptible("drainer", move |shutdown| async move {
+                shutdown.await;
+                tokio::time::sleep(DRAIN_DURATION).await;
+                child_drained.fetch_add(1, Ordering::SeqCst);
+            })
+            .await
+            .expect("should spawn");
+
+        supervisor.wait_for_children(1).await;
+
+        let result = supervisor.shutdown().await;
+        assert!(
+            result.is_ok(),
+            "child should have drained rather than been aborted: {result:?}"
+        );
+        assert_eq!(drained.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn interruptible_child_is_torn_down_with_the_supervisor() {
+        // An interruptible child that would otherwise run forever must be dropped when the supervisor shuts down.
+        let supervisor = TestComponentSupervisor::start("test_component").await;
+
+        supervisor
+            .spawner()
+            .spawn_interruptible("forever", std::future::pending::<()>())
+            .await
+            .expect("should spawn");
+
+        supervisor.wait_for_children(1).await;
+        assert!(supervisor.shutdown().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn on_worker_pool_places_child_on_the_worker_pool() {
+        // `on_worker_pool` must actually change where the child's task runs. The spawner is built with an explicit
+        // pool handle here so the child's thread name is unambiguous.
+        let pool = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("spawner-pool-test")
+            .enable_all()
+            .build()
+            .expect("should build pool");
+
+        let supervisor = TestComponentSupervisor::start("test_component").await;
+        let spawner = ComponentSpawner::new(supervisor.spawner().handle().clone(), pool.handle().clone());
+
+        let (thread_tx, thread_rx) = oneshot::channel();
+        spawner
+            .noninterruptible("pooled", move |shutdown| async move {
+                let _ = thread_tx.send(std::thread::current().name().unwrap_or_default().to_string());
+                shutdown.await;
+            })
+            .on_worker_pool()
+            .spawn()
+            .await
+            .expect("should spawn");
+
+        let thread_name = timeout(Duration::from_secs(5), thread_rx)
+            .await
+            .expect("child should report its thread promptly")
+            .expect("child should not be dropped before reporting");
+        assert!(
+            thread_name.starts_with("spawner-pool-test"),
+            "child must run on the worker pool, but ran on thread {thread_name:?}"
+        );
+
+        assert!(supervisor.shutdown().await.is_ok());
+        pool.shutdown_background();
+    }
+
+    #[tokio::test]
+    async fn child_exiting_does_not_shut_the_component_down() {
+        // Children are non-significant, so one finishing -- the normal case during a drain -- must not trip the
+        // supervisor's `AutoShutdown::AnySignificant` policy and tear the component down with it.
+        let supervisor = TestComponentSupervisor::start("test_component").await;
+
+        supervisor
+            .spawner()
+            .spawn_noninterruptible("brief", |_shutdown| async {})
+            .await
+            .expect("should spawn");
+
+        supervisor.wait_for_children(0).await;
+
+        // Still accepting work, so the supervisor is still running.
+        supervisor
+            .spawner()
+            .spawn_interruptible("second", std::future::pending::<()>())
+            .await
+            .expect("supervisor should still be running after a child exited");
+
+        assert!(supervisor.shutdown().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn spawned_children_record_poll_metrics() {
+        // Every supervised worker's task is timed, and a dynamically spawned child is no exception. The tag is the
+        // child's fully qualified process name, which is what gives one series per name rather than per task.
+        let recorder = TestRecorder::default();
+        let _guard = metrics::set_default_local_recorder(&recorder);
+
+        // The recorder must be installed before the child is spawned: metric handles are resolved once, at spawn.
+        let supervisor = TestComponentSupervisor::start("metrics_component").await;
+        supervisor
+            .spawner()
+            .spawn_noninterruptible("instrumented", |shutdown| shutdown)
+            .await
+            .expect("should spawn");
+        assert!(supervisor.shutdown().await.is_ok());
+
+        // Tagged with the child's fully qualified process name, matching what `spawn_traced_named` recorded.
+        let polls = recorder.counter((
+            "runtime_task_poll_count",
+            &[("task_name", "metrics_component.instrumented")],
+        ));
+        assert!(
+            polls.is_some_and(|polls| polls > 0),
+            "spawned child should have recorded poll metrics, got {polls:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawning_after_shutdown_reports_supervisor_gone() {
+        let supervisor = TestComponentSupervisor::start("test_component").await;
+        let spawner = supervisor.spawner();
+        assert!(supervisor.shutdown().await.is_ok());
+
+        let result = spawner.spawn_interruptible("late", std::future::pending::<()>()).await;
+        assert!(
+            matches!(result, Err(SpawnError::SupervisorGone)),
+            "spawning against a stopped supervisor should report `SupervisorGone`, got {result:?}"
+        );
+    }
+}

--- a/lib/saluki-core/src/components/spawner.rs
+++ b/lib/saluki-core/src/components/spawner.rs
@@ -204,7 +204,7 @@ impl ComponentSpawner {
 
 /// A child task that has been described but not yet spawned.
 ///
-/// Created by [`ComponentSpawner::noninterruptible` or [`ComponentSpawner::interruptible`], and consumed by
+/// Created by [`ComponentSpawner::noninterruptible`] or [`ComponentSpawner::interruptible`], and consumed by
 /// [`spawn`][Self::spawn].
 #[must_use = "a child is only started when `spawn` is called"]
 pub struct ChildBuilder<'a> {

--- a/lib/saluki-core/src/components/test_util.rs
+++ b/lib/saluki-core/src/components/test_util.rs
@@ -1,0 +1,137 @@
+//! Test helpers for exercising components that spawn supervised children.
+//!
+//! A [`ComponentSpawner`] is only useful while its supervisor is actually running: spawning against a supervisor that
+//! was built but never run fails with [`SpawnError::SupervisorGone`][crate::runtime::SpawnError::SupervisorGone]. That
+//! makes the obvious test fixture -- `Supervisor::new("test").handle()` -- a trap, because it looks right and fails
+//! only once the component under test tries to spawn something.
+//!
+//! [`TestComponentSupervisor`] runs a supervisor configured the way the topology configures a component's supervisor,
+//! and hands out a [`ComponentSpawner`] bound to it.
+
+use std::time::Duration;
+
+use tokio::{runtime::Handle, sync::oneshot, task::JoinHandle};
+
+use crate::components::ComponentSpawner;
+use crate::runtime::{AutoShutdown, ShutdownMode, Supervisor, SupervisorError, SupervisorHandle};
+
+/// Shutdown budget for the test supervisor.
+///
+/// Mirrors production, where a component supervisor -- not its children -- owns the deadline. Short enough that a test
+/// asserting on forced-abort behavior doesn't stall, long enough that well-behaved children have ample time to drain
+/// on a loaded CI machine.
+const TEST_SHUTDOWN_BUDGET: Duration = Duration::from_secs(5);
+
+/// Interval between readiness polls.
+const POLL_INTERVAL: Duration = Duration::from_millis(5);
+
+/// Overall budget for readiness polling before panicking.
+const POLL_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A running per-component supervisor for tests.
+///
+/// Configured like the supervisor the topology builds for each component ([`AutoShutdown::AnySignificant`],
+/// [`ShutdownMode::Concurrent`], and a shutdown budget), minus the component worker itself -- the test drives the
+/// component directly.
+pub struct TestComponentSupervisor {
+    handle: SupervisorHandle,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    task: JoinHandle<Result<(), SupervisorError>>,
+}
+
+impl TestComponentSupervisor {
+    /// Starts a supervisor named `id`, returning once it is running and able to accept spawns.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `id` isn't a valid supervisor name, or if the supervisor doesn't start within a few seconds.
+    pub async fn start(id: &str) -> Self {
+        let mut supervisor = Supervisor::new(id)
+            .expect("test supervisor name should be valid")
+            .with_auto_shutdown(AutoShutdown::AnySignificant)
+            .with_shutdown_mode(ShutdownMode::Concurrent)
+            .with_shutdown_budget(TEST_SHUTDOWN_BUDGET);
+
+        // Take the handle before moving the supervisor into its task; the handle is usable before the run starts, and
+        // is how we observe that it has.
+        let handle = supervisor.handle();
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let task = tokio::spawn(async move { supervisor.run_with_shutdown(shutdown_rx).await });
+
+        let supervisor = Self {
+            handle,
+            shutdown_tx: Some(shutdown_tx),
+            task,
+        };
+        supervisor
+            .poll_until("the test supervisor is running", || supervisor.handle.is_running())
+            .await;
+
+        supervisor
+    }
+
+    /// Returns a spawner bound to this supervisor.
+    ///
+    /// The current runtime stands in for the shared worker pool.
+    pub fn spawner(&self) -> ComponentSpawner {
+        ComponentSpawner::new(self.handle.clone(), Handle::current())
+    }
+
+    /// Returns the number of dynamic children currently running.
+    pub fn active_children(&self) -> usize {
+        self.handle.active_children()
+    }
+
+    /// Waits until exactly `count` dynamic children are running.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the count doesn't reach `count` within a few seconds.
+    pub async fn wait_for_children(&self, count: usize) {
+        self.poll_until(&format!("the supervisor has {count} running children"), || {
+            self.handle.active_children() == count
+        })
+        .await;
+    }
+
+    /// Signals shutdown and waits for the supervisor to finish draining its children.
+    ///
+    /// The result is the supervisor's own: `Err(SupervisorError::ShutdownTimedOut { .. })` means a child ignored
+    /// shutdown and had to be aborted, which is usually what a test wants to assert did *not* happen.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the supervisor task panicked.
+    pub async fn shutdown(mut self) -> Result<(), SupervisorError> {
+        // The receiver only goes away if the run already ended, in which case shutdown is moot.
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+
+        (&mut self.task).await.expect("test supervisor task should not panic")
+    }
+
+    async fn poll_until(&self, description: &str, mut condition: impl FnMut() -> bool) {
+        let deadline = tokio::time::Instant::now() + POLL_TIMEOUT;
+        loop {
+            if condition() {
+                return;
+            }
+
+            if tokio::time::Instant::now() >= deadline {
+                panic!("timed out after {POLL_TIMEOUT:?} waiting until {description}");
+            }
+
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+}
+
+impl Drop for TestComponentSupervisor {
+    fn drop(&mut self) {
+        // A test that returns (or panics) without calling `shutdown` shouldn't leak a supervisor and its children into
+        // the rest of the run. Dropping the sender signals shutdown; the task tears itself down from there.
+        self.shutdown_tx.take();
+    }
+}

--- a/lib/saluki-core/src/components/transforms/context.rs
+++ b/lib/saluki-core/src/components/transforms/context.rs
@@ -43,36 +43,36 @@ impl TransformContext {
         self.health_handle.take().expect("health handle already taken")
     }
 
-    /// Gets a reference to the topology context.
+    /// Returns a reference to the topology context.
     pub fn topology_context(&self) -> &TopologyContext {
         &self.topology_context
     }
 
-    /// Gets a reference to the component context.
+    /// Returns a reference to the component context.
     pub fn component_context(&self) -> &ComponentContext {
         &self.component_context
     }
 
-    /// Gets a reference to the events dispatcher.
+    /// Returns a reference to the events dispatcher.
     pub fn dispatcher(&self) -> &EventsDispatcher {
         &self.dispatcher
     }
 
-    /// Gets a mutable reference to the events consumer.
+    /// Returns a mutable reference to the events consumer.
     pub fn events(&mut self) -> &mut EventsConsumer {
         &mut self.consumer
     }
 
-    /// Gets a mutable reference to the component registry.
+    /// Returns a mutable reference to the component registry.
     pub fn component_registry(&self) -> &ComponentRegistry {
         &self.component_registry
     }
 
     /// Returns a spawner for supervised child tasks belonging to this component.
     ///
-    /// Children spawned through it have their lifecycle coupled to the component itself: if the
-    /// component restarts, or the component's supervisor dies, its children are terminated too.
-    pub fn spawn_handle(&self) -> &ComponentSpawner {
+    /// All child tasks spawned through this mechanism are tied to the lifecycle of the component itself, such that
+    /// they're automatically shutdown/stopped when the component is stopped during topology shutdown, etc.
+    pub fn spawner(&self) -> &ComponentSpawner {
         &self.spawner
     }
 }

--- a/lib/saluki-core/src/components/transforms/context.rs
+++ b/lib/saluki-core/src/components/transforms/context.rs
@@ -1,8 +1,7 @@
 use crate::accounting::ComponentRegistry;
 use crate::health::Health;
-use crate::runtime::SupervisorHandle;
 use crate::{
-    components::ComponentContext,
+    components::{ComponentContext, ComponentSpawner},
     topology::{EventsConsumer, EventsDispatcher, TopologyContext},
 };
 
@@ -14,7 +13,7 @@ pub struct TransformContext {
     health_handle: Option<Health>,
     dispatcher: EventsDispatcher,
     consumer: EventsConsumer,
-    supervisor_handle: SupervisorHandle,
+    spawner: ComponentSpawner,
 }
 
 impl TransformContext {
@@ -22,7 +21,7 @@ impl TransformContext {
     pub fn new(
         topology_context: &TopologyContext, component_context: &ComponentContext,
         component_registry: ComponentRegistry, health_handle: Health, dispatcher: EventsDispatcher,
-        consumer: EventsConsumer, supervisor_handle: SupervisorHandle,
+        consumer: EventsConsumer, spawner: ComponentSpawner,
     ) -> Self {
         Self {
             topology_context: topology_context.clone(),
@@ -31,7 +30,7 @@ impl TransformContext {
             health_handle: Some(health_handle),
             dispatcher,
             consumer,
-            supervisor_handle,
+            spawner,
         }
     }
 
@@ -69,12 +68,11 @@ impl TransformContext {
         &self.component_registry
     }
 
-    /// Returns a handle to the supervisor that this component is spawned on.
+    /// Returns a spawner for supervised child tasks belonging to this component.
     ///
-    /// Dynamic child processes can be spawned via the supervisor handle and thus have their lifecycle
-    /// coupled to the component itself: if the component restarts, or the component's supervisor dies,
-    /// the dynamic child processes will also be terminated automatically as well.
-    pub fn spawn_handle(&self) -> &SupervisorHandle {
-        &self.supervisor_handle
+    /// Children spawned through it have their lifecycle coupled to the component itself: if the
+    /// component restarts, or the component's supervisor dies, its children are terminated too.
+    pub fn spawn_handle(&self) -> &ComponentSpawner {
+        &self.spawner
     }
 }

--- a/lib/saluki-core/src/runtime/mod.rs
+++ b/lib/saluki-core/src/runtime/mod.rs
@@ -75,4 +75,7 @@ pub use self::supervisor::{
     WorkerSpec,
 };
 
+mod workers;
+pub use self::workers::{interruptible_worker, noninterruptible_worker, FnWorker, IntoWorkerResult};
+
 mod worker_state;

--- a/lib/saluki-core/src/runtime/supervisor.rs
+++ b/lib/saluki-core/src/runtime/supervisor.rs
@@ -297,6 +297,14 @@ impl ChildSpecification<WorkerSpec> {
         }
     }
 
+    /// Creates a specification for a worker that can only run once.
+    ///
+    /// This function is shorthand for calling [`worker`][Self::worker] followed by
+    /// [`with_restart_type`][Self::with_restart_type] set to [`RestartType::Temporary`][RestartType::Temporary].
+    pub fn one_shot_worker<T: Supervisable + 'static>(worker: T) -> Self {
+        Self::worker(worker).with_restart_type(RestartType::Temporary)
+    }
+
     /// Sets the restart policy for this worker.
     ///
     /// Defaults to [`RestartType::Permanent`].
@@ -412,6 +420,11 @@ pub(super) enum SupervisedChild {
 }
 
 impl SupervisedChild {
+    /// Returns whether this child is a nested supervisor rather than a leaf worker.
+    pub(super) fn is_supervisor(&self) -> bool {
+        matches!(self, Self::Supervisor(_))
+    }
+
     fn process_type(&self) -> &'static str {
         match self {
             Self::Worker(_) => "worker",
@@ -712,9 +725,10 @@ impl SupervisorHandle {
 /// # Instrumentation
 ///
 /// Supervisors automatically create their own allocation group
-/// ([`TrackingAllocator`][saluki_common::resource_tracking::TrackingAllocator]), which is used to track both the memory usage of the
-/// supervisor itself and its children. Additionally, individual worker processes are wrapped in a dedicated
-/// [`tracing::Span`] to allow tracing the causal relationship between arbitrary code and the worker executing it.
+/// ([`TrackingAllocator`][saluki_common::resource_tracking::TrackingAllocator]), which is used to track both the memory
+/// usage of the supervisor itself and its children. Additionally, individual worker processes are wrapped in a
+/// dedicated [`tracing::Span`] to allow tracing the causal relationship between arbitrary code and the worker executing
+/// it, and statistics about task polls (poll count, poll duration) are collected.
 ///
 /// # Restart Strategies
 ///
@@ -793,7 +807,7 @@ impl Supervisor {
         self
     }
 
-    /// Bounds how long this supervisor's entire shutdown may take.
+    /// Bounds how long this supervisor waits for its worker children during shutdown.
     ///
     /// Without a budget, a supervisor waits as long as each child's own [`ShutdownStrategy`] allows, and waits
     /// indefinitely for any child that has no finite deadline of its own. A budget makes the supervisor responsible for
@@ -803,6 +817,11 @@ impl Supervisor {
     ///
     /// The budget is a ceiling, not a replacement: a child that also carries its own finite deadline is still held to
     /// whichever elapses first.
+    ///
+    /// Two kinds of child are outside it. A nested supervisor is never cut off by its parent's budget -- it bounds its
+    /// own subtree, and aborting it would both truncate that drain and, for a supervisor running on a dedicated
+    /// runtime, fail to stop it at all. A [`ShutdownStrategy::Brutal`] child is aborted up front and never waited on.
+    /// Neither can a budget bound work that ignores cancellation, since an abort only takes effect at an await point.
     ///
     /// Use this where one deadline for a whole subtree is more meaningful than a guess per worker -- a topology
     /// component and its background tasks, for instance, where what matters is that the component as a whole stops in
@@ -1240,6 +1259,7 @@ mod tests {
 
     use async_trait::async_trait;
     use saluki_common::sync::shutdown::ShutdownCoordinator;
+    use saluki_metrics::test::TestRecorder;
     use tokio::{
         sync::oneshot,
         task::JoinHandle,
@@ -2984,23 +3004,27 @@ mod tests {
 
     #[tokio::test]
     async fn budget_does_not_delay_children_that_stop_on_their_own() {
-        // The budget is a ceiling, not a wait: children that observe shutdown promptly still exit promptly, and the
-        // supervisor reports a clean shutdown rather than burning the whole budget.
+        // The budget is a ceiling, not a wait. Asserting on elapsed time rather than merely on success is what makes
+        // this meaningful: a supervisor that waited out its budget regardless would still report `Ok`.
         let mut sup = Supervisor::new("test-sup")
             .unwrap()
             .with_shutdown_mode(ShutdownMode::Concurrent)
             .with_shutdown_budget(Duration::from_secs(30));
         sup.add_worker(
-            ChildSpecification::worker(noninterruptible_worker("prompt", |shutdown| shutdown))
-                .with_restart_type(RestartType::Temporary)
+            ChildSpecification::one_shot_worker(noninterruptible_worker("prompt", |shutdown| shutdown))
                 .with_shutdown_strategy(ShutdownStrategy::Graceful(Duration::MAX)),
         );
 
         let (tx, handle) = run_supervisor_with_trigger(sup).await;
+        let started = tokio::time::Instant::now();
         tx.send(()).unwrap();
 
-        // `join_supervisor` bounds this at two seconds, well inside the 30-second budget.
         assert!(join_supervisor(handle).await.is_ok());
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "shutdown should finish as soon as the child does, not burn the budget; took {elapsed:?}"
+        );
     }
 
     #[tokio::test]
@@ -3025,6 +3049,129 @@ mod tests {
         assert!(
             matches!(result, Err(SupervisorError::ShutdownTimedOut { aborted: 1 })),
             "the child's own 100ms deadline should have won over the budget, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn every_worker_records_poll_metrics() {
+        // Poll timing is a property of being supervised, not something a child opts into, so a plain statically
+        // registered worker gets it too -- tagged with its fully qualified process name.
+        let recorder = TestRecorder::default();
+        let _guard = metrics::set_default_local_recorder(&recorder);
+
+        // The recorder has to be installed before the worker spawns: its metric handles are resolved once, at spawn.
+        let mut sup = Supervisor::new("metrics_sup").unwrap();
+        sup.add_worker(ChildSpecification::one_shot_worker(noninterruptible_worker(
+            "timed",
+            |shutdown| shutdown,
+        )));
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+        tx.send(()).unwrap();
+        assert!(join_supervisor(handle).await.is_ok());
+
+        let polls = recorder.counter(("runtime_task_poll_count", &[("task_name", "metrics_sup.timed")]));
+        assert!(
+            polls.is_some_and(|polls| polls > 0),
+            "a supervised worker should have recorded poll metrics, got {polls:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn budget_bounds_the_whole_drain_in_ordered_mode() {
+        // Ordered shutdown stops children one at a time, so a budget has to cover the sequence as a whole rather than
+        // resetting per child. Three children that each ignore a 10-second deadline must all be aborted at the shared
+        // 150ms budget, not 30 seconds later.
+        let mut sup = Supervisor::new("test-sup")
+            .unwrap()
+            .with_shutdown_mode(ShutdownMode::Ordered)
+            .with_shutdown_budget(Duration::from_millis(150));
+
+        for name in ["stuck_one", "stuck_two", "stuck_three"] {
+            sup.add_worker(
+                ChildSpecification::one_shot_worker(noninterruptible_worker(name, |_shutdown| pending::<()>()))
+                    .with_shutdown_strategy(ShutdownStrategy::Graceful(Duration::from_secs(10))),
+            );
+        }
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+        tx.send(()).unwrap();
+
+        let result = join_supervisor(handle).await;
+        assert!(
+            matches!(result, Err(SupervisorError::ShutdownTimedOut { aborted: 3 })),
+            "the budget should have bounded the whole ordered drain, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn budget_of_duration_max_is_treated_as_no_budget() {
+        // `Duration::MAX` is the natural spelling of "no ceiling" and used to panic the supervisor task on an instant
+        // overflow.
+        let mut sup = Supervisor::new("test-sup")
+            .unwrap()
+            .with_shutdown_mode(ShutdownMode::Concurrent)
+            .with_shutdown_budget(Duration::MAX);
+        sup.add_worker(ChildSpecification::one_shot_worker(noninterruptible_worker(
+            "prompt",
+            |shutdown| shutdown,
+        )));
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+        tx.send(()).unwrap();
+        assert!(join_supervisor(handle).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn near_max_child_timeout_does_not_panic_in_ordered_mode() {
+        // The ordered path used to pass the timeout straight to `sleep`, which clamps. Resolving it to an instant
+        // instead made anything just under `Duration::MAX` overflow.
+        let mut sup = Supervisor::new("test-sup").unwrap();
+        sup.add_worker(
+            ChildSpecification::one_shot_worker(noninterruptible_worker("prompt", |shutdown| shutdown))
+                .with_shutdown_strategy(ShutdownStrategy::Graceful(Duration::MAX - Duration::from_nanos(1))),
+        );
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+        tx.send(()).unwrap();
+        assert!(join_supervisor(handle).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn budget_does_not_cut_off_a_nested_supervisor_mid_drain() {
+        // A nested supervisor bounds its own subtree, so a parent's budget must not abort it: doing so truncates the
+        // subtree's drain, discards its abort tally, and -- for a supervisor on a dedicated runtime, whose work is on
+        // another OS thread -- reports it as stopped without actually stopping it.
+        let drained = Arc::new(AtomicBool::new(false));
+        let child_drained = Arc::clone(&drained);
+
+        let mut nested = Supervisor::new("nested").unwrap();
+        nested.add_worker(
+            ChildSpecification::one_shot_worker(noninterruptible_worker("slow", move |shutdown| async move {
+                shutdown.await;
+                sleep(Duration::from_millis(300)).await;
+                child_drained.store(true, Ordering::SeqCst);
+            }))
+            .with_shutdown_strategy(ShutdownStrategy::Graceful(Duration::from_secs(10))),
+        );
+
+        let mut parent = Supervisor::new("parent")
+            .unwrap()
+            .with_shutdown_mode(ShutdownMode::Concurrent)
+            .with_shutdown_budget(Duration::from_millis(50));
+        parent.add_worker(nested);
+
+        let (tx, handle) = run_supervisor_with_trigger(parent).await;
+        tx.send(()).unwrap();
+
+        let result = join_supervisor(handle).await;
+        assert!(
+            drained.load(Ordering::SeqCst),
+            "the nested subtree should have drained rather than being cut off by the parent's budget: {result:?}"
+        );
+        assert!(
+            result.is_ok(),
+            "the nested drain finished in time, so shutdown was clean: {result:?}"
         );
     }
 }

--- a/lib/saluki-core/src/runtime/supervisor.rs
+++ b/lib/saluki-core/src/runtime/supervisor.rs
@@ -14,7 +14,9 @@ use saluki_common::sync::shutdown::ShutdownHandle;
 use saluki_error::GenericError;
 use snafu::{OptionExt as _, Snafu};
 use tokio::{
-    pin, select,
+    pin,
+    runtime::Handle,
+    select,
     sync::{mpsc, oneshot},
 };
 use tracing::{debug, error, warn};
@@ -129,6 +131,7 @@ impl From<GenericError> for InitializationError {
 }
 
 /// Strategy for shutting down a process.
+#[derive(Clone, Copy, Debug)]
 pub enum ShutdownStrategy {
     /// Waits for the configured duration for the process to exit, and then forcefully aborts it otherwise.
     Graceful(Duration),
@@ -314,6 +317,32 @@ impl ChildSpecification<WorkerSpec> {
         self
     }
 
+    /// Runs this worker on the given Tokio runtime rather than the supervisor's own runtime.
+    ///
+    /// By default, a worker runs on whatever runtime its supervisor runs on. Use this for compute-heavy workers that
+    /// shouldn't contend with the supervisor's runtime -- for example, a topology component offloading encoding work
+    /// onto a shared worker pool.
+    ///
+    /// Note that this only affects where the worker's task is spawned. Supervision itself -- shutdown signalling,
+    /// restart handling, and abort-on-timeout -- is unchanged, and is still driven from the supervisor's runtime.
+    #[must_use]
+    pub fn with_runtime(mut self, handle: Handle) -> Self {
+        self.spec_inner.config.runtime = Some(handle);
+        self
+    }
+
+    /// Overrides the shutdown strategy for this worker.
+    ///
+    /// By default, a worker's strategy comes from [`Supervisable::shutdown_strategy`], which itself defaults to
+    /// `Graceful(5s)`. Use this when the grace period depends on where the worker is used rather than on the worker
+    /// type: a worker that a component drains during its own shutdown needs at least as long as the component itself,
+    /// otherwise it is forcefully aborted while the component is still waiting on it.
+    #[must_use]
+    pub fn with_shutdown_strategy(mut self, strategy: ShutdownStrategy) -> Self {
+        self.spec_inner.config.shutdown_strategy = Some(strategy);
+        self
+    }
+
     /// Lowers this worker specification into its type-erased child and configuration.
     fn into_worker_parts(self) -> (SupervisedChild, ChildConfig) {
         (SupervisedChild::Worker(self.spec_inner.worker), self.spec_inner.config)
@@ -473,14 +502,35 @@ impl Clone for SupervisedChild {
     }
 }
 
-/// Per-child configuration: its [`RestartType`] and whether it is _significant_ (see [`AutoShutdown`]).
+/// Per-child configuration: its [`RestartType`], whether it is _significant_ (see [`AutoShutdown`]), and any
+/// per-child overrides for runtime placement and shutdown strategy.
 ///
-/// Defaults to a permanent, non-significant child. On a worker, this is set through
-/// [`ChildSpecification::with_restart_type`] and [`ChildSpecification::with_significant`].
-#[derive(Clone, Copy, Debug)]
-struct ChildConfig {
+/// Defaults to a permanent, non-significant child that runs on the supervisor's own runtime and takes its shutdown
+/// strategy from [`Supervisable::shutdown_strategy`]. On a worker, this is set through
+/// [`ChildSpecification::with_restart_type`], [`ChildSpecification::with_significant`],
+/// [`ChildSpecification::with_runtime`], and [`ChildSpecification::with_shutdown_strategy`].
+#[derive(Clone, Debug)]
+pub(super) struct ChildConfig {
     restart: RestartType,
     significant: bool,
+
+    /// Runtime to spawn the child on. `None` means the supervisor's own runtime.
+    runtime: Option<Handle>,
+
+    /// Shutdown strategy override. `None` means defer to [`Supervisable::shutdown_strategy`].
+    shutdown_strategy: Option<ShutdownStrategy>,
+}
+
+impl ChildConfig {
+    /// Returns the runtime the child should be spawned on, if it isn't the supervisor's own.
+    pub(super) fn runtime(&self) -> Option<&Handle> {
+        self.runtime.as_ref()
+    }
+
+    /// Returns the child's shutdown strategy override, if one was configured.
+    pub(super) fn shutdown_strategy(&self) -> Option<ShutdownStrategy> {
+        self.shutdown_strategy
+    }
 }
 
 impl Default for ChildConfig {
@@ -488,6 +538,8 @@ impl Default for ChildConfig {
         Self {
             restart: RestartType::Permanent,
             significant: false,
+            runtime: None,
+            shutdown_strategy: None,
         }
     }
 }
@@ -678,6 +730,7 @@ pub struct Supervisor {
     restart_strategy: RestartStrategy,
     auto_shutdown: AutoShutdown,
     shutdown_mode: ShutdownMode,
+    shutdown_budget: Option<Duration>,
     runtime_mode: RuntimeMode,
     // Shared across clones (a nested supervisor is cloned each time it runs) and across all handles. While a run is
     // active it holds that run's spawn-command sender so handles can reach the live supervisor; it's `None` whenever no
@@ -706,6 +759,7 @@ impl Supervisor {
             restart_strategy: RestartStrategy::default(),
             auto_shutdown: AutoShutdown::default(),
             shutdown_mode: ShutdownMode::default(),
+            shutdown_budget: None,
             runtime_mode: RuntimeMode::default(),
             current_tx: Arc::new(Mutex::new(None)),
             id_counter: Arc::new(AtomicU64::new(0)),
@@ -736,6 +790,26 @@ impl Supervisor {
     /// Sets the supervisor's shutdown mode. See [`ShutdownMode`]. Defaults to [`ShutdownMode::Ordered`].
     pub fn with_shutdown_mode(mut self, mode: ShutdownMode) -> Self {
         self.shutdown_mode = mode;
+        self
+    }
+
+    /// Bounds how long this supervisor's entire shutdown may take.
+    ///
+    /// Without a budget, a supervisor waits as long as each child's own [`ShutdownStrategy`] allows, and waits
+    /// indefinitely for any child that has no finite deadline of its own. A budget makes the supervisor responsible for
+    /// the deadline instead: children need no individual timeouts, and whatever is still running when the budget
+    /// elapses is forcefully aborted -- each one named in the logs, and counted in the resulting
+    /// [`SupervisorError::ShutdownTimedOut`].
+    ///
+    /// The budget is a ceiling, not a replacement: a child that also carries its own finite deadline is still held to
+    /// whichever elapses first.
+    ///
+    /// Use this where one deadline for a whole subtree is more meaningful than a guess per worker -- a topology
+    /// component and its background tasks, for instance, where what matters is that the component as a whole stops in
+    /// time.
+    #[must_use]
+    pub fn with_shutdown_budget(mut self, budget: Duration) -> Self {
+        self.shutdown_budget = Some(budget);
         self
     }
 
@@ -805,7 +879,7 @@ impl Supervisor {
         debug!(supervisor_id = %self.supervisor_id, "Spawning all static child processes.");
         for entry in &self.child_specs {
             let id = self.id_counter.fetch_add(1, Ordering::Relaxed);
-            worker_state.add_worker(id, &entry.spec)?;
+            worker_state.add_worker(id, &entry.spec, &entry.config)?;
             children.insert(id, entry.clone());
         }
 
@@ -830,7 +904,7 @@ impl Supervisor {
                 continue;
             }
             let id = self.id_counter.fetch_add(1, Ordering::Relaxed);
-            worker_state.add_worker(id, &entry.spec)?;
+            worker_state.add_worker(id, &entry.spec, &entry.config)?;
             children.insert(id, entry.clone());
         }
 
@@ -848,9 +922,9 @@ impl Supervisor {
             config,
             dynamic: true,
         };
-        match worker_state.add_worker(id, &entry.spec) {
+        match worker_state.add_worker(id, &entry.spec, &entry.config) {
             Ok(()) => {
-                if config.significant {
+                if entry.config.significant {
                     *significant_remaining += 1;
                 }
                 self.active.fetch_add(1, Ordering::Relaxed);
@@ -885,7 +959,7 @@ impl Supervisor {
         &self, process: Process, process_shutdown: ShutdownHandle, mut cmd_rx: mpsc::Receiver<PendingSpawn>,
     ) -> Result<(), SupervisorError> {
         let mut restart_state = RestartState::new(self.restart_strategy);
-        let mut worker_state = WorkerState::new(process, self.shutdown_mode);
+        let mut worker_state = WorkerState::new(process, self.shutdown_mode, self.shutdown_budget);
 
         // The live roster of children -- both static (seeded below) and dynamic (added via the handle) -- keyed by a
         // stable id. A restart re-runs a child by id; a child that isn't restarted is removed from the roster.
@@ -923,7 +997,7 @@ impl Supervisor {
                     // Pull out what we need from the roster before we mutate it.
                     let (child_name, config, dynamic) = {
                         let entry = children.get(&child_id).expect("completed worker must be present in the roster");
-                        (entry.spec.name().to_string(), entry.config, entry.dynamic)
+                        (entry.spec.name().to_string(), entry.config.clone(), entry.dynamic)
                     };
 
                     // Initialization failures are not eligible for restart -- they propagate immediately.
@@ -959,7 +1033,15 @@ impl Supervisor {
                         // if it was dynamic. Crucially, we do NOT consult `evaluate_restart` here: non-restarts must not
                         // consume the restart-intensity budget, otherwise a steady stream of terminating temporary
                         // children would eventually trip the limit and tear the supervisor (and its siblings) down.
-                        debug!(supervisor_id = %self.supervisor_id, worker_name = %child_name, restart = ?config.restart, ?worker_result, "Child process exited and is not eligible for restart.");
+                        //
+                        // An abnormal exit is reported at `warn` rather than `debug`: a child that isn't restarted --
+                        // every dynamically-spawned child, in practice -- has no other path back to its owner, so this
+                        // is the only place its failure is surfaced.
+                        if abnormal {
+                            warn!(supervisor_id = %self.supervisor_id, worker_name = %child_name, restart = ?config.restart, ?worker_result, "Child process exited with an error and is not eligible for restart.");
+                        } else {
+                            debug!(supervisor_id = %self.supervisor_id, worker_name = %child_name, restart = ?config.restart, "Child process exited and is not eligible for restart.");
+                        }
                         children.remove(&child_id);
                         if dynamic {
                             self.active.fetch_sub(1, Ordering::Relaxed);
@@ -986,7 +1068,7 @@ impl Supervisor {
                                 RestartMode::OneForOne => {
                                     warn!(supervisor_id = %self.supervisor_id, worker_name = %child_name, ?worker_result, "Child process terminated, restarting.");
                                     let spec = children.get(&child_id).expect("present for restart").spec.clone();
-                                    if let Err(e) = worker_state.add_worker(child_id, &spec) {
+                                    if let Err(e) = worker_state.add_worker(child_id, &spec, &config) {
                                         break Err(e);
                                     }
                                 }
@@ -1140,6 +1222,7 @@ impl Supervisor {
             restart_strategy: self.restart_strategy,
             auto_shutdown: self.auto_shutdown,
             shutdown_mode: self.shutdown_mode,
+            shutdown_budget: self.shutdown_budget,
             runtime_mode: self.runtime_mode.clone(),
             current_tx: Arc::clone(&self.current_tx),
             id_counter: Arc::clone(&self.id_counter),
@@ -1152,10 +1235,11 @@ impl Supervisor {
 mod tests {
     use std::{
         future::pending,
-        sync::atomic::{AtomicUsize, Ordering},
+        sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     };
 
     use async_trait::async_trait;
+    use saluki_common::sync::shutdown::ShutdownCoordinator;
     use tokio::{
         sync::oneshot,
         task::JoinHandle,
@@ -1163,6 +1247,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::runtime::noninterruptible_worker;
     use crate::test_support::wait_until;
 
     /// Behavior for a mock worker during initialization.
@@ -2701,6 +2786,245 @@ mod tests {
         assert!(
             matches!(result, Err(SupervisorError::ShutdownTimedOut { aborted: 1 })),
             "a stuck worker in a dedicated runtime must surface as an unclean shutdown aggregated to the root, got {result:?}"
+        );
+    }
+
+    // -- Per-child override tests ----------------------------------------------------------
+
+    #[tokio::test]
+    async fn child_with_runtime_override_runs_on_that_runtime() {
+        // `with_runtime` places an individual child's task on a caller-provided runtime instead of the supervisor's
+        // own. The child reports the name of the thread it's actually running on, which must belong to that runtime.
+        let child_runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("child-rt-test")
+            .enable_all()
+            .build()
+            .expect("should build child runtime");
+
+        let (thread_tx, thread_rx) = oneshot::channel();
+        let worker = noninterruptible_worker("placed", move |shutdown| async move {
+            let thread_name = std::thread::current().name().unwrap_or_default().to_string();
+            let _ = thread_tx.send(thread_name);
+            shutdown.await;
+        });
+
+        let mut sup = Supervisor::new("test-sup").unwrap();
+        sup.add_worker(
+            ChildSpecification::worker(worker)
+                .with_restart_type(RestartType::Temporary)
+                .with_runtime(child_runtime.handle().clone()),
+        );
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+
+        let thread_name = timeout(Duration::from_secs(2), thread_rx)
+            .await
+            .expect("child should report its thread promptly")
+            .expect("child should not be dropped before reporting");
+        assert!(
+            thread_name.starts_with("child-rt-test"),
+            "child must run on the runtime given to `with_runtime`, but ran on thread {thread_name:?}"
+        );
+
+        tx.send(()).unwrap();
+        assert!(join_supervisor(handle).await.is_ok());
+
+        // Dropping a `Runtime` from within an async context panics, so tear it down without blocking.
+        child_runtime.shutdown_background();
+    }
+
+    #[tokio::test]
+    async fn child_shutdown_strategy_override_takes_precedence_over_worker() {
+        // `with_shutdown_strategy` overrides what the worker reports for itself. The worker below asks for a 30-second
+        // grace period and then ignores shutdown entirely; the override cuts that to 50ms, so the supervisor must
+        // abort it and report an unclean shutdown well inside `join_supervisor`'s two-second bound. Without the
+        // override taking precedence, this test times out.
+        let worker = noninterruptible_worker("stuck", |_shutdown| std::future::pending::<()>())
+            .with_shutdown_timeout(Duration::from_secs(30));
+
+        let mut sup = Supervisor::new("test-sup").unwrap();
+        sup.add_worker(
+            ChildSpecification::worker(worker)
+                .with_restart_type(RestartType::Temporary)
+                .with_shutdown_strategy(ShutdownStrategy::Graceful(Duration::from_millis(50))),
+        );
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+        tx.send(()).unwrap();
+
+        let result = join_supervisor(handle).await;
+        assert!(
+            matches!(result, Err(SupervisorError::ShutdownTimedOut { aborted: 1 })),
+            "the overridden 50ms deadline should have aborted the stuck child, got {result:?}"
+        );
+    }
+
+    /// Builds two children modelling an owner that drains a background task during shutdown.
+    ///
+    /// `stuck` holds a shutdown handle and never releases it voluntarily, so the only way it goes away is a forced
+    /// abort. `waiter` blocks on that handle being dropped, standing in for a component's `shutdown_and_wait`. The
+    /// returned flag records whether `waiter` ran to completion rather than being aborted itself.
+    fn build_drain_pair(
+        stuck_strategy: ShutdownStrategy, waiter_strategy: ShutdownStrategy,
+    ) -> (Supervisor, Arc<AtomicBool>) {
+        let mut coordinator = ShutdownCoordinator::default();
+        let held_handle = coordinator.register();
+
+        let stuck = noninterruptible_worker("stuck", move |_shutdown| async move {
+            // Hold the handle for as long as this future lives, and ignore shutdown entirely.
+            let _held = held_handle;
+            pending::<()>().await;
+        });
+
+        let waiter_finished = Arc::new(AtomicBool::new(false));
+        let finished = Arc::clone(&waiter_finished);
+        let waiter = noninterruptible_worker("waiter", move |shutdown| async move {
+            shutdown.await;
+            coordinator.shutdown_and_wait().await;
+            finished.store(true, Ordering::SeqCst);
+        });
+
+        let mut sup = Supervisor::new("test-sup")
+            .unwrap()
+            .with_shutdown_mode(ShutdownMode::Concurrent);
+        sup.add_worker(
+            ChildSpecification::worker(stuck)
+                .with_restart_type(RestartType::Temporary)
+                .with_shutdown_strategy(stuck_strategy),
+        );
+        sup.add_worker(
+            ChildSpecification::worker(waiter)
+                .with_restart_type(RestartType::Temporary)
+                .with_shutdown_strategy(waiter_strategy),
+        );
+
+        (sup, waiter_finished)
+    }
+
+    #[tokio::test]
+    async fn shorter_child_deadline_releases_a_waiting_sibling() {
+        // Aborting a stuck child drops the shutdown handle it was holding, which is what releases anything waiting on
+        // it. A child bounded more tightly than its waiter therefore stays recoverable: the child is aborted, the
+        // waiter unblocks and finishes cleanly, and only one abort is reported.
+        let (sup, waiter_finished) = build_drain_pair(
+            ShutdownStrategy::Graceful(Duration::from_millis(100)),
+            ShutdownStrategy::Graceful(Duration::from_secs(1)),
+        );
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+        tx.send(()).unwrap();
+
+        let result = join_supervisor(handle).await;
+        assert!(
+            matches!(result, Err(SupervisorError::ShutdownTimedOut { aborted: 1 })),
+            "only the stuck child should have been aborted, got {result:?}"
+        );
+        assert!(
+            waiter_finished.load(Ordering::SeqCst),
+            "the waiter should have been released by the stuck child's abort and run to completion"
+        );
+    }
+
+    #[tokio::test]
+    async fn equal_child_deadlines_abort_the_waiter_too() {
+        // The counterpart: concurrent shutdown computes every deadline from one shared instant, so identical timeouts
+        // elapse in the same pass and the waiter is aborted alongside the child it was waiting on. This is also what a
+        // shutdown budget does to a whole subtree, which is why the budget is set at a level where losing the entire
+        // group at once is the intended outcome.
+        let (sup, waiter_finished) = build_drain_pair(
+            ShutdownStrategy::Graceful(Duration::from_millis(100)),
+            ShutdownStrategy::Graceful(Duration::from_millis(100)),
+        );
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+        tx.send(()).unwrap();
+
+        let result = join_supervisor(handle).await;
+        assert!(
+            matches!(result, Err(SupervisorError::ShutdownTimedOut { aborted: 2 })),
+            "both children should have been aborted together, got {result:?}"
+        );
+        assert!(
+            !waiter_finished.load(Ordering::SeqCst),
+            "the waiter should have been aborted mid-wait, not completed"
+        );
+    }
+
+    // -- Shutdown budget tests -------------------------------------------------------------
+
+    #[tokio::test]
+    async fn budget_bounds_children_that_have_no_deadline_of_their_own() {
+        // Without a budget, `Graceful(Duration::MAX)` children are waited on indefinitely and a stuck one hangs
+        // shutdown forever. A budget makes the supervisor responsible for the deadline instead, and each child it has
+        // to abort is still counted individually -- so an overrun says how many tasks were responsible, not merely
+        // that the group as a whole overran.
+        let mut sup = Supervisor::new("test-sup")
+            .unwrap()
+            .with_shutdown_mode(ShutdownMode::Concurrent)
+            .with_shutdown_budget(Duration::from_millis(100));
+
+        for name in ["stuck_one", "stuck_two"] {
+            sup.add_worker(
+                ChildSpecification::worker(noninterruptible_worker(name, |_shutdown| pending::<()>()))
+                    .with_restart_type(RestartType::Temporary)
+                    .with_shutdown_strategy(ShutdownStrategy::Graceful(Duration::MAX)),
+            );
+        }
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+        tx.send(()).unwrap();
+
+        let result = join_supervisor(handle).await;
+        assert!(
+            matches!(result, Err(SupervisorError::ShutdownTimedOut { aborted: 2 })),
+            "the budget should have aborted both deadline-less children, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn budget_does_not_delay_children_that_stop_on_their_own() {
+        // The budget is a ceiling, not a wait: children that observe shutdown promptly still exit promptly, and the
+        // supervisor reports a clean shutdown rather than burning the whole budget.
+        let mut sup = Supervisor::new("test-sup")
+            .unwrap()
+            .with_shutdown_mode(ShutdownMode::Concurrent)
+            .with_shutdown_budget(Duration::from_secs(30));
+        sup.add_worker(
+            ChildSpecification::worker(noninterruptible_worker("prompt", |shutdown| shutdown))
+                .with_restart_type(RestartType::Temporary)
+                .with_shutdown_strategy(ShutdownStrategy::Graceful(Duration::MAX)),
+        );
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+        tx.send(()).unwrap();
+
+        // `join_supervisor` bounds this at two seconds, well inside the 30-second budget.
+        assert!(join_supervisor(handle).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn child_deadline_shorter_than_budget_still_wins() {
+        // A child that carries its own finite deadline is held to whichever elapses first, so a component can still
+        // bound one particular task more tightly than the budget covering the rest.
+        let mut sup = Supervisor::new("test-sup")
+            .unwrap()
+            .with_shutdown_mode(ShutdownMode::Concurrent)
+            .with_shutdown_budget(Duration::from_secs(30));
+        sup.add_worker(
+            ChildSpecification::worker(noninterruptible_worker("stuck", |_shutdown| pending::<()>()))
+                .with_restart_type(RestartType::Temporary)
+                .with_shutdown_strategy(ShutdownStrategy::Graceful(Duration::from_millis(100))),
+        );
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+        tx.send(()).unwrap();
+
+        // Again bounded at two seconds: if the 30-second budget had won, this would time out instead.
+        let result = join_supervisor(handle).await;
+        assert!(
+            matches!(result, Err(SupervisorError::ShutdownTimedOut { aborted: 1 })),
+            "the child's own 100ms deadline should have won over the budget, got {result:?}"
         );
     }
 }

--- a/lib/saluki-core/src/runtime/worker_state.rs
+++ b/lib/saluki-core/src/runtime/worker_state.rs
@@ -33,6 +33,12 @@ struct ProcessState {
     /// aborted.
     worker_name: String,
     shutdown_strategy: ShutdownStrategy,
+    /// Whether this child is subject to the supervisor's shutdown budget.
+    ///
+    /// False for a nested supervisor, which bounds itself through its own children. Aborting one would cut its subtree
+    /// off mid-drain, and -- for a supervisor on a dedicated runtime, whose work lives on another OS thread -- would
+    /// not even stop it, while still reporting it as stopped.
+    budget_applies: bool,
     shutdown_coordinator: ShutdownCoordinator,
     abort_handle: AbortHandle,
 }
@@ -76,9 +82,10 @@ impl WorkerState {
             .shutdown_strategy()
             .unwrap_or_else(|| child_spec.shutdown_strategy());
 
-        // Task instrumentation is keyed on the fully qualified process name, matching what `spawn_traced_named` would
-        // have recorded for an unsupervised task. Names are per-process-name rather than per-task, so a supervisor with
-        // many identically-named children (one per connection, say) still reports a single series.
+        // Every worker's task is timed, keyed on its fully qualified process name -- the same name
+        // `spawn_traced_named` would have recorded for an equivalent standalone task. A worker is a top-level task, so
+        // it is polled once per wake-up rather than once per unit of work, which keeps the two clock reads per poll well
+        // amortized against whatever the poll actually does.
         let task = worker_future
             .into_process_future(process)
             .with_task_instrumentation(worker_name.clone());
@@ -92,6 +99,7 @@ impl WorkerState {
                 worker_id,
                 worker_name,
                 shutdown_strategy,
+                budget_applies: !child_spec.is_supervisor(),
                 shutdown_coordinator,
                 abort_handle,
             },
@@ -177,7 +185,7 @@ impl WorkerState {
         //
         // A shutdown budget, if set, bounds the sequence as a whole rather than each worker in turn: it is measured
         // from the start of the drain, so the workers shut down later in the order inherit whatever is left of it.
-        let budget_deadline = self.shutdown_budget.map(|budget| tokio::time::Instant::now() + budget);
+        let budget_deadline = resolve_budget_deadline(tokio::time::Instant::now(), self.shutdown_budget);
 
         let mut aborted_total = 0;
         while let Some((current_worker_task_id, process_state)) = self.worker_map.pop() {
@@ -185,9 +193,12 @@ impl WorkerState {
                 worker_id,
                 worker_name,
                 shutdown_strategy,
+                budget_applies,
                 shutdown_coordinator,
                 abort_handle,
             } = process_state;
+
+            let budget_deadline = budget_applies.then_some(budget_deadline).flatten();
 
             // Trigger the process to shutdown based on the configured shutdown strategy.
             let shutdown_deadline = match shutdown_strategy {
@@ -280,7 +291,7 @@ impl WorkerState {
         // graceful worker and immediately abort brutal ones, recording a per-worker abort deadline so each is held to
         // its own timeout rather than a single shared one.
         let now = tokio::time::Instant::now();
-        let budget_deadline = self.shutdown_budget.map(|budget| now + budget);
+        let budget_deadline = resolve_budget_deadline(now, self.shutdown_budget);
         let mut pending: FastIndexMap<Id, (u64, String, AbortHandle, Option<tokio::time::Instant>)> =
             FastIndexMap::default();
         for (task_id, process_state) in std::mem::take(&mut self.worker_map) {
@@ -288,6 +299,7 @@ impl WorkerState {
                 worker_id,
                 worker_name,
                 shutdown_strategy,
+                budget_applies,
                 shutdown_coordinator,
                 abort_handle,
             } = process_state;
@@ -296,6 +308,7 @@ impl WorkerState {
                 ShutdownStrategy::Graceful(timeout) => {
                     debug!(worker_id, shutdown_timeout = ?timeout, "Gracefully shutting down process.");
                     shutdown_coordinator.shutdown();
+                    let budget_deadline = budget_applies.then_some(budget_deadline).flatten();
                     let deadline = resolve_abort_deadline(now, timeout, budget_deadline);
                     pending.insert(task_id, (worker_id, worker_name, abort_handle, deadline));
                 }
@@ -367,11 +380,21 @@ impl WorkerState {
 fn resolve_abort_deadline(
     now: tokio::time::Instant, timeout: Duration, budget_deadline: Option<tokio::time::Instant>,
 ) -> Option<tokio::time::Instant> {
-    let own_deadline = (timeout != Duration::MAX).then(|| now + timeout);
+    // `checked_add` rather than `+`: adding a large duration to an instant panics on overflow, and both the sentinel
+    // (`Duration::MAX`) and any duration near it are reachable from caller-supplied configuration. A deadline too far
+    // out to represent is indistinguishable from no deadline at all, so both become `None`.
+    let own_deadline = now.checked_add(timeout);
     match (own_deadline, budget_deadline) {
         (Some(own), Some(budget)) => Some(own.min(budget)),
         (deadline, None) | (None, deadline) => deadline,
     }
+}
+
+/// Resolves the instant at which a supervisor's whole shutdown must be cut off, if it configured a budget.
+///
+/// Overflows the same way as [`resolve_abort_deadline`]: a budget too large to represent is treated as no budget.
+fn resolve_budget_deadline(now: tokio::time::Instant, budget: Option<Duration>) -> Option<tokio::time::Instant> {
+    budget.and_then(|budget| now.checked_add(budget))
 }
 
 /// Extracts the number of force-aborts a reaped child reported.
@@ -392,5 +415,86 @@ fn reported_abort_count(output: &Result<(), WorkerError>) -> usize {
             _ => 0,
         },
         _ => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn instant() -> tokio::time::Instant {
+        tokio::time::Instant::now()
+    }
+
+    #[tokio::test]
+    async fn abort_deadline_uses_the_workers_own_timeout_when_unbudgeted() {
+        let now = instant();
+        assert_eq!(
+            resolve_abort_deadline(now, Duration::from_secs(3), None),
+            Some(now + Duration::from_secs(3))
+        );
+    }
+
+    #[tokio::test]
+    async fn abort_deadline_is_none_for_an_unbounded_worker_without_a_budget() {
+        // `Duration::MAX` is the "no deadline of its own" sentinel: a nested supervisor, or a child whose supervisor
+        // holds the budget. With no budget in play there is nothing to bound it.
+        assert_eq!(resolve_abort_deadline(instant(), Duration::MAX, None), None);
+    }
+
+    #[tokio::test]
+    async fn abort_deadline_falls_back_to_the_budget_for_an_unbounded_worker() {
+        let now = instant();
+        let budget = now + Duration::from_secs(10);
+        assert_eq!(resolve_abort_deadline(now, Duration::MAX, Some(budget)), Some(budget));
+    }
+
+    #[tokio::test]
+    async fn abort_deadline_takes_whichever_of_worker_and_budget_is_sooner() {
+        let now = instant();
+        let budget = now + Duration::from_secs(10);
+
+        // Worker sooner than the budget.
+        assert_eq!(
+            resolve_abort_deadline(now, Duration::from_secs(2), Some(budget)),
+            Some(now + Duration::from_secs(2))
+        );
+
+        // Budget sooner than the worker: a worker cannot buy itself more time than its supervisor allows.
+        assert_eq!(
+            resolve_abort_deadline(now, Duration::from_secs(30), Some(budget)),
+            Some(budget)
+        );
+    }
+
+    #[tokio::test]
+    async fn abort_deadline_does_not_overflow_on_a_near_max_timeout() {
+        // Only `Duration::MAX` exactly used to be special-cased, so anything just under it panicked when added to an
+        // instant. A deadline too far out to represent is treated as no deadline.
+        let now = instant();
+        assert_eq!(
+            resolve_abort_deadline(now, Duration::MAX - Duration::from_nanos(1), None),
+            None
+        );
+
+        // Even then, a budget still bounds the worker.
+        let budget = now + Duration::from_secs(5);
+        assert_eq!(
+            resolve_abort_deadline(now, Duration::MAX - Duration::from_nanos(1), Some(budget)),
+            Some(budget)
+        );
+    }
+
+    #[tokio::test]
+    async fn budget_deadline_is_overflow_safe() {
+        let now = instant();
+        assert_eq!(resolve_budget_deadline(now, None), None);
+        assert_eq!(
+            resolve_budget_deadline(now, Some(Duration::from_secs(7))),
+            Some(now + Duration::from_secs(7))
+        );
+
+        // `Duration::MAX` is the natural spelling of "no ceiling", and used to panic the supervisor task.
+        assert_eq!(resolve_budget_deadline(now, Some(Duration::MAX)), None);
     }
 }

--- a/lib/saluki-core/src/runtime/worker_state.rs
+++ b/lib/saluki-core/src/runtime/worker_state.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 
 use saluki_common::collections::FastIndexMap;
 use saluki_common::sync::shutdown::{ShutdownCoordinator, ShutdownHandle};
+use saluki_common::task::TaskInstrument as _;
 use tokio::{
     pin, select,
     task::{AbortHandle, Id, JoinSet},
@@ -17,7 +18,9 @@ use tokio::{
 use tracing::{debug, warn};
 
 use super::process::{Process, ProcessExt as _};
-use super::supervisor::{ProcessError, ShutdownMode, ShutdownStrategy, SupervisedChild, SupervisorError, WorkerError};
+use super::supervisor::{
+    ChildConfig, ProcessError, ShutdownMode, ShutdownStrategy, SupervisedChild, SupervisorError, WorkerError,
+};
 
 /// Per-worker bookkeeping held by a [`WorkerState`].
 struct ProcessState {
@@ -38,28 +41,51 @@ struct ProcessState {
 pub(super) struct WorkerState {
     process: Process,
     shutdown_mode: ShutdownMode,
+    /// Ceiling on the whole shutdown, if the supervisor configured one.
+    ///
+    /// Applied on top of each child's own strategy, so a child with no finite deadline of its own is still bounded,
+    /// and one that has a shorter deadline still exits first.
+    shutdown_budget: Option<Duration>,
     worker_tasks: JoinSet<Result<(), WorkerError>>,
     worker_map: FastIndexMap<Id, ProcessState>,
 }
 
 impl WorkerState {
-    pub(super) fn new(process: Process, shutdown_mode: ShutdownMode) -> Self {
+    pub(super) fn new(process: Process, shutdown_mode: ShutdownMode, shutdown_budget: Option<Duration>) -> Self {
         Self {
             process,
             shutdown_mode,
+            shutdown_budget,
             worker_tasks: JoinSet::new(),
             worker_map: FastIndexMap::default(),
         }
     }
 
     /// Spawns the child described by `child_spec`, tracking it under the given `worker_id`.
-    pub(super) fn add_worker(&mut self, worker_id: u64, child_spec: &SupervisedChild) -> Result<(), SupervisorError> {
+    ///
+    /// `config` supplies the per-child overrides chosen at registration time: which runtime to spawn the child's task
+    /// on, and whether to override the shutdown strategy the child reports for itself.
+    pub(super) fn add_worker(
+        &mut self, worker_id: u64, child_spec: &SupervisedChild, config: &ChildConfig,
+    ) -> Result<(), SupervisorError> {
         let (shutdown_coordinator, shutdown_handle) = ShutdownHandle::paired();
         let process = child_spec.create_process(&self.process)?;
         let worker_name = process.name().to_string();
         let worker_future = child_spec.create_worker_future(process.clone(), shutdown_handle)?;
-        let shutdown_strategy = child_spec.shutdown_strategy();
-        let abort_handle = self.worker_tasks.spawn(worker_future.into_process_future(process));
+        let shutdown_strategy = config
+            .shutdown_strategy()
+            .unwrap_or_else(|| child_spec.shutdown_strategy());
+
+        // Task instrumentation is keyed on the fully qualified process name, matching what `spawn_traced_named` would
+        // have recorded for an unsupervised task. Names are per-process-name rather than per-task, so a supervisor with
+        // many identically-named children (one per connection, say) still reports a single series.
+        let task = worker_future
+            .into_process_future(process)
+            .with_task_instrumentation(worker_name.clone());
+        let abort_handle = match config.runtime() {
+            Some(handle) => self.worker_tasks.spawn_on(task, handle),
+            None => self.worker_tasks.spawn(task),
+        };
         self.worker_map.insert(
             abort_handle.id(),
             ProcessState {
@@ -148,6 +174,11 @@ impl WorkerState {
         // worker map and continue waiting for the current worker we're shutting down.
         //
         // We do this until the worker map is empty, at which point we can be sure that all processes have exited.
+        //
+        // A shutdown budget, if set, bounds the sequence as a whole rather than each worker in turn: it is measured
+        // from the start of the drain, so the workers shut down later in the order inherit whatever is left of it.
+        let budget_deadline = self.shutdown_budget.map(|budget| tokio::time::Instant::now() + budget);
+
         let mut aborted_total = 0;
         while let Some((current_worker_task_id, process_state)) = self.worker_map.pop() {
             let ProcessState {
@@ -164,7 +195,12 @@ impl WorkerState {
                     debug!(worker_id, shutdown_timeout = ?timeout, "Gracefully shutting down process.");
                     shutdown_coordinator.shutdown();
 
-                    tokio::time::sleep(timeout)
+                    match resolve_abort_deadline(tokio::time::Instant::now(), timeout, budget_deadline) {
+                        Some(deadline) => tokio::time::sleep_until(deadline),
+                        // Nothing bounds this worker, so wait for it to exit on its own. `sleep` clamps an
+                        // effectively-infinite duration internally, where `sleep_until` would overflow the instant.
+                        None => tokio::time::sleep(Duration::MAX),
+                    }
                 }
                 ShutdownStrategy::Brutal => {
                     debug!(worker_id, "Forcefully aborting process.");
@@ -244,6 +280,7 @@ impl WorkerState {
         // graceful worker and immediately abort brutal ones, recording a per-worker abort deadline so each is held to
         // its own timeout rather than a single shared one.
         let now = tokio::time::Instant::now();
+        let budget_deadline = self.shutdown_budget.map(|budget| now + budget);
         let mut pending: FastIndexMap<Id, (u64, String, AbortHandle, Option<tokio::time::Instant>)> =
             FastIndexMap::default();
         for (task_id, process_state) in std::mem::take(&mut self.worker_map) {
@@ -259,9 +296,7 @@ impl WorkerState {
                 ShutdownStrategy::Graceful(timeout) => {
                     debug!(worker_id, shutdown_timeout = ?timeout, "Gracefully shutting down process.");
                     shutdown_coordinator.shutdown();
-                    // An effectively-infinite timeout (`Duration::MAX`) maps to `None` -- "never abort" -- which is
-                    // correct for nested supervisors, since they bound themselves via their own children's deadlines.
-                    let deadline = (timeout != Duration::MAX).then(|| now + timeout);
+                    let deadline = resolve_abort_deadline(now, timeout, budget_deadline);
                     pending.insert(task_id, (worker_id, worker_name, abort_handle, deadline));
                 }
                 ShutdownStrategy::Brutal => {
@@ -320,6 +355,22 @@ impl WorkerState {
         }
 
         aborted_total
+    }
+}
+
+/// Resolves the instant at which a worker must be forcefully aborted, if it must be at all.
+///
+/// A timeout of `Duration::MAX` means the worker carries no deadline of its own. That's correct for a nested
+/// supervisor, which bounds itself through its own children, and for the children of a supervisor that holds a
+/// shutdown budget on their behalf. When both a worker deadline and a budget apply, whichever elapses first wins, so
+/// the budget acts as a ceiling rather than an override.
+fn resolve_abort_deadline(
+    now: tokio::time::Instant, timeout: Duration, budget_deadline: Option<tokio::time::Instant>,
+) -> Option<tokio::time::Instant> {
+    let own_deadline = (timeout != Duration::MAX).then(|| now + timeout);
+    match (own_deadline, budget_deadline) {
+        (Some(own), Some(budget)) => Some(own.min(budget)),
+        (deadline, None) | (None, deadline) => deadline,
     }
 }
 

--- a/lib/saluki-core/src/runtime/workers.rs
+++ b/lib/saluki-core/src/runtime/workers.rs
@@ -1,0 +1,276 @@
+//! Closure-style supervisable workers.
+use std::{future::Future, sync::Mutex, time::Duration};
+
+use async_trait::async_trait;
+use saluki_common::sync::shutdown::ShutdownHandle;
+use saluki_error::{generic_error, GenericError};
+use tracing::debug;
+
+use super::supervisor::{InitializationError, ShutdownStrategy, Supervisable, SupervisorFuture};
+
+/// Default graceful shutdown period for a function-based worker.
+///
+/// Matches the [`Supervisable`] trait default, and applies only when nothing else sets a strategy for the child.
+const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// An output type that a function-based worker can produce.
+///
+/// Implemented for `()` (a worker that can't fail) and `Result<(), GenericError>` (one that can), so both forms can be
+/// passed to [`noninterruptible_worker`] and [`interruptible_worker`] without wrapping.
+pub trait IntoWorkerResult {
+    /// Converts this output into a worker result.
+    fn into_worker_result(self) -> Result<(), GenericError>;
+}
+
+impl IntoWorkerResult for () {
+    fn into_worker_result(self) -> Result<(), GenericError> {
+        Ok(())
+    }
+}
+
+impl IntoWorkerResult for Result<(), GenericError> {
+    fn into_worker_result(self) -> Result<(), GenericError> {
+        self
+    }
+}
+
+type WorkerBody = Box<dyn FnOnce(ShutdownHandle) -> SupervisorFuture + Send>;
+
+/// A [`Supervisable`] worker built from a closure.
+///
+/// This worker cannot be restarted as the closure is consumed during initialization.
+pub struct FnWorker {
+    name: String,
+    shutdown_strategy: ShutdownStrategy,
+    body: Mutex<Option<WorkerBody>>,
+}
+
+impl FnWorker {
+    fn new(name: String, body: WorkerBody) -> Self {
+        Self {
+            name,
+            shutdown_strategy: ShutdownStrategy::Graceful(DEFAULT_SHUTDOWN_TIMEOUT),
+            body: Mutex::new(Some(body)),
+        }
+    }
+
+    /// Sets the shutdown timeout for this worker.
+    #[must_use]
+    pub const fn with_shutdown_timeout(mut self, timeout: Duration) -> Self {
+        self.shutdown_strategy = ShutdownStrategy::Graceful(timeout);
+        self
+    }
+}
+
+#[async_trait]
+impl Supervisable for FnWorker {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn shutdown_strategy(&self) -> ShutdownStrategy {
+        self.shutdown_strategy
+    }
+
+    async fn initialize(&self, process_shutdown: ShutdownHandle) -> Result<SupervisorFuture, InitializationError> {
+        let body = self
+            .body
+            .lock()
+            .expect("function worker mutex poisoned")
+            .take()
+            .ok_or_else(|| InitializationError::from(generic_error!("worker already initialized")))?;
+
+        Ok(body(process_shutdown))
+    }
+}
+
+/// Creates a one-shot [`Supervisable`] worker that is never interrupted mid-operation.
+///
+/// The future that is created is solely responsible for handling the shutdown signal exposed to it via
+/// `ShutdownHandle`. Callers should ensure that they respond to shutdown signals in a timely manner otherwise they risk
+/// failing to run to completion when the supervisor forcefully exits. Use this for workers that need to drain in
+/// response to shutdown; for workers that are safe to stop at an arbitrary await point, [`interruptible_worker`] is
+/// simpler.
+///
+/// Workers may return either `()` or `Result<(), GenericError>`.
+///
+/// The worker cannot be restarted as the given closure is consumed during initialization.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use saluki_core::runtime::noninterruptible_worker;
+/// # async fn drain_queue() {}
+/// let worker = noninterruptible_worker("queue_drainer", |shutdown| async move {
+///     tokio::select! {
+///         _ = shutdown => {},
+///         _ = drain_queue() => {},
+///     }
+/// });
+/// ```
+#[must_use]
+pub fn noninterruptible_worker<N, F, Fut>(name: N, f: F) -> FnWorker
+where
+    N: Into<String>,
+    F: FnOnce(ShutdownHandle) -> Fut + Send + 'static,
+    Fut: Future + Send + 'static,
+    Fut::Output: IntoWorkerResult,
+{
+    FnWorker::new(
+        name.into(),
+        Box::new(move |shutdown| Box::pin(async move { f(shutdown).await.into_worker_result() })),
+    )
+}
+
+/// Creates a one-shot [`Supervisable`] worker that runs `fut` until it completes or shutdown is signalled, whichever
+/// happens first.
+///
+/// The future that is given is subsequently wrapped such that shutdown is always handled: the underlying worker cannot
+/// ignore or defer honoring it. The future is dropped at whatever await point it happens to be parked on when shutdown
+/// fires, so use this only for work that is safe to interrupt: a server accept loop, a background refresher, a
+/// connection handler. Anything that must finish what it started should use [`noninterruptible_worker`] and observe the
+/// shutdown signal itself.
+///
+/// Workers may return either `()` or `Result<(), GenericError>`.
+///
+/// The worker cannot be restarted as the given future is consumed during initialization.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use saluki_core::runtime::interruptible_worker;
+/// # async fn run_accept_loop() {}
+/// let worker = interruptible_worker("acceptor", run_accept_loop());
+/// ```
+#[must_use]
+pub fn interruptible_worker<N, Fut>(name: N, fut: Fut) -> FnWorker
+where
+    N: Into<String>,
+    Fut: Future + Send + 'static,
+    Fut::Output: IntoWorkerResult,
+{
+    let name = name.into();
+    FnWorker::new(
+        name.clone(),
+        Box::new(move |shutdown| {
+            Box::pin(async move {
+                tokio::select! {
+                    _ = shutdown => {
+                        debug!(worker_name = %name, "Worker interrupted by shutdown signal.");
+                        Ok(())
+                    },
+                    output = fut => output.into_worker_result(),
+                }
+            })
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use saluki_common::sync::shutdown::ShutdownCoordinator;
+    use tokio::time::timeout;
+
+    use super::*;
+
+    /// Bound on any worker-body await in these tests.
+    ///
+    /// A worker that stops observing shutdown would otherwise hang the test process until the harness kills it, which
+    /// reads as a stall rather than a failure.
+    const RUN_TIMEOUT: Duration = Duration::from_secs(5);
+
+    #[tokio::test]
+    async fn noninterruptible_worker_receives_shutdown_signal() {
+        // A non-interruptible worker is handed the shutdown signal and is expected to observe it and return.
+        let observed = Arc::new(AtomicUsize::new(0));
+        let worker_observed = Arc::clone(&observed);
+
+        let worker = noninterruptible_worker("test", move |shutdown| async move {
+            shutdown.await;
+            worker_observed.fetch_add(1, Ordering::SeqCst);
+        });
+
+        let mut coordinator = ShutdownCoordinator::default();
+        let handle = coordinator.register();
+        let run = worker.initialize(handle).await.expect("should initialize");
+
+        coordinator.shutdown();
+        timeout(RUN_TIMEOUT, run)
+            .await
+            .expect("worker should observe shutdown and exit")
+            .expect("should exit cleanly");
+
+        assert_eq!(observed.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn noninterruptible_worker_propagates_error() {
+        let worker = noninterruptible_worker("test", |_shutdown| async move {
+            Err::<(), _>(generic_error!("worker failed"))
+        });
+
+        let run = worker
+            .initialize(ShutdownHandle::noop())
+            .await
+            .expect("should initialize");
+
+        let error = run.await.expect_err("should surface the worker's error");
+        assert!(error.to_string().contains("worker failed"));
+    }
+
+    #[tokio::test]
+    async fn interruptible_worker_is_interrupted_at_shutdown() {
+        // The future never completes on its own, so the only way out is being interrupted -- which is reported as a
+        // clean exit rather than an error.
+        let worker = interruptible_worker("test", std::future::pending::<()>());
+
+        let mut coordinator = ShutdownCoordinator::default();
+        let handle = coordinator.register();
+        let run = worker.initialize(handle).await.expect("should initialize");
+
+        coordinator.shutdown();
+        timeout(RUN_TIMEOUT, run)
+            .await
+            .expect("worker should be interrupted by shutdown and exit")
+            .expect("being interrupted should be reported as a clean exit");
+    }
+
+    #[tokio::test]
+    async fn interruptible_worker_returns_future_output_when_it_completes_first() {
+        let worker = interruptible_worker("test", async { Err::<(), _>(generic_error!("boom")) });
+
+        let run = worker
+            .initialize(ShutdownHandle::noop())
+            .await
+            .expect("should initialize");
+
+        let error = run.await.expect_err("should surface the future's error");
+        assert!(error.to_string().contains("boom"));
+    }
+
+    #[tokio::test]
+    async fn second_initialization_fails() {
+        // Function-based workers are one-shot: a restart would re-initialize, which must fail loudly rather than
+        // silently running nothing.
+        let worker = noninterruptible_worker("test", |_shutdown| async {});
+
+        // Drop the run-future without polling it; we only care that the body was consumed.
+        drop(
+            worker
+                .initialize(ShutdownHandle::noop())
+                .await
+                .expect("first initialization should succeed"),
+        );
+
+        // `SupervisorFuture` isn't `Debug`, so match rather than using `expect_err`.
+        match worker.initialize(ShutdownHandle::noop()).await {
+            Ok(_) => panic!("second initialization should fail"),
+            Err(e) => assert!(e.to_string().contains("already initialized")),
+        }
+    }
+}

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -959,7 +959,7 @@ mod tests {
             if let Some(started) = self.spawned_child {
                 context
                     .spawn_handle()
-                    .spawn(CountingChild { started })
+                    .spawn_supervisable(CountingChild { started })
                     .await
                     .expect("should spawn dynamic child");
             }

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -958,7 +958,7 @@ mod tests {
             let shutdown = context.take_shutdown_handle();
             if let Some(started) = self.spawned_child {
                 context
-                    .spawn_handle()
+                    .spawner()
                     .spawn_supervisable(CountingChild { started })
                     .await
                     .expect("should spawn dynamic child");

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -46,7 +46,6 @@ use crate::health::{Health, HealthRegistry};
 use crate::runtime::state::DataspaceRegistry;
 use crate::runtime::{
     AutoShutdown, ChildSpecification, RestartMode, RestartStrategy, RestartType, ShutdownMode, Supervisor,
-    SupervisorHandle,
 };
 use crate::support::SubsystemIdentifier;
 use crate::topology::ids::get_component_relative_identifier;
@@ -60,7 +59,7 @@ use crate::{
         relays::{Relay, RelayContext},
         sources::{Source, SourceContext},
         transforms::{Transform, TransformContext},
-        ComponentContext, ComponentType,
+        ComponentContext, ComponentSpawner, ComponentType,
     },
     topology::{context::TopologyContext, EventsDispatcher, PayloadsBuffer, PayloadsDispatcher},
 };
@@ -191,16 +190,18 @@ impl BuiltTopology {
             let health_handle = build_health_handle(health_registry, &component_context)?;
 
             let component_sup =
-                build_component_supervisor(&component_context, shutdown_timeout, |handle| SourceRunnable {
-                    component,
-                    context: SourceContext::new(
-                        &topology_context,
-                        &component_context,
-                        component_registry,
-                        health_handle,
-                        dispatcher,
-                        handle,
-                    ),
+                build_component_supervisor(&component_context, &topology_context, shutdown_timeout, |spawner| {
+                    SourceRunnable {
+                        component,
+                        context: SourceContext::new(
+                            &topology_context,
+                            &component_context,
+                            component_registry,
+                            health_handle,
+                            dispatcher,
+                            spawner,
+                        ),
+                    }
                 })?;
             topology_sup.add_worker(component_sup);
         }
@@ -211,16 +212,18 @@ impl BuiltTopology {
             let health_handle = build_health_handle(health_registry, &component_context)?;
 
             let component_sup =
-                build_component_supervisor(&component_context, shutdown_timeout, |handle| RelayRunnable {
-                    component,
-                    context: RelayContext::new(
-                        &topology_context,
-                        &component_context,
-                        component_registry,
-                        health_handle,
-                        dispatcher,
-                        handle,
-                    ),
+                build_component_supervisor(&component_context, &topology_context, shutdown_timeout, |spawner| {
+                    RelayRunnable {
+                        component,
+                        context: RelayContext::new(
+                            &topology_context,
+                            &component_context,
+                            component_registry,
+                            health_handle,
+                            dispatcher,
+                            spawner,
+                        ),
+                    }
                 })?;
             topology_sup.add_worker(component_sup);
         }
@@ -232,17 +235,19 @@ impl BuiltTopology {
             let health_handle = build_health_handle(health_registry, &component_context)?;
 
             let component_sup =
-                build_component_supervisor(&component_context, shutdown_timeout, |handle| DecoderRunnable {
-                    component,
-                    context: DecoderContext::new(
-                        &topology_context,
-                        &component_context,
-                        component_registry,
-                        health_handle,
-                        dispatcher,
-                        consumer,
-                        handle,
-                    ),
+                build_component_supervisor(&component_context, &topology_context, shutdown_timeout, |spawner| {
+                    DecoderRunnable {
+                        component,
+                        context: DecoderContext::new(
+                            &topology_context,
+                            &component_context,
+                            component_registry,
+                            health_handle,
+                            dispatcher,
+                            consumer,
+                            spawner,
+                        ),
+                    }
                 })?;
             topology_sup.add_worker(component_sup);
         }
@@ -254,17 +259,19 @@ impl BuiltTopology {
             let health_handle = build_health_handle(health_registry, &component_context)?;
 
             let component_sup =
-                build_component_supervisor(&component_context, shutdown_timeout, |handle| TransformRunnable {
-                    component,
-                    context: TransformContext::new(
-                        &topology_context,
-                        &component_context,
-                        component_registry,
-                        health_handle,
-                        dispatcher,
-                        consumer,
-                        handle,
-                    ),
+                build_component_supervisor(&component_context, &topology_context, shutdown_timeout, |spawner| {
+                    TransformRunnable {
+                        component,
+                        context: TransformContext::new(
+                            &topology_context,
+                            &component_context,
+                            component_registry,
+                            health_handle,
+                            dispatcher,
+                            consumer,
+                            spawner,
+                        ),
+                    }
                 })?;
             topology_sup.add_worker(component_sup);
         }
@@ -275,16 +282,18 @@ impl BuiltTopology {
             let health_handle = build_health_handle(health_registry, &component_context)?;
 
             let component_sup =
-                build_component_supervisor(&component_context, shutdown_timeout, |handle| DestinationRunnable {
-                    component,
-                    context: DestinationContext::new(
-                        &topology_context,
-                        &component_context,
-                        component_registry,
-                        health_handle,
-                        consumer,
-                        handle,
-                    ),
+                build_component_supervisor(&component_context, &topology_context, shutdown_timeout, |spawner| {
+                    DestinationRunnable {
+                        component,
+                        context: DestinationContext::new(
+                            &topology_context,
+                            &component_context,
+                            component_registry,
+                            health_handle,
+                            consumer,
+                            spawner,
+                        ),
+                    }
                 })?;
             topology_sup.add_worker(component_sup);
         }
@@ -296,17 +305,19 @@ impl BuiltTopology {
             let health_handle = build_health_handle(health_registry, &component_context)?;
 
             let component_sup =
-                build_component_supervisor(&component_context, shutdown_timeout, |handle| EncoderRunnable {
-                    component,
-                    context: EncoderContext::new(
-                        &topology_context,
-                        &component_context,
-                        component_registry,
-                        health_handle,
-                        dispatcher,
-                        consumer,
-                        handle,
-                    ),
+                build_component_supervisor(&component_context, &topology_context, shutdown_timeout, |spawner| {
+                    EncoderRunnable {
+                        component,
+                        context: EncoderContext::new(
+                            &topology_context,
+                            &component_context,
+                            component_registry,
+                            health_handle,
+                            dispatcher,
+                            consumer,
+                            spawner,
+                        ),
+                    }
                 })?;
             topology_sup.add_worker(component_sup);
         }
@@ -317,16 +328,18 @@ impl BuiltTopology {
             let health_handle = build_health_handle(health_registry, &component_context)?;
 
             let component_sup =
-                build_component_supervisor(&component_context, shutdown_timeout, |handle| ForwarderRunnable {
-                    component,
-                    context: ForwarderContext::new(
-                        &topology_context,
-                        &component_context,
-                        component_registry,
-                        health_handle,
-                        consumer,
-                        handle,
-                    ),
+                build_component_supervisor(&component_context, &topology_context, shutdown_timeout, |spawner| {
+                    ForwarderRunnable {
+                        component,
+                        context: ForwarderContext::new(
+                            &topology_context,
+                            &component_context,
+                            component_registry,
+                            health_handle,
+                            consumer,
+                            spawner,
+                        ),
+                    }
                 })?;
             topology_sup.add_worker(component_sup);
         }
@@ -557,20 +570,26 @@ fn build_consumer_pair<T: Dispatchable>(
 /// sole (initial) child process, set as a significant child such that when it terminates, the supervisor shuts down as
 /// well. This provides us with a decent approximation of structured concurrency for components and their subtasks.
 fn build_component_supervisor<C, F>(
-    context: &ComponentContext, shutdown_timeout: Duration, make_runnable: F,
+    context: &ComponentContext, topology_context: &TopologyContext, shutdown_timeout: Duration, make_runnable: F,
 ) -> Result<Supervisor, GenericError>
 where
     C: RunnableComponent,
-    F: FnOnce(SupervisorHandle) -> C,
+    F: FnOnce(ComponentSpawner) -> C,
 {
+    // The supervisor owns the shutdown deadline for its whole subtree: neither the component nor anything it spawns
+    // carries a timeout of its own, and the budget bounds all of them together. Whatever is still running when it
+    // elapses is aborted and named individually, so an overrun still says which task was responsible.
     let component_sup_id = get_component_relative_identifier(context.component_type(), context.component_id());
     let mut component_sup = Supervisor::new(component_sup_id.to_string())?
         .with_auto_shutdown(AutoShutdown::AnySignificant)
-        .with_shutdown_mode(ShutdownMode::Concurrent);
+        .with_shutdown_mode(ShutdownMode::Concurrent)
+        .with_shutdown_budget(shutdown_timeout);
 
-    let runnable = make_runnable(component_sup.handle());
+    let spawner = ComponentSpawner::new(component_sup.handle(), topology_context.global_thread_pool().clone());
+
+    let runnable = make_runnable(spawner);
     component_sup.add_worker(
-        ChildSpecification::worker(ComponentWorker::new(context.clone(), shutdown_timeout, runnable))
+        ChildSpecification::worker(ComponentWorker::new(context.clone(), runnable))
             .with_restart_type(RestartType::Temporary)
             .with_significant(true),
     );

--- a/lib/saluki-core/src/topology/component_worker.rs
+++ b/lib/saluki-core/src/topology/component_worker.rs
@@ -9,6 +9,10 @@
 //! held behind a take-once [`Mutex`] and consumed by [`Supervisable::initialize`]. Sources and relays
 //! drive their own shutdown, so the supervisor-provided shutdown handle is installed into their context;
 //! the remaining component kinds stop when their upstream channels close and ignore it.
+//!
+//! A component carries no shutdown deadline of its own. Its supervisor holds one budget covering the
+//! component and every task it spawned, so the whole subtree is bounded by a single number rather than a
+//! guess per worker. See [`Supervisor::with_shutdown_budget`][crate::runtime::Supervisor::with_shutdown_budget].
 
 use std::sync::Mutex;
 use std::time::Duration;
@@ -47,24 +51,19 @@ pub(super) trait RunnableComponent: Send + 'static {
 /// A [`Supervisable`] adapter over a single built topology component.
 ///
 /// Holds the component behind a take-once [`Mutex`] -- a component is built and run exactly once -- and
-/// exposes it to a supervisor via [`Supervisable`]. The supervisor's shutdown grace period is bounded by
-/// [`shutdown_strategy`][Supervisable::shutdown_strategy], which carries the shutdown timeout configured
-/// for the topology.
+/// exposes it to a supervisor via [`Supervisable`].
 pub(super) struct ComponentWorker<C> {
     component_context: ComponentContext,
-    shutdown_timeout: Duration,
     inner: Mutex<Option<C>>,
 }
 
 impl<C: RunnableComponent> ComponentWorker<C> {
     /// Creates a new `ComponentWorker` for the given runnable component.
     ///
-    /// `component_context` identifies the component (its kind and id); `shutdown_timeout` bounds how long
-    /// the supervisor waits for the component to stop gracefully before aborting it.
-    pub(super) fn new(component_context: ComponentContext, shutdown_timeout: Duration, runnable: C) -> Self {
+    /// `component_context` identifies the component (its kind and id).
+    pub(super) fn new(component_context: ComponentContext, runnable: C) -> Self {
         Self {
             component_context,
-            shutdown_timeout,
             inner: Mutex::new(Some(runnable)),
         }
     }
@@ -77,7 +76,9 @@ impl<C: RunnableComponent> Supervisable for ComponentWorker<C> {
     }
 
     fn shutdown_strategy(&self) -> ShutdownStrategy {
-        ShutdownStrategy::Graceful(self.shutdown_timeout)
+        // No deadline of its own: the component's supervisor holds a single budget covering the component
+        // and everything it spawned, and aborts whatever is still running when that budget elapses.
+        ShutdownStrategy::Graceful(Duration::MAX)
     }
 
     async fn initialize(&self, process_shutdown: ShutdownHandle) -> Result<SupervisorFuture, InitializationError> {


### PR DESCRIPTION
## Summary

This PR adds helpers to support easily spawning associated workers/child tasks under a component's dedicated supervisor in order to replace bespoke/one-off tasks spawned directly on the ambient runtime or global thread pool.

In prior PRs, we've moved topologies, and indeed the individual components within them, to be managed entirely via supervision trees. However, we stopped short of also managing the individual child tasks that some components will spawn. These are things like connection handlers, compute-heavy encoding/decoding, and so on.

This PR adds a new helper, `ComponentSpawner`, designed specifically for components to spawn associated workers/child tasks directly on their dedicated supervisor such that they become implicitly associated with the component (good for attribution) _and_ share the same lifecycle as the component: when components are shut down, so are their associated tasks.

We explicitly are _not_ porting over components to use this new helper in this PR, as there's a few different patterns of how components spawn tasks, and we'll tackle those in follow-up PRs as so more work will be required to support each pattern.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

New and existing tests.

## References

DADP-2
