### PR TITLE
fix(ci): use `localhost` instead of `127.0.0.1` to avoid dual-stack issues in certain SMP experiments

### DIFF
--- a/test/smp/regression/adp/experiments.yaml
+++ b/test/smp/regression/adp/experiments.yaml
@@ -271,7 +271,7 @@ templates:
       generator:
         - grpc:
             seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-            target_uri: "http://127.0.0.1:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
+            target_uri: "http://localhost:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
             bytes_per_second: "5 MiB"
             parallel_connections: 1
             maximum_prebuild_cache_size_bytes: "10 MiB"
@@ -558,7 +558,7 @@ experiments:
       generator:
         - grpc:
             seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-            target_uri: "http://127.0.0.1:6317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export"
+            target_uri: "http://localhost:6317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export"
             bytes_per_second: "5 MiB"
             parallel_connections: 1
             maximum_prebuild_cache_size_bytes: "512 MiB"
@@ -580,7 +580,7 @@ experiments:
             seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
             headers:
               content-type: "application/x-protobuf"
-            target_uri: "http://127.0.0.1:6318/v1/logs"
+            target_uri: "http://localhost:6318/v1/logs"
             bytes_per_second: "5 MiB"
             parallel_connections: 1
             method:

--- a/test/smp/regression/adp/full/cases/otlp_ingest_logs_5mb_cpu/lading/lading.yaml
+++ b/test/smp/regression/adp/full/cases/otlp_ingest_logs_5mb_cpu/lading/lading.yaml
@@ -10,7 +10,7 @@ generator:
       109, 113, 127, 131]
     headers:
       content-type: application/x-protobuf
-    target_uri: http://127.0.0.1:6318/v1/logs
+    target_uri: http://localhost:6318/v1/logs
     bytes_per_second: 5 MiB
     parallel_connections: 1
     method:

--- a/test/smp/regression/adp/full/cases/otlp_ingest_logs_5mb_memory/lading/lading.yaml
+++ b/test/smp/regression/adp/full/cases/otlp_ingest_logs_5mb_memory/lading/lading.yaml
@@ -10,7 +10,7 @@ generator:
       109, 113, 127, 131]
     headers:
       content-type: application/x-protobuf
-    target_uri: http://127.0.0.1:6318/v1/logs
+    target_uri: http://localhost:6318/v1/logs
     bytes_per_second: 5 MiB
     parallel_connections: 1
     method:

--- a/test/smp/regression/adp/full/cases/otlp_ingest_logs_5mb_throughput/lading/lading.yaml
+++ b/test/smp/regression/adp/full/cases/otlp_ingest_logs_5mb_throughput/lading/lading.yaml
@@ -10,7 +10,7 @@ generator:
       109, 113, 127, 131]
     headers:
       content-type: application/x-protobuf
-    target_uri: http://127.0.0.1:6318/v1/logs
+    target_uri: http://localhost:6318/v1/logs
     bytes_per_second: 5 MiB
     parallel_connections: 1
     method:

--- a/test/smp/regression/adp/full/cases/otlp_ingest_metrics_5mb_cpu/lading/lading.yaml
+++ b/test/smp/regression/adp/full/cases/otlp_ingest_metrics_5mb_cpu/lading/lading.yaml
@@ -8,7 +8,7 @@ generator:
 - grpc:
     seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107,
       109, 113, 127, 131]
-    target_uri: http://127.0.0.1:6317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export
+    target_uri: http://localhost:6317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export
     bytes_per_second: 5 MiB
     parallel_connections: 1
     maximum_prebuild_cache_size_bytes: 512 MiB

--- a/test/smp/regression/adp/full/cases/otlp_ingest_metrics_5mb_memory/lading/lading.yaml
+++ b/test/smp/regression/adp/full/cases/otlp_ingest_metrics_5mb_memory/lading/lading.yaml
@@ -8,7 +8,7 @@ generator:
 - grpc:
     seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107,
       109, 113, 127, 131]
-    target_uri: http://127.0.0.1:6317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export
+    target_uri: http://localhost:6317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export
     bytes_per_second: 5 MiB
     parallel_connections: 1
     maximum_prebuild_cache_size_bytes: 512 MiB

--- a/test/smp/regression/adp/full/cases/otlp_ingest_metrics_5mb_throughput/lading/lading.yaml
+++ b/test/smp/regression/adp/full/cases/otlp_ingest_metrics_5mb_throughput/lading/lading.yaml
@@ -8,7 +8,7 @@ generator:
 - grpc:
     seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107,
       109, 113, 127, 131]
-    target_uri: http://127.0.0.1:6317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export
+    target_uri: http://localhost:6317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export
     bytes_per_second: 5 MiB
     parallel_connections: 1
     maximum_prebuild_cache_size_bytes: 512 MiB

--- a/test/smp/regression/adp/full/cases/otlp_ingest_traces_5mb_cpu/lading/lading.yaml
+++ b/test/smp/regression/adp/full/cases/otlp_ingest_traces_5mb_cpu/lading/lading.yaml
@@ -8,7 +8,7 @@ generator:
 - grpc:
     seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107,
       109, 113, 127, 131]
-    target_uri: http://127.0.0.1:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
+    target_uri: http://localhost:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
     bytes_per_second: 5 MiB
     parallel_connections: 1
     maximum_prebuild_cache_size_bytes: 10 MiB

--- a/test/smp/regression/adp/full/cases/otlp_ingest_traces_5mb_memory/lading/lading.yaml
+++ b/test/smp/regression/adp/full/cases/otlp_ingest_traces_5mb_memory/lading/lading.yaml
@@ -8,7 +8,7 @@ generator:
 - grpc:
     seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107,
       109, 113, 127, 131]
-    target_uri: http://127.0.0.1:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
+    target_uri: http://localhost:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
     bytes_per_second: 5 MiB
     parallel_connections: 1
     maximum_prebuild_cache_size_bytes: 10 MiB

--- a/test/smp/regression/adp/full/cases/otlp_ingest_traces_5mb_throughput/lading/lading.yaml
+++ b/test/smp/regression/adp/full/cases/otlp_ingest_traces_5mb_throughput/lading/lading.yaml
@@ -8,7 +8,7 @@ generator:
 - grpc:
     seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107,
       109, 113, 127, 131]
-    target_uri: http://127.0.0.1:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
+    target_uri: http://localhost:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
     bytes_per_second: 5 MiB
     parallel_connections: 1
     maximum_prebuild_cache_size_bytes: 10 MiB

--- a/test/smp/regression/adp/full/cases/otlp_ingest_traces_ottl_filtering_5mb_cpu/lading/lading.yaml
+++ b/test/smp/regression/adp/full/cases/otlp_ingest_traces_ottl_filtering_5mb_cpu/lading/lading.yaml
@@ -8,7 +8,7 @@ generator:
 - grpc:
     seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107,
       109, 113, 127, 131]
-    target_uri: http://127.0.0.1:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
+    target_uri: http://localhost:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
     bytes_per_second: 5 MiB
     parallel_connections: 1
     maximum_prebuild_cache_size_bytes: 10 MiB

--- a/test/smp/regression/adp/full/cases/otlp_ingest_traces_ottl_filtering_5mb_memory/lading/lading.yaml
+++ b/test/smp/regression/adp/full/cases/otlp_ingest_traces_ottl_filtering_5mb_memory/lading/lading.yaml
@@ -8,7 +8,7 @@ generator:
 - grpc:
     seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107,
       109, 113, 127, 131]
-    target_uri: http://127.0.0.1:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
+    target_uri: http://localhost:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
     bytes_per_second: 5 MiB
     parallel_connections: 1
     maximum_prebuild_cache_size_bytes: 10 MiB

--- a/test/smp/regression/adp/full/cases/otlp_ingest_traces_ottl_filtering_5mb_throughput/lading/lading.yaml
+++ b/test/smp/regression/adp/full/cases/otlp_ingest_traces_ottl_filtering_5mb_throughput/lading/lading.yaml
@@ -8,7 +8,7 @@ generator:
 - grpc:
     seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107,
       109, 113, 127, 131]
-    target_uri: http://127.0.0.1:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
+    target_uri: http://localhost:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
     bytes_per_second: 5 MiB
     parallel_connections: 1
     maximum_prebuild_cache_size_bytes: 10 MiB

--- a/test/smp/regression/adp/full/cases/otlp_ingest_traces_ottl_transform_5mb_cpu/lading/lading.yaml
+++ b/test/smp/regression/adp/full/cases/otlp_ingest_traces_ottl_transform_5mb_cpu/lading/lading.yaml
@@ -8,7 +8,7 @@ generator:
 - grpc:
     seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107,
       109, 113, 127, 131]
-    target_uri: http://127.0.0.1:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
+    target_uri: http://localhost:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
     bytes_per_second: 5 MiB
     parallel_connections: 1
     maximum_prebuild_cache_size_bytes: 10 MiB

--- a/test/smp/regression/adp/full/cases/otlp_ingest_traces_ottl_transform_5mb_memory/lading/lading.yaml
+++ b/test/smp/regression/adp/full/cases/otlp_ingest_traces_ottl_transform_5mb_memory/lading/lading.yaml
@@ -8,7 +8,7 @@ generator:
 - grpc:
     seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107,
       109, 113, 127, 131]
-    target_uri: http://127.0.0.1:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
+    target_uri: http://localhost:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
     bytes_per_second: 5 MiB
     parallel_connections: 1
     maximum_prebuild_cache_size_bytes: 10 MiB

--- a/test/smp/regression/adp/full/cases/otlp_ingest_traces_ottl_transform_5mb_throughput/lading/lading.yaml
+++ b/test/smp/regression/adp/full/cases/otlp_ingest_traces_ottl_transform_5mb_throughput/lading/lading.yaml
@@ -8,7 +8,7 @@ generator:
 - grpc:
     seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107,
       109, 113, 127, 131]
-    target_uri: http://127.0.0.1:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
+    target_uri: http://localhost:6317/opentelemetry.proto.collector.trace.v1.TraceService/Export
     bytes_per_second: 5 MiB
     parallel_connections: 1
     maximum_prebuild_cache_size_bytes: 10 MiB


### PR DESCRIPTION
## Summary

This PR fixes an issue with the OTLP-specific SMP experiments referencing `127.0.0.1` directly when ADP was referencing `localhost`, leading to mismatches in dual-stack environments where one side was expecting IPv4 and the other expecting IPv6.

This was a little messed up with some recent refactoring around how the ports are defined and we had added some compensating configuration changes in _some_ tests, but not SMP experiments. Rather than add the same compensating changes (listen on `0.0.0.0` instead of `localhost`, basically), we've simply mirrored the use of `localhost` on the `lading` side, which means that while we may use IPv4 _or_ IPv6... both sides (ADP and `lading`) always use the same version.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [x] Locally reproduced the issue and then observed that this PR fixed it.
- [ ] Ran the "full" SMP experiment suite in CI and ensured all OTLP-specific experiments completed successfully, including analysis.

## References

DADP-2