### PR TITLE
chore(docs): improve config-system skill

### DIFF
--- a/.claude/skills/config-system/SKILL.md
+++ b/.claude/skills/config-system/SKILL.md
@@ -131,8 +131,8 @@ and coerced to the int `8125`. `1` or `"T"` is coerced to a `bool`.
 ## Documented enum settings
 
 A `string` setting whose schema documentation names a closed set of values becomes an enum in
-`agent-data-plane-config` with `#[default]` and `FromStr`. Match Agent behavior; warn and fallback
-to default, or record a `TranslateError`. Serialize using the `FromStr` spelling.
+`agent-data-plane-config` with `#[default]` and `FromStr`. Match Agent behavior; warn and fallback,
+or record a `TranslateError`. Serialize using the `FromStr` spelling.
 
 ## Saluki-only values
 

--- a/.claude/skills/config-system/SKILL.md
+++ b/.claude/skills/config-system/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: config-system
 description: >
-  Architecture and working rules for Saluki's typed configuration system and Datadog configuration
-  inventory. Read this when working with lib/agent-data-plane-config*, lib/datadog-agent/config*,
-  GenericConfiguration, schema_overlay.yaml, SalukiConfiguration, DatadogConfiguration, config
-  loading or updates, or a component's configuration inputs.
+  Architecture and working rules for Saluki's configuration system and inventory. Read this when
+  working with lib/agent-data-plane-config*, lib/datadog-agent/config*, GenericConfiguration,
+  schema_overlay.yaml, SalukiConfiguration, DatadogConfiguration, or typed config migrations.
 disable-model-invocation: false
 ---
 # /config-system
 
 Saluki is replacing direct reads from the raw `GenericConfiguration` map with a typed configuration
-boundary. This skill explains the architecture, the transitional state, and the workflows for
-changing configuration without losing defaults, validation, reachability, or dynamic behavior.
+boundary. This skill explains the architecture, transitional state, and workflows.
+
+Paths and type names can move. Notify the user when this skill needs an update.
 
 ## Why this system exists
 
@@ -43,28 +43,22 @@ into `SalukiConfiguration`.
 | Source-agnostic typed model and `Live<T>`                       | `lib/agent-data-plane-config/`                                             |
 | Loading, translation, authority, updates, compatibility         | `lib/agent-data-plane-config-system/`                                      |
 | Datadog source model, witness, classifier, environment decoding | `lib/datadog-agent/config/`                                                |
-| Hand-edited Datadog support inventory                           | `lib/datadog-agent/config/schema/schema_overlay.yaml`                      |
+| Hand-edited ADP support inventory for Datadog schema keys.      | `lib/datadog-agent/config/schema/schema_overlay.yaml`                      |
 | Vendored Datadog JSON-schema (written in YAML)                  | `lib/datadog-agent/config/schema/core/`                                    |
-| Overlay types, validation, schema generation                    | `lib/datadog-agent/config-overlay-model/`                                  |
-| Legacy test registry, legacy smoke test support, doc gen        | `lib/datadog-agent/config-testing/`                                        |
+| Overlay types, validation, `SALUKI_KEYS`, smoke-test metadata   | `lib/datadog-agent/config-overlay-model/`                                  |
+| Config registry, `run_config_smoke_tests`, doc gen              | `lib/datadog-agent/config-testing/`                                        |
+| Raw map (`GenericConfiguration`) and the by-key view            | `lib/saluki-config/`                                                       |
 | Hand-written Datadog witness implementation                     | `lib/agent-data-plane-config-system/src/translators/datadog_translator.rs` |
 | Saluki-only source model and `seed`                             | `lib/agent-data-plane-config-system/src/saluki_only.rs`                    |
 | Saluki-only defaults                                            | `lib/agent-data-plane-config/src/defaults.rs`                              |
 | Runtime loading and authority selection                         | `lib/agent-data-plane-config-system/src/loaded.rs`                         |
 | Translation gate and update loop                                | `lib/agent-data-plane-config-system/src/system.rs`                         |
-| Schema-driven environment reader (Datadog keys)                 | `lib/datadog-agent/config/src/env_reader.rs`                               |
-| Figment provider wrapping that reader                           | `lib/datadog-agent/config/src/env_provider.rs`                             |
-| Same provider, plus Saluki-only keys                            | `lib/agent-data-plane-config-system/src/env_provider.rs`                   |
+| Datadog env reader plus its Figment provider                    | `lib/datadog-agent/config/src/env_reader.rs`, `env_provider.rs`            |
+| Saluki-only env reader (convention, no table)                   | `lib/agent-data-plane-config-system/src/saluki_env_overlay.rs`             |
+| Provider carrying both key classes                              | `lib/agent-data-plane-config-system/src/env_provider.rs`                   |
 
-In `SalukiConfiguration`, you may use `ConfigValue<T>` when we need to know the difference between a
-value that was explicitly set by the user, or where the value is a default. The Agent API provides a
-`source` field which we are simplifying into `Provenance`, which is either `Default` or `Explicit`.
-
-Some values must be resolved based on their provenance, for example `dd_url` overrides `site` only
-if it is explicitly set. This sort of resolution should be done in the config layer with a member
-function getter on the relevant struct. The component should store the resolved value.
-
-Paths and type names can move. Notify the user when this skill needs an update.
+Use `ConfigValue<T>` in `SalukiConfiguration` when a default must be detectable:
+`Provenance::Default` vs `Provenance::Explicit`. See `dd_url`, `site`.
 
 ### Architectural dependency boundaries
 
@@ -73,30 +67,36 @@ The intended end state is:
 - `agent-data-plane-config` depends on neither the raw map nor the Datadog source model.
 - `agent-data-plane-config-system` bridges sources to the model and constructs no components.
 - Components and runtime code do not access `GenericConfiguration` in the end state.
-- `saluki-components` accepts domain/shared slices and `Live<T>`.
-- `bin/agent-data-plane` hands each component only its required slices.
+- `saluki-components` define their own input arguments and structs.
+- `bin/agent-data-plane` hands each component what it requires.
 
-Dedicated migration PRs remove the temporary violations component by component.
+Dedicated migration PRs remove temporary violations component by component.
+
+### `saluki-components` mistake
+
+Initially we wanted `saluki-components` to depend on `agent-data-plane-config` but we changed our
+mind. We cannot immediately end this dependency because of `Live<T>` and `ConfigValue<T>`. However,
+most migrations do not require these types. Migrations that do not require these types should *not*
+depend on types in `agent-data-plane-config` and should, instead, rely on the binary to copy data
+into fields or an args struct that they present.
+
+The end state deletes `agent-data-plane-config` from the `saluki-components` `Cargo.toml`. Minimize
+the impact of that change when migrating components. Some migrations predate this design change; do
+not follow them, they are temporary exceptions.
 
 ## Datadog vs. Saluki keys
 
-One rule determines a key's source class: whether it exists in the Datadog schema. The build
-enforces that `schema_overlay.yaml` lists every schema leaf exactly once, so the overlay is a
-convenient membership index. When resolving schema-update drift, inspect `schema/core/*.yaml`
-directly.
-
-A key present in the overlay is a Datadog key; an absent key is Saluki-only. Names do not decide:
-`data_plane.foo` can belong to either class.
+A key in the Datadog schema is a Datadog key; a key absent from the overlay is Saluki-only. Names
+are no help: `data_plane.foo` can belong to either class.
 
 ## Datadog inventory and generated code
 
 The vendored schema and overlay have different jobs:
 
-- `schema/core/*.yaml` defines the Datadog keys as JSON Schema rendered in YAML.
+- `schema/core/*.yaml` defines Datadog keys as JSON Schema rendered in YAML.
 - `schema_overlay.yaml` classifies every schema leaf for ADP. Its shape is defined by ADP.
 
-Under `inventory`, support is `full|partial|none|unknown`; `excluded` is a separate section. ADP
-adds metadata used by tests and generated documentation.
+Under `inventory`, support is `full|partial|none|unknown`; `excluded` is a separate section.
 
 Code is generated in-tree from the schema and overlay bearing `@generated` / `DO NOT EDIT` warnings.
 Use the following command to regenerate it:
@@ -107,25 +107,20 @@ make build-schema-overlay
 
 ## Environment variables and key shape
 
-The Datadog Agent does not derive a variable's name from its key path: it looks up each known key's
-declared variable names. `DD_PROXY_HTTP` reaches `proxy.http` while `DD_DOGSTATSD_PORT` reaches the
-flat `dogstatsd_port`, and nothing in either name marks the nesting boundary. No separator
-convention can reproduce this, so both configuration paths read the environment through the
-generated tables instead:
+The Datadog Agent does not derive a variable's name from its key path: `DD_PROXY_HTTP` reaches
+`proxy.http` while `DD_DOGSTATSD_PORT` reaches the flat `dogstatsd_port`. No separator convention
+reproduces this. Datadog keys read the environment through the generated tables. Saluki-only keys
+have no table: the name is the canonical path, upper-cased, underscore-joined, `DD_`-prefixed. Both
+readers serve both paths: the typed path via `apply_datadog_env` plus the Saluki-only reader, and
+the by-key path via `EnvironmentProvider`, a legacy Figment provider wrapping those readers.
 
-- the typed path via `apply_datadog_env` plus the Saluki-only reader, and
-- the by-key path via `EnvironmentProvider`, a Figment provider wrapping those same readers.
+**A modeled key arrives in the Agent's canonical shape.** A struct deserialized from
+`GenericConfiguration` MUST read that shape. Do not add a `#[serde(rename)]` or `#[serde(alias)]`
+and do not reintroduce a key-alias or environment-remapping table. A key that no model declares
+still arrives flat from the `DD_` prefix-scanning provider, at lower precedence.
 
-**Every source therefore delivers the Agent's canonical shape.** A struct deserialized from
-`GenericConfiguration` **MUST** read that shape. Do not add a `#[serde(rename)]` or
-`#[serde(alias)]` that maps a nested key onto a flattened spelling, and do not reintroduce a
-key-alias or environment-remapping table. Those existed once, only ran on file load, and so never
-applied to the Datadog Agent's configuration stream — which is the authority in the Core Agent
-deployment.
-
-Reserve `#[serde(flatten)]` for a struct that genuinely groups several *top-level* Agent keys (for
-example, the forwarder's `forwarder_*` retry settings). Name a Rust field after its canonical
-section rather than renaming it onto one.
+For deserialization paths, reserve `#[serde(flatten)]` for a struct that groups several *top-level*
+Agent keys (for example, the forwarder's `forwarder_*` retry settings).
 
 ## Scalar leaf coercion
 
@@ -135,13 +130,9 @@ and coerced to the int `8125`. `1` or `"T"` is coerced to a `bool`.
 
 ## Documented enum settings
 
-A `string` setting whose documentation names a closed set of values (`otlp_config.metrics.histograms.mode`)
-becomes an enum in `agent-data-plane-config` with `#[default]` on the schema default and a `FromStr`
-listing the accepted spellings. The translator parses it and records the error, recovering to the value
-the Agent uses. When the Agent defines that recovery itself rather than falling back to a default
-(`use_v3_api.series.enabled`: warn and route to v2), warn instead of recording an error, so the strict
-startup gate does not reject a configuration the Agent runs with. Serialize each variant to the
-spelling `FromStr` reads.
+A `string` setting whose schema documentation names a closed set of values becomes an enum in
+`agent-data-plane-config` with `#[default]` and `FromStr`. Match Agent behavior; warn and fallback
+to default, or record a `TranslateError`. Serialize using the `FromStr` spelling.
 
 ## Saluki-only values
 
@@ -170,11 +161,11 @@ requires a value, model `T`; use `Option<T>` only when absence is meaningful, no
 default.
 
 Push source parsing, defaults, and input validation to the configuration boundary. Components keep
-only validation that is truly business logic.
+only validation that is business logic.
 
 ## The transitional state
 
-The migration proceeds in isolated changes, largely component by component. At any given commit, the
+The migration proceeds in isolated changes, largely component by component. At any commit, the
 repository can contain:
 
 - bootstrap and CLI paths that still use `GenericConfiguration` before a `ConfigurationSystem`
@@ -207,14 +198,13 @@ the witnessed model.
 
 ### Add or change a Saluki-only key
 
-1. Verify that the key is absent from `schema_overlay.yaml`.
+1. Verify the key is absent from `schema_overlay.yaml`.
 2. Add its destination to the correct `SalukiConfiguration` slice.
 3. If it has a default, define it once in `agent-data-plane-config/src/defaults.rs` and reference it
    from the model and source defaults.
 4. Add the exact source hierarchy and a reliable parsing type to `SalukiOnly`. A **nested** key
-   *requires* this even when its only consumer reads the by-key view: the Saluki-only environment
-   reader discovers its paths from `SalukiOnly`, and it is the sole source that places `DD_FOO_BAR`
-   at `foo.bar`. Without a field, the key is silently unreachable from the environment.
+   *requires* this even when its only consumer reads the by-key view: the reader discovers paths
+   from `SalukiOnly`, so without a field the key is unreachable from the environment.
 5. Add one `seed` assignment to the destination.
 6. (legacy): Keep `SALUKI_KEYS` consistent with the source key, type, and default.
 
@@ -235,21 +225,21 @@ the witnessed model.
    retain migration residue.
 8. Update topology call sites and tests. Preserve behavior tests using typed inputs; remove tests
    only when they tested legacy deserialization and nothing else.
-   - Do *not* rename `from_configuration`. Just change its signature to take typed configuration.
+   - Do *not* rename `from_configuration`. Change its signature to take typed configuration.
 9. Remove the component's `run_config_smoke_tests` invocation once it no longer deserializes from
-   `GenericConfiguration`. Replace migrated structs in the `used_by` field with
-   `TYPED_CONFIG_SYSTEM`.
+   `GenericConfiguration`. Replace migrated structs in `used_by` with `TypedConfigSystem` in
+   `schema_overlay.yaml`, or the string `TYPED_CONFIG_SYSTEM` in `SALUKI_KEYS`.
 10. Higher risk cutovers should be tested with correctness or integration tests that exercise the
     affected configurations.
 
 A cutover should be behaviorally transparent. If the old behavior conflicts with the source schema
 or typed-system invariants, surface the conflict rather than silently choosing one. After cutover
 artifacts of deserialization logic should not be left behind. For example, no `derive(Deserialize)`
-and if possible a held `Option<SomeType>` should collapse to a held `SomeType` if possible.
+and a held `Option<SomeType>` should collapse to a held `SomeType` if possible.
 
 ## Review checklist
 
-For any configuration change, check the following risks:
+For any configuration change, check the risks:
 
 - **Reachability:** every formerly configurable value still has a source-to-model-to-consumer path.
 - **Defaults:** the effective default is unchanged and is stated once in the config layer.


### PR DESCRIPTION
## Summary

Tighten the config-system skill and add to it a section explaining that our desired end-state is to eliminate saluki-components dependency on agent-data-plane-config. This should help prevent further dependency entrenchment as we migrate to typed config.

## Change Type
- [x] Non-functional (chore, refactoring, docs)


## How did you test this PR?

N/A

## References

- Directly related to #2328 
- The larger project is #2169