### PR TITLE
chore(app, components, core, io): migrate sources/relays to full supervision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4446,6 +4446,7 @@ name = "saluki-io"
 version = "0.1.0"
 dependencies = [
  "async-compression",
+ "async-trait",
  "axum",
  "bytes",
  "chrono",

--- a/bin/agent-data-plane/tests/config_cli.rs
+++ b/bin/agent-data-plane/tests/config_cli.rs
@@ -5,7 +5,7 @@ use http::{Request, Response};
 use http_body_util::Full;
 use hyper::{body::Bytes, service::service_fn};
 use rcgen::{generate_simple_self_signed, CertifiedKey};
-use saluki_io::net::{listener::ConnectionOrientedListener, server::http::HttpServer, ListenAddress};
+use saluki_io::net::{listener::ConnectionOrientedListener, server::http::UnsupervisedHttpServer, ListenAddress};
 use tokio::{process::Command, time::timeout};
 
 const PROCESS_TIMEOUT: Duration = Duration::from_secs(15);
@@ -40,7 +40,7 @@ async fn run_config_request(extra_args: &[&str], response_body: &'static str) ->
             Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(response_body.as_bytes()))))
         }
     });
-    let (server_shutdown, error_handle) = HttpServer::from_listener(listener, service)
+    let (server_shutdown, error_handle) = UnsupervisedHttpServer::from_listener(listener, service)
         .with_tls_config(server_tls_config)
         .listen();
 

--- a/lib/saluki-app/src/api.rs
+++ b/lib/saluki-app/src/api.rs
@@ -11,7 +11,7 @@ use saluki_api::APIHandler;
 use saluki_error::GenericError;
 use saluki_io::net::{
     listener::ConnectionOrientedListener,
-    server::{http::HttpServer, multiplex_service::MultiplexService},
+    server::{http::UnsupervisedHttpServer, multiplex_service::MultiplexService},
     util::hyper::TowerToHyperService,
     ListenAddress,
 };
@@ -156,7 +156,7 @@ impl APIBuilder {
         ));
 
         // Create and spawn the HTTP server.
-        let mut http_server = HttpServer::from_listener(listener, multiplexed_service);
+        let mut http_server = UnsupervisedHttpServer::from_listener(listener, multiplexed_service);
         if let Some(tls_config) = self.tls_config {
             http_server = http_server.with_tls_config(tls_config);
         }

--- a/lib/saluki-app/src/dynamic_api.rs
+++ b/lib/saluki-app/src/dynamic_api.rs
@@ -31,7 +31,7 @@ use saluki_core::runtime::{
 use saluki_error::{generic_error, GenericError};
 use saluki_io::net::{
     listener::ConnectionOrientedListener,
-    server::{http::HttpServer, multiplex_service::MultiplexService},
+    server::{http::UnsupervisedHttpServer, multiplex_service::MultiplexService},
     util::hyper::TowerToHyperService,
     ListenAddress,
 };
@@ -214,7 +214,7 @@ impl Supervisable for DynamicAPIBuilder {
 
         let multiplexed_service = TowerToHyperService::new(MultiplexService::new(outer_http, outer_grpc));
 
-        let mut http_server = HttpServer::from_listener(listener, multiplexed_service);
+        let mut http_server = UnsupervisedHttpServer::from_listener(listener, multiplexed_service);
         if let Some(tls_config) = self.tls_config.clone() {
             http_server = http_server.with_tls_config(tls_config);
         }

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -29,20 +29,15 @@ use otlp_protos::opentelemetry::proto::collector::metrics::v1::{
 use otlp_protos::opentelemetry::proto::collector::trace::v1::trace_service_server::{TraceService, TraceServiceServer};
 use otlp_protos::opentelemetry::proto::collector::trace::v1::{ExportTraceServiceRequest, ExportTraceServiceResponse};
 use prost::Message;
-use saluki_common::sync::shutdown::ShutdownCoordinator;
-use saluki_common::task::HandleExt as _;
 use saluki_core::accounting::MemoryLimiter;
-use saluki_core::components::ComponentContext;
+use saluki_core::components::{ComponentContext, ComponentSpawner};
 use saluki_core::observability::ComponentMetricsExt;
-use saluki_error::{generic_error, GenericError};
-use saluki_io::net::listener::ConnectionOrientedListener;
-use saluki_io::net::server::http::{ErrorHandle, HttpServer};
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use saluki_io::net::server::{grpc::GrpcServer, http::HttpServer};
 use saluki_io::net::util::hyper::TowerToHyperService;
 use saluki_io::net::ListenAddress;
 use saluki_metrics::MetricsBuilder;
 use stringtheory::MetaString;
-use tokio::runtime::Handle;
-use tonic::transport::Server;
 use tonic::{Request as TonicRequest, Response, Status};
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use tracing::error;
@@ -162,50 +157,46 @@ impl OtlpServerBuilder {
 
     /// Builds and starts the OTLP servers (HTTP and gRPC).
     ///
-    /// Returns the HTTP server shutdown handle and error handle.
+    /// Both servers run on the shared worker pool, since request handling shouldn't contend with the runtime driving
+    /// the topology, and decoding can be compute-heavy for large requests.
+    ///
+    /// # Errors
+    ///
+    /// If the gRPC endpoint isn't a TCP address, the listen addresses can't be bound, or either server can't be
+    /// spawned, an error is returned.
     pub async fn build<H: OtlpHandler>(
-        self, handler: H, memory_limiter: MemoryLimiter, thread_pool_handle: Handle, metrics: Metrics,
-    ) -> Result<(ShutdownCoordinator, ErrorHandle), GenericError> {
+        self, handler: H, memory_limiter: MemoryLimiter, metrics: Metrics, spawner: &ComponentSpawner,
+    ) -> Result<(), GenericError> {
         let otlp_handler = Arc::new(handler);
         let metrics = Arc::new(metrics);
 
         // Create and spawn the gRPC server.
-        let grpc_metrics_server = MetricsServiceServer::new(GrpcServiceImpl::new(
-            otlp_handler.clone(),
-            memory_limiter.clone(),
-            metrics.clone(),
-        ))
-        .max_decoding_message_size(self.grpc_max_recv_msg_size_bytes);
+        let inner_grpc = GrpcServiceImpl::new(otlp_handler.clone(), memory_limiter.clone(), metrics.clone());
 
-        let grpc_logs_server = LogsServiceServer::new(GrpcServiceImpl::new(
-            otlp_handler.clone(),
-            memory_limiter.clone(),
-            metrics.clone(),
-        ))
-        .max_decoding_message_size(self.grpc_max_recv_msg_size_bytes);
+        let grpc_metrics_server =
+            MetricsServiceServer::new(inner_grpc.clone()).max_decoding_message_size(self.grpc_max_recv_msg_size_bytes);
 
-        let grpc_traces_server = TraceServiceServer::new(GrpcServiceImpl::new(
-            otlp_handler.clone(),
-            memory_limiter.clone(),
-            metrics.clone(),
-        ))
-        .max_decoding_message_size(self.grpc_max_recv_msg_size_bytes);
+        let grpc_logs_server =
+            LogsServiceServer::new(inner_grpc.clone()).max_decoding_message_size(self.grpc_max_recv_msg_size_bytes);
 
-        let grpc_server = Server::builder()
+        let grpc_traces_server =
+            TraceServiceServer::new(inner_grpc).max_decoding_message_size(self.grpc_max_recv_msg_size_bytes);
+
+        let ListenAddress::Tcp(grpc_socket_addr) = self.grpc_endpoint else {
+            return Err(generic_error!("OTLP gRPC endpoint must be a TCP address."));
+        };
+
+        let grpc_server = GrpcServer::new(grpc_socket_addr)
             .add_service(grpc_metrics_server)
             .add_service(grpc_logs_server)
             .add_service(grpc_traces_server);
 
-        let grpc_socket_addr = match self.grpc_endpoint {
-            ListenAddress::Tcp(addr) => addr,
-            _ => return Err(generic_error!("OTLP gRPC endpoint must be a TCP address.")),
-        };
-
-        let grpc_listener = tokio::net::TcpListener::bind(grpc_socket_addr)
+        spawner
+            .supervisable(grpc_server)
+            .on_worker_pool()
+            .spawn()
             .await
-            .map_err(|e| generic_error!("Failed to bind OTLP gRPC listener on '{}': {}", grpc_socket_addr, e))?;
-        let grpc_incoming = tonic::transport::server::TcpIncoming::from(grpc_listener);
-        thread_pool_handle.spawn_traced_named("otlp-grpc-server", grpc_server.serve_with_incoming(grpc_incoming));
+            .error_context("Failed to spawn OTLP gRPC server.")?;
 
         // Create and spawn the HTTP server.
         let router = Router::new()
@@ -223,15 +214,16 @@ impl OtlpServerBuilder {
 
         let service = TowerToHyperService::new(router);
 
-        let http_listener = ConnectionOrientedListener::from_listen_address(self.http_endpoint)
+        let http_server = HttpServer::from_listen_address(self.http_endpoint, service);
+
+        spawner
+            .supervisable(http_server)
+            .on_worker_pool()
+            .spawn()
             .await
-            .map_err(|e| generic_error!("Failed to create OTLP HTTP listener: {}", e))?;
+            .error_context("Failed to spawn OTLP HTTP server.")?;
 
-        let (http_shutdown_coordinator, http_error) = HttpServer::from_listener(http_listener, service)
-            .with_executor(thread_pool_handle)
-            .listen();
-
-        Ok((http_shutdown_coordinator, http_error))
+        Ok(())
     }
 }
 

--- a/lib/saluki-components/src/destinations/prometheus/mod.rs
+++ b/lib/saluki-components/src/destinations/prometheus/mod.rs
@@ -26,7 +26,7 @@ use saluki_core::data_model::event::{
 use saluki_error::GenericError;
 use saluki_io::net::{
     listener::ConnectionOrientedListener,
-    server::http::{ErrorHandle, HttpServer},
+    server::http::{ErrorHandle, UnsupervisedHttpServer},
     ListenAddress,
 };
 use serde::Deserialize;
@@ -267,7 +267,7 @@ fn spawn_prom_scrape_service(
         }
     });
 
-    let http_server = HttpServer::from_listener(listener, service);
+    let http_server = UnsupervisedHttpServer::from_listener(listener, service);
     http_server.listen()
 }
 

--- a/lib/saluki-components/src/relays/otlp/mod.rs
+++ b/lib/saluki-components/src/relays/otlp/mod.rs
@@ -114,12 +114,11 @@ impl Relay for OtlpRelay {
         pin!(global_shutdown);
 
         let mut health = context.take_health_handle();
-        let global_thread_pool = context.topology_context().global_thread_pool().clone();
         let memory_limiter = context.topology_context().memory_limiter().clone();
-        let dispatcher = context.dispatcher();
 
         let (payload_tx, mut payload_rx) = mpsc::channel(1024);
 
+        // Build our gRPC and HTTP servers and spawn them.
         let handler = RelayHandler::new(payload_tx);
         let server_builder = OtlpServerBuilder::new(
             http_endpoint.clone(),
@@ -128,8 +127,8 @@ impl Relay for OtlpRelay {
         )
         .with_cors(cors);
 
-        let (http_shutdown, mut http_error) = server_builder
-            .build(handler, memory_limiter, global_thread_pool, metrics)
+        server_builder
+            .build(handler, memory_limiter, metrics, context.spawner())
             .await?;
 
         health.mark_ready();
@@ -141,16 +140,10 @@ impl Relay for OtlpRelay {
                     debug!("Received shutdown signal.");
                     break
                 },
-                error = &mut http_error => {
-                    if let Some(error) = error {
-                        debug!(%error, "HTTP server error.");
-                    }
-                    break;
-                },
                 Some(otlp_payload) = payload_rx.recv() => {
                     let output_name = otlp_payload.signal_type.as_str();
                     let payload = Payload::Grpc(otlp_payload.into_grpc_payload());
-                    if let Err(e) = dispatcher.dispatch_named(output_name, payload).await {
+                    if let Err(e) = context.dispatcher().dispatch_named(output_name, payload).await {
                         error!(error = %e, output = output_name, "Failed to dispatch OTLP payload.");
                     }
                 },
@@ -159,9 +152,6 @@ impl Relay for OtlpRelay {
         }
 
         debug!("Stopping OTLP relay...");
-
-        http_shutdown.shutdown();
-
         debug!("OTLP relay stopped.");
 
         Ok(())

--- a/lib/saluki-components/src/sources/checks_ipc/mod.rs
+++ b/lib/saluki-components/src/sources/checks_ipc/mod.rs
@@ -11,7 +11,6 @@ use datadog_protos::checks::{
     service_check::{ServiceCheck as ProtoServiceCheck, Status as ServiceCheckStatus},
     SendCheckPayloadRequest, SendCheckPayloadResponse,
 };
-use saluki_common::task::HandleExt as _;
 use saluki_context::tags::{Tag, TagSet};
 use saluki_context::Context;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
@@ -25,12 +24,11 @@ use saluki_core::{
     components::{sources::*, ComponentContext},
     data_model::event::log::LogStatus,
 };
-use saluki_error::{generic_error, GenericError};
-use saluki_io::net::ListenAddress;
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use saluki_io::net::{server::grpc::GrpcServer, ListenAddress};
 use stringtheory::MetaString;
 use tokio::sync::mpsc;
 use tokio::{pin, select};
-use tonic::transport::Server;
 use tonic::{Response, Status};
 use tracing::{debug, trace, warn};
 
@@ -101,19 +99,22 @@ impl Source for ChecksIPC {
 
         let (events_tx, mut events_rx) = mpsc::channel(16);
 
-        let grpc_server = Server::builder().add_service(ChecksServer::new(ChecksService {
+        let ListenAddress::Tcp(grpc_socket_addr) = grpc_endpoint else {
+            return Err(generic_error!("Checks IPC gRPC endpoint must be a TCP address."));
+        };
+
+        let grpc_server = GrpcServer::new(grpc_socket_addr).add_service(ChecksServer::new(ChecksService {
             events_tx,
             default_hostname,
         }));
 
-        let grpc_socket_addr = match grpc_endpoint {
-            ListenAddress::Tcp(addr) => addr,
-            _ => return Err(generic_error!("OTLP gRPC endpoint must be a TCP address.")),
-        };
         context
-            .topology_context()
-            .global_thread_pool()
-            .spawn_traced_named("checks-ipc-grpc-server", grpc_server.serve(grpc_socket_addr));
+            .spawner()
+            .supervisable(grpc_server)
+            .on_worker_pool()
+            .spawn()
+            .await
+            .error_context("Failed to spawn Checks IPC gRPC server.")?;
 
         health.mark_ready();
         debug!("Checks IPC source started.");

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -14,7 +14,6 @@ use otlp_protos::opentelemetry::proto::metrics::v1::ResourceMetrics as OtlpResou
 use otlp_protos::opentelemetry::proto::trace::v1::ResourceSpans as OtlpResourceSpans;
 use prost::Message;
 use saluki_common::sync::shutdown::{ShutdownCoordinator, ShutdownHandle};
-use saluki_common::task::HandleExt as _;
 use saluki_context::tags::{SharedTagSet, TagSet};
 use saluki_context::ContextResolver;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
@@ -249,8 +248,6 @@ impl Source for Otlp {
         // Create the internal channel for decoupling the servers from the converter.
         let (tx, rx) = mpsc::channel::<OtlpResource>(1024);
 
-        let mut converter_shutdown_coordinator = ShutdownCoordinator::default();
-
         let metrics_translator = OtlpMetricsTranslator::new(
             metrics_translator_config,
             default_hostname,
@@ -259,29 +256,37 @@ impl Source for Otlp {
             metric_tags,
         )?;
 
-        let thread_pool_handle = context.topology_context().global_thread_pool().clone();
-
-        // Spawn the converter task. This task is shared by both servers.
-        thread_pool_handle.spawn_traced_named(
-            "otlp-resource-converter",
-            run_converter(
-                rx,
-                context.clone(),
-                origin_tag_resolver,
-                converter_shutdown_coordinator.register(),
-                metrics_translator,
-                metrics.clone(),
-                traces_translator,
-            ),
-        );
-
+        // Build our gRPC and HTTP servers and spawn them.
         let handler = SourceHandler::new(tx);
         let server_builder =
             OtlpServerBuilder::new(http_endpoint, grpc_endpoint, grpc_max_recv_msg_size_bytes).with_cors(cors);
-
-        let (http_shutdown, mut http_error) = server_builder
-            .build(handler, memory_limiter.clone(), thread_pool_handle, metrics)
+        server_builder
+            .build(handler, memory_limiter.clone(), metrics.clone(), context.spawner())
             .await?;
+
+        // Run the converter task on the worker pool: translating OTLP resources is highly compute-bound.
+        let converter_context = context.clone();
+
+        let mut converter_shutdown_coordinator = ShutdownCoordinator::default();
+        let converter_shutdown = converter_shutdown_coordinator.register();
+
+        context
+            .spawner()
+            .noninterruptible("resource_converter", |_shutdown| {
+                run_converter(
+                    rx,
+                    converter_context,
+                    origin_tag_resolver,
+                    converter_shutdown,
+                    metrics_translator,
+                    metrics,
+                    traces_translator,
+                )
+            })
+            .on_worker_pool()
+            .spawn()
+            .await
+            .error_context("Failed to spawn OTLP resource converter.")?;
 
         health.mark_ready();
         debug!("OTLP source started.");
@@ -293,19 +298,12 @@ impl Source for Otlp {
                     debug!("Received shutdown signal.");
                     break
                 },
-                error = &mut http_error => {
-                    if let Some(error) = error {
-                        debug!(%error, "HTTP server error.");
-                    }
-                    break;
-                },
                 _ = health.live() => continue,
             }
         }
 
         debug!("Stopping OTLP source...");
 
-        http_shutdown.shutdown();
         converter_shutdown_coordinator.shutdown_and_wait().await;
 
         debug!("OTLP source stopped.");

--- a/lib/saluki-core/src/components/mod.rs
+++ b/lib/saluki-core/src/components/mod.rs
@@ -13,7 +13,7 @@ pub mod sources;
 pub mod transforms;
 
 mod spawner;
-pub use self::spawner::{ChildBuilder, ComponentSpawner};
+pub use self::spawner::{BuilderState, ChildBuilder, ComponentSpawner, OneShot, Restartable};
 
 #[cfg(any(test, feature = "test-util"))]
 pub mod test_util;

--- a/lib/saluki-core/src/components/relays/context.rs
+++ b/lib/saluki-core/src/components/relays/context.rs
@@ -52,6 +52,15 @@ impl RelayContext {
         self.shutdown_handle = Some(shutdown_handle);
     }
 
+    /// Installs the shutdown handle for this relay context, for tests.
+    ///
+    /// The topology runtime does this itself before a relay runs, using the shutdown signal of the component's
+    /// dedicated supervisor. A test that drives a relay through a real shutdown has to stand in for it.
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn set_shutdown_handle_for_test(&mut self, shutdown_handle: ShutdownHandle) {
+        self.set_shutdown_handle(shutdown_handle);
+    }
+
     /// Consumes the shutdown handle of this relay context.
     ///
     /// # Panics

--- a/lib/saluki-core/src/components/sources/context.rs
+++ b/lib/saluki-core/src/components/sources/context.rs
@@ -52,6 +52,15 @@ impl SourceContext {
         self.shutdown_handle = Some(shutdown_handle);
     }
 
+    /// Installs the shutdown handle for this source context, for tests.
+    ///
+    /// The topology runtime does this itself before a source runs, using the shutdown signal of the component's
+    /// dedicated supervisor. A test that drives a source through a real shutdown has to stand in for it.
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn set_shutdown_handle_for_test(&mut self, shutdown_handle: ShutdownHandle) {
+        self.set_shutdown_handle(shutdown_handle);
+    }
+
     /// Consumes the shutdown handle of this source context.
     ///
     /// # Panics

--- a/lib/saluki-core/src/components/spawner.rs
+++ b/lib/saluki-core/src/components/spawner.rs
@@ -1,12 +1,12 @@
 //! Utilities for spawning child tasks attached to specific components in a topology.
-use std::{future::Future, time::Duration};
+use std::{future::Future, marker::PhantomData, time::Duration};
 
 use saluki_common::sync::shutdown::ShutdownHandle;
 use tokio::runtime::Handle;
 
 use crate::runtime::{
-    interruptible_worker, noninterruptible_worker, ChildId, ChildSpecification, FnWorker, IntoWorkerResult,
-    ShutdownStrategy, SpawnError, Supervisable, SupervisorHandle,
+    interruptible_worker, noninterruptible_worker, ChildId, ChildSpecification, IntoWorkerResult, RestartType,
+    ShutdownStrategy, SpawnError, Supervisable, SupervisorHandle, WorkerSpec,
 };
 
 /// Component-scoped spawner for child tasks.
@@ -20,12 +20,21 @@ use crate::runtime::{
 /// spawned through this mechanism are properly attributed to the component, and also that their lifecycle is one-to-one
 /// with the component itself.
 ///
-/// # Child lifecycle
+/// # Child lifecycle, and one-shot vs supervisable
 ///
-/// All child tasks are spawned as [`temporary`][crate::runtime::RestartType::Temporary] and non-significant, which
-/// ensures that the component supervisor does not prematurely exit when they do. This means that, for example, a child
-/// task handling a network error doesn't take down the component if it aborts, which would otherwise be the normal
-/// behavior for a standard child task under supervision.
+/// We classify tasks as either _one-shot_ or _supervisable_: one-shot tasks are those based on a provided closure,
+/// which cannot be reinitialized and so cannot be restarted, and supervisable tasks are those based on an implementation
+/// of [`Supervisable`], which allows for (potentially) initializing the underlying task future multiple times.
+///
+/// One-shot tasks are always [`temporary`][crate::runtime::RestartType::Temporary], since they cannot be
+/// reinitialized. Supervisable tasks default to the same, and opt into being restarted via
+/// [`ChildBuilder::with_restart_type`] when the worker is built to be initialized more than once.
+///
+/// All child tasks default to being marked as non-significant, so their termination -- clean or otherwise -- leaves the
+/// component running. This is usually the correct behavior, but a component that cannot function without a particular
+/// child may wish to mark it significant, which stops the component when that child terminates.
+///
+/// See [`ChildBuilder::with_significant`] for more information.
 ///
 /// # Interruptible vs non-interruptible
 ///
@@ -91,13 +100,91 @@ impl ComponentSpawner {
         Self { handle, worker_pool }
     }
 
-    /// Spawns a child that observes shutdown itself, on the component's own runtime.
+    /// Creates a builder for an interruptible child task.
     ///
-    /// The function receives the supervisor's shutdown signal and decides when it's finished, which makes this the
-    /// right choice for a child that has work to drain.
+    /// Interruptible tasks are implicitly wrapped such that shutdown is polled alongside the underlying task future,
+    /// ensuring that shutdown is observed at the earliest possible moment. They are best used for work which has no
+    /// requirements on orderly shutdown, draining of remaining work, and so on.
     ///
-    /// To place the child on another runtime, or to bound it more tightly than the component as a whole, use
-    /// [`noninterruptible`][Self::noninterruptible] instead.
+    /// Use this method when advanced configuration of the underlying task is required. Otherwise, prefer
+    /// [`spawn_interruptible`][Self::spawn_interruptible].
+    pub fn interruptible<N, Fut>(&self, name: N, fut: Fut) -> ChildBuilder<'_>
+    where
+        N: Into<String>,
+        Fut: Future + Send + 'static,
+        Fut::Output: IntoWorkerResult,
+    {
+        ChildBuilder::one_shot(self, interruptible_worker(name, fut))
+    }
+
+    /// Creates a builder for a non-interruptible child task.
+    ///
+    /// Non-interruptible tasks are those which handle shutdown signals directly in order to precisely control when the
+    /// task completes. They are best used for tasks which must perform some operation, or operations, between the
+    /// receiving of a shutdown signal and completion.
+    ///
+    /// Non-interruptible tasks are not necessarily blocking: running a non-interruptible does not mean that it is guaranteed
+    /// to complete, only that it won't be wrapped in a way that tries to shutdown at the earliest possible moment.
+    ///
+    /// Use this method when advanced configuration of the underlying task is required. Otherwise, prefer
+    /// [`spawn_noninterruptible`][Self::spawn_noninterruptible].
+    pub fn noninterruptible<N, F, Fut>(&self, name: N, f: F) -> ChildBuilder<'_>
+    where
+        N: Into<String>,
+        F: FnOnce(ShutdownHandle) -> Fut + Send + 'static,
+        Fut: Future + Send + 'static,
+        Fut::Output: IntoWorkerResult,
+    {
+        ChildBuilder::one_shot(self, noninterruptible_worker(name, f))
+    }
+
+    /// Creates a builder for a supervisable child task.
+    ///
+    /// Supervisable tasks are those where the worker already implements [`Supervisable`], which lets
+    /// `ComponentSpawner` serve as a consistent control surface for spawning both arbitrary asynchronous functions
+    /// and more full-fledged workers.
+    ///
+    /// Supervisable tasks are set to permanently restart by default.
+    ///
+    /// Use this method when advanced configuration of the underlying task is required. Otherwise, prefer
+    /// [`spawn_supervisable`][Self::spawn_supervisable].
+    pub fn supervisable<T>(&self, worker: T) -> ChildBuilder<'_, Restartable>
+    where
+        T: Supervisable + 'static,
+    {
+        ChildBuilder::restartable(self, worker)
+    }
+
+    /// Spawns an interruptible child task.
+    ///
+    /// Interruptible tasks are implicitly wrapped such that shutdown is polled alongside the underlying task future,
+    /// ensuring that shutdown is observed at the earliest possible moment. They are best used for work which has no
+    /// requirements on orderly shutdown, draining of remaining work, and so on.
+    ///
+    /// Use [`interruptible`][Self::interruptible] when advanced configuration of the underlying task is required.
+    ///
+    /// # Errors
+    ///
+    /// If the component's supervisor isn't running, or the child specification is invalid, an error is returned.
+    pub async fn spawn_interruptible<N, Fut>(&self, name: N, fut: Fut) -> Result<ChildId, SpawnError>
+    where
+        N: Into<String>,
+        Fut: Future + Send + 'static,
+        Fut::Output: IntoWorkerResult,
+    {
+        self.interruptible(name, fut).spawn().await
+    }
+
+    /// Spawns a non-interruptible child task.
+    ///
+    /// Non-interruptible tasks are those which handle shutdown signals directly in order to precisely control when the
+    /// task completes. They are best used for tasks which must perform some operation, or operations, between the
+    /// receiving of a shutdown signal and completion.
+    ///
+    /// Non-interruptible tasks are not necessarily blocking: running a non-interruptible does not mean that it is guaranteed
+    /// to complete, only that it won't be wrapped in a way that tries to shutdown at the earliest possible moment.
+    ///
+    /// Use [`noninterruptible`][Self::noninterruptible] when advanced configuration of the underlying task is required.
     ///
     /// # Errors
     ///
@@ -112,65 +199,13 @@ impl ComponentSpawner {
         self.noninterruptible(name, f).spawn().await
     }
 
-    /// Spawns a child that runs until it completes or shutdown is signalled, on the component's own runtime.
+    /// Spawns a supervisable child task.
     ///
-    /// The future is dropped at whatever await point it's parked on when shutdown fires, so use this only for work
-    /// that is safe to interrupt -- a server accept loop, a connection handler, a periodic refresher.
+    /// Supervisable tasks are those where the worker already implements [`Supervisable`], which lets
+    /// `ComponentSpawner` serve as a consistent control surface for spawning both arbitrary asynchronous functions
+    /// and more full-fledged workers.
     ///
-    /// To place the child on another runtime, or to bound it more tightly than the component as a whole, use
-    /// [`interruptible`][Self::interruptible] instead.
-    ///
-    /// # Errors
-    ///
-    /// If the component's supervisor isn't running, or the child specification is invalid, an error is returned.
-    pub async fn spawn_interruptible<N, Fut>(&self, name: N, fut: Fut) -> Result<ChildId, SpawnError>
-    where
-        N: Into<String>,
-        Fut: Future + Send + 'static,
-        Fut::Output: IntoWorkerResult,
-    {
-        self.interruptible(name, fut).spawn().await
-    }
-
-    /// Describes a child that observes shutdown itself, for configuring before spawning.
-    ///
-    /// Same semantics as [`spawn_noninterruptible`][Self::spawn_noninterruptible]; use this form only when the child
-    /// needs a non-default runtime or grace period. The returned builder does nothing until
-    /// [`spawn`][ChildBuilder::spawn] is called.
-    pub fn noninterruptible<N, F, Fut>(&self, name: N, f: F) -> ChildBuilder<'_>
-    where
-        N: Into<String>,
-        F: FnOnce(ShutdownHandle) -> Fut + Send + 'static,
-        Fut: Future + Send + 'static,
-        Fut::Output: IntoWorkerResult,
-    {
-        ChildBuilder::new(self, noninterruptible_worker(name, f))
-    }
-
-    /// Describes a child that runs until it completes or shutdown is signalled, for configuring before spawning.
-    ///
-    /// Same semantics as [`spawn_interruptible`][Self::spawn_interruptible]; use this form only when the child needs a
-    /// non-default runtime or grace period. The returned builder does nothing until [`spawn`][ChildBuilder::spawn] is
-    /// called.
-    pub fn interruptible<N, Fut>(&self, name: N, fut: Fut) -> ChildBuilder<'_>
-    where
-        N: Into<String>,
-        Fut: Future + Send + 'static,
-        Fut::Output: IntoWorkerResult,
-    {
-        ChildBuilder::new(self, interruptible_worker(name, fut))
-    }
-
-    /// Spawns a child from a hand-written [`Supervisable`].
-    ///
-    /// Use this when a child needs real asynchronous initialization, or state that can't be captured in a closure.
-    ///
-    /// Unlike the other spawn methods, the child's shutdown strategy comes from the worker itself, so a worker that
-    /// reports a finite grace period is held to it in addition to the component's budget -- including the
-    /// [`Supervisable`] default of five seconds, which a worker that doesn't override
-    /// [`shutdown_strategy`][Supervisable::shutdown_strategy] silently inherits. Return
-    /// `ShutdownStrategy::Graceful(Duration::MAX)` from the worker to be bounded by the budget alone, as the other
-    /// spawn methods are.
+    /// Use [`supervisable`][Self::supervisable] when advanced configuration of the underlying task is required.
     ///
     /// # Errors
     ///
@@ -179,9 +214,7 @@ impl ComponentSpawner {
     where
         T: Supervisable + 'static,
     {
-        self.handle
-            .spawn_with(ChildSpecification::one_shot_worker(worker))
-            .await
+        self.supervisable(worker).spawn().await
     }
 
     /// Returns a handle to the shared worker pool owned by the topology.
@@ -202,53 +235,117 @@ impl ComponentSpawner {
     }
 }
 
-/// A child task that has been described but not yet spawned.
-///
-/// Created by [`ComponentSpawner::noninterruptible`] or [`ComponentSpawner::interruptible`], and consumed by
-/// [`spawn`][Self::spawn].
-#[must_use = "a child is only started when `spawn` is called"]
-pub struct ChildBuilder<'a> {
-    spawner: &'a ComponentSpawner,
-    worker: FnWorker,
-    shutdown_timeout: Option<Duration>,
-    runtime: Option<Handle>,
+mod sealed {
+    pub trait Sealed {}
 }
 
-impl<'a> ChildBuilder<'a> {
-    fn new(spawner: &'a ComponentSpawner, worker: FnWorker) -> Self {
+/// The kind of worker a [`ChildBuilder`] is describing.
+///
+/// This trait is sealed, and exists only to mark which configuration a builder makes available: a worker that can be
+/// initialized more than once accepts a restart policy, and one that can't doesn't.
+pub trait BuilderState: sealed::Sealed {}
+
+/// Marks a builder whose worker can only be initialized once.
+///
+/// Closure-based children ([`ComponentSpawner::noninterruptible`], [`ComponentSpawner::interruptible`]) consume their
+/// body when they start, so they can never be restarted, and [`ChildBuilder::with_restart_type`] is not available.
+pub struct OneShot;
+
+/// Marks a builder whose worker can be initialized more than once.
+///
+/// A [`Supervisable`] builds its work in [`initialize`][Supervisable::initialize] each time it starts, so it can be
+/// restarted and [`ChildBuilder::with_restart_type`] is available.
+pub struct Restartable;
+
+impl sealed::Sealed for OneShot {}
+impl BuilderState for OneShot {}
+impl sealed::Sealed for Restartable {}
+impl BuilderState for Restartable {}
+
+/// Builder for a yet-to-be-spawned child task.
+///
+/// Advanced properties of a task can be configured with this builder prior to spawning. This builder uses the
+/// typestate pattern to control which properties of the child task that can be configured (by controlling which
+/// configuration methods are exposed) based on whether the worker is supervisable or not.
+///
+/// See [`BuilderState`] for more information on worker types.
+#[must_use = "a child is only started when `spawn` is called"]
+pub struct ChildBuilder<'a, S = OneShot> {
+    spawner: &'a ComponentSpawner,
+    spec: ChildSpecification<WorkerSpec>,
+    _state: PhantomData<S>,
+}
+
+impl<'a, S: BuilderState> ChildBuilder<'a, S> {
+    fn new(spawner: &'a ComponentSpawner, spec: ChildSpecification<WorkerSpec>) -> Self {
         Self {
             spawner,
-            worker,
-            shutdown_timeout: None,
-            runtime: None,
+            spec,
+            _state: PhantomData,
         }
     }
 
-    /// Runs this child on the shared worker pool owned by the topology, instead of the component's runtime.
+    fn map_spec<F>(self, f: F) -> Self
+    where
+        F: FnOnce(ChildSpecification<WorkerSpec>) -> ChildSpecification<WorkerSpec>,
+    {
+        let Self { spawner, spec, .. } = self;
+
+        Self::new(spawner, f(spec))
+    }
+
+    /// Runs this child task on the shared worker pool owned by the topology, instead of the component's runtime.
     ///
     /// Use this for compute-heavy work -- encoding, serialization, protocol servers -- that shouldn't contend with the
     /// runtime that drives the supervisors and I/O for the topology.
-    pub fn on_worker_pool(mut self) -> Self {
-        self.runtime = Some(self.spawner.worker_pool.clone());
-        self
+    pub fn on_worker_pool(self) -> Self {
+        let worker_pool = self.spawner.worker_pool.clone();
+        self.on_runtime(worker_pool)
     }
 
-    /// Runs this child on a specific runtime.
+    /// Runs this child task on a specific runtime.
     ///
     /// Prefer [`on_worker_pool`][Self::on_worker_pool] unless the component owns a runtime of its own.
-    pub fn on_runtime(mut self, handle: Handle) -> Self {
-        self.runtime = Some(handle);
-        self
+    pub fn on_runtime(self, handle: Handle) -> Self {
+        self.map_spec(|spec| spec.with_runtime(handle))
     }
 
-    /// Bounds this child more tightly than the component as a whole.
+    /// Sets an explicit shutdown timeout for this child task.
     ///
-    /// By default a child has no deadline of its own and is bounded only by the component's shutdown budget. Set this
-    /// when the component wants a particular child abandoned sooner than that -- a deadline it is deliberately
-    /// imposing, rather than a guess at how long the child ought to take.
-    pub fn with_shutdown_timeout(mut self, timeout: Duration) -> Self {
-        self.shutdown_timeout = Some(timeout);
-        self
+    /// By default a closure-based child has no deadline of its own and is bounded only by the component's shutdown
+    /// budget. Set this when the component wants a particular child abandoned sooner than that -- a deadline it is
+    /// deliberately imposing, rather than a guess at how long the child ought to take. A value longer than the budget
+    /// has no effect, since the two are resolved to whichever elapses first.
+    ///
+    /// For a [`Supervisable`] child, this overrides the strategy the task reports for itself.
+    pub fn with_shutdown_timeout(self, timeout: Duration) -> Self {
+        self.with_shutdown_strategy(ShutdownStrategy::Graceful(timeout))
+    }
+
+    /// Sets the explicit shutdown strategy used for this child task.
+    pub fn with_shutdown_strategy(self, strategy: ShutdownStrategy) -> Self {
+        self.map_spec(|spec| spec.with_shutdown_strategy(strategy))
+    }
+
+    /// Sets whether this child task's termination should stop the component.
+    ///
+    /// A component's supervisor uses [`AutoShutdown::AnySignificant`][auto_shutdown], so a significant child
+    /// terminating **shuts the component down**: the child is not individually restarted. That happens even when the
+    /// child exits cleanly, so this suits a child the component cannot function without, and not one that is expected
+    /// to finish on its own.
+    ///
+    /// For example, a component handling client connections generally shouldn't stop just because one connection
+    /// failed, but a component forwarding work to a child task may become inoperable if that task dies and cannot be
+    /// reattached to the necessary channels or state without recreating the component.
+    ///
+    /// Only meaningful for a child that can terminate without being restarted, so setting it alongside
+    /// [`RestartType::Permanent`] has no effect: such a child is always restarted and so never reaches this path.
+    ///
+    /// Defaults to `false`.
+    ///
+    /// [auto_shutdown]: crate::runtime::AutoShutdown::AnySignificant
+    pub fn with_significant(self, significant: bool) -> Self {
+        self.map_spec(|spec| spec.with_significant(significant))
     }
 
     /// Spawns the child, returning once the supervisor has started it.
@@ -260,48 +357,169 @@ impl<'a> ChildBuilder<'a> {
     /// the component's `run`, so `SupervisorGone` in a component indicates that the topology is already being torn
     /// down.
     pub async fn spawn(self) -> Result<ChildId, SpawnError> {
-        let Self {
-            spawner,
-            worker,
-            shutdown_timeout,
-            runtime,
-        } = self;
-
-        // `one_shot_worker` registers the child as temporary, which a function-based worker requires: restarting one
-        // re-initializes a body that has already been consumed, failing the child and its supervisor.
-        //
-        // Unless the caller asked for a tighter bound, the child gets no deadline of its own and is bounded solely by
-        // the component supervisor's shutdown budget.
-        let strategy = ShutdownStrategy::Graceful(shutdown_timeout.unwrap_or(Duration::MAX));
-        let mut spec = ChildSpecification::one_shot_worker(worker).with_shutdown_strategy(strategy);
-
-        if let Some(runtime) = runtime {
-            spec = spec.with_runtime(runtime);
-        }
+        let Self { spawner, spec, .. } = self;
 
         spawner.handle.spawn_with(spec).await
     }
 }
 
+impl<'a> ChildBuilder<'a, OneShot> {
+    fn one_shot<T>(spawner: &'a ComponentSpawner, worker: T) -> Self
+    where
+        T: Supervisable + 'static,
+    {
+        let spec = ChildSpecification::one_shot_worker(worker)
+            .with_restart_type(RestartType::Temporary)
+            .with_shutdown_strategy(ShutdownStrategy::Graceful(Duration::MAX));
+
+        Self::new(spawner, spec)
+    }
+}
+
+impl<'a> ChildBuilder<'a, Restartable> {
+    fn restartable<T>(spawner: &'a ComponentSpawner, worker: T) -> Self
+    where
+        T: Supervisable + 'static,
+    {
+        Self::new(spawner, ChildSpecification::worker(worker))
+    }
+
+    /// Sets the restart type for this child task.
+    ///
+    /// Supervised tasks that are defined through [`Supervisable`] default to being restarted permanently, since their
+    /// structure naturally exposes a mechanism to allow initializing a worker more than once. However, in some cases,
+    /// it may be desirable to disallow restarting a specific worker and instead treat their exit differently: only
+    /// restart when the worker exits abnormally, or never restart the worker, and so on.
+    ///
+    /// Defaults to [`RestartType::Permanent`].
+    pub fn with_restart_type(self, restart_type: RestartType) -> Self {
+        self.map_spec(|spec| spec.with_restart_type(restart_type))
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
+    use std::{
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc, Mutex,
+        },
+        thread::ThreadId,
     };
 
+    use async_trait::async_trait;
     use saluki_metrics::test::TestRecorder;
     use tokio::sync::oneshot;
     use tokio::time::timeout;
 
     use super::*;
     use crate::components::test_util::TestComponentSupervisor;
+    use crate::runtime::SupervisorError;
 
     /// How long the drain-participating child in these tests takes to finish after observing shutdown.
     ///
     /// Long enough that a child given any short deadline of its own would be aborted before completing, so the tests
     /// fail if children stop being bounded by the supervisor's budget alone.
     const DRAIN_DURATION: Duration = Duration::from_millis(300);
+
+    /// A hand-written [`Supervisable`] that records where and how often it was initialized, then runs until shutdown.
+    struct CountingWorker {
+        name: &'static str,
+        initializations: Arc<AtomicUsize>,
+        thread_id: Arc<Mutex<Option<ThreadId>>>,
+    }
+
+    impl CountingWorker {
+        fn new(name: &'static str) -> (Self, Arc<AtomicUsize>, Arc<Mutex<Option<ThreadId>>>) {
+            let thread_id = Arc::new(Mutex::new(None));
+            let initializations = Arc::new(AtomicUsize::new(0));
+
+            (
+                Self {
+                    name,
+                    initializations: Arc::clone(&initializations),
+                    thread_id: Arc::clone(&thread_id),
+                },
+                initializations,
+                thread_id,
+            )
+        }
+    }
+
+    #[async_trait]
+    impl Supervisable for CountingWorker {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn shutdown_strategy(&self) -> ShutdownStrategy {
+            ShutdownStrategy::Graceful(Duration::MAX)
+        }
+
+        async fn initialize(
+            &self, process_shutdown: ShutdownHandle,
+        ) -> Result<crate::runtime::SupervisorFuture, crate::runtime::InitializationError> {
+            self.initializations.fetch_add(1, Ordering::SeqCst);
+            *self.thread_id.lock().unwrap() = Some(std::thread::current().id());
+
+            Ok(Box::pin(async move {
+                process_shutdown.await;
+                Ok(())
+            }))
+        }
+    }
+
+    /// A [`Supervisable`] that fails its first run and waits for shutdown on every run after.
+    struct FailingOnceWorker {
+        initializations: Arc<AtomicUsize>,
+    }
+
+    impl FailingOnceWorker {
+        fn new() -> (Self, Arc<AtomicUsize>) {
+            let initializations = Arc::new(AtomicUsize::new(0));
+            (
+                Self {
+                    initializations: Arc::clone(&initializations),
+                },
+                initializations,
+            )
+        }
+    }
+
+    #[async_trait]
+    impl Supervisable for FailingOnceWorker {
+        fn name(&self) -> &str {
+            "failing_once"
+        }
+
+        fn shutdown_strategy(&self) -> ShutdownStrategy {
+            ShutdownStrategy::Graceful(Duration::MAX)
+        }
+
+        async fn initialize(
+            &self, process_shutdown: ShutdownHandle,
+        ) -> Result<crate::runtime::SupervisorFuture, crate::runtime::InitializationError> {
+            let first_run = self.initializations.fetch_add(1, Ordering::SeqCst) == 0;
+
+            Ok(Box::pin(async move {
+                if first_run {
+                    return Err(saluki_error::generic_error!("first run always fails"));
+                }
+
+                process_shutdown.await;
+                Ok(())
+            }))
+        }
+    }
+
+    /// Polls `condition` until it holds, panicking after a few seconds.
+    async fn wait_for(mut condition: impl FnMut() -> bool) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while !condition() {
+            assert!(tokio::time::Instant::now() < deadline, "condition never became true");
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    }
 
     #[tokio::test]
     async fn noninterruptible_child_observes_shutdown_and_supervisor_exits_cleanly() {
@@ -435,6 +653,135 @@ mod tests {
         assert!(
             polls.is_some_and(|polls| polls > 0),
             "spawned child should have recorded poll metrics, got {polls:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn supervisable_child_can_be_configured_before_spawning() {
+        let worker_pool_thread_id = Arc::new(Mutex::new(None));
+        let worker_pool_thread_id2 = Arc::clone(&worker_pool_thread_id);
+
+        // Create a dedicated worker pool that we'll set as the worker pool on our spawner.
+        //
+        // This pool tracks the thread ID of the single worker thread we create, such that we can take the thread ID in
+        // our running task, and compare it to ensure the worker ran on the worker pool as intended.
+        let pool = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .on_thread_start(move || {
+                worker_pool_thread_id2
+                    .lock()
+                    .unwrap()
+                    .replace(std::thread::current().id());
+            })
+            .enable_all()
+            .build()
+            .expect("should build pool");
+
+        let supervisor = TestComponentSupervisor::start("test_component").await;
+        let spawner = ComponentSpawner::new(supervisor.spawner().handle().clone(), pool.handle().clone());
+
+        let (worker, initializations, worker_thread_id) = CountingWorker::new("counting");
+        spawner
+            .supervisable(worker)
+            .on_worker_pool()
+            .spawn()
+            .await
+            .expect("should spawn");
+
+        // `spawn` returns once the supervisor has registered the child, but `initialize` runs inside the child's own
+        // task -- on the pool's runtime here -- so wait for it rather than assuming it has been polled.
+        supervisor.wait_for_children(1).await;
+        wait_for(|| initializations.load(Ordering::SeqCst) == 1).await;
+
+        // Assert where it actually ran, not just that it ran: without this, `on_worker_pool` could be a no-op and the
+        // test would still pass.
+        let worker_pool_thread_id = worker_pool_thread_id
+            .lock()
+            .unwrap()
+            .expect("worker pool thread should have recorded its thread ID");
+        let worker_thread_id = worker_thread_id
+            .lock()
+            .unwrap()
+            .expect("worker should have recorded its thread ID");
+        assert_eq!(
+            worker_pool_thread_id, worker_thread_id,
+            "child should have run on the worker pool"
+        );
+
+        assert!(supervisor.shutdown().await.is_ok());
+        pool.shutdown_background();
+    }
+
+    #[tokio::test]
+    async fn supervisable_children_are_restarted_by_default() {
+        let supervisor = TestComponentSupervisor::start("test_component").await;
+
+        let (worker, initializations) = FailingOnceWorker::new();
+        supervisor
+            .spawner()
+            .supervisable(worker)
+            .spawn()
+            .await
+            .expect("should spawn");
+
+        // The worker fails its first run, but then runs forever after that, so we should observe two initializations
+        // and no more after that.
+        wait_for(|| initializations.load(Ordering::SeqCst) == 2).await;
+        assert!(supervisor.shutdown().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn one_shot_children_are_bounded_by_the_supervisors_budget() {
+        // A one-shot child carries no deadline of its own, so the supervisor's budget is what bounds it and a stuck
+        // child is aborted when the budget elapses.
+        //
+        // This deliberately does not try to distinguish that from a child having silently fallen back to the
+        // `Supervisable` trait default of five seconds: deadlines resolve to whichever elapses first, so any budget
+        // under five seconds produces an identical result, and telling them apart would need a test that runs for
+        // longer than five seconds. The distinction is unobservable in practice too -- a component supervisor's budget
+        // comes from the topology shutdown timeout, four seconds by default in ADP.
+        let supervisor = TestComponentSupervisor::start_with_budget("test_component", Duration::from_millis(200)).await;
+
+        supervisor
+            .spawner()
+            .spawn_noninterruptible("stuck", |_shutdown| std::future::pending::<()>())
+            .await
+            .expect("should spawn");
+        supervisor.wait_for_children(1).await;
+
+        let started = tokio::time::Instant::now();
+        let result = supervisor.shutdown().await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            matches!(result, Err(SupervisorError::ShutdownTimedOut { aborted: 1 })),
+            "the budget should have aborted the stuck child, got {result:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "the child should have been bounded by the 200ms budget rather than a deadline of its own; took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_significant_child_exiting_stops_the_component() {
+        // The counterpart to `child_exiting_does_not_shut_the_component_down`: a component supervisor uses
+        // `AutoShutdown::AnySignificant`, so a child marked significant takes the component with it when it terminates
+        // -- here on a perfectly clean exit, which is the part that surprises.
+        let supervisor = TestComponentSupervisor::start("test_component").await;
+
+        supervisor
+            .spawner()
+            .noninterruptible("brief", |_shutdown| async {})
+            .with_significant(true)
+            .spawn()
+            .await
+            .expect("should spawn");
+
+        let result = supervisor.shutdown().await;
+        assert!(
+            matches!(result, Err(SupervisorError::SignificantChildExited)),
+            "a significant child's exit should have stopped the supervisor, got {result:?}"
         );
     }
 

--- a/lib/saluki-core/src/components/test_util.rs
+++ b/lib/saluki-core/src/components/test_util.rs
@@ -46,11 +46,24 @@ impl TestComponentSupervisor {
     ///
     /// Panics if `id` isn't a valid supervisor name, or if the supervisor doesn't start within a few seconds.
     pub async fn start(id: &str) -> Self {
+        Self::start_with_budget(id, TEST_SHUTDOWN_BUDGET).await
+    }
+
+    /// Starts a supervisor named `id` with a specific shutdown budget.
+    ///
+    /// Use this to assert that a child is bounded by the budget rather than by a deadline of its own: pick a budget
+    /// shorter than the [`Supervisable`][crate::runtime::Supervisable] default of five seconds, and a child that had
+    /// silently acquired its own deadline will miss it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `id` isn't a valid supervisor name, or if the supervisor doesn't start within a few seconds.
+    pub async fn start_with_budget(id: &str, budget: Duration) -> Self {
         let mut supervisor = Supervisor::new(id)
             .expect("test supervisor name should be valid")
             .with_auto_shutdown(AutoShutdown::AnySignificant)
             .with_shutdown_mode(ShutdownMode::Concurrent)
-            .with_shutdown_budget(TEST_SHUTDOWN_BUDGET);
+            .with_shutdown_budget(budget);
 
         // Take the handle before moving the supervisor into its task; the handle is usable before the run starts, and
         // is how we observe that it has.

--- a/lib/saluki-core/src/runtime/mod.rs
+++ b/lib/saluki-core/src/runtime/mod.rs
@@ -76,6 +76,6 @@ pub use self::supervisor::{
 };
 
 mod workers;
-pub use self::workers::{interruptible_worker, noninterruptible_worker, FnWorker, IntoWorkerResult};
+pub use self::workers::{interruptible_worker, noninterruptible_worker, IntoWorkerResult};
 
 mod worker_state;

--- a/lib/saluki-core/src/topology/component_worker.rs
+++ b/lib/saluki-core/src/topology/component_worker.rs
@@ -1,18 +1,21 @@
 //! Adapts a built topology component into a [`Supervisable`] worker.
 //!
-//! Each component in a topology runs as the sole, _significant_ child of its own dedicated supervisor
-//! (see [`BuiltTopology::spawn_inner`][super::built::BuiltTopology::spawn_inner]). To be supervised, a
-//! component must be presented as a [`Supervisable`]: [`ComponentWorker`] wraps an already-built
-//! component together with its context and bridges the two.
+//! Each component in a topology runs as the sole, _significant_ child of its own dedicated supervisor (see
+//! [`BuiltTopology::spawn_inner`][super::built::BuiltTopology::spawn_inner]). To be supervised, a component must be
+//! presented as a [`Supervisable`]: [`ComponentWorker`] wraps an already-built component together with its context and
+//! bridges the two.
 //!
-//! A component is built once (during topology initialization) and run once, so the wrapped component is
-//! held behind a take-once [`Mutex`] and consumed by [`Supervisable::initialize`]. Sources and relays
-//! drive their own shutdown, so the supervisor-provided shutdown handle is installed into their context;
-//! the remaining component kinds stop when their upstream channels close and ignore it.
+//! A component is built once (during topology initialization) and run once, so the wrapped component is held behind a
+//! take-once [`Mutex`] and consumed by [`Supervisable::initialize`]. Sources and relays drive their own shutdown, so
+//! the supervisor-provided shutdown handle is installed into their context; the remaining component kinds stop when
+//! their upstream channels close and ignore it.
 //!
-//! A component carries no shutdown deadline of its own. Its supervisor holds one budget covering the
-//! component and every task it spawned, so the whole subtree is bounded by a single number rather than a
-//! guess per worker. See [`Supervisor::with_shutdown_budget`][crate::runtime::Supervisor::with_shutdown_budget].
+//! A component carries no shutdown deadline of its own. Its supervisor holds one budget covering the component and
+//! every task it spawned, so the subtree is bounded by a single number rather than a guess per worker. See
+//! [`Supervisor::with_shutdown_budget`][crate::runtime::Supervisor::with_shutdown_budget].
+//!
+//! The one exception is a child spawned from a hand-written [`Supervisable`][crate::runtime::Supervisable], which
+//! reports its own shutdown strategy; that child is held to whichever of its deadline and the budget elapses first.
 
 use std::sync::Mutex;
 use std::time::Duration;

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -14,6 +14,7 @@ fips = ["saluki-tls/fips"]
 
 [dependencies]
 async-compression = { workspace = true, features = ["gzip", "tokio", "zlib"] }
+async-trait = { workspace = true }
 axum = { workspace = true, features = ["tokio"] }
 bytes = { workspace = true }
 chrono = { workspace = true }
@@ -65,7 +66,7 @@ tokio = { workspace = true, features = [
   "sync",
 ] }
 tokio-rustls = { workspace = true }
-tonic = { workspace = true }
+tonic = { workspace = true, features = ["server"] }
 tower = { workspace = true, features = ["retry", "timeout", "util"] }
 tracing = { workspace = true }
 # Adds support for `Arc::into_unique` to recover `UniqueArc` instances.

--- a/lib/saluki-io/src/net/server/grpc.rs
+++ b/lib/saluki-io/src/net/server/grpc.rs
@@ -1,0 +1,234 @@
+use std::{convert::Infallible, net::SocketAddr, time::Duration};
+
+use async_trait::async_trait;
+use http::Request;
+use saluki_common::sync::shutdown::ShutdownHandle;
+use saluki_core::runtime::{InitializationError, ShutdownStrategy, Supervisable, SupervisorFuture};
+use saluki_error::ErrorContext as _;
+use tokio::{pin, select, sync::oneshot, time::timeout};
+use tonic::{
+    body::Body,
+    server::NamedService,
+    service::Routes,
+    transport::{server::TcpIncoming, Server},
+};
+use tower::Service;
+use tracing::warn;
+
+/// A gRPC server.
+///
+/// Allows serving multiple gRPC services from a single endpoint.
+///
+/// This type is a thin wrapper over helper types from `tonic` and `axum`, and principally is meant to provide an opaque
+/// gRPC server implementation that operates correctly when run under supervision. As such, this type can't be manually
+/// served: it is only usable by adding it to a supervisor.
+///
+/// # Supervision
+///
+/// The listen address is bound during initialization, so a failure to bind is raised before the supervised worker
+/// starts running, and a restart rebinds.
+///
+/// The server will attempt to gracefully shutdown existing connections when the parent supervisor signals shutdown.
+/// This will cause the worker to utilize the maximum allowable grace period during shutdown: it will attempt to take as
+/// long as necessary to gracefully shutdown existing connections, bounded only by the parent supervisor.
+///
+/// # Missing
+///
+/// - Accepting `ListenAddress` to optionally listen on a Unix Domain socket or other connection-oriented transport.
+pub struct GrpcServer {
+    listen_addr: SocketAddr,
+    routes: Option<Routes>,
+    graceful_shutdown_timeout: Option<Duration>,
+}
+
+impl GrpcServer {
+    /// Creates an empty server with no attached services, configured to listen on the given address.
+    pub fn new(listen_addr: SocketAddr) -> Self {
+        Self {
+            listen_addr,
+            routes: None,
+            graceful_shutdown_timeout: None,
+        }
+    }
+
+    /// Sets the graceful shutdown timeout for this server.
+    ///
+    /// During shutdown, the server will for all in-flight connections to complete before ultimately completing itself.
+    /// When no timeout is specified, this will lead to the worker taking the maximum allowable time to shutdown if
+    /// connections are blocked or otherwise "stuck." Setting an explicit graceful shutdown timeout will cause the
+    /// worker to bound how long it waits for in-flight connections to shutdown before forcefully completing and moving
+    /// on.
+    ///
+    /// Defaults to no timeout (wait as long as allowed).
+    pub fn with_graceful_shutdown_timeout(mut self, timeout: Duration) -> Self {
+        self.graceful_shutdown_timeout = Some(timeout);
+        self
+    }
+
+    /// Adds a new service to this server.
+    pub fn add_service<S>(mut self, svc: S) -> Self
+    where
+        S: Service<Request<Body>, Error = Infallible> + NamedService + Clone + Send + Sync + 'static,
+        S::Response: axum::response::IntoResponse,
+        S::Future: Send + 'static,
+    {
+        let routes = self.routes.take().unwrap_or_default().add_service(svc);
+
+        Self {
+            routes: Some(routes),
+            ..self
+        }
+    }
+}
+
+#[async_trait]
+impl Supervisable for GrpcServer {
+    fn name(&self) -> &str {
+        "grpc_server"
+    }
+
+    fn shutdown_strategy(&self) -> ShutdownStrategy {
+        // Utilize the maximum allowable grace period to give connections a chance to gracefully shutdown.
+        ShutdownStrategy::Graceful(Duration::MAX)
+    }
+
+    async fn initialize(&self, process_shutdown: ShutdownHandle) -> Result<SupervisorFuture, InitializationError> {
+        // Try binding our listen address during initialization to surface issues earlier.
+        let listener = TcpIncoming::bind(self.listen_addr)
+            .with_error_context(|| format!("Failed to bind listener for gRPC server ({}).", self.listen_addr))?;
+
+        let listen_addr = self.listen_addr;
+        let routes = self.routes.clone().unwrap_or_default();
+        let shutdown_timeout = self.graceful_shutdown_timeout.unwrap_or(Duration::MAX);
+
+        Ok(Box::pin(async move {
+            let (drain_tx, drain_rx) = oneshot::channel();
+            let serve = Server::default().serve_with_incoming_shutdown(routes, listener, async move {
+                let _ = drain_rx.await;
+            });
+
+            pin!(serve, process_shutdown);
+
+            select! {
+                result = &mut serve => result.error_context("Failed to serve gRPC server."),
+
+                _ = &mut process_shutdown => {
+                    // Tell the server to shutdown and drain connections, and then continue driving the server
+                    // future to actually let it finish up and wait for all connections to drain/close.
+                    let _ = drain_tx.send(());
+
+                    match timeout(shutdown_timeout, serve).await {
+                        Ok(Ok(())) => Ok(()),
+                        Ok(Err(e)) => Err(e).error_context("Failed to serve gRPC server."),
+                        Err(_) => {
+                            warn!(%listen_addr, "Failed to gracefully drain gRPC connections.");
+                            Ok(())
+                        },
+                    }
+                },
+            }
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::TcpListener as StdTcpListener;
+
+    use saluki_common::sync::shutdown::ShutdownCoordinator;
+    use tokio::io::AsyncWriteExt as _;
+    use tokio::net::TcpStream;
+    use tokio::time::timeout;
+
+    use super::*;
+
+    /// Bound on any server await in these tests, so a hang fails rather than stalling the suite.
+    const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+    /// Reserves a loopback port and releases it, yielding an address a server can bind.
+    fn free_local_addr() -> SocketAddr {
+        let listener = StdTcpListener::bind("127.0.0.1:0").expect("should bind an ephemeral port");
+        let addr = listener.local_addr().expect("should have a local address");
+        drop(listener);
+        addr
+    }
+
+    #[tokio::test]
+    async fn binds_during_initialization() {
+        // The listener is bound by `initialize`, so the port is taken before anything serves. That is what makes a bind
+        // failure a non-restartable initialization error rather than a runtime one.
+        let addr = free_local_addr();
+        let run = GrpcServer::new(addr)
+            .initialize(ShutdownHandle::noop())
+            .await
+            .expect("should initialize");
+
+        assert!(
+            StdTcpListener::bind(addr).is_err(),
+            "initialization should have bound {addr} before the worker future ran"
+        );
+
+        drop(run);
+    }
+
+    #[tokio::test]
+    async fn bind_failure_is_an_initialization_error() {
+        let addr = free_local_addr();
+        let _held = StdTcpListener::bind(addr).expect("should hold the address");
+
+        match GrpcServer::new(addr).initialize(ShutdownHandle::noop()).await {
+            Ok(_) => panic!("initialization should have failed to bind {addr}"),
+            Err(e) => {
+                let error = e.to_string();
+                assert!(error.contains("Failed to bind listener"), "unexpected error: {error}");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn releases_its_port_once_the_worker_finishes() {
+        let addr = free_local_addr();
+        let mut coordinator = ShutdownCoordinator::default();
+        let run = GrpcServer::new(addr)
+            .initialize(coordinator.register())
+            .await
+            .expect("should initialize");
+
+        coordinator.shutdown();
+        timeout(TEST_TIMEOUT, run)
+            .await
+            .expect("server should stop on shutdown")
+            .expect("server should stop cleanly");
+
+        assert!(
+            StdTcpListener::bind(addr).is_ok(),
+            "the server should have released {addr} when its worker finished"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_idle_peer_does_not_wedge_the_drain() {
+        // `tonic` waits for every connection to close and imposes no bound of its own, so a peer that connects and then
+        // does nothing would otherwise hold shutdown open indefinitely.
+        let addr = free_local_addr();
+        let mut coordinator = ShutdownCoordinator::default();
+        let run = GrpcServer::new(addr)
+            .with_graceful_shutdown_timeout(Duration::from_secs(1))
+            .initialize(coordinator.register())
+            .await
+            .expect("should initialize");
+        let run = tokio::spawn(run);
+
+        let mut stream = TcpStream::connect(addr).await.expect("should connect");
+        stream.write_all(b"PRI * HTTP/2.0\r\n").await.expect("should write");
+        stream.flush().await.expect("should flush");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        coordinator.shutdown();
+        timeout(TEST_TIMEOUT, run)
+            .await
+            .expect("server should finish draining rather than waiting on an idle peer")
+            .expect("server task should not panic")
+            .expect("server should stop cleanly");
+    }
+}

--- a/lib/saluki-io/src/net/server/http.rs
+++ b/lib/saluki-io/src/net/server/http.rs
@@ -1,17 +1,27 @@
-//! Basic HTTP server.
+//! HTTP servers.
+//!
+//! [`HttpServer`] is the supervised server, and is what new code should use: it runs as a child of whatever supervisor
+//! it is added to, binds its listener during initialization, and drains in-flight connections before it reports being
+//! done. [`UnsupervisedHttpServer`] is the older, self-spawning form, kept only until its remaining callers move over.
 
 use std::{
     future::Future,
     pin::Pin,
     sync::Arc,
     task::{ready, Context, Poll},
+    time::Duration,
 };
 
+use async_trait::async_trait;
 use http::{Request, Response};
 use http_body::Body;
-use hyper::{body::Incoming, service::Service};
+use hyper::{
+    body::Incoming,
+    rt::{Read, Write},
+    service::Service,
+};
 use hyper_util::{
-    rt::{TokioExecutor, TokioIo},
+    rt::{TokioExecutor, TokioIo, TokioTimer},
     server::conn::auto::Builder,
 };
 use rustls::ServerConfig;
@@ -19,36 +29,158 @@ use saluki_common::{
     sync::shutdown::{ShutdownCoordinator, ShutdownHandle},
     task::{spawn_traced_named, HandleExt as _},
 };
-use saluki_error::GenericError;
+use saluki_core::runtime::{InitializationError, ShutdownStrategy, Supervisable, SupervisorFuture};
+use saluki_error::{ErrorContext as _, GenericError};
 use saluki_tls::ensure_server_config_fips_compliant;
-use tokio::{pin, runtime::Handle, select, sync::oneshot};
+use tokio::{pin, runtime::Handle, select, sync::oneshot, time::timeout};
 use tokio_rustls::TlsAcceptor;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
-use crate::net::listener::ConnectionOrientedListener;
+use crate::net::{listener::ConnectionOrientedListener, ListenAddress};
+
+fn build_conn_builder() -> Builder<TokioExecutor> {
+    let mut builder = Builder::new(TokioExecutor::new());
+    builder
+        .http1()
+        .timer(TokioTimer::new())
+        .header_read_timeout(Duration::from_secs(10));
+    builder
+}
 
 /// An HTTP server.
+///
+/// Serves a single [`Service`] over a connection-oriented listener, optionally with TLS. The server can't be run
+/// directly: it is only usable by adding it to a supervisor.
+///
+/// # Supervision
+///
+/// The listen address is bound during initialization, so a failure to bind is raised before the supervised worker
+/// starts running, and a restart rebinds.
+///
+/// The server will attempt to gracefully shutdown existing connections when the parent supervisor signals shutdown.
+/// This will cause the worker to utilize the maximum allowable grace period during shutdown: it will attempt to take as
+/// long as necessary to gracefully shutdown existing connections, bounded only by the parent supervisor.
 pub struct HttpServer<S> {
-    executor: Handle,
-    listener: ConnectionOrientedListener,
-    conn_builder: Builder<TokioExecutor>,
-    service: S,
+    listen_address: ListenAddress,
     tls_config: Option<ServerConfig>,
+    conn_builder: Builder<TokioExecutor>,
+    graceful_shutdown_timeout: Option<Duration>,
+    service: S,
 }
 
 impl<S> HttpServer<S> {
-    /// Creates a new `HttpServer` from the given listener and service.
+    /// Creates a server that will listen on the given address.
+    pub fn from_listen_address(listen_address: ListenAddress, service: S) -> Self {
+        Self {
+            listen_address,
+            tls_config: None,
+            conn_builder: build_conn_builder(),
+            graceful_shutdown_timeout: None,
+            service,
+        }
+    }
+
+    /// Sets the graceful shutdown timeout for this server.
+    ///
+    /// During shutdown, the server will for all in-flight connections to complete before ultimately completing itself.
+    /// When no timeout is specified, this will lead to the worker taking the maximum allowable time to shutdown if
+    /// connections are blocked or otherwise "stuck." Setting an explicit graceful shutdown timeout will cause the
+    /// worker to bound how long it waits for in-flight connections to shutdown before forcefully completing and moving
+    /// on.
+    ///
+    /// Defaults to no timeout (wait as long as allowed).
+    pub fn with_graceful_shutdown_timeout(mut self, timeout: Duration) -> Self {
+        self.graceful_shutdown_timeout = Some(timeout);
+        self
+    }
+
+    /// Sets the TLS configuration for the server.
+    ///
+    /// This enables TLS, after which the server only accepts connections that are encrypted with TLS.
+    ///
+    /// Defaults to TLS being disabled.
+    pub fn with_tls_config(mut self, config: ServerConfig) -> Self {
+        self.tls_config = Some(config);
+        self
+    }
+}
+
+#[async_trait]
+impl<S, B> Supervisable for HttpServer<S>
+where
+    S: Service<Request<Incoming>, Response = Response<B>> + Send + Sync + Clone + 'static,
+    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Future: Send + 'static,
+    B: Body + Send + 'static,
+    B::Data: Send,
+    B::Error: std::error::Error + Send + Sync,
+{
+    fn name(&self) -> &str {
+        "http_server"
+    }
+
+    fn shutdown_strategy(&self) -> ShutdownStrategy {
+        // Utilize the maximum allowable grace period to give connections a chance to gracefully shutdown.
+        ShutdownStrategy::Graceful(Duration::MAX)
+    }
+
+    async fn initialize(&self, process_shutdown: ShutdownHandle) -> Result<SupervisorFuture, InitializationError> {
+        // Try binding our listener during initialization to surface issues earlier.
+        let listener = ConnectionOrientedListener::from_listen_address(self.listen_address.clone())
+            .await
+            .with_error_context(|| format!("Failed to bind listener for HTTP server ({}).", self.listen_address))?;
+
+        let conn_builder = self.conn_builder.clone();
+        let service = self.service.clone();
+        let tls_config = self.tls_config.clone();
+        let maybe_shutdown_timeout = self.graceful_shutdown_timeout;
+
+        // Connection handlers land on whichever runtime the supervisor placed this worker on, so nothing needs to be
+        // threaded through: where the server runs is decided at the point it's spawned.
+        //
+        // TODO: Create our own custom `Executor` impl that can be used to bridge to a given supervisor such that we
+        // spawn dynamic/temporary child workers instead of directly on the underlying Tokio runtime.
+        let executor = Handle::current();
+
+        Ok(Box::pin(run_accept_loop(
+            listener,
+            conn_builder,
+            service,
+            tls_config,
+            executor,
+            process_shutdown,
+            maybe_shutdown_timeout,
+        )))
+    }
+}
+
+/// An HTTP server that spawns and manages itself.
+///
+/// # Deprecated
+///
+/// Callers should generally prefer to use [`HttpServer`], as it is designed to run under supervision and play nicely
+/// with supervision trees: graceful shutdown, spawning of connection handlers in the right place, etc.
+pub struct UnsupervisedHttpServer<S> {
+    listener: ConnectionOrientedListener,
+    tls_config: Option<ServerConfig>,
+    conn_builder: Builder<TokioExecutor>,
+    executor: Handle,
+    service: S,
+}
+
+impl<S> UnsupervisedHttpServer<S> {
+    /// Creates a new `UnsupervisedHttpServer` from the given listener and service.
     ///
     /// # Panics
     ///
     /// This will panic if called outside the context of a Tokio runtime.
     pub fn from_listener(listener: ConnectionOrientedListener, service: S) -> Self {
         Self {
-            executor: Handle::current(),
             listener,
-            conn_builder: Builder::new(TokioExecutor::new()),
-            service,
             tls_config: None,
+            conn_builder: build_conn_builder(),
+            executor: Handle::current(),
+            service,
         }
     }
 
@@ -67,14 +199,14 @@ impl<S> HttpServer<S> {
     /// This executor will be used for spawning tasks to handle incoming connections, but _not_ for the spawn that accepts
     /// new connections.
     ///
-    /// Defaults to the current Tokio runtime at the time `HttpServer::new` is called.
+    /// Defaults to the current Tokio runtime at the time [`from_listener`][Self::from_listener] is called.
     pub fn with_executor(mut self, executor: Handle) -> Self {
         self.executor = executor;
         self
     }
 }
 
-impl<S, B> HttpServer<S>
+impl<S, B> UnsupervisedHttpServer<S>
 where
     S: Service<Request<Incoming>, Response = Response<B>> + Send + Clone + 'static,
     S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
@@ -93,88 +225,152 @@ where
 
         let Self {
             executor,
-            mut listener,
+            listener,
             conn_builder,
             service,
             tls_config,
-            ..
         } = self;
 
         spawn_traced_named("http-server-acceptor", async move {
-            let maybe_tls_acceptor = match tls_config {
-                Some(mut config) => {
-                    // Allow for HTTP/1.1 and HTTP/2.
-                    config.alpn_protocols.push(b"h2".to_vec());
-                    config.alpn_protocols.push(b"http/1.1".to_vec());
-
-                    if let Err(e) = ensure_server_config_fips_compliant(&mut config) {
-                        let _ = error_tx.send(e);
-                        return;
-                    }
-
-                    Some(TlsAcceptor::from(Arc::new(config)))
-                }
-                None => None,
-            };
-            let tls_enabled = maybe_tls_acceptor.is_some();
-
-            info!(listen_addr = %listener.listen_address(), tls_enabled, "HTTP server started.");
-
-            pin!(shutdown);
-
-            loop {
-                select! {
-                    result = listener.accept() => match result {
-                        Ok(stream) => {
-                            let service = service.clone();
-                            let conn_builder = conn_builder.clone();
-                            let listen_addr = listener.listen_address().clone();
-                            match &maybe_tls_acceptor {
-                                Some(acceptor) => {
-                                    let tls_stream = match acceptor.accept(stream).await {
-                                        Ok(stream) => stream,
-                                        Err(e) => {
-                                            error!(%listen_addr, error = %e, "Failed to complete TLS handshake.");
-                                            continue
-                                        },
-                                    };
-
-                                    executor.spawn_traced_named("http-server-tls-conn-handler", async move {
-                                        if let Err(e) = conn_builder.serve_connection(TokioIo::new(tls_stream), service).await {
-                                            error!(%listen_addr, error = %e, "Failed to serve HTTP connection.");
-                                        }
-                                    });
-                                },
-                                None => {
-                                    executor.spawn_traced_named("http-server-conn-handler", async move {
-                                        if let Err(e) = conn_builder.serve_connection(TokioIo::new(stream), service).await {
-                                            error!(%listen_addr, error = %e, "Failed to serve HTTP connection.");
-                                        }
-                                    });
-                                },
-                            }
-                        },
-                        Err(e) => {
-                            let _ = error_tx.send(e.into());
-                            break;
-                        }
-                    },
-
-                    _ = &mut shutdown => {
-                        debug!(listen_addr = %listener.listen_address(), "Received shutdown signal.");
-                        break;
-                    }
-                }
+            if let Err(e) = run_accept_loop(listener, conn_builder, service, tls_config, executor, shutdown, None).await
+            {
+                let _ = error_tx.send(e);
             }
-
-            info!(listen_addr = %listener.listen_address(), "HTTP server stopped.");
         });
 
         (shutdown_coordinator, ErrorHandle(error_rx))
     }
 }
 
-/// A future that resolves when [`HttpServer`] encounters an unrecoverable error.
+/// Accepts connections until shutdown is signalled or the listener fails.
+///
+/// Returns once every connection it accepted has finished, so a caller that awaits this can be sure no request is still
+/// being served.
+async fn run_accept_loop<S, B>(
+    mut listener: ConnectionOrientedListener, conn_builder: Builder<TokioExecutor>, service: S,
+    tls_config: Option<ServerConfig>, executor: Handle, shutdown: ShutdownHandle,
+    maybe_shutdown_timeout: Option<Duration>,
+) -> Result<(), GenericError>
+where
+    S: Service<Request<Incoming>, Response = Response<B>> + Send + Clone + 'static,
+    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Future: Send + 'static,
+    B: Body + Send + 'static,
+    B::Data: Send,
+    B::Error: std::error::Error + Send + Sync,
+{
+    let maybe_tls_acceptor = match tls_config {
+        Some(mut config) => {
+            // Allow for HTTP/1.1 and HTTP/2.
+            config.alpn_protocols.push(b"h2".to_vec());
+            config.alpn_protocols.push(b"http/1.1".to_vec());
+
+            ensure_server_config_fips_compliant(&mut config)?;
+
+            Some(TlsAcceptor::from(Arc::new(config)))
+        }
+        None => None,
+    };
+    let tls_enabled = maybe_tls_acceptor.is_some();
+    let listen_addr = listener.listen_address().clone();
+
+    info!(%listen_addr, tls_enabled, "HTTP server started.");
+
+    // Every connection handler holds a handle from this coordinator, which is what lets us wait for in-flight requests
+    // below instead of abandoning them.
+    let mut conn_shutdown_coordinator = ShutdownCoordinator::default();
+
+    pin!(shutdown);
+
+    let result = loop {
+        select! {
+            result = listener.accept() => match result {
+                Ok(stream) => {
+                    let conn_builder = conn_builder.clone();
+                    let service = service.clone();
+                    let listen_addr = listen_addr.clone();
+                    let conn_shutdown = conn_shutdown_coordinator.register();
+
+                    match &maybe_tls_acceptor {
+                        Some(acceptor) => {
+                            let tls_stream = match acceptor.accept(stream).await {
+                                Ok(stream) => stream,
+                                Err(e) => {
+                                    error!(%listen_addr, error = %e, "Failed to complete TLS handshake.");
+                                    continue
+                                },
+                            };
+
+                            executor.spawn_traced_named("http_server_tls_conn", drive_connection(
+                                conn_builder, TokioIo::new(tls_stream), service, listen_addr, conn_shutdown, maybe_shutdown_timeout
+                            ));
+                        },
+                        None => {
+                            executor.spawn_traced_named("http_server_conn", drive_connection(
+                                conn_builder, TokioIo::new(stream), service, listen_addr, conn_shutdown, maybe_shutdown_timeout
+                            ));
+                        },
+                    }
+                },
+                Err(e) => break Err(GenericError::from(e)),
+            },
+
+            _ = &mut shutdown => {
+                debug!(%listen_addr, "Received shutdown signal.");
+                break Ok(());
+            }
+        }
+    };
+
+    // We've stopped accepting; now let anything still being served finish before we report being done.
+    debug!(%listen_addr, "Waiting for in-flight HTTP connections to finish...");
+    conn_shutdown_coordinator.shutdown_and_wait().await;
+
+    info!(%listen_addr, "HTTP server stopped.");
+
+    result
+}
+
+/// Serves a single connection, finishing what it has started if asked to shut down.
+///
+/// When shutdown is triggered, the connection is gracefully shutdown: new requests aren't allowed, but any pending
+/// or in-flight reads/writes will be completed prior to closing the connection.
+async fn drive_connection<I, S, B>(
+    conn_builder: Builder<TokioExecutor>, io: I, service: S, listen_addr: ListenAddress, shutdown: ShutdownHandle,
+    maybe_shutdown_timeout: Option<Duration>,
+) where
+    I: Read + Write + Unpin + Send + 'static,
+    S: Service<Request<Incoming>, Response = Response<B>> + 'static,
+    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Future: Send + 'static,
+    B: Body + Send + 'static,
+    B::Data: Send,
+    B::Error: std::error::Error + Send + Sync,
+{
+    let conn = conn_builder.serve_connection(io, service);
+    pin!(conn, shutdown);
+
+    select! {
+        result = conn.as_mut() => if let Err(e) = result {
+            error!(%listen_addr, error = %e, "Failed to serve HTTP connection.");
+        },
+
+        _ = &mut shutdown => {
+            debug!(%listen_addr, "Draining HTTP connection.");
+
+            conn.as_mut().graceful_shutdown();
+
+            let shutdown_timeout = maybe_shutdown_timeout.unwrap_or(Duration::MAX);
+            match timeout(shutdown_timeout, conn.as_mut()).await {
+                Ok(Ok(())) => {},
+                Ok(Err(e)) => warn!(%listen_addr, error = %e, "Failed to drain HTTP connection."),
+                Err(_) => warn!(%listen_addr, "Failed to gracefully drain HTTP connection after {:?}.", shutdown_timeout)
+            }
+        },
+    }
+}
+
+/// A future that resolves when [`UnsupervisedHttpServer`] encounters an unrecoverable error.
 pub struct ErrorHandle(oneshot::Receiver<GenericError>);
 
 impl Future for ErrorHandle {
@@ -185,5 +381,220 @@ impl Future for ErrorHandle {
             Ok(err) => Poll::Ready(Some(err)),
             Err(_) => Poll::Ready(None),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{SocketAddr, TcpListener as StdTcpListener};
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use http_body_util::Full;
+    use hyper::service::service_fn;
+    use saluki_common::sync::shutdown::ShutdownCoordinator;
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+    use tokio::net::TcpStream;
+    use tokio::time::timeout;
+
+    use super::*;
+
+    /// Bound on any server await in these tests, so a hang fails rather than stalling the suite.
+    const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// Reserves a loopback port and releases it, yielding an address a server can bind.
+    ///
+    /// Inherently racy against anything else on the host, but the window is small and there is no way to hand an
+    /// already-bound listener to the supervised server.
+    fn free_local_addr() -> SocketAddr {
+        let listener = StdTcpListener::bind("127.0.0.1:0").expect("should bind an ephemeral port");
+        let addr = listener.local_addr().expect("should have a local address");
+        drop(listener);
+        addr
+    }
+
+    /// Builds a server whose handler runs `f` for every request.
+    fn server_with<F, Fut>(
+        addr: SocketAddr, f: F,
+    ) -> HttpServer<
+        impl Service<
+                Request<Incoming>,
+                Response = Response<Full<bytes::Bytes>>,
+                Error = std::convert::Infallible,
+                Future = Fut,
+            > + Send
+            + Sync
+            + Clone
+            + 'static,
+    >
+    where
+        F: Fn() -> Fut + Send + Sync + Clone + 'static,
+        Fut: Future<Output = Result<Response<Full<bytes::Bytes>>, std::convert::Infallible>> + Send + 'static,
+    {
+        let service = service_fn(move |_req: Request<Incoming>| f());
+        HttpServer::from_listen_address(ListenAddress::Tcp(addr), service)
+    }
+
+    /// A handler that responds immediately.
+    async fn ok_response() -> Result<Response<Full<bytes::Bytes>>, std::convert::Infallible> {
+        Ok(Response::new(Full::new(bytes::Bytes::from_static(b"ok"))))
+    }
+
+    #[tokio::test]
+    async fn binds_during_initialization() {
+        // The listener is bound by `initialize`, not by the worker future, so the port is already taken before anything
+        // starts serving. That is what makes a bind failure a non-restartable initialization error.
+        let addr = free_local_addr();
+        let server = server_with(addr, ok_response);
+
+        let run = server
+            .initialize(ShutdownHandle::noop())
+            .await
+            .expect("should initialize");
+
+        assert!(
+            StdTcpListener::bind(addr).is_err(),
+            "initialization should have bound {addr} before the worker future ran"
+        );
+
+        drop(run);
+    }
+
+    #[tokio::test]
+    async fn bind_failure_is_an_initialization_error() {
+        // Hold the address so the server can't have it. An initialization error is non-restartable, which is the point:
+        // an unusable listen address should fail the child rather than being retried forever.
+        let addr = free_local_addr();
+        let _held = StdTcpListener::bind(addr).expect("should hold the address");
+
+        let server = server_with(addr, ok_response);
+        match server.initialize(ShutdownHandle::noop()).await {
+            Ok(_) => panic!("initialization should have failed to bind {addr}"),
+            Err(e) => {
+                let error = e.to_string();
+                assert!(error.contains("Failed to bind listener"), "unexpected error: {error}");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn releases_its_port_once_the_worker_finishes() {
+        // The whole reason for supervising the server: when its worker stops, the socket is gone. Previously the
+        // acceptor was a detached task that outlived whatever spawned it.
+        let addr = free_local_addr();
+        let server = server_with(addr, ok_response);
+
+        let mut coordinator = ShutdownCoordinator::default();
+        let run = server
+            .initialize(coordinator.register())
+            .await
+            .expect("should initialize");
+
+        coordinator.shutdown();
+        timeout(TEST_TIMEOUT, run)
+            .await
+            .expect("server should stop on shutdown")
+            .expect("server should stop cleanly");
+
+        assert!(
+            StdTcpListener::bind(addr).is_ok(),
+            "the server should have released {addr} when its worker finished"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_half_sent_request_does_not_wedge_the_drain() {
+        // A peer that writes a partial request head and stalls keeps its connection permanently non-idle, so
+        // `graceful_shutdown` alone never closes it. Before the connection builder had a timer and the drain had a
+        // deadline, one such socket stalled shutdown indefinitely -- for the OTLP receivers that meant every ADP
+        // shutdown hanging until the component budget forced an abort.
+        let addr = free_local_addr();
+        let server = server_with(addr, ok_response).with_graceful_shutdown_timeout(Duration::from_secs(1));
+
+        let mut coordinator = ShutdownCoordinator::default();
+        let run = server
+            .initialize(coordinator.register())
+            .await
+            .expect("should initialize");
+        let run = tokio::spawn(run);
+
+        let mut stream = TcpStream::connect(addr).await.expect("should connect");
+        stream
+            .write_all(b"GET / HTTP/1.1\r\nHost: localhost")
+            .await
+            .expect("should write a partial request head");
+        stream.flush().await.expect("should flush");
+
+        // Let the server read what there is before signalling, so the connection is genuinely mid-parse.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        coordinator.shutdown();
+
+        timeout(TEST_TIMEOUT, run)
+            .await
+            .expect("server should finish draining rather than waiting on a half-sent request")
+            .expect("server task should not panic")
+            .expect("server should stop cleanly");
+    }
+
+    #[tokio::test]
+    async fn does_not_finish_until_in_flight_requests_do() {
+        // Shutdown stops the server accepting, but a request already being served has to complete first. Without the
+        // connection drain, the worker future would return immediately and the response would be lost.
+        let addr = free_local_addr();
+
+        let handler_started = Arc::new(AtomicBool::new(false));
+        let started = Arc::clone(&handler_started);
+        let server = server_with(addr, move || {
+            let started = Arc::clone(&started);
+            async move {
+                started.store(true, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                ok_response().await
+            }
+        });
+
+        let mut coordinator = ShutdownCoordinator::default();
+        let run = server
+            .initialize(coordinator.register())
+            .await
+            .expect("should initialize");
+        let mut run = tokio::spawn(run);
+
+        // Issue a request by hand rather than pulling in a client: all we need is for the handler to be running.
+        let mut stream = TcpStream::connect(addr).await.expect("should connect");
+        stream
+            .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+            .await
+            .expect("should write request");
+
+        while !handler_started.load(Ordering::SeqCst) {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        // Signal shutdown mid-request.
+        coordinator.shutdown();
+
+        // The handler is still working, so the worker must not be finished yet. This ordering is the actual assertion:
+        // without the drain the worker returns here and the response is abandoned to a detached task.
+        assert!(
+            timeout(Duration::from_millis(50), &mut run).await.is_err(),
+            "server should not finish while a request is still being served"
+        );
+
+        let mut response = Vec::new();
+        timeout(TEST_TIMEOUT, stream.read_to_end(&mut response))
+            .await
+            .expect("response should arrive")
+            .expect("should read response");
+        assert!(
+            response.ends_with(b"ok"),
+            "expected the in-flight response to complete, got {:?}",
+            String::from_utf8_lossy(&response)
+        );
+
+        timeout(TEST_TIMEOUT, &mut run)
+            .await
+            .expect("server should finish after draining")
+            .expect("server task should not panic")
+            .expect("server should stop cleanly");
     }
 }

--- a/lib/saluki-io/src/net/server/mod.rs
+++ b/lib/saluki-io/src/net/server/mod.rs
@@ -1,2 +1,3 @@
+pub mod grpc;
 pub mod http;
 pub mod multiplex_service;


### PR DESCRIPTION
## Summary

This PR is the first of many (hopefully just a few) for converting components to spawn all of their child tasks under their dedicated supervisor to fully unify task execution in Saluki under the supervision tree model, starting with sources and relays.

In terms of the changes here, the actual code changed happens in three main areas:

- creating gRPC/HTTP server implementations that are `Supervisable`
- updating `ComponentSpawner` to clean it up and make it more misuse-resistant
- actually updating the source/relay components to use the new gRPC/HTTP servers and `ComponentSpawner`, etc

### gRPC / HTTP servers

This mostly boiled down to creating a new `GrpcServer` and `HttpServer` in `saluki-io` which implement `Supervisable`, in service of trying to make it easier to integrate "natively" with supervision trees.

We also moved the old `HttpServer` implementation to `UnsupervisedHttpServer` -- which is now considered deprecated -- and updated previous references to it, which means we touched things like the dynamic API and some destinations, etc.

There's more work to do in `GrpcServer`/`HttpServer` around how _they_ manage their child tasks, but I'm leaving that as a follow up because it requires more work and this PR was already getting large enough.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing tests.

## References

DADP-2
