### PR TITLE
fix(agent-data-plane): align stray APP identity values with the Makefile

### DIFF
--- a/ci/tooling/windows-build-adp.ps1
+++ b/ci/tooling/windows-build-adp.ps1
@@ -50,7 +50,7 @@ Install-CachedZipTool `
 # the same way as the linux/darwin binaries do.
 $env:APP_FULL_NAME = "Agent Data Plane"
 $env:APP_SHORT_NAME = "data-plane"
-$env:APP_IDENTIFIER = "agent-data-plane"
+$env:APP_IDENTIFIER = "adp"
 $env:APP_VERSION = $env:ADP_VERSION
 # Windows PowerShell 5.1 (the default `powershell.exe` in the LTSC2022 build image) doesn't
 # have Get-Date's -AsUTC switch (added in PS 7.1). ToUniversalTime() works on both.

--- a/test/antithesis/scenarios/differential/Dockerfile
+++ b/test/antithesis/scenarios/differential/Dockerfile
@@ -30,7 +30,7 @@ RUN --mount=type=bind,source=rust-toolchain.toml,target=/tmp/rust-toolchain.toml
 # ---------------------------------------------------------------------------
 FROM build-base AS adp-builder
 ENV APP_FULL_NAME="Agent Data Plane" \
-    APP_SHORT_NAME="agent-data-plane" \
+    APP_SHORT_NAME="data-plane" \
     APP_IDENTIFIER="adp" \
     CARGO_PROFILE_RELEASE_LTO=off
 WORKDIR /adp

--- a/test/antithesis/scenarios/general/Dockerfile
+++ b/test/antithesis/scenarios/general/Dockerfile
@@ -46,7 +46,7 @@ RUN --mount=type=bind,source=rust-toolchain.toml,target=/tmp/rust-toolchain.toml
 # ---------------------------------------------------------------------------
 FROM build-base AS adp-builder
 ENV APP_FULL_NAME="Agent Data Plane" \
-    APP_SHORT_NAME="agent-data-plane" \
+    APP_SHORT_NAME="data-plane" \
     APP_IDENTIFIER="adp" \
     CARGO_PROFILE_RELEASE_LTO=off
 WORKDIR /adp


### PR DESCRIPTION
## Human summary

Align all of the places we build `agent-data-plane` to use the same `APP_FULL_NAME`, `APP_SHORT_NAME`, `APP_IDENTIFIER`.

## AI Summary
`agent-data-plane`'s application identity (`APP_FULL_NAME`, `APP_SHORT_NAME`, `APP_IDENTIFIER`) is meant to be set consistently everywhere it's built, with the `Makefile`'s `ADP_APP_*` values treated as canonical (and documented as such in `docs/agent-data-plane/releasing.md`). `ci/tooling/windows-build-adp.ps1` had drifted to `APP_IDENTIFIER="agent-data-plane"` instead of `"adp"` (its own comment says it must match the Makefile), and both antithesis test Dockerfiles had `APP_SHORT_NAME="agent-data-plane"` instead of `"data-plane"`. This fixes both so the Windows and antithesis builds report the same identity as the Linux/macOS builds and CI packaging.

## Test plan
- [x] Confirmed no other spots in the repo still set these to values inconsistent with the Makefile