### PR TITLE
chore(agent-data-plane): drop orphaned build-dependency

### DIFF
--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -78,9 +78,6 @@ tikv-jemallocator = { workspace = true, features = [
   "stats",
 ] }
 
-[build-dependencies]
-chrono = { workspace = true }
-
 [dev-dependencies]
 datadog-agent-config-testing = { workspace = true }
 derive-where = { workspace = true }


### PR DESCRIPTION
## Summary
`agent-data-plane` declares a `[build-dependencies]` entry for `chrono` but has no build script, so the dependency does nothing. It's a leftover: the crate did have a `build.rs` until #291 moved build metadata capture into `saluki-metadata` and deleted it, and the build-dependency was never cleaned up alongside it.

## Test plan
- [x] Confirmed no `build.rs` exists anywhere under `bin/`, and traced the history — added in #45, deleted in #291
- [x] `cargo build --package agent-data-plane` succeeds with `Cargo.lock` unchanged, confirming nothing was resolving through the build-dependency
- [x] `make check-unused-deps` still passes
