### PR TITLE
fix(agent-data-plane): ignore remote tagger entity prefixes we have no use for

### DIFF
--- a/bin/agent-data-plane/src/internal/env/workload/collectors/tagger.rs
+++ b/bin/agent-data-plane/src/internal/env/workload/collectors/tagger.rs
@@ -236,8 +236,26 @@ fn remote_entity_id_to_entity_id(remote_entity_id: RemoteEntityId) -> Option<Ent
                 None
             }
         },
-        // We don't care about this, so we just ignore it.
-        "gpu" => None,
+        // Entities that the Agent's tagger publishes but that we have no use for.
+        //
+        // We ignore these explicitly so that the catch-all arm below stays a meaningful signal: it should only fire
+        // for a prefix that the Agent has newly added and that we haven't yet made a decision about.
+        //
+        // - `gpu`: keyed by GPU device UUID, which never arrives as origin information.
+        // - `kueue_workload`, `kubernetes_kueue_queue`, `kueue_resource_flavor`: the Agent folds these same Kueue tags
+        //   into the pod and container entities, which we do handle, so consuming them here would be redundant.
+        // - `crd`, `kubernetes_capabilities`: describe cluster-level objects rather than workloads, and carry no
+        //   identifier that origin detection can resolve.
+        // - `host`, `kubelet`: no tagger entity is ever published for these today, so they're listed only for
+        //   completeness against the Agent's set of prefixes.
+        "gpu"
+        | "kueue_workload"
+        | "kubernetes_kueue_queue"
+        | "kueue_resource_flavor"
+        | "crd"
+        | "kubernetes_capabilities"
+        | "host"
+        | "kubelet" => None,
         prefix => {
             warn!("Unhandled entity ID prefix: {}://{}", prefix, remote_entity_id.uid);
             None
@@ -281,6 +299,31 @@ mod tests {
                     uid: uid.to_owned(),
                 }),
                 Some(expected),
+                "{prefix}://{uid}"
+            );
+        }
+    }
+
+    #[test]
+    fn ignores_known_unused_entity_prefixes_from_the_remote_tagger() {
+        let cases = [
+            ("gpu", "GPU-00000000-0000-0000-0000-000000000000"),
+            ("kueue_workload", "spark-jobs/spark-driver-0"),
+            ("kubernetes_kueue_queue", "spark-jobs/local-queue"),
+            ("kueue_resource_flavor", "default-flavor"),
+            ("crd", "apps/v1/default/example"),
+            ("kubernetes_capabilities", "kube_capabilities"),
+            ("host", "host"),
+            ("kubelet", "kubelet"),
+        ];
+
+        for (prefix, uid) in cases {
+            assert_eq!(
+                remote_entity_id_to_entity_id(RemoteEntityId {
+                    prefix: prefix.to_owned(),
+                    uid: uid.to_owned(),
+                }),
+                None,
                 "{prefix}://{uid}"
             );
         }


### PR DESCRIPTION
## Human Summary

We see a lot of warnings internally about `Unhandled entity ID prefix: kueue_workload://...`. After some analysis, it seems like this prefix is safe to ignore (the pod level entity tags are a superset). While I was in there I figured I'd evaluate the rest of the additional 8 prefixes that the Datadog Agent uses that ADP doesn't recognize. Findings below, but basically they all seem ignorable.

An alternative approach is to have the Datadog Agent filter out the entities with the ignored prefixes before sending the list to ADP so ADP would never see them. The entity subscribe endpoint already accepts a `filter` option. I'm open to this approach, too, but figured I'd follow the precedent set here by the `gpu` prefix. If we do go that way I think we want to preserve some way to identify new entity tags that ADP _should_ be handling but isn't. Maybe this could be done as an integration test though.

## AI Summary

ADP subscribes to every entity prefix the Core Agent's tagger publishes, but only converts nine of them. Everything else falls to a catch-all arm that logs a warning per event, unthrottled. As environments have onboarded Kueue-scheduled Spark jobs, `kueue_workload://` entities alone have grown to over 1.1B warning lines per week — more than 94% of ADP's total warn volume — for entities we were always going to discard. This makes that decision explicit for the seven prefixes we've reviewed, so the catch-all goes back to meaning "the Agent added a prefix we haven't looked at yet."

To be clear about impact: this is a logging fix, not a tag-enrichment fix. No tags are lost today. The Kueue tags in question are folded onto pod and container entities by the same `extractKueueWorkloadAndRelatedTags` extractor in the Core Agent (`comp/core/tagger/collectors/workloadmeta_extract.go`), and ADP consumes those entities, so ADP has tag parity with the Core Agent's own DogStatsD path.

Verdict per prefix:

| Prefix | Why ignored |
|---|---|
| `gpu` (already ignored) | Keyed by GPU device UUID; never arrives as origin info |
| `kueue_workload`, `kubernetes_kueue_queue`, `kueue_resource_flavor` | Same tags are already folded onto pods/containers |
| `crd`, `kubernetes_capabilities` | Cluster-level objects; no origin-resolvable identifier, and Cluster Agent-only |
| `host`, `kubelet` | No tagger entity is ever published; listed for completeness |

## Alternative considered

`StreamTagsRequest` supports a `prefixes` field, and the Agent builds a server-side subscription filter from it (`comp/core/tagger/server/server.go`), falling back to all prefixes when the list is empty — which is what ADP sends today. Passing our nine prefixes would fix the log volume *and* save the Agent serializing and streaming events we discard.

I went with explicit ignore arms instead because the filter makes the failure mode silent: a future entity type we *do* want would be dropped server-side with nothing in the logs to point at it, whereas an unhandled prefix here is at least visible. Happy to switch, or do both, if the team prefers — the two aren't exclusive.

## Follow-up worth discussing

This change doesn't address what made the volume so large: the catch-all warns per event with no throttling, so the next prefix the Agent adds reproduces this at the same scale. A warn-once-per-prefix guard, or a counter on the collector's `Telemetry` struct plus `debug!` for detail, would bound it. Left out to keep this reviewable.

## Test plan

- [x] New `ignores_known_unused_entity_prefixes_from_the_remote_tagger` test asserts all eight ignored prefixes return `None`
- [x] Existing `converts_all_otlp_metric_entity_prefixes_from_the_remote_tagger` still passes, confirming no handled prefix was caught by the new arm

🤖 Generated with [Claude Code](https://claude.com/claude-code)
