### PR TITLE
feat(otlp): support and wire through delta_ttl config option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1558,7 +1558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1843,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2936,7 +2936,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4044,7 +4044,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4115,7 +4115,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4646,7 +4646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5188,7 +5188,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6141,7 +6141,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -823,6 +823,7 @@ Both commands scrub recognized secret values before writing JSON to standard out
 | `observability_pipelines_worker.metrics.use_v3_api.series`     | Use V3 series for OPW                              |
 | `origin_detection_unified`                                     | Unified origin detection mode                      |
 | `otlp_config.logs.enabled`                                     | otlp_config.logs.enabled                           |
+| `otlp_config.metrics.delta_ttl`                                | TTL (seconds) for cached delta-conversion points   |
 | `otlp_config.metrics.enabled`                                  | otlp_config.metrics.enabled                        |
 | `otlp_config.metrics.histograms.mode`                          | OTLP histogram bucket reporting mode               |
 | `otlp_config.metrics.histograms.send_aggregation_metrics`      | Emit OTLP histogram aggregation metrics.           |

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -927,8 +927,13 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_otlp_config_metrics_delta_ttl(&mut self, value: i64) {
-        // The schema types this as an integer denominated in seconds. Convert to a `Duration` at the
-        // earliest opportunity so the resolved model never carries the raw scalar.
+        if value <= 0 {
+            self.record_error(TranslateError::new_with_message(
+                "otlp_config.metrics.delta_ttl",
+                format!("time to live must be positive: {value}"),
+            ));
+            return;
+        }
         match parse_seconds("otlp_config.metrics.delta_ttl", value) {
             Ok(ttl) => self.config.domains.otlp.metrics.delta_ttl = ttl,
             Err(error) => self.record_error(error),
@@ -1859,5 +1864,18 @@ mod tests {
         assert_eq!(config.domains.otlp.metrics.delta_ttl, DEFAULT_DELTA_TTL);
         let errors = errors.expect("negative delta_ttl should record a translation error");
         assert!(errors.to_string().contains("otlp_config.metrics.delta_ttl"));
+        assert!(errors.to_string().contains("time to live must be positive"));
+    }
+
+    #[test]
+    fn otlp_metrics_delta_ttl_zero_records_error_and_keeps_default() {
+        let (config, errors) = translate_explicit(json!({
+            "otlp_config": { "metrics": { "delta_ttl": 0 } }
+        }));
+
+        assert_eq!(config.domains.otlp.metrics.delta_ttl, DEFAULT_DELTA_TTL);
+        let errors = errors.expect("zero delta_ttl should record a translation error");
+        assert!(errors.to_string().contains("otlp_config.metrics.delta_ttl"));
+        assert!(errors.to_string().contains("time to live must be positive"));
     }
 }

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -926,6 +926,15 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
         self.config.domains.otlp.receiver.logs_enabled = value;
     }
 
+    fn consume_otlp_config_metrics_delta_ttl(&mut self, value: i64) {
+        // The schema types this as an integer denominated in seconds. Convert to a `Duration` at the
+        // earliest opportunity so the resolved model never carries the raw scalar.
+        match parse_seconds("otlp_config.metrics.delta_ttl", value) {
+            Ok(ttl) => self.config.domains.otlp.metrics.delta_ttl = ttl,
+            Err(error) => self.record_error(error),
+        }
+    }
+
     fn consume_otlp_config_metrics_enabled(&mut self, value: bool) {
         self.config.domains.otlp.receiver.metrics_enabled = value;
     }
@@ -1229,7 +1238,8 @@ mod tests {
     use agent_data_plane_config::domains::{
         dogstatsd::OriginTagCardinality,
         otlp::{
-            CumulativeMonotonicMode, InitialCumulativeMonotonicValue, SummaryMode, DEFAULT_GRPC_MAX_RECV_MSG_SIZE_MIB,
+            CumulativeMonotonicMode, InitialCumulativeMonotonicValue, SummaryMode, DEFAULT_DELTA_TTL,
+            DEFAULT_GRPC_MAX_RECV_MSG_SIZE_MIB,
         },
     };
     use agent_data_plane_config::shared::V3SeriesMode;
@@ -1819,5 +1829,38 @@ mod tests {
             assert!(errors.is_none());
             assert_eq!(config.domains.otlp.receiver.grpc.max_recv_msg_size_mib, expected);
         }
+    }
+
+    #[test]
+    fn otlp_metrics_delta_ttl_translates_explicit_value() {
+        // An explicit integer (seconds) is carried through the witness as a `Duration`.
+        let (config, errors) = translate_explicit(json!({
+            "otlp_config": { "metrics": { "delta_ttl": 7200 } }
+        }));
+
+        assert!(errors.is_none());
+        assert_eq!(config.domains.otlp.metrics.delta_ttl, Duration::from_secs(7200));
+    }
+
+    #[test]
+    fn otlp_metrics_delta_ttl_defaults_to_3600s_when_unset() {
+        // Omitted, the Datadog schema default of 3600 seconds applies.
+        let (config, errors) = translate_explicit(json!({}));
+
+        assert!(errors.is_none());
+        assert_eq!(config.domains.otlp.metrics.delta_ttl, DEFAULT_DELTA_TTL);
+    }
+
+    #[test]
+    fn otlp_metrics_delta_ttl_negative_records_error_and_keeps_default() {
+        // A negative TTL is not a valid duration; the witness records an error and leaves the
+        // last-known-good (default) value in place.
+        let (config, errors) = translate_explicit(json!({
+            "otlp_config": { "metrics": { "delta_ttl": -1 } }
+        }));
+
+        assert_eq!(config.domains.otlp.metrics.delta_ttl, DEFAULT_DELTA_TTL);
+        let errors = errors.expect("negative delta_ttl should record a translation error");
+        assert!(errors.to_string().contains("otlp_config.metrics.delta_ttl"));
     }
 }

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -1844,7 +1844,6 @@ mod tests {
 
     #[test]
     fn otlp_metrics_delta_ttl_defaults_to_3600s_when_unset() {
-        // Omitted, the Datadog schema default of 3600 seconds applies.
         let (config, errors) = translate_explicit(json!({}));
 
         assert!(errors.is_none());
@@ -1853,8 +1852,6 @@ mod tests {
 
     #[test]
     fn otlp_metrics_delta_ttl_negative_records_error_and_keeps_default() {
-        // A negative TTL is not a valid duration; the witness records an error and leaves the
-        // last-known-good (default) value in place.
         let (config, errors) = translate_explicit(json!({
             "otlp_config": { "metrics": { "delta_ttl": -1 } }
         }));

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -65,14 +65,7 @@ pub struct Metrics {
     pub summaries: Summaries,
 
     /// Time-to-live for cached prior data points used when converting cumulative monotonic sums
-    /// to deltas.
-    ///
-    /// Once a series' cached prior value is older than this TTL, it is evicted and the next value
-    /// is treated as an initial value again. Defaults to `3600` seconds ([`DEFAULT_DELTA_TTL`]).
-    ///
-    /// Raise this for high-cardinality or low-frequency series that report infrequently enough to
-    /// trip spurious "initial value" resets. Lower it to bound memory use when many short-lived
-    /// series are seen, since each cached point is held for the full TTL regardless of activity.
+    /// to deltas. Defaults to `3600` seconds. Must be greater than zero.
     pub delta_ttl: Duration,
 }
 

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -1,6 +1,7 @@
 //! OTLP domain: the OTLP receiver (gRPC/HTTP transports, logs/metrics activation), the OTLP proxy
 //! gating, and OTLP context sizing. OTLP trace handling lives in the `traces` domain.
 
+use std::time::Duration;
 use std::{num::NonZeroUsize, str::FromStr};
 
 use serde::Serialize;
@@ -27,8 +28,13 @@ pub struct Domain {
     pub contexts: Contexts,
 }
 
+/// Default TTL for cached prior points used when converting cumulative sums to deltas.
+///
+/// Matches the Datadog Agent schema default of 3600 seconds. See [`Metrics::delta_ttl`].
+pub const DEFAULT_DELTA_TTL: Duration = Duration::from_secs(3600);
+
 /// OTLP metrics translation settings.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Metrics {
     /// Tag cardinality applied to entity and global tags enriched onto OTLP metrics.
     ///
@@ -59,6 +65,32 @@ pub struct Metrics {
 
     /// OTLP summary translation settings.
     pub summaries: Summaries,
+
+    /// Time-to-live for cached prior data points used when converting cumulative monotonic sums
+    /// to deltas.
+    ///
+    /// Once a series' cached prior value is older than this TTL, it is evicted and the next value
+    /// is treated as an initial value again. Defaults to `3600` seconds ([`DEFAULT_DELTA_TTL`]).
+    ///
+    /// Raise this for high-cardinality or low-frequency series that report infrequently enough to
+    /// trip spurious "initial value" resets. Lower it to bound memory use when many short-lived
+    /// series are seen, since each cached point is held for the full TTL regardless of activity.
+    pub delta_ttl: Duration,
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        Self {
+            tag_cardinality: OriginTagCardinality::default(),
+            histogram_mode: HistogramMode::default(),
+            send_histogram_aggregations: false,
+            resource_attributes_as_tags: false,
+            sums: Sums::default(),
+            tags: String::new(),
+            summaries: Summaries::default(),
+            delta_ttl: DEFAULT_DELTA_TTL,
+        }
+    }
 }
 
 /// How explicit OTLP histogram buckets are reported.

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -29,8 +29,6 @@ pub struct Domain {
 }
 
 /// Default TTL for cached prior points used when converting cumulative sums to deltas.
-///
-/// Matches the Datadog Agent schema default of 3600 seconds. See [`Metrics::delta_ttl`].
 pub const DEFAULT_DELTA_TTL: Duration = Duration::from_secs(3600);
 
 /// OTLP metrics translation settings.

--- a/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
@@ -267,6 +267,17 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
     };
+    /// `otlp_config.metrics.delta_ttl`-TTL (seconds) for cached delta-conversion points
+    OTLP_CONFIG_METRICS_DELTA_TTL = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_METRICS_DELTA_TTL,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
     /// `otlp_config.metrics.histograms.mode`-OTLP histogram bucket reporting mode
     OTLP_CONFIG_METRICS_HISTOGRAMS_MODE = SalukiAnnotation {
         schema: &schema::OTLP_CONFIG_METRICS_HISTOGRAMS_MODE,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -2090,6 +2090,22 @@ inventory:
       The core Agent batches OTLP metric input before translation through its serializer exporter queue.
       ADP's architecture does not have the same batching mechanism and is unaffected by this configuration value.
 
+  otlp_config.metrics.delta_ttl:
+    support: full
+    pipelines: [otlp]
+    description: "TTL (seconds) for cached delta-conversion points"
+    documentation: |-
+      Controls how long previously-seen data points are kept in memory when converting cumulative
+      monotonic sums to deltas. Once a series' cached prior value is older than this TTL, it is
+      evicted and the next value is treated as an initial value again. Defaults to `3600` seconds.
+      Raise this for high-cardinality or low-frequency series that report infrequently enough to
+      trip spurious "initial value" resets; lower it to bound memory use when many short-lived
+      series are seen.
+    test_support:
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: otlp.rs
+
   otlp_config.metrics.enabled:
     support: full
     pipelines: [otlp]
@@ -4324,7 +4340,6 @@ excluded:
   otlp_config.logs.batch.flush_timeout: "ignored in initial audit 2026-04-23"
   otlp_config.logs.batch.max_size: "ignored in initial audit 2026-04-23"
   otlp_config.logs.batch.min_size: "ignored in initial audit 2026-04-23"
-  otlp_config.metrics.delta_ttl: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.histograms.send_count_sum_metrics: "deprecated; ADP supports only send_aggregation_metrics"
   otlp_config.metrics.instrumentation_scope_metadata_as_tags: "ignored in initial audit 2026-04-23"
   otlp_config.traces.infra_attributes.enabled: "ignored in initial audit 2026-04-23"

--- a/lib/datadog-agent/config/src/generated/datadog_configuration.rs
+++ b/lib/datadog-agent/config/src/generated/datadog_configuration.rs
@@ -1461,6 +1461,10 @@ impl Default for OtlpConfigLogs {
 
 #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
 pub struct OtlpConfigMetrics {
+    #[serde(default = "defaults::default_u64::<i64, 3600>")]
+    #[serde(deserialize_with = "crate::cast_de::deserialize_i64")]
+    pub delta_ttl: i64,
+
     #[serde(default = "defaults::default_bool::<true>")]
     #[serde(deserialize_with = "crate::cast_de::deserialize_bool")]
     pub enabled: bool,
@@ -1492,6 +1496,7 @@ pub struct OtlpConfigMetrics {
 impl Default for OtlpConfigMetrics {
     fn default() -> Self {
         Self {
+            delta_ttl: defaults::default_u64::<i64, 3600>(),
             enabled: defaults::default_bool::<true>(),
             histograms: Default::default(),
             resource_attributes_as_tags: Default::default(),

--- a/lib/datadog-agent/config/src/generated/env_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_keys.rs
@@ -776,6 +776,11 @@ pub static DATADOG_ENV_KEYS: &[EnvKey] = &[
         decode: EnvDecode::Bool,
     },
     EnvKey {
+        env_vars: &["DD_OTLP_CONFIG_METRICS_DELTA_TTL"],
+        path: &["otlp_config", "metrics", "delta_ttl"],
+        decode: EnvDecode::Integer,
+    },
+    EnvKey {
         env_vars: &["DD_OTLP_CONFIG_METRICS_ENABLED"],
         path: &["otlp_config", "metrics", "enabled"],
         decode: EnvDecode::Bool,

--- a/lib/datadog-agent/config/src/generated/witness.rs
+++ b/lib/datadog-agent/config/src/generated/witness.rs
@@ -165,6 +165,7 @@ pub trait DatadogConfigWitness {
     fn consume_observability_pipelines_worker_metrics_use_v3_api_series(&mut self, value: bool);
     fn consume_origin_detection_unified(&mut self, value: bool);
     fn consume_otlp_config_logs_enabled(&mut self, value: bool);
+    fn consume_otlp_config_metrics_delta_ttl(&mut self, value: i64);
     fn consume_otlp_config_metrics_enabled(&mut self, value: bool);
     fn consume_otlp_config_metrics_histograms_mode(&mut self, value: String);
     fn consume_otlp_config_metrics_histograms_send_aggregation_metrics(&mut self, value: bool);
@@ -434,6 +435,7 @@ pub fn drive(config: &DatadogConfiguration, consumer: &mut impl DatadogConfigWit
     );
     consumer.consume_origin_detection_unified(config.origin_detection_unified.clone());
     consumer.consume_otlp_config_logs_enabled(config.otlp_config.logs.enabled.clone());
+    consumer.consume_otlp_config_metrics_delta_ttl(config.otlp_config.metrics.delta_ttl.clone());
     consumer.consume_otlp_config_metrics_enabled(config.otlp_config.metrics.enabled.clone());
     consumer.consume_otlp_config_metrics_histograms_mode(config.otlp_config.metrics.histograms.mode.clone());
     consumer.consume_otlp_config_metrics_histograms_send_aggregation_metrics(

--- a/lib/saluki-components/src/sources/otlp/metrics/cache.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/cache.rs
@@ -36,7 +36,7 @@ pub struct PointsCache {
 impl PointsCache {
     pub fn from_config(config: OtlpMetricsTranslatorConfig) -> Self {
         let ttl = config.delta_ttl;
-        let interval = config.sweep_interval;
+        let interval = std::cmp::max(Duration::from_secs(1), ttl / 2);
 
         let number_points = CacheBuilder::from_identifier("otlp/metrics/number_points")
             .expect("identifier cannot be invalid")

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -7,7 +7,6 @@ use agent_data_plane_config::domains::{
 use saluki_error::{generic_error, GenericError};
 
 const DEFAULT_DELTA_TTL: Duration = Duration::from_secs(3600);
-const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(1800);
 
 #[derive(Debug, Clone, Copy)]
 #[allow(dead_code)]
@@ -34,7 +33,6 @@ pub struct OtlpMetricsTranslatorConfig {
     pub quantiles: bool,
     // Points cache settings
     pub delta_ttl: Duration,
-    pub sweep_interval: Duration,
     pub infer_delta_interval: bool,
 }
 
@@ -114,11 +112,6 @@ impl OtlpMetricsTranslatorConfig {
         self.delta_ttl = ttl;
         self
     }
-
-    pub fn with_sweep_interval(mut self, interval: Duration) -> Self {
-        self.sweep_interval = interval;
-        self
-    }
 }
 
 impl Default for OtlpMetricsTranslatorConfig {
@@ -137,7 +130,6 @@ impl Default for OtlpMetricsTranslatorConfig {
             quantiles: false,
             infer_delta_interval: false,
             delta_ttl: DEFAULT_DELTA_TTL,
-            sweep_interval: DEFAULT_SWEEP_INTERVAL,
         }
     }
 }

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -642,7 +642,6 @@ mod tests {
 
     #[test]
     fn delta_ttl_defaults_to_3600s() {
-        // Omitted from the domain, default (3600s) flows through unchanged.
         assert_eq!(
             config_with_metrics(domains::otlp::Metrics::default())
                 .metrics_translator_config()

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -107,7 +107,8 @@ impl OtlpConfiguration {
             .with_send_histogram_aggregations(self.otlp.metrics.send_histogram_aggregations)
             .with_cumulative_monotonic_mode(self.otlp.metrics.sums.cumulative_monotonic_mode)
             .with_initial_cumulative_monotonic_value(self.otlp.metrics.sums.initial_cumulative_monotonic_value)
-            .with_resource_attributes_as_tags(self.otlp.metrics.resource_attributes_as_tags);
+            .with_resource_attributes_as_tags(self.otlp.metrics.resource_attributes_as_tags)
+            .with_delta_ttl(self.otlp.metrics.delta_ttl);
         config.tag_cardinality = self.otlp.metrics.tag_cardinality;
         config
     }
@@ -473,6 +474,8 @@ async fn run_converter(
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use agent_data_plane_config::domains;
     use agent_data_plane_config::domains::otlp::{
         CumulativeMonotonicMode, HistogramMode, InitialCumulativeMonotonicValue, SummaryMode,
@@ -624,6 +627,28 @@ mod tests {
                 value
             );
         }
+    }
+
+    #[test]
+    fn delta_ttl_flows_to_metrics_translator() {
+        // An explicit TTL overrides the 3600s default end-to-end into the translator config.
+        let config = config_with_metrics(domains::otlp::Metrics {
+            delta_ttl: Duration::from_secs(7200),
+            ..Default::default()
+        });
+
+        assert_eq!(config.metrics_translator_config().delta_ttl, Duration::from_secs(7200));
+    }
+
+    #[test]
+    fn delta_ttl_defaults_to_3600s() {
+        // Omitted from the domain, default (3600s) flows through unchanged.
+        assert_eq!(
+            config_with_metrics(domains::otlp::Metrics::default())
+                .metrics_translator_config()
+                .delta_ttl,
+            Duration::from_secs(3600)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Wire up `otlp_config.metrics.delta_ttl` for  use when converting cumulative sums to deltas. 

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
Unit tests 
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->
- Closes: #2026

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
