### PR TITLE
fix(config): ignore core-Agent-only dogstatsd_experimental_http keys

### DIFF
--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -19,17 +19,6 @@ If you find an error on this page, please [open an issue].
 
 ## Unsupported Settings
 
-<!-- section:unsupported-in-progress -->
-### Being Worked On
-
-The following settings are not yet supported in ADP but are planned with GitHub issue links for
-tracking.
-
-| Config Key                                   | Description                                     | Issue   |
-| -------------------------------------------- | ----------------------------------------------- | ------- |
-| `dogstatsd_experimental_http.enabled`        | Enable experimental HTTP/H2C DSD listener       | [#1682] |
-| `dogstatsd_experimental_http.listen_address` | Bind address for experimental HTTP DSD listener | [#1682] |
-
 <!-- section:unsupported-not-planned -->
 ### Not Planned
 
@@ -892,7 +881,6 @@ Both commands scrub recognized secret values before writing JSON to standard out
 [#1381]: https://github.com/DataDog/saluki/issues/1381
 [#1679]: https://github.com/DataDog/saluki/issues/1679
 [#1681]: https://github.com/DataDog/saluki/issues/1681
-[#1682]: https://github.com/DataDog/saluki/issues/1682
 [#1687]: https://github.com/DataDog/saluki/issues/1687
 [#1749]: https://github.com/DataDog/saluki/issues/1749
 [#1753]: https://github.com/DataDog/saluki/issues/1753

--- a/docs/agent-data-plane/configuration/configuration.md.tmpl
+++ b/docs/agent-data-plane/configuration/configuration.md.tmpl
@@ -19,14 +19,14 @@ If you find an error on this page, please [open an issue].
 
 ## Unsupported Settings
 
-<!-- section:unsupported-in-progress -->
+{{ if working_on_table }}<!-- section:unsupported-in-progress -->
 ### Being Worked On
 
 The following settings are not yet supported in ADP but are planned with GitHub issue links for
 tracking.
 
 { working_on_table }
-<!-- section:unsupported-not-planned -->
+{{ endif }}<!-- section:unsupported-not-planned -->
 ### Not Planned
 
 The following settings exist in the core agent but are not planned for ADP, typically because ADP's

--- a/lib/datadog-agent/config-testing/src/config_registry/unsupported.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/unsupported.rs
@@ -104,28 +104,6 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
     };
-    /// `dogstatsd_experimental_http.enabled`-Enable experimental HTTP/H2C DSD listener
-    DOGSTATSD_EXPERIMENTAL_HTTP_ENABLED = SalukiAnnotation {
-        schema: &schema::DOGSTATSD_EXPERIMENTAL_HTTP_ENABLED,
-        support_level: SupportLevel::Incompatible(Severity::High),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
-    };
-    /// `dogstatsd_experimental_http.listen_address`-Bind address for experimental HTTP DSD listener
-    DOGSTATSD_EXPERIMENTAL_HTTP_LISTEN_ADDRESS = SalukiAnnotation {
-        schema: &schema::DOGSTATSD_EXPERIMENTAL_HTTP_LISTEN_ADDRESS,
-        support_level: SupportLevel::Incompatible(Severity::High),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
-    };
     /// `forwarder_requeue_buffer_size`-In-memory re-queue buffer size
     FORWARDER_REQUEUE_BUFFER_SIZE = SalukiAnnotation {
         schema: &schema::FORWARDER_REQUEUE_BUFFER_SIZE,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -826,24 +826,6 @@ inventory:
       additional_attributes:
         config_registry_filename: dogstatsd.rs
 
-  dogstatsd_experimental_http.enabled:
-    support: none
-    severity: high
-    planned: true
-    pipelines: [dogstatsd]
-    description: "Enable experimental HTTP/H2C DSD listener"
-    documentation: "Experimental HTTP path for pre-aggregated DogStatsD metrics; planned when the DogStatsD-over-HTTP work resumes."
-    issue: "#1682"
-
-  dogstatsd_experimental_http.listen_address:
-    support: none
-    severity: high
-    planned: true
-    pipelines: [dogstatsd]
-    description: "Bind address for experimental HTTP DSD listener"
-    documentation: "Experimental HTTP path for pre-aggregated DogStatsD metrics; planned when the DogStatsD-over-HTTP work resumes."
-    issue: "#1682"
-
   dogstatsd_expiry_seconds:
     support: full
     pipelines: [dogstatsd]
@@ -3648,6 +3630,8 @@ excluded:
   docker_env_as_tags: "ignored in initial audit 2026-04-23"
   docker_labels_as_tags: "ignored in initial audit 2026-04-23"
   docker_query_timeout: "ignored in initial audit 2026-04-23"
+  dogstatsd_experimental_http.enabled: "served entirely by the core Agent (comp/dogstatsd/http); never reaches ADP"
+  dogstatsd_experimental_http.listen_address: "served entirely by the core Agent (comp/dogstatsd/http); never reaches ADP"
   ec2_imdsv2_transition_payload_enabled: "ignored in initial audit 2026-04-23"
   ec2_metadata_timeout: "ignored in initial audit 2026-04-23"
   ec2_metadata_token_lifetime: "ignored in initial audit 2026-04-23"

--- a/lib/datadog-agent/config/src/generated/classifier_data.rs
+++ b/lib/datadog-agent/config/src/generated/classifier_data.rs
@@ -75,20 +75,6 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         default: DefaultValue::Json("\"tcp://0.0.0.0:5102\""),
     },
     ClassifierEntry {
-        yaml_path: "dogstatsd_experimental_http.enabled",
-        aliases: &[],
-        support_level: SupportLevel::Incompatible(Severity::High),
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
-        default: DefaultValue::Json("false"),
-    },
-    ClassifierEntry {
-        yaml_path: "dogstatsd_experimental_http.listen_address",
-        aliases: &[],
-        support_level: SupportLevel::Incompatible(Severity::High),
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
-        default: DefaultValue::Json("\"127.0.0.1:8125\""),
-    },
-    ClassifierEntry {
         yaml_path: "dogstatsd_host_socket_path",
         aliases: &[],
         support_level: SupportLevel::Incompatible(Severity::Low),


### PR DESCRIPTION
## Summary

Downgrade experimental dogstatsd http settings from high severity to excluded. 

HTTP dogstatsd traffic does not reach ADP and these settings do not impact anything about regular dogstatsd processing. Both can coexist at the same time with no issue, so there is no reason to block ADP from running if dogstatsd http is enabled.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

## References
