### PR TITLE
fix(agent-data-plane): emit error logs matching existing forwarder alerting

### DIFF
--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -911,6 +911,14 @@ fn build_diagnostics_layer(emitter: DiagnosticsEmitter, endpoint_url: String) ->
             format!("Datadog API key rejected as invalid (HTTP 403) when forwarding to '{endpoint_url}'."),
             DiagnosticDetails::InvalidApiKey,
         ));
+
+        // The message text here is kept in sync with an equivalent log emitted by another implementation of
+        // this forwarder, so that log-based alerting on this condition matches regardless of which implementation
+        // is deployed.
+        error!(
+            endpoint_url,
+            "API Key invalid (403 response), dropping transaction for {endpoint_url}."
+        );
     };
 
     HttpInspectionLayer::new().with_inspector(StatusCode::FORBIDDEN, forbidden_inspector)

--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -10,7 +10,7 @@ use fs4::{available_space, total_space};
 use rand::RngExt as _;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use serde::{de::DeserializeOwned, Serialize};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use super::{EventContainer, PushResult};
 
@@ -390,7 +390,15 @@ where
             self.total_on_disk_bytes -= entry.size_bytes;
             push_result.track_dropped_item(&deserialized);
 
-            warn!(entry.path = %entry.path.display(), entry.len = entry.size_bytes, "Dropped persisted entry.");
+            // The message text here is kept in sync with an equivalent log emitted by another implementation of
+            // this queue, so that log-based alerting on this condition matches regardless of which implementation
+            // is deployed.
+            error!(
+                entry.path = %entry.path.display(),
+                entry.len = entry.size_bytes,
+                "Maximum disk space for retry transactions is reached. Removing {}.",
+                entry.path.display()
+            );
         }
 
         Ok(push_result)


### PR DESCRIPTION
## Summary

Mirror the logs from Datadog Agent that we depend on for internal monitors and in troubleshooting documentation. This reduces friction as we move to ADP being the default and also increases the reliability of the disk queue monitor since the log goes through a different pipeline (if the metrics queue is full then the metric about the metric queue may be dropped).

## Test plan

- [x] `cargo nextest run` for `saluki-io` retry queue tests (persisted queue eviction path)
- [x] `cargo nextest run` for `saluki-components` invalid API key diagnostic tests