### PR TITLE
fix(config): ignore core-Agent-only dogstatsd_experimental_http keys (#2358)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,7 +915,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1553,7 +1553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1905,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3018,7 +3018,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4116,7 +4116,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4187,7 +4187,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4721,7 +4721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5251,7 +5251,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6214,7 +6214,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,7 +915,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1553,7 +1553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1905,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3018,7 +3018,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4116,7 +4116,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4187,7 +4187,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4721,7 +4721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5251,7 +5251,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6214,7 +6214,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -25,11 +25,9 @@ If you find an error on this page, please [open an issue].
 The following settings are not yet supported in ADP but are planned with GitHub issue links for
 tracking.
 
-| Config Key                                   | Description                                     | Issue   |
-| -------------------------------------------- | ----------------------------------------------- | ------- |
-| `dogstatsd_experimental_http.enabled`        | Enable experimental HTTP/H2C DSD listener       | [#1682] |
-| `dogstatsd_experimental_http.listen_address` | Bind address for experimental HTTP DSD listener | [#1682] |
-| `tls_handshake_timeout`                      | HTTP TLS handshake timeout                      | [#178]  |
+| Config Key              | Description                | Issue  |
+| ----------------------- | -------------------------- | ------ |
+| `tls_handshake_timeout` | HTTP TLS handshake timeout | [#178] |
 
 <!-- section:unsupported-not-planned -->
 ### Not Planned
@@ -811,7 +809,6 @@ Both commands scrub recognized secret values before writing JSON to standard out
 [#1381]: https://github.com/DataDog/saluki/issues/1381
 [#1679]: https://github.com/DataDog/saluki/issues/1679
 [#1681]: https://github.com/DataDog/saluki/issues/1681
-[#1682]: https://github.com/DataDog/saluki/issues/1682
 [#1687]: https://github.com/DataDog/saluki/issues/1687
 [#1749]: https://github.com/DataDog/saluki/issues/1749
 [#1753]: https://github.com/DataDog/saluki/issues/1753

--- a/docs/agent-data-plane/configuration/configuration.md.tmpl
+++ b/docs/agent-data-plane/configuration/configuration.md.tmpl
@@ -19,14 +19,14 @@ If you find an error on this page, please [open an issue].
 
 ## Unsupported Settings
 
-<!-- section:unsupported-in-progress -->
+{{ if working_on_table }}<!-- section:unsupported-in-progress -->
 ### Being Worked On
 
 The following settings are not yet supported in ADP but are planned with GitHub issue links for
 tracking.
 
 { working_on_table }
-<!-- section:unsupported-not-planned -->
+{{ endif }}<!-- section:unsupported-not-planned -->
 ### Not Planned
 
 The following settings exist in the core agent but are not planned for ADP, typically because ADP's

--- a/lib/datadog-agent/config-testing/src/config_registry/unsupported.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/unsupported.rs
@@ -115,28 +115,6 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
     };
-    /// `dogstatsd_experimental_http.enabled`-Enable experimental HTTP/H2C DSD listener
-    DOGSTATSD_EXPERIMENTAL_HTTP_ENABLED = SalukiAnnotation {
-        schema: &schema::DOGSTATSD_EXPERIMENTAL_HTTP_ENABLED,
-        support_level: SupportLevel::Incompatible(Severity::High),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
-    };
-    /// `dogstatsd_experimental_http.listen_address`-Bind address for experimental HTTP DSD listener
-    DOGSTATSD_EXPERIMENTAL_HTTP_LISTEN_ADDRESS = SalukiAnnotation {
-        schema: &schema::DOGSTATSD_EXPERIMENTAL_HTTP_LISTEN_ADDRESS,
-        support_level: SupportLevel::Incompatible(Severity::High),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
-    };
     /// `forwarder_requeue_buffer_size`-In-memory re-queue buffer size
     FORWARDER_REQUEUE_BUFFER_SIZE = SalukiAnnotation {
         schema: &schema::FORWARDER_REQUEUE_BUFFER_SIZE,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -817,24 +817,6 @@ inventory:
       additional_attributes:
         config_registry_filename: dogstatsd.rs
 
-  dogstatsd_experimental_http.enabled:
-    support: none
-    severity: high
-    planned: true
-    pipelines: [dogstatsd]
-    description: "Enable experimental HTTP/H2C DSD listener"
-    documentation: "Experimental HTTP path for pre-aggregated DogStatsD metrics; planned when the DogStatsD-over-HTTP work resumes."
-    issue: "#1682"
-
-  dogstatsd_experimental_http.listen_address:
-    support: none
-    severity: high
-    planned: true
-    pipelines: [dogstatsd]
-    description: "Bind address for experimental HTTP DSD listener"
-    documentation: "Experimental HTTP path for pre-aggregated DogStatsD metrics; planned when the DogStatsD-over-HTTP work resumes."
-    issue: "#1682"
-
   dogstatsd_expiry_seconds:
     support: full
     pipelines: [dogstatsd]
@@ -3321,6 +3303,8 @@ excluded:
   docker_env_as_tags: "ignored in initial audit 2026-04-23"
   docker_labels_as_tags: "ignored in initial audit 2026-04-23"
   docker_query_timeout: "ignored in initial audit 2026-04-23"
+  dogstatsd_experimental_http.enabled: "served entirely by the core Agent (comp/dogstatsd/http); never reaches ADP"
+  dogstatsd_experimental_http.listen_address: "served entirely by the core Agent (comp/dogstatsd/http); never reaches ADP"
   ec2_imdsv2_transition_payload_enabled: "ignored in initial audit 2026-04-23"
   ec2_metadata_timeout: "ignored in initial audit 2026-04-23"
   ec2_metadata_token_lifetime: "ignored in initial audit 2026-04-23"

--- a/lib/datadog-agent/config/src/generated/classifier_data.rs
+++ b/lib/datadog-agent/config/src/generated/classifier_data.rs
@@ -75,20 +75,6 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         default: DefaultValue::Json("\"tcp://0.0.0.0:5102\""),
     },
     ClassifierEntry {
-        yaml_path: "dogstatsd_experimental_http.enabled",
-        aliases: &[],
-        support_level: SupportLevel::Incompatible(Severity::High),
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
-        default: DefaultValue::Json("false"),
-    },
-    ClassifierEntry {
-        yaml_path: "dogstatsd_experimental_http.listen_address",
-        aliases: &[],
-        support_level: SupportLevel::Incompatible(Severity::High),
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
-        default: DefaultValue::Json("\"127.0.0.1:8125\""),
-    },
-    ClassifierEntry {
         yaml_path: "dogstatsd_host_socket_path",
         aliases: &[],
         support_level: SupportLevel::Incompatible(Severity::Low),


### PR DESCRIPTION
## Summary

Backport of #2358 to `releases/1.5.x` for the 1.5.2 release: downgrades the experimental dogstatsd HTTP settings from high severity to excluded, since HTTP dogstatsd traffic doesn't reach ADP and these settings have no impact on regular dogstatsd processing, so there's no reason to block ADP from running when they're set.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Test plan

- [x] Cherry-picked from `a02262d717` with the generated `configuration.md` doc reconciled by rebuilding against the `releases/1.5.x` schema state
- [x] `cargo check` passes for `datadog-agent-config-testing` and `datadog-agent-config`