### PR TITLE
feat(otlp): wired through instrumentation scope metadata as tags config key

### DIFF
--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -812,6 +812,7 @@ Both commands scrub recognized secret values before writing JSON to standard out
 | `otlp_config.metrics.enabled`                                  | otlp_config.metrics.enabled                        |
 | `otlp_config.metrics.histograms.mode`                          | OTLP histogram bucket reporting mode               |
 | `otlp_config.metrics.histograms.send_aggregation_metrics`      | Emit OTLP histogram aggregation metrics.           |
+| `otlp_config.metrics.instrumentation_scope_metadata_as_tags`   | Add instrumentation scope metadata as metric tags. |
 | `otlp_config.metrics.resource_attributes_as_tags`              | Add scalar resource attributes as raw tags.        |
 | `otlp_config.metrics.summaries.mode`                           | OTLP summary quantile reporting mode.              |
 | `otlp_config.metrics.sums.cumulative_monotonic_mode`           | Cumulative monotonic sum reporting mode.           |

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -959,6 +959,10 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
         self.config.domains.otlp.metrics.resource_attributes_as_tags = value;
     }
 
+    fn consume_otlp_config_metrics_instrumentation_scope_metadata_as_tags(&mut self, value: bool) {
+        self.config.domains.otlp.metrics.instrumentation_scope_metadata_as_tags = value;
+    }
+
     fn consume_otlp_config_metrics_sums_cumulative_monotonic_mode(&mut self, value: String) {
         match value.parse::<CumulativeMonotonicMode>() {
             Ok(mode) => self.config.domains.otlp.metrics.sums.cumulative_monotonic_mode = mode,

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -54,7 +54,8 @@ pub struct Metrics {
 
     /// Whether instrumentation scope name, version, and attributes are added as metric tags.
     ///
-    /// Defaults to `true`.
+    /// Defaults to `true`. When `false`, no scope tags are emitted (no `n/a` placeholders).
+    /// Disable this in high-cardinality scope environments where per-scope tag overhead outweighs queryability.
     pub instrumentation_scope_metadata_as_tags: bool,
 
     /// OTLP sum translation settings.

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -52,6 +52,11 @@ pub struct Metrics {
     /// semantic-convention mappings that are always applied.
     pub resource_attributes_as_tags: bool,
 
+    /// Whether instrumentation scope name, version, and attributes are added as metric tags.
+    ///
+    /// Defaults to `true`.
+    pub instrumentation_scope_metadata_as_tags: bool,
+
     /// OTLP sum translation settings.
     pub sums: Sums,
 
@@ -76,6 +81,7 @@ impl Default for Metrics {
             histogram_mode: HistogramMode::default(),
             send_histogram_aggregations: false,
             resource_attributes_as_tags: false,
+            instrumentation_scope_metadata_as_tags: true,
             sums: Sums::default(),
             tags: String::new(),
             summaries: Summaries::default(),

--- a/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
@@ -300,6 +300,17 @@ crate::declare_annotations! {
         test_json: Some("true"),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
     };
+    /// `otlp_config.metrics.instrumentation_scope_metadata_as_tags`-Add instrumentation scope metadata as metric tags.
+    OTLP_CONFIG_METRICS_INSTRUMENTATION_SCOPE_METADATA_AS_TAGS = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_METRICS_INSTRUMENTATION_SCOPE_METADATA_AS_TAGS,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
     /// `otlp_config.metrics.resource_attributes_as_tags`-Add scalar resource attributes as raw tags.
     OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS = SalukiAnnotation {
         schema: &schema::OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -2117,6 +2117,15 @@ inventory:
       additional_attributes:
         config_registry_filename: otlp.rs
 
+  otlp_config.metrics.instrumentation_scope_metadata_as_tags:
+    support: full
+    pipelines: [otlp]
+    description: "Add instrumentation scope metadata as metric tags."
+    test_support:
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: otlp.rs
+
   otlp_config.metrics.resource_attributes_as_tags:
     support: full
     pipelines: [otlp]
@@ -4345,7 +4354,6 @@ excluded:
   otlp_config.logs.batch.max_size: "ignored in initial audit 2026-04-23"
   otlp_config.logs.batch.min_size: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.histograms.send_count_sum_metrics: "deprecated; ADP supports only send_aggregation_metrics"
-  otlp_config.metrics.instrumentation_scope_metadata_as_tags: "ignored in initial audit 2026-04-23"
   otlp_config.traces.infra_attributes.enabled: "ignored in initial audit 2026-04-23"
   otlp_config.traces.span_name_as_resource_name: "ignored in initial audit 2026-04-23"
   otlp_config.traces.span_name_remappings: "ignored in initial audit 2026-04-23"

--- a/lib/datadog-agent/config/src/generated/datadog_configuration.rs
+++ b/lib/datadog-agent/config/src/generated/datadog_configuration.rs
@@ -1472,6 +1472,10 @@ pub struct OtlpConfigMetrics {
     #[serde(default)]
     pub histograms: OtlpConfigMetricsHistograms,
 
+    #[serde(default = "defaults::default_bool::<true>")]
+    #[serde(deserialize_with = "crate::cast_de::deserialize_bool")]
+    pub instrumentation_scope_metadata_as_tags: bool,
+
     #[serde(default)]
     #[serde(deserialize_with = "crate::cast_de::deserialize_bool")]
     pub resource_attributes_as_tags: bool,
@@ -1499,6 +1503,7 @@ impl Default for OtlpConfigMetrics {
             delta_ttl: defaults::default_u64::<i64, 3600>(),
             enabled: defaults::default_bool::<true>(),
             histograms: Default::default(),
+            instrumentation_scope_metadata_as_tags: defaults::default_bool::<true>(),
             resource_attributes_as_tags: Default::default(),
             summaries: Default::default(),
             sums: Default::default(),

--- a/lib/datadog-agent/config/src/generated/env_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_keys.rs
@@ -796,6 +796,11 @@ pub static DATADOG_ENV_KEYS: &[EnvKey] = &[
         decode: EnvDecode::Bool,
     },
     EnvKey {
+        env_vars: &["DD_OTLP_CONFIG_METRICS_INSTRUMENTATION_SCOPE_METADATA_AS_TAGS"],
+        path: &["otlp_config", "metrics", "instrumentation_scope_metadata_as_tags"],
+        decode: EnvDecode::Bool,
+    },
+    EnvKey {
         env_vars: &["DD_OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS"],
         path: &["otlp_config", "metrics", "resource_attributes_as_tags"],
         decode: EnvDecode::Bool,

--- a/lib/datadog-agent/config/src/generated/witness.rs
+++ b/lib/datadog-agent/config/src/generated/witness.rs
@@ -169,6 +169,7 @@ pub trait DatadogConfigWitness {
     fn consume_otlp_config_metrics_enabled(&mut self, value: bool);
     fn consume_otlp_config_metrics_histograms_mode(&mut self, value: String);
     fn consume_otlp_config_metrics_histograms_send_aggregation_metrics(&mut self, value: bool);
+    fn consume_otlp_config_metrics_instrumentation_scope_metadata_as_tags(&mut self, value: bool);
     fn consume_otlp_config_metrics_resource_attributes_as_tags(&mut self, value: bool);
     fn consume_otlp_config_metrics_summaries_mode(&mut self, value: String);
     fn consume_otlp_config_metrics_sums_cumulative_monotonic_mode(&mut self, value: String);
@@ -444,6 +445,13 @@ pub fn drive(config: &DatadogConfiguration, consumer: &mut impl DatadogConfigWit
     consumer.consume_otlp_config_metrics_histograms_mode(config.otlp_config.metrics.histograms.mode.clone());
     consumer.consume_otlp_config_metrics_histograms_send_aggregation_metrics(
         config.otlp_config.metrics.histograms.send_aggregation_metrics.clone(),
+    );
+    consumer.consume_otlp_config_metrics_instrumentation_scope_metadata_as_tags(
+        config
+            .otlp_config
+            .metrics
+            .instrumentation_scope_metadata_as_tags
+            .clone(),
     );
     consumer.consume_otlp_config_metrics_resource_attributes_as_tags(
         config.otlp_config.metrics.resource_attributes_as_tags.clone(),

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -118,6 +118,7 @@ impl OtlpConfiguration {
             .with_cumulative_monotonic_mode(self.otlp.metrics.sums.cumulative_monotonic_mode)
             .with_initial_cumulative_monotonic_value(self.otlp.metrics.sums.initial_cumulative_monotonic_value)
             .with_resource_attributes_as_tags(self.otlp.metrics.resource_attributes_as_tags)
+            .with_instrumentation_scope_metadata_as_tags(self.otlp.metrics.instrumentation_scope_metadata_as_tags)
             .with_delta_ttl(self.otlp.metrics.delta_ttl);
         config.tag_cardinality = self.otlp.metrics.tag_cardinality;
         config
@@ -662,6 +663,29 @@ mod tests {
                 .metrics_translator_config()
                 .delta_ttl,
             Duration::from_secs(3600)
+        );
+    }
+
+    #[test]
+    fn instrumentation_scope_metadata_as_tags_defaults_to_true() {
+        assert!(
+            config_with_metrics(domains::otlp::Metrics::default())
+                .metrics_translator_config()
+                .instrumentation_scope_metadata_as_tags
+        );
+    }
+
+    #[test]
+    fn instrumentation_scope_metadata_as_tags_flows_to_metrics_translator() {
+        let config = config_with_metrics(domains::otlp::Metrics {
+            instrumentation_scope_metadata_as_tags: false,
+            ..Default::default()
+        });
+
+        assert!(
+            !config
+                .metrics_translator_config()
+                .instrumentation_scope_metadata_as_tags
         );
     }
 


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Previously, `otlp_config.metrics.instrumentation_scope_metadata_as_tags` was harcoded to `true`. This PR aims to expose a configuration option that allows for this value to be toggled on or off. 

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

Unit tests
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->
- Closes: #2025
<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
