### PR TITLE
fix(protos): honor PROTOC for protobuf codegen

### DIFF
--- a/lib/protos/datadog/build.rs
+++ b/lib/protos/datadog/build.rs
@@ -155,10 +155,12 @@ fn field_name_to_go_case(field_name: &str) -> String {
 
 fn protobuf_codegen() -> protobuf_codegen::Codegen {
     let mut codegen = protobuf_codegen::Codegen::new();
-    match std::env::var_os("PROTOC") {
-        Some(protoc) => codegen.protoc_path(Path::new(&protoc)),
-        None => codegen.protoc(),
-    };
+    codegen.protoc();
+
+    if let Some(protoc) = std::env::var_os("PROTOC") {
+        codegen.protoc_path(Path::new(&protoc));
+    }
+
     codegen
 }
 

--- a/lib/protos/datadog/build.rs
+++ b/lib/protos/datadog/build.rs
@@ -153,10 +153,20 @@ fn field_name_to_go_case(field_name: &str) -> String {
         .join("")
 }
 
+fn protobuf_codegen() -> protobuf_codegen::Codegen {
+    let mut codegen = protobuf_codegen::Codegen::new();
+    match std::env::var_os("PROTOC") {
+        Some(protoc) => codegen.protoc_path(Path::new(&protoc)),
+        None => codegen.protoc(),
+    };
+    codegen
+}
+
 fn main() {
     // Always rerun if the build script itself changes.
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=proto");
+    println!("cargo:rerun-if-env-changed=PROTOC");
 
     // Handle code generation for pure Protocol Buffers message types.
     let codegen_customize = protobuf_codegen::Customize::default()
@@ -167,8 +177,7 @@ fn main() {
     // Two separate invocations are required here because the filename of the trace payload is identical,
     // and `protobuf_codegen` ends up trying to generate code to the same output filename, which
     // means that whichever of the two files that gets processed last overwrites the other.
-    protobuf_codegen::Codegen::new()
-        .protoc()
+    protobuf_codegen()
         .includes(["proto", "proto/datadog-agent"])
         .inputs([
             "proto/agent-payload/agent_payload.proto",
@@ -179,8 +188,7 @@ fn main() {
         .run_from_script();
 
     let staged_trace_root = stage_trace_protos();
-    protobuf_codegen::Codegen::new()
-        .protoc()
+    protobuf_codegen()
         .includes([&staged_trace_root])
         .inputs([
             staged_trace_root.join("datadog/trace/stats.proto"),
@@ -195,8 +203,7 @@ fn main() {
         .customize_callback(SerdeCapableStructs)
         .run_from_script();
 
-    protobuf_codegen::Codegen::new()
-        .protoc()
+    protobuf_codegen()
         .includes(["proto/sketches-go"])
         .inputs(["proto/sketches-go/ddsketch/pb/ddsketch.proto"])
         .cargo_out_dir("sketch_protos")


### PR DESCRIPTION
## Summary

Use the conventional `PROTOC` environment variable for the `protobuf-codegen` invocations in `datadog-protos` when it is set. Continue searching `PATH` when it is unset so existing Cargo builds keep working.

Also declare `PROTOC` as a build-script input so Cargo reruns code generation when it changes.

This allows hermetic build systems such as Bazel to provide an explicitly declared compiler instead of requiring `protoc` on the host `PATH`.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ran the `datadog-protos` check both with an explicit compiler and with the existing `PATH` fallback:

```console
PROTOC=/opt/homebrew/bin/protoc cargo check -p datadog-protos
env -u PROTOC cargo check -p datadog-protos
```
