### PR TITLE
chore(ci): update SMP CLI to 0.28.0 and lading to 0.33.0

### DIFF
--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -1,6 +1,6 @@
 .setup-smp-env: &setup-smp-env
   - export AWS_NAMED_PROFILE=single-machine-performance
-  - export SMP_VERSION=0.27.0
+  - export SMP_VERSION=0.28.0
   - export RUST_LOG=info,aws_config::profile::credentials=error
   - export SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.saluki.smp-account-id --with-decryption --query "Parameter.Value" --out text)
   - export SMP_TEAM_ID=$(aws ssm get-parameter --region us-east-1 --name ci.saluki.smp-team-id --with-decryption --query "Parameter.Value" --out text)

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ export CARGO_TOOL_VERSION_cargo-machete ?= 0.9.1
 export CARGO_TOOL_VERSION_rustfilt ?= 0.2.1
 export CARGO_TOOL_VERSION_cargo-auditable ?= 0.7.4
 export DDPROF_VERSION ?= 0.20.0
-export LADING_VERSION ?= sha-d608ffbce8f8c77b147d6750b3bb6d6948af239a
+export LADING_VERSION ?= 0.33.0
 
 # Windows cross-compilation settings. These targets currently assume a local macOS host.
 export WINDOWS_CROSS_TARGET ?= x86_64-pc-windows-msvc

--- a/test/smp/regression/adp/config.yaml
+++ b/test/smp/regression/adp/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.32.0
+  version: 0.33.0
 
 target:
   ddprof_replicas: 2

--- a/test/smp/regression/adp/full/config.yaml
+++ b/test/smp/regression/adp/full/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.32.0
+  version: 0.33.0
 
 target:
   ddprof_replicas: 2

--- a/test/smp/regression/adp/quality-gates/config.yaml
+++ b/test/smp/regression/adp/quality-gates/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.32.0
+  version: 0.33.0
 
 target:
   ddprof_replicas: 2


### PR DESCRIPTION
## Summary

- Update the SMP CLI to `0.28.0`. [Release notes](https://github.com/DataDog/single-machine-performance/releases/tag/v0.28.0).
- Update lading to `0.33.0` in the SMP regression configs and the Makefile local profiling target. [Release notes.](https://github.com/DataDog/lading/releases/tag/v0.33.0)

Note there's no hard dependency between these two updates; I can split this into two PRs if requested.

*sent with claude*