### PR TITLE
fix(ci): use correct releases/x.y.x branch naming in bump-adp-version workflow

### DIFF
--- a/.github/workflows/bump-adp-version.yml
+++ b/.github/workflows/bump-adp-version.yml
@@ -33,7 +33,7 @@ jobs:
               TARGET_BRANCH="main"
               RELEASE_TYPE="minor"
             else
-              TARGET_BRANCH="release/${MAJOR}.${MINOR}.x"
+              TARGET_BRANCH="releases/${MAJOR}.${MINOR}.x"
               RELEASE_TYPE="patch"
             fi
           else
@@ -171,7 +171,7 @@ jobs:
             });
 
             // Look for other open PRs bumping the ADP version on the same target branch, and close them out so this
-            // one takes precedence. Scoping by base branch keeps minor bumps (main) and patch bumps (release/*)
+            // one takes precedence. Scoping by base branch keeps minor bumps (main) and patch bumps (releases/*)
             // from closing each other.
             const { data: labeledPRData } = await github.rest.search.issuesAndPullRequests({
               q: `repo:${context.repo.owner}/${context.repo.repo} is:pr is:open label:"${prLabel}" base:${targetBranch}`


### PR DESCRIPTION
## Summary

The `bump-adp-version` workflow failed on the 1.5.2 tag push because it computed the target branch for patch releases as `release/1.5.x` (singular), but the repo's release branches are actually named `releases/1.5.x` (plural). The checkout step's fetch of the non-existent ref failed after retries, so no bump PR was opened.

## Test plan

- [x] Verified via `git ls-remote` that existing release branches use the `releases/x.y.x` naming (e.g. `releases/1.1.x`, `releases/1.5.x`), confirming the workflow's branch name was wrong.
- [x] After merge, manually re-trigger `bump-adp-version.yml` (or push a new tag) to confirm it opens the bump PR against `releases/1.5.x`.