### PR TITLE
chore(agent-data-plane): bump version to 1.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-data-plane"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "agent-data-plane-config",
  "agent-data-plane-config-system",

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-data-plane"
-version = "1.5.2"
+version = "1.5.3"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
## Summary

This PR bumps the Agent Data Plane version to 1.5.3 for the next development cycle. It replicates what the [Bump ADP Version](.github/workflows/bump-adp-version.yml) workflow should have done on the `1.5.2` tag push, opened manually since that run failed due to a branch-naming bug in the workflow (see #2372).

### Details of change

- **Previous version:** 1.5.2
- **New version:** 1.5.3

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance