### PR TITLE
chore(components): migrate encoders to full supervision

### DIFF
--- a/lib/saluki-components/src/encoders/buffered_incremental/mod.rs
+++ b/lib/saluki-components/src/encoders/buffered_incremental/mod.rs
@@ -2,14 +2,14 @@ use std::time::Duration;
 
 use agent_data_plane_config::defaults::DEFAULT_ENCODER_FLUSH_TIMEOUT;
 use async_trait::async_trait;
-use saluki_common::task::HandleExt as _;
+use saluki_common::sync::shutdown::ShutdownCoordinator;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
     components::{encoders::*, ComponentContext},
     data_model::{event::EventType, payload::PayloadType},
     observability::ComponentMetricsExt,
 };
-use saluki_error::GenericError;
+use saluki_error::{ErrorContext as _, GenericError};
 use saluki_metrics::MetricsBuilder;
 use tokio::{pin, select, time::sleep};
 use tracing::{debug, error};
@@ -115,25 +115,48 @@ where
             flush_timeout,
         } = *self;
 
-        // Spawn our background incremental encoder task.
-        let thread_pool_handle = context.topology_context().global_thread_pool().clone();
-        let runner_name = format!(
-            "{}-incremental-encoder",
-            context.component_context().component_id().replace("_", "-")
-        );
-        let runner = run_incremental_encoder(context, encoder, telemetry, flush_timeout);
-        let runner_handle = thread_pool_handle.spawn_traced_named(runner_name, runner);
+        // Run our encoder task on the worker pool.
+        //
+        // The encoder task owns _everything_ -- health checking, encoding, dispatching payloads, etc -- so we just
+        // end up as a glorified watchdog here, where we block until the encoder task has completed. The encoder task
+        // itself is what waits for the shutdown signal and all of that.
+        //
+        // We're abusing `ShutdownCoordinator` here to basically detect when the encoder task exits: we immediately
+        // call `shutdown_and_wait` after spawning the task, which will wait until the `ShutdownHandle` we've given to
+        // the encoder tasks is dropped... which only happens when the task exits.
+        let spawner = context.spawner().clone();
+
+        let mut shutdown_coordinator = ShutdownCoordinator::default();
+        let task_shutdown_handle = shutdown_coordinator.register();
+
+        spawner
+            .noninterruptible("incremental_encoder", move |_shutdown| async move {
+                // TODO: Conceptually, all components downstream of sources/relays should drain their incoming events
+                // consumer until it's empty, so on and so forth until forwarders/destinations have done so and nothing
+                // is left to process.
+                //
+                // However, this isn't feasible if we ever want to support restarting individual components or stitching
+                // in new components to a topology... which we eventually do. We'd have to respond to shutdown (which
+                // we're ignoring here by aliasing the handle as `_shutdown`) to shut down in a timely fashion.
+                //
+                // We should consider a mechanism to expose consumers/dispatchers such that they're borrowed in an owned
+                // fashion, allowing a component to hold on to them when running, but then effectively release them when
+                // they exit. This would allow us to stop a component, and without dropping its interconnect channel and
+                // losing all of the events or payloads within it, reconnect it to the new instance of the component (or
+                // whatever component takes its place, etc) which would allow us to more cleanly respond to shutdown
+                // here as more of an exceptional thing: an immediate stoppage of work, without throwing away _pending_
+                // work.
+                let _task_shutdown_handle = task_shutdown_handle;
+                run_incremental_encoder(context, encoder, telemetry, flush_timeout).await
+            })
+            .on_worker_pool()
+            .spawn()
+            .await
+            .error_context("Failed to spawn incremental encoder task.")?;
 
         debug!("Buffered Incremental encoder started.");
 
-        // Simply wait for the runner to finish.
-        //
-        // It handles all of the health checking, event consuming, encoding, dispatching, etc.
-        match runner_handle.await {
-            Ok(Ok(())) => debug!("Incremental encoder task stopped."),
-            Ok(Err(e)) => error!(error = %e, "Incremental encoder task failed."),
-            Err(e) => error!(error = %e, "Incremental encoder task panicked."),
-        }
+        shutdown_coordinator.shutdown_and_wait().await;
 
         debug!("Buffered Incremental encoder stopped.");
 

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -8,7 +8,6 @@ use protobuf::{rt::WireType, CodedOutputStream};
 use saluki_common::{
     buf::{ChunkedBytesBuffer, FrozenChunkedBytesBuffer},
     iter::ReusableDeduplicator,
-    task::HandleExt as _,
 };
 use saluki_context::tags::{SharedTagSet, Tag};
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
@@ -550,9 +549,13 @@ impl Encoder for DatadogMetrics {
 
         let mut health = context.take_health_handle();
 
-        // Spawn our request builder task.
         let (events_tx, events_rx) = mpsc::channel(8);
         let (payloads_tx, mut payloads_rx) = mpsc::channel(8);
+
+        // Run our request builder task on the worker pool.
+        //
+        // The request builder task ignores the shutdown signal on purpose: it drains its incoming event buffer channel
+        // until the channel closes, which is what guarantees every buffered metric is encoded and dispatched.
         let request_builder_fut = run_request_builder(
             v2_series_builder,
             v2_sketch_builder,
@@ -565,10 +568,13 @@ impl Encoder for DatadogMetrics {
             flush_timeout,
             log_payloads,
         );
-        let request_builder_handle = context
-            .topology_context()
-            .global_thread_pool()
-            .spawn_traced_named("dd-metrics-request-builder", request_builder_fut);
+        context
+            .spawner()
+            .noninterruptible("request_builder", |_shutdown| request_builder_fut)
+            .on_worker_pool()
+            .spawn()
+            .await
+            .error_context("Failed to spawn request builder task.")?;
 
         health.mark_ready();
         debug!("Datadog Metrics encoder started.");
@@ -628,13 +634,8 @@ impl Encoder for DatadogMetrics {
             }
         }
 
-        // Request build task should now be stopped.
-        match request_builder_handle.await {
-            Ok(Ok(())) => debug!("Request builder task stopped."),
-            Ok(Err(e)) => error!(error = %e, "Request builder task failed."),
-            Err(e) => error!(error = %e, "Request builder task panicked."),
-        }
-
+        // Draining `payloads_rx` to completion already implies the request builder finished: it owns the only sender,
+        // so the channel only closes once that child's future has run to completion (or been dropped).
         debug!("Datadog Metrics encoder stopped.");
 
         Ok(())

--- a/lib/saluki-components/src/encoders/datadog/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/mod.rs
@@ -11,7 +11,6 @@ mod logs;
 pub use self::logs::DatadogLogsConfiguration;
 
 mod stats;
-#[allow(unused)]
 pub use self::stats::DatadogApmStatsEncoderConfiguration;
 
 mod traces;

--- a/lib/saluki-components/src/encoders/datadog/stats/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/stats/mod.rs
@@ -9,7 +9,6 @@ use datadog_protos::traces::{
     ClientStatsPayload as ProtoClientStatsPayload, StatsPayload as ProtoStatsPayload, Trilean,
 };
 use http::{uri::PathAndQuery, HeaderValue, Method, Uri};
-use saluki_common::task::HandleExt as _;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
     components::{encoders::*, ComponentContext},
@@ -158,11 +157,18 @@ impl Encoder for DatadogStats {
         let (events_tx, events_rx) = mpsc::channel(8);
         let (payloads_tx, mut payloads_rx) = mpsc::channel(8);
 
+        // Run our request builder task on the worker pool.
+        //
+        // The request builder task ignores the shutdown signal on purpose: it drains its incoming event buffer channel
+        // until the channel closes, which is what guarantees every buffered metric is encoded and dispatched.
         let request_builder_fut = run_request_builder(stats_rb, telemetry, events_rx, payloads_tx, flush_timeout);
-        let request_builder_handle = context
-            .topology_context()
-            .global_thread_pool()
-            .spawn_traced_named("dd-stats-request-builder", request_builder_fut);
+        context
+            .spawner()
+            .noninterruptible("request_builder", |_shutdown| request_builder_fut)
+            .on_worker_pool()
+            .spawn()
+            .await
+            .error_context("Failed to spawn request builder task.")?;
 
         health.mark_ready();
         debug!("Datadog APM Stats encoder started.");
@@ -197,13 +203,8 @@ impl Encoder for DatadogStats {
             }
         }
 
-        // Request build task should now be stopped.
-        match request_builder_handle.await {
-            Ok(Ok(())) => debug!("Request builder task stopped."),
-            Ok(Err(e)) => error!(error = %e, "Request builder task failed."),
-            Err(e) => error!(error = %e, "Request builder task panicked."),
-        }
-
+        // Draining `payloads_rx` to completion already implies the request builder finished: it owns the only sender,
+        // so the channel only closes once that child's future has run to completion (or been dropped).
         debug!("Datadog APM Stats encoder stopped.");
 
         Ok(())

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -7,7 +7,6 @@ use http::{uri::PathAndQuery, HeaderName, HeaderValue, Method, Uri};
 use piecemeal::{ScratchBuffer, ScratchWriter};
 use saluki_common::collections::{FastHashMap, FastIndexSet};
 use saluki_common::strings::StringBuilder;
-use saluki_common::task::HandleExt as _;
 use saluki_context::tags::TagSet;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::data_model::event::trace::AttributeValue;
@@ -274,17 +273,21 @@ impl Encoder for DatadogTrace {
 
         let mut health = context.take_health_handle();
 
-        // The encoder runs two async loops, the main encoder loop and the request builder loop,
-        // this channel is used to send events from the main encoder loop to the request builder loop safely.
         let (events_tx, events_rx) = mpsc::channel(8);
-        // adds a channel to send payloads to the dispatcher and a channel to receive them.
         let (payloads_tx, mut payloads_rx) = mpsc::channel(8);
+
+        // Run our request builder task on the worker pool.
+        //
+        // The request builder task ignores the shutdown signal on purpose: it drains its incoming event buffer channel
+        // until the channel closes, which is what guarantees every buffered metric is encoded and dispatched.
         let request_builder_fut = run_request_builder(trace_rb, telemetry, events_rx, payloads_tx, flush_timeout);
-        // Spawn the request builder task on the global thread pool, this task is responsible for encoding traces and flushing requests.
-        let request_builder_handle = context
-            .topology_context()
-            .global_thread_pool() // Use the shared Tokio runtime thread pool.
-            .spawn_traced_named("dd-traces-request-builder", request_builder_fut);
+        context
+            .spawner()
+            .noninterruptible("request_builder", |_shutdown| request_builder_fut)
+            .on_worker_pool()
+            .spawn()
+            .await
+            .error_context("Failed to spawn request builder task.")?;
 
         health.mark_ready();
         debug!("Datadog Trace encoder started.");
@@ -321,13 +324,8 @@ impl Encoder for DatadogTrace {
             }
         }
 
-        // Request build task should now be stopped.
-        match request_builder_handle.await {
-            Ok(Ok(())) => debug!("Request builder task stopped."),
-            Ok(Err(e)) => error!(error = %e, "Request builder task failed."),
-            Err(e) => error!(error = %e, "Request builder task panicked."),
-        }
-
+        // Draining `payloads_rx` to completion already implies the request builder finished: it owns the only sender,
+        // so the channel only closes once that child's future has run to completion (or been dropped).
         debug!("Datadog Trace encoder stopped.");
 
         Ok(())


### PR DESCRIPTION
## Summary

This PR is the second of many (hopefully just a few) for converting components to spawn all of their child tasks under their dedicated supervisor to fully unify task execution in Saluki under the supervision tree model, continuing with encoders.[

This one is really simply, because all existing encoders just spawned a separate request/payload builder task and ran it... so we're just updating _how_ we spawn that task.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing tests.

## References

DADP-2
