### PR TITLE
chore(smp): regenerate SMP experiment configs

### DIFF
--- a/test/smp/regression/adp/full/cases/tagvaluefilter_0rules_100mb/experiment.yaml
+++ b/test/smp/regression/adp/full/cases/tagvaluefilter_0rules_100mb/experiment.yaml
@@ -13,6 +13,7 @@ target:
     DD_IPC_CERT_FILE_PATH: /etc/agent-data-plane/cert.pem
     DD_LOG_FORMAT_JSON: "true"
     DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_METRICS_LEVEL: trace
     DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
     DD_DOGSTATSD_PORT: "0"
     DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock

--- a/test/smp/regression/adp/full/cases/tagvaluefilter_0rules_idle/experiment.yaml
+++ b/test/smp/regression/adp/full/cases/tagvaluefilter_0rules_idle/experiment.yaml
@@ -13,6 +13,7 @@ target:
     DD_IPC_CERT_FILE_PATH: /etc/agent-data-plane/cert.pem
     DD_LOG_FORMAT_JSON: "true"
     DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_METRICS_LEVEL: trace
     DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
     DD_DOGSTATSD_PORT: "0"
     DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock

--- a/test/smp/regression/adp/full/cases/tagvaluefilter_10000rules_10values_idle/experiment.yaml
+++ b/test/smp/regression/adp/full/cases/tagvaluefilter_10000rules_10values_idle/experiment.yaml
@@ -13,6 +13,7 @@ target:
     DD_IPC_CERT_FILE_PATH: /etc/agent-data-plane/cert.pem
     DD_LOG_FORMAT_JSON: "true"
     DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_METRICS_LEVEL: trace
     DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
     DD_DOGSTATSD_PORT: "0"
     DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock

--- a/test/smp/regression/adp/full/cases/tagvaluefilter_10000rules_allow_100mb/experiment.yaml
+++ b/test/smp/regression/adp/full/cases/tagvaluefilter_10000rules_allow_100mb/experiment.yaml
@@ -13,6 +13,7 @@ target:
     DD_IPC_CERT_FILE_PATH: /etc/agent-data-plane/cert.pem
     DD_LOG_FORMAT_JSON: "true"
     DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_METRICS_LEVEL: trace
     DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
     DD_DOGSTATSD_PORT: "0"
     DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock

--- a/test/smp/regression/adp/full/cases/tagvaluefilter_10000rules_miss_100mb/experiment.yaml
+++ b/test/smp/regression/adp/full/cases/tagvaluefilter_10000rules_miss_100mb/experiment.yaml
@@ -13,6 +13,7 @@ target:
     DD_IPC_CERT_FILE_PATH: /etc/agent-data-plane/cert.pem
     DD_LOG_FORMAT_JSON: "true"
     DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_METRICS_LEVEL: trace
     DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
     DD_DOGSTATSD_PORT: "0"
     DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock

--- a/test/smp/regression/adp/full/cases/tagvaluefilter_1rule_10000values_idle/experiment.yaml
+++ b/test/smp/regression/adp/full/cases/tagvaluefilter_1rule_10000values_idle/experiment.yaml
@@ -13,6 +13,7 @@ target:
     DD_IPC_CERT_FILE_PATH: /etc/agent-data-plane/cert.pem
     DD_LOG_FORMAT_JSON: "true"
     DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_METRICS_LEVEL: trace
     DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
     DD_DOGSTATSD_PORT: "0"
     DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock

--- a/test/smp/regression/adp/full/cases/tagvaluefilter_1rule_10values_idle/experiment.yaml
+++ b/test/smp/regression/adp/full/cases/tagvaluefilter_1rule_10values_idle/experiment.yaml
@@ -13,6 +13,7 @@ target:
     DD_IPC_CERT_FILE_PATH: /etc/agent-data-plane/cert.pem
     DD_LOG_FORMAT_JSON: "true"
     DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_METRICS_LEVEL: trace
     DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
     DD_DOGSTATSD_PORT: "0"
     DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock

--- a/test/smp/regression/adp/full/cases/tagvaluefilter_1rule_allow_100mb/experiment.yaml
+++ b/test/smp/regression/adp/full/cases/tagvaluefilter_1rule_allow_100mb/experiment.yaml
@@ -13,6 +13,7 @@ target:
     DD_IPC_CERT_FILE_PATH: /etc/agent-data-plane/cert.pem
     DD_LOG_FORMAT_JSON: "true"
     DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_METRICS_LEVEL: trace
     DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
     DD_DOGSTATSD_PORT: "0"
     DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock

--- a/test/smp/regression/adp/full/cases/tagvaluefilter_1rule_remove25_100mb/experiment.yaml
+++ b/test/smp/regression/adp/full/cases/tagvaluefilter_1rule_remove25_100mb/experiment.yaml
@@ -13,6 +13,7 @@ target:
     DD_IPC_CERT_FILE_PATH: /etc/agent-data-plane/cert.pem
     DD_LOG_FORMAT_JSON: "true"
     DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_METRICS_LEVEL: trace
     DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
     DD_DOGSTATSD_PORT: "0"
     DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock

--- a/test/smp/regression/adp/full/cases/tagvaluefilter_1rule_replace25_100mb/experiment.yaml
+++ b/test/smp/regression/adp/full/cases/tagvaluefilter_1rule_replace25_100mb/experiment.yaml
@@ -13,6 +13,7 @@ target:
     DD_IPC_CERT_FILE_PATH: /etc/agent-data-plane/cert.pem
     DD_LOG_FORMAT_JSON: "true"
     DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_METRICS_LEVEL: trace
     DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
     DD_DOGSTATSD_PORT: "0"
     DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock

--- a/test/smp/regression/adp/full/cases/tagvaluefilter_500rules_10values_idle/experiment.yaml
+++ b/test/smp/regression/adp/full/cases/tagvaluefilter_500rules_10values_idle/experiment.yaml
@@ -13,6 +13,7 @@ target:
     DD_IPC_CERT_FILE_PATH: /etc/agent-data-plane/cert.pem
     DD_LOG_FORMAT_JSON: "true"
     DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_METRICS_LEVEL: trace
     DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
     DD_DOGSTATSD_PORT: "0"
     DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock

--- a/test/smp/regression/adp/full/cases/tagvaluefilter_500rules_allow_100mb/experiment.yaml
+++ b/test/smp/regression/adp/full/cases/tagvaluefilter_500rules_allow_100mb/experiment.yaml
@@ -13,6 +13,7 @@ target:
     DD_IPC_CERT_FILE_PATH: /etc/agent-data-plane/cert.pem
     DD_LOG_FORMAT_JSON: "true"
     DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_METRICS_LEVEL: trace
     DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
     DD_DOGSTATSD_PORT: "0"
     DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock


### PR DESCRIPTION
## Summary
SMP experiment configs for the `tagvaluefilter_*` cases had drifted from `experiments.yaml`: `DD_METRICS_LEVEL: trace` was added to the generator inputs in #2369, but those 12 cases weren't regenerated at the time, so their checked-in `experiment.yaml` files were missing it. This re-runs `make generate-smp-experiments` to bring them back in sync.

## Test plan
- [x] `make check-smp-experiments` passes (configs match `experiments.yaml`)