### PR TITLE
enhancement(core): add registry for external resources

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -40,7 +40,7 @@ use saluki_components::{
 use saluki_config::GenericConfiguration;
 use saluki_core::accounting::{ComponentBounds, ComponentRegistry};
 use saluki_core::health::HealthRegistry;
-use saluki_core::runtime::{RestartMode, RestartStrategy, Supervisor, SupervisorError};
+use saluki_core::runtime::{state::ResourceRegistry, RestartMode, RestartStrategy, Supervisor, SupervisorError};
 use saluki_core::topology::TopologyBlueprint;
 use saluki_env::{features, EnvironmentProvider as _, HostProvider as _};
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
@@ -159,6 +159,7 @@ pub async fn handle_run_command(
     // Set up all of the building blocks for building our topologies and launching internal processes.
     let component_registry = ComponentRegistry::default();
     let health_registry = HealthRegistry::new();
+    let resource_registry = ResourceRegistry::new();
     let (env_provider, maybe_env_supervisor) = ADPEnvironmentProvider::from_configuration(
         standalone,
         &config_sys.raw_map(),
@@ -205,6 +206,7 @@ pub async fn handle_run_command(
     blueprint
         .with_health_registry(health_registry.clone())
         .with_memory_limiter(memory_limiter)
+        .with_resource_registry(resource_registry.clone())
         .with_environment_readiness(env_provider.wait_for_ready());
 
     // Acquire a readiness handle before handing the blueprint off to the supervisor. This waits until the topology has
@@ -216,6 +218,7 @@ pub async fn handle_run_command(
     let mut root_supervisor = Supervisor::new("adp-root")?.with_restart_strategy(root_restart_strategy);
 
     root_supervisor.add_worker(bootstrap_supervisor);
+    internal_supervisor.add_worker(resource_registry.worker());
     if let Some(env_supervisor) = maybe_env_supervisor {
         internal_supervisor.add_worker(env_supervisor);
     }
@@ -1036,11 +1039,11 @@ mod tests {
         components::{
             destinations::{Destination, DestinationBuilder, DestinationContext},
             sources::{Source, SourceBuilder, SourceContext},
-            ComponentContext,
+            BuildContext,
         },
         data_model::event::{metric::Metric, Event, EventType},
         health::HealthRegistry,
-        runtime::Supervisor,
+        runtime::{state::ResourceRegistry, Supervisor},
         topology::{OutputDefinition, TopologyBlueprint},
     };
     use saluki_error::{generic_error, GenericError};
@@ -1164,6 +1167,7 @@ mod tests {
             blueprint
                 .with_health_registry(HealthRegistry::new())
                 .with_memory_limiter(MemoryLimiter::noop())
+                .with_resource_registry(ResourceRegistry::new())
                 .with_ambient_worker_pool();
 
             let mut supervisor =
@@ -1333,7 +1337,7 @@ mod tests {
             &self.outputs
         }
 
-        async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError> {
+        async fn build(&self, _context: BuildContext) -> Result<Box<dyn Source + Send>, GenericError> {
             let events = self
                 .events
                 .lock()
@@ -1366,7 +1370,7 @@ mod tests {
             EventType::Metric
         }
 
-        async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
+        async fn build(&self, _context: BuildContext) -> Result<Box<dyn Destination + Send>, GenericError> {
             Ok(Box::new(DrainingMetricDestination))
         }
     }

--- a/bin/agent-data-plane/src/components/apm_onboarding/mod.rs
+++ b/bin/agent-data-plane/src/components/apm_onboarding/mod.rs
@@ -5,7 +5,7 @@ use saluki_common::{
 };
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
-    components::{transforms::*, ComponentContext},
+    components::{transforms::*, BuildContext},
     data_model::event::trace::{AttributeValue, Span, Trace},
     topology::EventsBuffer,
 };
@@ -29,7 +29,7 @@ pub struct ApmOnboardingConfiguration;
 
 #[async_trait]
 impl SynchronousTransformBuilder for ApmOnboardingConfiguration {
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
         let install_info = match InstallInfo::load_or_create().await {
             Ok(info) => Some(info),
             Err(e) => {

--- a/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/mod.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/mod.rs
@@ -7,7 +7,7 @@ use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
     components::{
         transforms::{Transform, TransformBuilder, TransformContext},
-        ComponentContext,
+        BuildContext,
     },
     data_model::event::{
         metric::{Metric, MetricValues},
@@ -110,8 +110,8 @@ impl TransformBuilder for DogStatsDPostAggregateFilterConfiguration {
         OUTPUTS
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
-        let metrics_builder = MetricsBuilder::from_component_context(&context);
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Transform + Send>, GenericError> {
+        let metrics_builder = MetricsBuilder::from_component_context(context.component_context());
         let histogram_suffixes =
             HistogramSuffixes::from_configuration(&self.histogram_aggregates, &self.histogram_percentiles)?;
         let effective_filterlist = EffectiveFilterlist::new(

--- a/bin/agent-data-plane/src/components/dogstatsd_prefix_filter/mod.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_prefix_filter/mod.rs
@@ -8,7 +8,7 @@ use saluki_core::data_model::event::{metric::Metric, EventType};
 use saluki_core::{
     components::{
         transforms::{Transform, TransformBuilder, TransformContext},
-        ComponentContext,
+        BuildContext,
     },
     observability::ComponentMetricsExt as _,
     topology::OutputDefinition,
@@ -110,14 +110,14 @@ impl TransformBuilder for DogStatsDPrefixFilterConfiguration {
         OUTPUTS
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Transform + Send>, GenericError> {
         // Ensure our metric prefix has a trailing period so that we don't have to check for, and possibly add it, when we're
         // actually processing metrics.
         let mut metric_prefix = self.metric_prefix.clone();
         if !metric_prefix.is_empty() && !metric_prefix.ends_with(".") {
             metric_prefix.push('.');
         }
-        let metrics_builder = MetricsBuilder::from_component_context(&context);
+        let metrics_builder = MetricsBuilder::from_component_context(context.component_context());
         let effective_filterlist = EffectiveFilterlist::new(
             self.metric_filterlist.clone(),
             self.metric_filterlist_match_prefix,

--- a/bin/agent-data-plane/src/components/host_tags/mod.rs
+++ b/bin/agent-data-plane/src/components/host_tags/mod.rs
@@ -9,7 +9,7 @@ use saluki_config::{DurationString, GenericConfiguration};
 use saluki_context::tags::{SharedTagSet, Tag};
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{components::transforms::*, topology::EventsBuffer};
-use saluki_core::{components::ComponentContext, data_model::event::metric::Metric};
+use saluki_core::{components::BuildContext, data_model::event::metric::Metric};
 use saluki_error::GenericError;
 use stringtheory::MetaString;
 
@@ -50,7 +50,7 @@ impl HostTagsConfiguration {
 
 #[async_trait]
 impl SynchronousTransformBuilder for HostTagsConfiguration {
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
         // Only fetch host tags when enrichment is enabled (`expected_tags_duration > 0`), matching the Core
         // Agent; at the default of 0 the tags are discarded immediately. Fetching always would block `build()`
         // on the Core Agent's slow `GetHostTags` RPC, delaying DogStatsD draining and starving origin detection.

--- a/bin/agent-data-plane/src/components/liveness/mod.rs
+++ b/bin/agent-data-plane/src/components/liveness/mod.rs
@@ -11,7 +11,7 @@ use saluki_context::{
 };
 use saluki_core::{
     accounting::{MemoryBounds, MemoryBoundsBuilder},
-    components::{sources::*, ComponentContext},
+    components::{sources::*, BuildContext},
     data_model::event::{
         metric::Metric,
         service_check::{CheckStatus, ServiceCheck},
@@ -76,7 +76,7 @@ impl LivenessConfiguration {
 
 #[async_trait]
 impl SourceBuilder for LivenessConfiguration {
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn Source + Send>, GenericError> {
         Ok(Box::new(Liveness::new(
             self.hostname.clone(),
             self.version.clone(),

--- a/bin/agent-data-plane/src/components/ottl_filter_processor/mod.rs
+++ b/bin/agent-data-plane/src/components/ottl_filter_processor/mod.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use ottl::{CallbackMap, EnumMap, OttlParser, Value};
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
-    components::{transforms::*, ComponentContext},
+    components::{transforms::*, BuildContext},
     data_model::event::trace::{Span, Trace},
     topology::EventsBuffer,
 };
@@ -40,7 +40,7 @@ impl SynchronousTransformBuilder for OttlFilterConfiguration {
     /// # Errors
     ///
     /// Returns an error if any OTTL span condition string fails to parse.
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
         let path_resolvers = span_context::span_filter_path_resolvers();
         let editors = CallbackMap::new();
         let converters = CallbackMap::new();
@@ -138,7 +138,7 @@ mod tests {
     use std::collections::HashMap;
 
     use saluki_core::{
-        components::{transforms::*, ComponentContext},
+        components::{transforms::*, BuildContext},
         data_model::event::{trace::AttributeValue, Event},
         topology::EventsBuffer,
     };
@@ -156,8 +156,8 @@ mod tests {
             .sum()
     }
 
-    fn test_component_context() -> ComponentContext {
-        ComponentContext::test_transform("ottl_filter")
+    fn test_component_context() -> BuildContext {
+        BuildContext::test_transform("ottl_filter")
     }
 
     fn test_config(value: serde_json::Value) -> OttlFilterConfiguration {

--- a/bin/agent-data-plane/src/components/ottl_transform_processor/mod.rs
+++ b/bin/agent-data-plane/src/components/ottl_transform_processor/mod.rs
@@ -13,7 +13,7 @@ use ottl::{CallbackMap, EnumMap, OttlParser};
 use saluki_common::collections::FastHashMap;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
-    components::{transforms::*, ComponentContext},
+    components::{transforms::*, BuildContext},
     data_model::event::trace::{AttributeValue, Span},
     topology::EventsBuffer,
 };
@@ -47,7 +47,7 @@ impl SynchronousTransformBuilder for OttlTransformConfiguration {
     /// # Errors
     ///
     /// If the OTTL statement fails to parse, an error is returned.
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
         let path_resolvers = span_context::span_transform_path_resolvers();
 
         let editors = ottl::editors::standard();
@@ -141,7 +141,7 @@ mod tests {
     use std::collections::HashMap;
 
     use saluki_core::{
-        components::{transforms::*, ComponentContext},
+        components::{transforms::*, BuildContext},
         data_model::event::{
             service_check::{CheckStatus, ServiceCheck},
             trace::AttributeValue,
@@ -174,8 +174,8 @@ mod tests {
             })
     }
 
-    fn test_component_context() -> ComponentContext {
-        ComponentContext::test_transform("ottl_transform")
+    fn test_component_context() -> BuildContext {
+        BuildContext::test_transform("ottl_transform")
     }
 
     fn test_config(value: Option<serde_json::Value>) -> TypedOttlTransform {

--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -28,7 +28,7 @@ use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
     components::{
         transforms::{Transform, TransformBuilder, TransformContext},
-        ComponentContext,
+        BuildContext,
     },
     data_model::event::{
         metric::{Metric, MetricValues},
@@ -285,8 +285,8 @@ impl TransformBuilder for TagFilterlistConfiguration {
         OUTPUTS
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
-        let metrics_builder = MetricsBuilder::from_component_context(&context);
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Transform + Send>, GenericError> {
+        let metrics_builder = MetricsBuilder::from_component_context(context.component_context());
         let telemetry = Telemetry::new(&metrics_builder);
         let filters = compile_filters_with_values(&self.entries, self.value_prefix_filters.clone());
         telemetry.set_size(filters.rule_count());
@@ -502,14 +502,17 @@ mod tests {
     use saluki_core::components::ComponentSpawner;
     use saluki_core::components::{
         transforms::{TransformBuilder, TransformContext},
-        ComponentContext,
+        BuildContext, ComponentContext,
     };
     use saluki_core::data_model::event::{
         metric::{Metric, MetricValues},
         Event,
     };
     use saluki_core::health::HealthRegistry;
-    use saluki_core::runtime::{state::DataspaceRegistry, Supervisor};
+    use saluki_core::runtime::{
+        state::{DataspaceRegistry, ResourceRegistry},
+        Supervisor,
+    };
     use saluki_core::topology::interconnect::{Consumer, Dispatcher};
     use saluki_core::topology::{EventsBuffer, OutputName, TopologyContext};
     use saluki_metrics::{test::TestRecorder, MetricsBuilder};
@@ -1405,7 +1408,7 @@ mod tests {
 
         let component_context = ComponentContext::test_transform("tag_filterlist");
         let transform = builder
-            .build(component_context.clone())
+            .build(BuildContext::new(component_context.clone(), ResourceRegistry::new()))
             .await
             .expect("tag filterlist should build");
 

--- a/lib/saluki-components/src/decoders/otlp/mod.rs
+++ b/lib/saluki-components/src/decoders/otlp/mod.rs
@@ -8,7 +8,7 @@ use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
     components::{
         decoders::{Decoder, DecoderBuilder, DecoderContext},
-        ComponentContext,
+        BuildContext,
     },
     data_model::{event::EventType, payload::PayloadType},
     topology::interconnect::EventBufferManager,
@@ -49,8 +49,8 @@ impl DecoderBuilder for OtlpDecoderConfiguration {
         EventType::Trace
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Decoder + Send>, GenericError> {
-        let metrics = build_metrics(&context);
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Decoder + Send>, GenericError> {
+        let metrics = build_metrics(context.component_context());
         let traces_translator = OtlpTracesTranslator::new(self.traces.clone());
 
         Ok(Box::new(OtlpDecoder {

--- a/lib/saluki-components/src/destinations/blackhole/mod.rs
+++ b/lib/saluki-components/src/destinations/blackhole/mod.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
-use saluki_core::components::{destinations::*, ComponentContext};
+use saluki_core::components::{destinations::*, BuildContext};
 use saluki_core::data_model::event::EventType;
 use saluki_error::GenericError;
 use tokio::select;
@@ -21,7 +21,7 @@ impl DestinationBuilder for BlackholeConfiguration {
         EventType::all_bits()
     }
 
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn Destination + Send>, GenericError> {
         Ok(Box::new(Blackhole))
     }
 }

--- a/lib/saluki-components/src/destinations/dogstatsd_client_telemetry.rs
+++ b/lib/saluki-components/src/destinations/dogstatsd_client_telemetry.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use metrics::Counter;
 use saluki_core::{
     accounting::{MemoryBounds, MemoryBoundsBuilder},
-    components::{destinations::*, ComponentContext},
+    components::{destinations::*, BuildContext},
     data_model::event::{
         metric::{Metric, MetricValues},
         Event, EventType,
@@ -24,9 +24,9 @@ impl DestinationBuilder for DogStatsDClientTelemetryConfiguration {
         EventType::Metric
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Destination + Send>, GenericError> {
         Ok(Box::new(DogStatsDClientTelemetry::new(
-            MetricsBuilder::from_component_context(&context),
+            MetricsBuilder::from_component_context(context.component_context()),
         )))
     }
 }

--- a/lib/saluki-components/src/destinations/dsd_debug_log/mod.rs
+++ b/lib/saluki-components/src/destinations/dsd_debug_log/mod.rs
@@ -9,7 +9,7 @@ use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
     components::{
         destinations::{Destination, DestinationBuilder, DestinationContext},
-        ComponentContext,
+        BuildContext,
     },
     data_model::event::{metric::Metric, Event, EventType},
 };
@@ -186,7 +186,7 @@ impl DestinationBuilder for DogStatsDDebugLogConfiguration {
         EventType::Metric
     }
 
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn Destination + Send>, GenericError> {
         DogStatsDDebugLog::new(self).map(|destination| Box::new(destination) as Box<dyn Destination + Send>)
     }
 }

--- a/lib/saluki-components/src/destinations/dsd_stats/mod.rs
+++ b/lib/saluki-components/src/destinations/dsd_stats/mod.rs
@@ -13,7 +13,7 @@ use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
     components::{
         destinations::{Destination, DestinationBuilder, DestinationContext},
-        ComponentContext,
+        BuildContext,
     },
     data_model::event::{Event, EventType},
 };
@@ -296,7 +296,7 @@ impl DestinationBuilder for DogStatsDStatisticsConfiguration {
         EventType::Metric
     }
 
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn Destination + Send>, GenericError> {
         let rx = self.rx.clone().try_lock_owned()?;
         Ok(Box::new(DogStatsDStats { rx }))
     }
@@ -390,7 +390,7 @@ mod tests {
         use saluki_core::components::ComponentContext;
         use saluki_core::data_model::event::metric::Metric;
         use saluki_core::health::HealthRegistry;
-        use saluki_core::runtime::state::DataspaceRegistry;
+        use saluki_core::runtime::state::{DataspaceRegistry, ResourceRegistry};
         use saluki_core::runtime::Supervisor;
         use saluki_core::topology::interconnect::Consumer;
         use saluki_core::topology::{EventsBuffer, TopologyContext};
@@ -403,7 +403,7 @@ mod tests {
 
         let component_context = ComponentContext::test_destination("test");
         let destination = config
-            .build(component_context.clone())
+            .build(BuildContext::new(component_context.clone(), ResourceRegistry::new()))
             .await
             .expect("dsd_stats destination should build");
 

--- a/lib/saluki-components/src/destinations/prometheus/mod.rs
+++ b/lib/saluki-components/src/destinations/prometheus/mod.rs
@@ -18,7 +18,7 @@ use prometheus_exposition::{MetricType, PrometheusRenderer};
 use saluki_common::{collections::FastIndexMap, iter::ReusableDeduplicator, sync::shutdown::ShutdownCoordinator};
 use saluki_context::{tags::Tag, Context};
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
-use saluki_core::components::{destinations::*, ComponentContext};
+use saluki_core::components::{destinations::*, BuildContext};
 use saluki_core::data_model::event::{
     metric::{Histogram, Metric, MetricValues},
     EventType,
@@ -129,7 +129,7 @@ impl DestinationBuilder for PrometheusConfiguration {
         EventType::Metric
     }
 
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn Destination + Send>, GenericError> {
         Ok(Box::new(Prometheus {
             listener: ConnectionOrientedListener::from_listen_address(self.listen_addr.clone()).await?,
             additional_routes: self.additional_routes.clone(),

--- a/lib/saluki-components/src/encoders/buffered_incremental/mod.rs
+++ b/lib/saluki-components/src/encoders/buffered_incremental/mod.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use saluki_common::sync::shutdown::ShutdownCoordinator;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
-    components::{encoders::*, ComponentContext},
+    components::{encoders::*, BuildContext},
     data_model::{event::EventType, payload::PayloadType},
     observability::ComponentMetricsExt,
 };
@@ -63,8 +63,8 @@ where
         self.encoder_builder.output_payload_type()
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Encoder + Send>, GenericError> {
-        let metrics_builder = MetricsBuilder::from_component_context(&context);
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Encoder + Send>, GenericError> {
+        let metrics_builder = MetricsBuilder::from_component_context(context.component_context());
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
 
         let encoder = self.encoder_builder.build(context).await?;

--- a/lib/saluki-components/src/encoders/datadog/events/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/events/mod.rs
@@ -6,7 +6,7 @@ use saluki_common::iter::ReusableDeduplicator;
 use saluki_context::tags::Tag;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
-    components::{encoders::*, ComponentContext},
+    components::{encoders::*, BuildContext},
     data_model::{
         event::{eventd::EventD, Event, EventType},
         payload::{HttpPayload, Payload, PayloadMetadata, PayloadType},
@@ -85,8 +85,8 @@ impl IncrementalEncoderBuilder for DatadogEventsConfiguration {
         PayloadType::Http
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Self::Output, GenericError> {
-        let metrics_builder = MetricsBuilder::from_component_context(&context);
+    async fn build(&self, context: BuildContext) -> Result<Self::Output, GenericError> {
+        let metrics_builder = MetricsBuilder::from_component_context(context.component_context());
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
         let compression_scheme = CompressionScheme::new(&self.compressor_kind, self.zstd_level);
 

--- a/lib/saluki-components/src/encoders/datadog/logs/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/logs/mod.rs
@@ -5,7 +5,7 @@ use saluki_common::iter::ReusableDeduplicator;
 use saluki_context::tags::Tag;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
-    components::{encoders::*, ComponentContext},
+    components::{encoders::*, BuildContext},
     data_model::{
         event::{log::Log, Event, EventType},
         payload::{HttpPayload, Payload, PayloadMetadata, PayloadType},
@@ -64,8 +64,8 @@ impl IncrementalEncoderBuilder for DatadogLogsConfiguration {
         PayloadType::Http
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Self::Output, GenericError> {
-        let metrics_builder = MetricsBuilder::from_component_context(&context);
+    async fn build(&self, context: BuildContext) -> Result<Self::Output, GenericError> {
+        let metrics_builder = MetricsBuilder::from_component_context(context.component_context());
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
         let compression_scheme = CompressionScheme::new(&self.compressor_kind, self.zstd_level);
 

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -12,7 +12,7 @@ use saluki_common::{
 use saluki_context::tags::{SharedTagSet, Tag};
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
-    components::{encoders::*, ComponentContext},
+    components::{encoders::*, BuildContext},
     data_model::{
         event::{
             metric::{Metric, MetricOrigin, MetricValues},
@@ -380,8 +380,8 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
         PayloadType::Http
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Encoder + Send>, GenericError> {
-        let metrics_builder = MetricsBuilder::from_component_context(&context);
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Encoder + Send>, GenericError> {
+        let metrics_builder = MetricsBuilder::from_component_context(context.component_context());
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
         let v3_serializer_telemetry = V3SerializerTelemetry::from_builder(&metrics_builder);
 

--- a/lib/saluki-components/src/encoders/datadog/service_checks/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/service_checks/mod.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use http::{uri::PathAndQuery, HeaderValue, Method, Uri};
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
-    components::{encoders::*, ComponentContext},
+    components::{encoders::*, BuildContext},
     data_model::{
         event::{service_check::ServiceCheck, Event, EventType},
         payload::{HttpPayload, Payload, PayloadMetadata, PayloadType},
@@ -82,8 +82,8 @@ impl IncrementalEncoderBuilder for DatadogServiceChecksConfiguration {
         PayloadType::Http
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Self::Output, GenericError> {
-        let metrics_builder = MetricsBuilder::from_component_context(&context);
+    async fn build(&self, context: BuildContext) -> Result<Self::Output, GenericError> {
+        let metrics_builder = MetricsBuilder::from_component_context(context.component_context());
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
         let compression_scheme = CompressionScheme::new(&self.compressor_kind, self.zstd_level);
 

--- a/lib/saluki-components/src/encoders/datadog/stats/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/stats/mod.rs
@@ -11,7 +11,7 @@ use datadog_protos::traces::{
 use http::{uri::PathAndQuery, HeaderValue, Method, Uri};
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
-    components::{encoders::*, ComponentContext},
+    components::{encoders::*, BuildContext},
     data_model::{
         event::{
             trace_stats::{ClientGroupedStats, ClientStatsBucket, ClientStatsPayload, TraceStats},
@@ -90,8 +90,8 @@ impl EncoderBuilder for DatadogApmStatsEncoderConfiguration {
         PayloadType::Http
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Encoder + Send>, GenericError> {
-        let metrics_builder = MetricsBuilder::from_component_context(&context);
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Encoder + Send>, GenericError> {
+        let metrics_builder = MetricsBuilder::from_component_context(context.component_context());
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
         let compression_scheme = CompressionScheme::gzip_default();
 

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -12,7 +12,7 @@ use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::data_model::event::trace::AttributeValue;
 use saluki_core::topology::{EventsBuffer, PayloadsBuffer};
 use saluki_core::{
-    components::{encoders::*, ComponentContext},
+    components::{encoders::*, BuildContext},
     data_model::{
         event::{trace::Trace, EventType},
         payload::{HttpPayload, Payload, PayloadMetadata, PayloadType},
@@ -197,8 +197,8 @@ impl EncoderBuilder for DatadogTraceConfiguration {
         PayloadType::Http
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Encoder + Send>, GenericError> {
-        let metrics_builder = MetricsBuilder::from_component_context(&context);
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Encoder + Send>, GenericError> {
+        let metrics_builder = MetricsBuilder::from_component_context(context.component_context());
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
         let compression_scheme = CompressionScheme::new(&self.compressor_kind, self.zstd_compressor_level);
 

--- a/lib/saluki-components/src/forwarders/cluster_agent/mod.rs
+++ b/lib/saluki-components/src/forwarders/cluster_agent/mod.rs
@@ -11,7 +11,7 @@ use saluki_common::buf::FrozenChunkedBytesBuffer;
 use saluki_config::GenericConfiguration;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder, UsageExpr};
 use saluki_core::{
-    components::{forwarders::*, ComponentContext},
+    components::{forwarders::*, BuildContext},
     data_model::payload::PayloadType,
     observability::ComponentMetricsExt as _,
 };
@@ -80,12 +80,12 @@ impl ForwarderBuilder for ClusterAgentForwarderConfiguration {
         PayloadType::Http
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Forwarder + Send>, GenericError> {
-        let metrics_builder = MetricsBuilder::from_component_context(&context);
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Forwarder + Send>, GenericError> {
+        let metrics_builder = MetricsBuilder::from_component_context(context.component_context());
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
         let endpoint_request_mapper_factory = cluster_agent_request_mapper_factory(self.auth_header_value.clone());
         let forwarder = TransactionForwarder::from_config_with_endpoint_request_mapper(
-            context,
+            context.component_context().clone(),
             self.forwarder_config.clone(),
             None,
             get_cluster_agent_endpoint_name,

--- a/lib/saluki-components/src/forwarders/datadog/mod.rs
+++ b/lib/saluki-components/src/forwarders/datadog/mod.rs
@@ -5,7 +5,7 @@ use saluki_common::buf::FrozenChunkedBytesBuffer;
 use saluki_config::GenericConfiguration;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder, UsageExpr};
 use saluki_core::{
-    components::{forwarders::*, ComponentContext},
+    components::{forwarders::*, BuildContext},
     data_model::payload::{PayloadMetadata, PayloadType},
     observability::ComponentMetricsExt as _,
 };
@@ -82,11 +82,11 @@ impl ForwarderBuilder for DatadogForwarderConfiguration {
         PayloadType::Http
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Forwarder + Send>, GenericError> {
-        let metrics_builder = MetricsBuilder::from_component_context(&context);
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Forwarder + Send>, GenericError> {
+        let metrics_builder = MetricsBuilder::from_component_context(context.component_context());
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
         let forwarder = TransactionForwarder::from_config(
-            context,
+            context.component_context().clone(),
             self.forwarder_config.clone(),
             Some(self.configuration.clone()),
             get_dd_endpoint_name,

--- a/lib/saluki-components/src/forwarders/otlp/mod.rs
+++ b/lib/saluki-components/src/forwarders/otlp/mod.rs
@@ -14,7 +14,7 @@ use saluki_common::buf::FrozenChunkedBytesBuffer;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::data_model::payload::Payload;
 use saluki_core::{
-    components::{forwarders::*, ComponentContext},
+    components::{forwarders::*, BuildContext},
     data_model::payload::PayloadType,
 };
 use saluki_error::ErrorContext as _;
@@ -51,7 +51,7 @@ impl ForwarderBuilder for OtlpForwarderConfiguration {
         PayloadType::Grpc
     }
 
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Forwarder + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn Forwarder + Send>, GenericError> {
         let trace_agent_endpoint = format!("http://localhost:{}", self.core_agent_traces_internal_port);
         let trace_agent_channel = Channel::from_shared(trace_agent_endpoint.clone())
             .error_context("Failed to construct gRPC channel due to an invalid endpoint.")?

--- a/lib/saluki-components/src/relays/otlp/mod.rs
+++ b/lib/saluki-components/src/relays/otlp/mod.rs
@@ -6,7 +6,7 @@ use axum::body::Bytes;
 use saluki_common::buf::FrozenChunkedBytesBuffer;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::components::relays::{Relay, RelayBuilder, RelayContext};
-use saluki_core::components::ComponentContext;
+use saluki_core::components::BuildContext;
 use saluki_core::data_model::payload::{GrpcPayload, Payload, PayloadMetadata, PayloadType};
 use saluki_core::topology::OutputDefinition;
 use saluki_error::{ErrorContext as _, GenericError};
@@ -81,13 +81,13 @@ impl RelayBuilder for OtlpRelayConfiguration {
         &OUTPUTS
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Relay + Send>, GenericError> {
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Relay + Send>, GenericError> {
         Ok(Box::new(OtlpRelay {
             http_endpoint: self.http_endpoint(),
             grpc_endpoint: self.grpc_endpoint(),
             grpc_max_recv_msg_size_bytes: self.grpc_max_recv_msg_size_bytes(),
             cors: cors_configuration(&self.receiver.http.cors),
-            metrics: build_metrics(&context),
+            metrics: build_metrics(context.component_context()),
         }))
     }
 }

--- a/lib/saluki-components/src/sources/checks_ipc/mod.rs
+++ b/lib/saluki-components/src/sources/checks_ipc/mod.rs
@@ -21,7 +21,7 @@ use saluki_core::data_model::event::service_check::{CheckStatus, ServiceCheck};
 use saluki_core::data_model::event::{Event, EventType};
 use saluki_core::topology::OutputDefinition;
 use saluki_core::{
-    components::{sources::*, ComponentContext},
+    components::{sources::*, BuildContext},
     data_model::event::log::LogStatus,
 };
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
@@ -64,7 +64,7 @@ impl SourceBuilder for ChecksIPCConfiguration {
         &OUTPUTS
     }
 
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn Source + Send>, GenericError> {
         Ok(Box::new(ChecksIPC {
             grpc_endpoint: self.grpc_endpoint.clone(),
             default_hostname: self.default_hostname.clone(),

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -34,7 +34,7 @@ use saluki_core::data_model::event::{
     Event, EventType,
 };
 use saluki_core::{
-    components::{sources::*, ComponentContext},
+    components::{sources::*, BuildContext},
     pooling::{ElasticObjectPool, ObjectPool as _},
     topology::{EventsBuffer, OutputDefinition},
 };
@@ -994,7 +994,7 @@ impl DogStatsDConfiguration {
 
 #[async_trait]
 impl SourceBuilder for DogStatsDConfiguration {
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError> {
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Source + Send>, GenericError> {
         let listeners = self.build_listeners().await?;
         if listeners.is_empty() {
             return Err(Error::NoListenersConfigured.into());
@@ -1020,7 +1020,7 @@ impl SourceBuilder for DogStatsDConfiguration {
         let maybe_origin_tags_resolver = self.workload_provider.clone().map(|provider| {
             DogStatsDOriginTagResolver::new(self.origin_enrichment.clone(), provider, captured_tagger.clone())
         });
-        let context_resolvers = ContextResolvers::new(self, &context, maybe_origin_tags_resolver)
+        let context_resolvers = ContextResolvers::new(self, context.component_context(), maybe_origin_tags_resolver)
             .error_context("Failed to create context resolvers.")?;
 
         let codec_config = DogStatsDCodecConfiguration::default()

--- a/lib/saluki-components/src/sources/heartbeat/mod.rs
+++ b/lib/saluki-components/src/sources/heartbeat/mod.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use saluki_context::Context;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
-use saluki_core::components::{sources::*, ComponentContext};
+use saluki_core::components::{sources::*, BuildContext};
 use saluki_core::data_model::event::{metric::Metric, Event, EventType};
 use saluki_core::topology::OutputDefinition;
 use saluki_error::GenericError;
@@ -75,7 +75,7 @@ impl Source for Heartbeat {
 
 #[async_trait]
 impl SourceBuilder for HeartbeatConfiguration {
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn Source + Send>, GenericError> {
         Ok(Box::new(Heartbeat {
             heartbeat_interval_secs: self.heartbeat_interval_secs,
         }))

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -21,7 +21,7 @@ use saluki_core::topology::interconnect::BufferedDispatcher;
 use saluki_core::{
     components::{
         sources::{Source, SourceBuilder, SourceContext},
-        ComponentContext,
+        BuildContext,
     },
     data_model::event::EventType,
     topology::{EventsBuffer, OutputDefinition},
@@ -144,7 +144,7 @@ impl SourceBuilder for OtlpConfiguration {
         &OUTPUTS
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError> {
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Source + Send>, GenericError> {
         if !self.otlp.receiver.metrics_enabled && !self.otlp.receiver.logs_enabled && !self.otlp.traces.enabled {
             return Err(generic_error!(
                 "OTLP metrics, logs and traces support is disabled. Please enable at least one of them."
@@ -170,14 +170,14 @@ impl SourceBuilder for OtlpConfiguration {
 
         // Metrics resolve their full OTLP entity list at the resource boundary. Keep the context resolver free of an
         // origin resolver so it cannot apply the legacy RawOrigin-only lookup a second time. Logs retain that resolver.
-        let context_resolver = build_context_resolver(&self.otlp.contexts, &context, None)?;
+        let context_resolver = build_context_resolver(&self.otlp.contexts, context.component_context(), None)?;
         let metrics_translator_config = self.metrics_translator_config();
 
         let metric_tags = parse_configured_metric_tags(&self.otlp.metrics.tags);
         let traces_translator = OtlpTracesTranslator::new(self.otlp.traces.clone());
         let grpc_max_recv_msg_size_bytes = self.otlp.receiver.grpc.max_recv_msg_size_mib as usize * 1024 * 1024;
         let cors = cors_configuration(&self.otlp.receiver.http.cors);
-        let metrics = build_metrics(&context);
+        let metrics = build_metrics(context.component_context());
 
         Ok(Box::new(Otlp {
             context_resolver,

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -12,7 +12,7 @@ use saluki_common::time::get_unix_timestamp;
 use saluki_context::Context;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder, UsageExpr};
 use saluki_core::{
-    components::{transforms::*, ComponentContext},
+    components::{transforms::*, BuildContext},
     data_model::event::{metric::*, Event, EventType},
     observability::ComponentMetricsExt as _,
     topology::{interconnect::BufferedDispatcher, OutputDefinition},
@@ -392,9 +392,9 @@ impl AggregateConfiguration {
 
 #[async_trait]
 impl TransformBuilder for AggregateConfiguration {
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Transform + Send>, GenericError> {
         let context_snapshot_requests = self.context_snapshot_receiver.take_receiver()?;
-        let metrics_builder = MetricsBuilder::from_component_context(&context);
+        let metrics_builder = MetricsBuilder::from_component_context(context.component_context());
         let telemetry = Telemetry::new(&metrics_builder);
 
         let state = AggregationState::new(
@@ -1127,7 +1127,7 @@ mod tests {
             ComponentContext,
         },
         health::HealthRegistry,
-        runtime::Supervisor,
+        runtime::{state::ResourceRegistry, Supervisor},
         support::SubsystemIdentifier,
         topology::{interconnect::Dispatcher, OutputDefinition, OutputName, TopologyBlueprint},
     };
@@ -1193,7 +1193,7 @@ mod tests {
             &self.outputs
         }
 
-        async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError> {
+        async fn build(&self, _context: BuildContext) -> Result<Box<dyn Source + Send>, GenericError> {
             let events = self
                 .events
                 .lock()
@@ -1226,7 +1226,7 @@ mod tests {
             EventType::Metric
         }
 
-        async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
+        async fn build(&self, _context: BuildContext) -> Result<Box<dyn Destination + Send>, GenericError> {
             Ok(Box::new(DrainingMetricDestination))
         }
     }
@@ -1606,6 +1606,7 @@ mod tests {
             blueprint
                 .with_health_registry(HealthRegistry::new())
                 .with_memory_limiter(MemoryLimiter::noop())
+                .with_resource_registry(ResourceRegistry::new())
                 .with_ambient_worker_pool();
 
             let mut supervisor =
@@ -1718,10 +1719,10 @@ mod tests {
     #[tokio::test]
     async fn aggregate_configuration_receiver_can_only_be_taken_once() {
         let config = AggregateConfiguration::for_test();
-        let first = config.build(ComponentContext::test_transform("aggregate_one")).await;
+        let first = config.build(BuildContext::test_transform("aggregate_one")).await;
         assert!(first.is_ok());
 
-        let second = config.build(ComponentContext::test_transform("aggregate_two")).await;
+        let second = config.build(BuildContext::test_transform("aggregate_two")).await;
         let error = match second {
             Ok(_) => panic!("second build should not take the snapshot receiver again"),
             Err(error) => error,

--- a/lib/saluki-components/src/transforms/apm_stats/mod.rs
+++ b/lib/saluki-components/src/transforms/apm_stats/mod.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use saluki_context::{origin::OriginTagCardinality, tags::TagSet};
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
-    components::{transforms::*, ComponentContext},
+    components::{transforms::*, BuildContext},
     data_model::event::{
         trace::{AttributeValue, Trace},
         trace_stats::{ClientStatsPayload, TraceStats},
@@ -100,7 +100,7 @@ impl ApmStatsTransformConfiguration {
 
 #[async_trait]
 impl TransformBuilder for ApmStatsTransformConfiguration {
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn Transform + Send>, GenericError> {
         let agent_hostname = MetaString::from(self.default_hostname.clone().unwrap_or_default());
         let concentrator = SpanConcentrator::new(
             self.compute_stats_by_span_kind,

--- a/lib/saluki-components/src/transforms/autoscaling_failover_gateway/mod.rs
+++ b/lib/saluki-components/src/transforms/autoscaling_failover_gateway/mod.rs
@@ -7,7 +7,7 @@ use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
     components::{
         transforms::{Transform, TransformBuilder, TransformContext},
-        ComponentContext,
+        BuildContext,
     },
     data_model::event::{metric::MetricValues, Event, EventType},
     topology::{EventsBuffer, OutputDefinition},
@@ -100,7 +100,7 @@ impl AutoscalingFailoverGateway {
 
 #[async_trait]
 impl TransformBuilder for AutoscalingFailoverGatewayConfiguration {
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn Transform + Send>, GenericError> {
         Ok(Box::new(AutoscalingFailoverGateway::new(self.failover_config.clone())))
     }
 

--- a/lib/saluki-components/src/transforms/chained/mod.rs
+++ b/lib/saluki-components/src/transforms/chained/mod.rs
@@ -3,7 +3,7 @@ use saluki_common::strings::lower_alphanumeric;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::data_model::event::EventType;
 use saluki_core::{
-    components::{transforms::*, ComponentContext},
+    components::{transforms::*, BuildContext},
     topology::OutputDefinition,
 };
 use saluki_error::GenericError;
@@ -55,7 +55,7 @@ impl MemoryBounds for ChainedConfiguration {
 
 #[async_trait]
 impl TransformBuilder for ChainedConfiguration {
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Transform + Send>, GenericError> {
         let mut subtransforms = Vec::new();
         for (subtransform_id, subtransform_builder) in &self.subtransform_builders {
             let subtransform = subtransform_builder.build(context.clone()).await?;

--- a/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
@@ -13,7 +13,7 @@ use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
     components::{
         transforms::{SynchronousTransform, SynchronousTransformBuilder},
-        ComponentContext,
+        BuildContext,
     },
     topology::EventsBuffer,
 };
@@ -79,7 +79,7 @@ impl DogStatsDMapperConfiguration {
         }
     }
 
-    fn build_mapper(&self, context: ComponentContext) -> Result<MetricMapper, GenericError> {
+    fn build_mapper(&self, context: BuildContext) -> Result<MetricMapper, GenericError> {
         let mut profiles = Vec::with_capacity(self.profiles.len());
         for config_profile in &self.profiles {
             if config_profile.name.is_empty() {
@@ -317,7 +317,7 @@ impl MetricMapper {
 
 #[async_trait]
 impl SynchronousTransformBuilder for DogStatsDMapperConfiguration {
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
         let metric_mapper = self.build_mapper(context)?;
         Ok(Box::new(DogStatsDMapper { metric_mapper }))
     }
@@ -364,7 +364,7 @@ mod tests {
 
     use saluki_context::{Context, ContextResolverBuilder};
     use saluki_core::{
-        components::{transforms::SynchronousTransform, ComponentContext},
+        components::{transforms::SynchronousTransform, BuildContext},
         data_model::event::{metric::Metric, Event},
         topology::EventsBuffer,
     };
@@ -424,7 +424,7 @@ mod tests {
     ) -> Result<MetricMapper, GenericError> {
         let config =
             DogStatsDMapperConfiguration::new(NonZeroUsize::new(64 * 1024).expect("not zero"), cache_size, profiles);
-        config.build_mapper(ComponentContext::test_transform("test_mapper"))
+        config.build_mapper(BuildContext::test_transform("test_mapper"))
     }
 
     fn assert_tags(context: &Context, expected_tags: &[&str]) {

--- a/lib/saluki-components/src/transforms/host_enrichment/mod.rs
+++ b/lib/saluki-components/src/transforms/host_enrichment/mod.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{components::transforms::*, topology::EventsBuffer};
 use saluki_core::{
-    components::ComponentContext,
+    components::BuildContext,
     data_model::event::{eventd::EventD, service_check::ServiceCheck},
 };
 use saluki_env::{EnvironmentProvider, HostProvider};
@@ -30,7 +30,7 @@ where
     E: EnvironmentProvider + Send + Sync + 'static,
     <E::Host as HostProvider>::Error: Into<GenericError>,
 {
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
         Ok(Box::new(
             HostEnrichment::from_environment_provider(&self.env_provider).await?,
         ))

--- a/lib/saluki-components/src/transforms/metric_router/mod.rs
+++ b/lib/saluki-components/src/transforms/metric_router/mod.rs
@@ -5,7 +5,7 @@ use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
     components::{
         transforms::{Transform, TransformBuilder, TransformContext},
-        ComponentContext,
+        BuildContext,
     },
     data_model::event::{Event, EventType},
     topology::{EventsBuffer, OutputDefinition},
@@ -93,7 +93,7 @@ impl MetricRouter {
 
 #[async_trait]
 impl TransformBuilder for MetricRouterConfiguration {
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn Transform + Send>, GenericError> {
         Ok(Box::new(MetricRouter::new(self.clone())?))
     }
 

--- a/lib/saluki-components/src/transforms/mrf_gateway/mod.rs
+++ b/lib/saluki-components/src/transforms/mrf_gateway/mod.rs
@@ -8,7 +8,7 @@ use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
     components::{
         transforms::{Transform, TransformBuilder, TransformContext},
-        ComponentContext,
+        BuildContext,
     },
     data_model::event::{Event, EventType},
     topology::{EventsBuffer, OutputDefinition},
@@ -131,7 +131,7 @@ impl MrfMetricsGateway {
 
 #[async_trait]
 impl TransformBuilder for MrfMetricsGatewayConfiguration {
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn Transform + Send>, GenericError> {
         Ok(Box::new(MrfMetricsGateway::new(
             self.mrf_config.clone(),
             self.configuration.clone(),

--- a/lib/saluki-components/src/transforms/trace_obfuscation/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_obfuscation/mod.rs
@@ -14,7 +14,7 @@ use agent_data_plane_config::domains;
 use async_trait::async_trait;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
-    components::{transforms::*, ComponentContext},
+    components::{transforms::*, BuildContext},
     data_model::event::{
         trace::{AttributeValue, Span},
         Event,
@@ -43,7 +43,7 @@ impl TraceObfuscationConfiguration {
 
 #[async_trait]
 impl SynchronousTransformBuilder for TraceObfuscationConfiguration {
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
         Ok(Box::new(TraceObfuscation {
             obfuscator: Obfuscator::new(self.config.clone()),
         }))

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use saluki_common::collections::FastHashMap;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
-    components::{transforms::*, ComponentContext},
+    components::{transforms::*, BuildContext},
     data_model::event::{
         trace::{AttributeValue, Span, Trace},
         Event,
@@ -107,7 +107,7 @@ impl TraceSamplerConfiguration {
 
 #[async_trait]
 impl SynchronousTransformBuilder for TraceSamplerConfiguration {
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
+    async fn build(&self, _context: BuildContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
         // TODO: Need to support remote configuration changing these at runtime
         // See https://github.com/DataDog/saluki/issues/1326
         let sampler = TraceSampler {

--- a/lib/saluki-core/src/components/build_context.rs
+++ b/lib/saluki-core/src/components/build_context.rs
@@ -1,0 +1,100 @@
+//! Context provided to component builders.
+
+use std::fmt;
+
+use super::{ComponentContext, ComponentType};
+use crate::{
+    runtime::state::{AcquireError, ResourceLease, ResourceRegistry, ResourceSpecification},
+    support::SubsystemIdentifier,
+    topology::ComponentId,
+};
+
+/// Build-time component context.
+///
+/// Carries information about the component being built, as well as access to the resource registry in order to acquire
+/// external resources if necessary.
+#[derive(Clone)]
+pub struct BuildContext {
+    component_context: ComponentContext,
+    resource_registry: ResourceRegistry,
+}
+
+impl BuildContext {
+    /// Creates a new `BuildContext` for the given component.
+    pub fn new(component_context: ComponentContext, resource_registry: ResourceRegistry) -> Self {
+        Self {
+            component_context,
+            resource_registry,
+        }
+    }
+
+    /// Returns the context of the component being built.
+    pub fn component_context(&self) -> &ComponentContext {
+        &self.component_context
+    }
+
+    /// Returns the component identifier.
+    ///
+    /// This is the relative identifier of the component, unique within its topology but not guaranteed to be globally
+    /// unique. See [`BuildContext::identity`] for the fully qualified identity.
+    pub fn component_id(&self) -> &ComponentId {
+        self.component_context.component_id()
+    }
+
+    /// Returns the component type.
+    pub fn component_type(&self) -> ComponentType {
+        self.component_context.component_type()
+    }
+
+    /// Returns the fully qualified identity of this component.
+    ///
+    /// The returned identifier uniquely identifies the component within the process, inclusive of the topology to
+    /// which it belongs.
+    pub fn identity(&self) -> SubsystemIdentifier {
+        self.component_context.identity()
+    }
+
+    /// Acquires a resource on behalf of the component being built.
+    ///
+    /// # Errors
+    ///
+    /// If the resource is already held elsewhere in the process, or can't be created, an error is returned.
+    pub async fn acquire_resource<S: ResourceSpecification>(
+        &self, spec: S,
+    ) -> Result<ResourceLease<S::Resource>, AcquireError> {
+        self.resource_registry.acquire(&self.identity(), spec).await
+    }
+}
+
+impl fmt::Display for BuildContext {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.component_context)
+    }
+}
+
+macro_rules! test_build_contexts {
+    ($($name:ident => $component_context:ident, $doc:literal;)*) => {
+        $(
+            #[doc = $doc]
+            ///
+            /// The returned context carries its own empty [`ResourceRegistry`], so resources acquired through it are
+            /// isolated to this context.
+            #[cfg(any(test, feature = "test-util"))]
+            pub fn $name<S: AsRef<str>>(component_id: S) -> Self {
+                Self::new(ComponentContext::$component_context(component_id), ResourceRegistry::new())
+            }
+        )*
+    };
+}
+
+impl BuildContext {
+    test_build_contexts! {
+        test_source => test_source, "Creates a new `BuildContext` for a source component with the given identifier, in a test topology.";
+        test_relay => test_relay, "Creates a new `BuildContext` for a relay component with the given identifier, in a test topology.";
+        test_decoder => test_decoder, "Creates a new `BuildContext` for a decoder component with the given identifier, in a test topology.";
+        test_transform => test_transform, "Creates a new `BuildContext` for a transform component with the given identifier, in a test topology.";
+        test_encoder => test_encoder, "Creates a new `BuildContext` for an encoder component with the given identifier, in a test topology.";
+        test_forwarder => test_forwarder, "Creates a new `BuildContext` for a forwarder component with the given identifier, in a test topology.";
+        test_destination => test_destination, "Creates a new `BuildContext` for a destination component with the given identifier, in a test topology.";
+    }
+}

--- a/lib/saluki-core/src/components/decoders/builder.rs
+++ b/lib/saluki-core/src/components/decoders/builder.rs
@@ -6,7 +6,7 @@ use saluki_error::GenericError;
 use super::Decoder;
 use crate::accounting::MemoryBounds;
 use crate::{
-    components::ComponentContext,
+    components::BuildContext,
     data_model::{event::EventType, payload::PayloadType},
 };
 
@@ -28,5 +28,5 @@ pub trait DecoderBuilder: MemoryBounds {
     /// # Errors
     ///
     /// If the decoder can't be built for any reason, an error is returned.
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Decoder + Send>, GenericError>;
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Decoder + Send>, GenericError>;
 }

--- a/lib/saluki-core/src/components/destinations/builder.rs
+++ b/lib/saluki-core/src/components/destinations/builder.rs
@@ -3,7 +3,7 @@ use saluki_error::GenericError;
 
 use super::Destination;
 use crate::accounting::MemoryBounds;
-use crate::{components::ComponentContext, data_model::event::EventType};
+use crate::{components::BuildContext, data_model::event::EventType};
 
 /// A destination builder.
 ///
@@ -19,5 +19,5 @@ pub trait DestinationBuilder: MemoryBounds {
     /// ## Errors
     ///
     /// If the destination can't be built for any reason, an error is returned.
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError>;
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Destination + Send>, GenericError>;
 }

--- a/lib/saluki-core/src/components/encoders/builder.rs
+++ b/lib/saluki-core/src/components/encoders/builder.rs
@@ -6,7 +6,7 @@ use saluki_error::GenericError;
 use super::{Encoder, IncrementalEncoder};
 use crate::accounting::MemoryBounds;
 use crate::{
-    components::ComponentContext,
+    components::BuildContext,
     data_model::{event::EventType, payload::PayloadType},
 };
 
@@ -28,7 +28,7 @@ pub trait EncoderBuilder: MemoryBounds {
     /// # Errors
     ///
     /// If the encoder can't be built for any reason, an error is returned.
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Encoder + Send>, GenericError>;
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Encoder + Send>, GenericError>;
 }
 
 /// An incremental encoder builder.
@@ -52,5 +52,5 @@ pub trait IncrementalEncoderBuilder: MemoryBounds {
     /// # Errors
     ///
     /// If the incremental encoder can't be built for any reason, an error is returned.
-    async fn build(&self, context: ComponentContext) -> Result<Self::Output, GenericError>;
+    async fn build(&self, context: BuildContext) -> Result<Self::Output, GenericError>;
 }

--- a/lib/saluki-core/src/components/forwarders/builder.rs
+++ b/lib/saluki-core/src/components/forwarders/builder.rs
@@ -3,7 +3,7 @@ use saluki_error::GenericError;
 
 use super::Forwarder;
 use crate::accounting::MemoryBounds;
-use crate::{components::ComponentContext, data_model::payload::PayloadType};
+use crate::{components::BuildContext, data_model::payload::PayloadType};
 
 /// A forwarder builder.
 ///
@@ -19,5 +19,5 @@ pub trait ForwarderBuilder: MemoryBounds {
     /// ## Errors
     ///
     /// If the forwarder can't be built for any reason, an error is returned.
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Forwarder + Send>, GenericError>;
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Forwarder + Send>, GenericError>;
 }

--- a/lib/saluki-core/src/components/mod.rs
+++ b/lib/saluki-core/src/components/mod.rs
@@ -12,6 +12,9 @@ pub mod relays;
 pub mod sources;
 pub mod transforms;
 
+mod build_context;
+pub use self::build_context::BuildContext;
+
 mod spawner;
 pub use self::spawner::{BuilderState, ChildBuilder, ComponentSpawner, OneShot, Restartable};
 

--- a/lib/saluki-core/src/components/relays/builder.rs
+++ b/lib/saluki-core/src/components/relays/builder.rs
@@ -3,7 +3,7 @@ use saluki_error::GenericError;
 
 use super::Relay;
 use crate::accounting::MemoryBounds;
-use crate::{components::ComponentContext, data_model::payload::PayloadType, topology::OutputDefinition};
+use crate::{components::BuildContext, data_model::payload::PayloadType, topology::OutputDefinition};
 
 /// A relay builder.
 ///
@@ -19,5 +19,5 @@ pub trait RelayBuilder: MemoryBounds {
     /// ## Errors
     ///
     /// If the relay can't be built for any reason, an error is returned.
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Relay + Send>, GenericError>;
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Relay + Send>, GenericError>;
 }

--- a/lib/saluki-core/src/components/sources/builder.rs
+++ b/lib/saluki-core/src/components/sources/builder.rs
@@ -3,7 +3,7 @@ use saluki_error::GenericError;
 
 use super::Source;
 use crate::accounting::MemoryBounds;
-use crate::{components::ComponentContext, data_model::event::EventType, topology::OutputDefinition};
+use crate::{components::BuildContext, data_model::event::EventType, topology::OutputDefinition};
 
 /// A source builder.
 ///
@@ -19,5 +19,5 @@ pub trait SourceBuilder: MemoryBounds {
     /// ## Errors
     ///
     /// If the source can't be built for any reason, an error is returned.
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError>;
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Source + Send>, GenericError>;
 }

--- a/lib/saluki-core/src/components/transforms/builder.rs
+++ b/lib/saluki-core/src/components/transforms/builder.rs
@@ -3,7 +3,7 @@ use saluki_error::GenericError;
 
 use super::{SynchronousTransform, Transform};
 use crate::accounting::MemoryBounds;
-use crate::{components::ComponentContext, data_model::event::EventType, topology::OutputDefinition};
+use crate::{components::BuildContext, data_model::event::EventType, topology::OutputDefinition};
 
 /// A transform builder.
 ///
@@ -23,7 +23,7 @@ pub trait TransformBuilder: MemoryBounds {
     /// ## Errors
     ///
     /// If the transform can't be built for any reason, an error is returned.
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError>;
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn Transform + Send>, GenericError>;
 }
 
 /// A synchronous transform builder.
@@ -40,5 +40,5 @@ pub trait SynchronousTransformBuilder: MemoryBounds {
     /// ## Errors
     ///
     /// If the synchronous transform can't be built for any reason, an error is returned.
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError>;
+    async fn build(&self, context: BuildContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError>;
 }

--- a/lib/saluki-core/src/runtime/state/mod.rs
+++ b/lib/saluki-core/src/runtime/state/mod.rs
@@ -10,6 +10,12 @@ mod dataspace;
 pub(crate) use self::dataspace::CURRENT_DATASPACE;
 pub use self::dataspace::{DataspaceRegistry, DataspaceUpdate, Subscription};
 
+mod resources;
+pub use self::resources::{
+    AcquireError, ResourceKind, ResourceLease, ResourceRegistry, ResourceRegistryAPIHandler, ResourceRegistryState,
+    ResourceRegistryWorker, ResourceSpecification, ResourceStatus,
+};
+
 /// An identifier used to key values in a [`DataspaceRegistry`].
 ///
 /// Identifiers come in two flavors:

--- a/lib/saluki-core/src/runtime/state/resources/api.rs
+++ b/lib/saluki-core/src/runtime/state/resources/api.rs
@@ -1,0 +1,47 @@
+use saluki_api::{
+    extract::State,
+    response::IntoResponse,
+    routing::{get, Router},
+    APIHandler, Json,
+};
+
+use super::ResourceRegistry;
+
+/// State used for the resource registry API handler.
+#[derive(Clone)]
+pub struct ResourceRegistryState {
+    registry: ResourceRegistry,
+}
+
+/// An API handler for reporting the state of all registered resources.
+///
+/// This handler exposes a single route -- `/resources/status` -- returning a JSON array describing every registered
+/// resource group: its key and kind, how many instances it holds, how many are currently lent out, and which subsystem
+/// and process hold them.
+pub struct ResourceRegistryAPIHandler {
+    state: ResourceRegistryState,
+}
+
+impl ResourceRegistryAPIHandler {
+    pub(super) fn from_registry(registry: ResourceRegistry) -> Self {
+        Self {
+            state: ResourceRegistryState { registry },
+        }
+    }
+
+    async fn status_handler(State(state): State<ResourceRegistryState>) -> impl IntoResponse {
+        Json(state.registry.snapshot())
+    }
+}
+
+impl APIHandler for ResourceRegistryAPIHandler {
+    type State = ResourceRegistryState;
+
+    fn generate_initial_state(&self) -> Self::State {
+        self.state.clone()
+    }
+
+    fn generate_routes(&self) -> Router<Self::State> {
+        Router::new().route("/resources/status", get(Self::status_handler))
+    }
+}

--- a/lib/saluki-core/src/runtime/state/resources/mod.rs
+++ b/lib/saluki-core/src/runtime/state/resources/mod.rs
@@ -1,0 +1,656 @@
+//! External resource management.
+
+use std::{
+    any::{Any, TypeId},
+    fmt, mem,
+    ops::{Deref, DerefMut},
+    sync::{Arc, Mutex},
+};
+
+use async_trait::async_trait;
+use saluki_common::collections::FastHashMap;
+use saluki_error::GenericError;
+use serde::Serialize;
+use snafu::Snafu;
+use stringtheory::MetaString;
+use tracing::{debug, warn};
+
+use crate::{runtime::process::Id as ProcessId, support::SubsystemIdentifier};
+
+mod api;
+pub use self::api::{ResourceRegistryAPIHandler, ResourceRegistryState};
+
+mod worker;
+pub use self::worker::ResourceRegistryWorker;
+
+#[cfg(test)]
+mod tests;
+
+/// The kind of an external resource.
+///
+/// Deliberately a closed set: the registry coordinates a known, bounded collection of scarce things, so introducing a
+/// kind is a design decision that belongs here rather than in a downstream crate. This names the kind only; it implies
+/// no dependency on the types that implement it.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceKind {
+    /// A bound network socket.
+    Socket,
+
+    /// A synthetic kind for exercising cross-kind behavior in tests.
+    #[cfg(test)]
+    Test,
+}
+
+impl ResourceKind {
+    /// Returns the string representation of this kind.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Socket => "socket",
+            #[cfg(test)]
+            Self::Test => "test",
+        }
+    }
+}
+
+impl fmt::Display for ResourceKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A specification naming one resource, and the blueprint for creating it.
+///
+/// A specification describes *what* to create without creating it, so it can be built and compared long before the
+/// underlying resource exists. It also names exactly one resource type, which is what keeps two callers from acquiring
+/// the same resource as two different types: there is no way to express the mismatch.
+#[async_trait]
+pub trait ResourceSpecification: Clone + fmt::Debug + Send + Sync + 'static {
+    /// Type of the resource this specification creates.
+    type Resource: Send + 'static;
+
+    /// Kind of the resource this specification names.
+    const KIND: ResourceKind;
+
+    /// Returns the key for the resource this specification names.
+    ///
+    /// Keys must be unique within their kind: two specifications of the same kind that yield the same key are
+    /// understood to name the same underlying scarce thing and will conflict with each other. Keys of different kinds
+    /// never collide, so a key only has to distinguish a resource from its siblings.
+    ///
+    /// Only the parts of a specification that identify the underlying thing belong in the key. Settings that do not
+    /// change *which* resource is named should be left out, so that two specifications differing only in their
+    /// settings are correctly recognized as naming the same resource.
+    fn key(&self) -> MetaString;
+
+    /// Creates the resource.
+    ///
+    /// A resource that is only meaningful as a set of underlying handles -- several sockets bound to one address with
+    /// `SO_REUSEPORT`, say -- holds all of them itself. Creating them together in a single call is what makes them
+    /// atomic: if any one fails, this returns an error and nothing is registered.
+    ///
+    /// # Errors
+    ///
+    /// If the resource can't be created, an error is returned and nothing is registered.
+    async fn create(&self) -> Result<Self::Resource, GenericError>;
+
+    /// Prepares a returning resource for its next holder.
+    ///
+    /// Called when a lease is dropped, before the resource becomes available again. Implement this only for a resource
+    /// that accumulates state over the course of a single lease and must start clean for the next one -- a listener
+    /// tracking how many of its pre-bound sockets it has handed out, for example. Everything the resource is *for*,
+    /// such as the sockets themselves, must survive: the point of the registry is that it outlives its holders.
+    ///
+    /// Defaults to doing nothing, which is right for a resource that carries no per-lease state.
+    ///
+    /// This is deliberately infallible. A resource that can't be made fit for reuse should be
+    /// [`discard`][ResourceLease::discard]ed by its holder instead, so the next acquisition builds a fresh one.
+    fn reset(_resource: &mut Self::Resource) {}
+}
+
+/// Erases the specification type so [`Entry`] can reset a resource it only knows as `dyn Any`.
+fn reset_shim<S: ResourceSpecification>(resource: &mut (dyn Any + Send)) {
+    match resource.downcast_mut::<S::Resource>() {
+        Some(resource) => S::reset(resource),
+        None => unreachable!("entry only ever holds the resource type its specification names"),
+    }
+}
+
+/// An error that occurred while acquiring a resource.
+#[derive(Debug, Snafu)]
+#[snafu(context(suffix(false)))]
+pub enum AcquireError {
+    /// The resource is already leased by something else in this process.
+    #[snafu(display(
+        "{} resource '{}' is already leased by '{}' (acquired by process {})",
+        kind,
+        key,
+        owner,
+        acquisition_process_id.as_usize()
+    ))]
+    AlreadyLeased {
+        /// Kind of the resource.
+        kind: ResourceKind,
+
+        /// Key of the resource.
+        key: MetaString,
+
+        /// Rendered identity of the subsystem holding the resource.
+        ///
+        /// This is the authoritative answer to who holds the resource. Rendered rather than kept as a
+        /// [`SubsystemIdentifier`], which stores enough segments inline to make this error large enough to slow down
+        /// every `Result` that carries it.
+        owner: MetaString,
+
+        /// Identifier of the process that acquired the resource.
+        acquisition_process_id: ProcessId,
+    },
+
+    /// The key is registered, but holds a different type of resource.
+    ///
+    /// Two specifications of the same kind produced the same key while naming different resource types, which means
+    /// their keys are not as unique as they need to be.
+    #[snafu(display(
+        "{} resource '{}' is registered as `{}`, but was requested as `{}`",
+        kind,
+        key,
+        existing_type,
+        requested_type
+    ))]
+    TypeMismatch {
+        /// Kind of the resource.
+        kind: ResourceKind,
+
+        /// Key of the resource.
+        key: MetaString,
+
+        /// Type the resource was registered as.
+        existing_type: &'static str,
+
+        /// Type the resource was requested as.
+        requested_type: &'static str,
+    },
+
+    /// The resource could not be created.
+    #[snafu(display("failed to create {} resource '{}': {}", kind, key, source))]
+    CreationFailed {
+        /// Kind of the resource.
+        kind: ResourceKind,
+
+        /// Key of the resource.
+        key: MetaString,
+
+        /// Source of the error.
+        source: GenericError,
+    },
+}
+
+/// Identifies one registry entry.
+///
+/// Keying on the kind as well as the key means a kind namespaces its own keys, so two unrelated resource families can
+/// never collide on a coincidentally equal key. It stays deliberately coarser than the resource type: two
+/// representations of the same scarce thing must collide, and keying by type would let each of them claim it.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct EntryKey {
+    kind: ResourceKind,
+    key: MetaString,
+}
+
+impl EntryKey {
+    fn new<S: ResourceSpecification>(spec: &S) -> Self {
+        Self {
+            kind: S::KIND,
+            key: spec.key(),
+        }
+    }
+}
+
+impl fmt::Display for EntryKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.kind, self.key)
+    }
+}
+
+/// Identity of whatever currently holds a resource.
+#[derive(Clone, Debug)]
+struct LeaseInfo {
+    owner: SubsystemIdentifier,
+    acquisition_process_id: ProcessId,
+}
+
+impl LeaseInfo {
+    fn from_owner(owner: &SubsystemIdentifier) -> Self {
+        Self {
+            owner: owner.clone(),
+            acquisition_process_id: ProcessId::current(),
+        }
+    }
+}
+
+/// RAII guard to disarm in-progress leases when resource creation fails to run to completion.
+///
+/// [`ResourceRegistry::acquire`] marks an entry as [`EntryState::Creating`] before awaiting
+/// [`ResourceSpecification::create`], and
+/// that await is a cancellation point: a supervisor aborts a worker that is still initializing when shutdown arrives,
+/// so a builder's acquisition can be dropped partway through. Without this guard the claim would outlive the
+/// acquisition and block the key for the life of the process.
+struct ClaimCreationGuard<'a> {
+    registry: &'a ResourceRegistry,
+    key: &'a EntryKey,
+    armed: bool,
+}
+
+impl<'a> ClaimCreationGuard<'a> {
+    /// Creates a new guard for the given key in the armed state.
+    fn from_key(registry: &'a ResourceRegistry, key: &'a EntryKey) -> Self {
+        Self {
+            registry,
+            key,
+            armed: true,
+        }
+    }
+
+    /// Disarm and consume the guard.
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ClaimCreationGuard<'_> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        let mut state = self.registry.inner.lock().unwrap();
+
+        // Only take back a claim that is still ours to take back.
+        if matches!(
+            state.entries.get(self.key).map(|entry| &entry.state),
+            Some(EntryState::Creating(_))
+        ) {
+            debug!(key = %self.key, "Resource creation was cancelled. Releasing the claim on its key.");
+            state.entries.remove(self.key);
+        }
+    }
+}
+
+/// Lifecycle state of a registry entry.
+enum EntryState {
+    /// The resource is held by the registry and can be acquired.
+    Idle(Box<dyn Any + Send>),
+
+    /// Creation is in flight. The entry holds nothing yet, but is already spoken for.
+    Creating(LeaseInfo),
+
+    /// The resource is lent out.
+    Leased(LeaseInfo),
+}
+
+impl EntryState {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Idle(_) => "idle",
+            Self::Creating(_) => "creating",
+            Self::Leased(_) => "leased",
+        }
+    }
+
+    fn holder(&self) -> Option<&LeaseInfo> {
+        match self {
+            Self::Idle(_) => None,
+            Self::Creating(info) | Self::Leased(info) => Some(info),
+        }
+    }
+}
+
+/// One resource registered under a single key.
+struct Entry {
+    type_id: TypeId,
+    type_name: &'static str,
+    reset: fn(&mut (dyn Any + Send)),
+    spec_desc: String,
+    state: EntryState,
+    acquisitions: u64,
+}
+
+impl Entry {
+    fn new<S: ResourceSpecification>(spec: &S, lease_info: LeaseInfo) -> Self {
+        Self {
+            type_id: TypeId::of::<S::Resource>(),
+            type_name: std::any::type_name::<S::Resource>(),
+            reset: reset_shim::<S>,
+            spec_desc: format!("{:?}", spec),
+            state: EntryState::Creating(lease_info),
+            acquisitions: 0,
+        }
+    }
+
+    /// Hands out an idle resource, or explains why it can't.
+    fn lease<S: ResourceSpecification>(
+        &mut self, registry: &ResourceRegistry, key: &EntryKey, new_spec: &S, lease_info: LeaseInfo,
+    ) -> Result<ResourceLease<S::Resource>, AcquireError> {
+        if self.type_id != TypeId::of::<S::Resource>() {
+            return Err(AcquireError::TypeMismatch {
+                kind: S::KIND,
+                key: key.key.clone(),
+                existing_type: self.type_name,
+                requested_type: std::any::type_name::<S::Resource>(),
+            });
+        }
+
+        if let Some(holder) = self.state.holder() {
+            return Err(AcquireError::AlreadyLeased {
+                kind: S::KIND,
+                key: key.key.clone(),
+                owner: MetaString::from(holder.owner.to_string()),
+                acquisition_process_id: holder.acquisition_process_id,
+            });
+        }
+
+        // The key identifies the resource, so a specification differing only in its settings still names this same
+        // resource. Hand back what exists rather than rebuilding it, but say so, since the new settings have no effect.
+        let new_spec_desc = format!("{:?}", new_spec);
+        if self.spec_desc != new_spec_desc {
+            warn!(
+                %key,
+                existing = %self.spec_desc,
+                requested = %new_spec_desc,
+                "Resource acquired with a different specification than it was created with. Using the existing resource; \
+                 the requested specification has no effect."
+            );
+        }
+
+        // `holder` returned `None` just above, so the entry is idle and holds its value.
+        let value = match mem::replace(&mut self.state, EntryState::Leased(lease_info)) {
+            EntryState::Idle(value) => value,
+            _ => unreachable!("entry without a holder is idle"),
+        };
+
+        self.acquisitions += 1;
+
+        Ok(ResourceLease {
+            value: Some(*value.downcast::<S::Resource>().expect("entry type checked above")),
+            registry: registry.clone(),
+            key: key.clone(),
+        })
+    }
+}
+
+#[derive(Default)]
+struct RegistryState {
+    entries: FastHashMap<EntryKey, Entry>,
+}
+
+impl RegistryState {
+    fn snapshot(&self) -> Vec<ResourceStatus> {
+        let mut statuses = self
+            .entries
+            .iter()
+            .map(|(key, entry)| ResourceStatus {
+                kind: key.kind,
+                key: key.key.to_string(),
+                spec: entry.spec_desc.clone(),
+                state: entry.state.as_str(),
+                owner: entry.state.holder().map(|info| info.owner.to_string()),
+                acquisition_process_id: entry.state.holder().map(|info| info.acquisition_process_id.as_usize()),
+                acquisitions: entry.acquisitions,
+            })
+            .collect::<Vec<_>>();
+        statuses.sort_by(|a, b| (a.kind, &a.key).cmp(&(b.kind, &b.key)));
+
+        statuses
+    }
+}
+
+/// A registry for scarce, externally backed resources.
+///
+/// In many cases, data planes will have to interact with the outside world by way of exposing network endpoints, or
+/// exposing files, and so on... referred to here as "resources." These resources are unique, or are conceptually meant
+/// to be unique: there should be no other OS processes trying to take ownership of them, and only one part of the code
+/// in the data plane should own them.
+///
+/// A [`ResourceRegistry`] owns those resources on behalf of the entire data plane and lends them out. A child process
+/// never owns a resource, but instead holds a [`ResourceLease`]. When the lease drops -- including when the child
+/// process holding it dies -- the resource returns to the registry intact and still live, ready for the next acquirer.
+/// Since the registry outlives the components that use its resources, a component can be torn down and rebuilt without
+/// the underlying resource being automatically released back to the operating system due to typical Rust drop
+/// semantics.
+///
+/// # Groups
+///
+/// Resources are named by a [`ResourceSpecification`], which provides the blueprint for how to create a particular
+/// resource, such as a network socket, when a caller attempts to acquire it. Resource specifications are generally tied
+/// one-to-one with a particular type.
+///
+/// The specification provides both the information necessary to properly determine one unique resource from
+/// another, as well as a mechanism for consistent creation of potentially complex resources, including asynchronous
+/// initialization.
+///
+/// # Keys and conflicts
+///
+/// Entries are keyed by kind and key together, deliberately *not* by resource type. Two different Rust types can
+/// easily describe the same scarce thing -- a connection-oriented listener and a general one over the same address --
+/// and keying by type would let each of them claim it. Kind is coarse enough that such representations still collide,
+/// while keeping unrelated resource families from colliding on a coincidentally equal key. A key therefore only has to
+/// be unique within its own kind.
+#[derive(Clone, Default)]
+pub struct ResourceRegistry {
+    inner: Arc<Mutex<RegistryState>>,
+}
+
+impl ResourceRegistry {
+    /// Creates an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Acquires the resource named by `spec`, creating it if it isn't registered yet.
+    ///
+    /// `owner` identifies the subsystem taking the lease and is recorded, alongside the current process identifier, for
+    /// accounting.
+    ///
+    /// If the resource is already registered, the existing one is handed back rather than a new one being created. This
+    /// is the mechanism by which a resource outlives the components that use it.
+    ///
+    /// # Errors
+    ///
+    /// If the resource is already leased, if the key is registered to a different type of resource, or if creation
+    /// fails, an error is returned.
+    pub async fn acquire<S: ResourceSpecification>(
+        &self, owner: &SubsystemIdentifier, spec: S,
+    ) -> Result<ResourceLease<S::Resource>, AcquireError> {
+        let key = EntryKey::new(&spec);
+        let lease_info = LeaseInfo::from_owner(owner);
+
+        // Attempt to lease the resource if it's already registered.
+        //
+        // Otherwise, start the registration process by insert an uninitialized entry that gives us lease ownership
+        // prior to actually creating the resource and finalizing it.
+        {
+            let mut state = self.inner.lock().unwrap();
+            if let Some(entry) = state.entries.get_mut(&key) {
+                return entry.lease(self, &key, &spec, lease_info);
+            }
+
+            let new_entry = Entry::new(&spec, lease_info.clone());
+            state.entries.insert(key.clone(), new_entry);
+        }
+
+        // Create the resource.
+        //
+        // We establish a "creation guard" which is a drop guard that ensures we remove our pending entry if we fail to
+        // create the resource, including if this asynchronous call is cancelled, so that we don't permanently tie up
+        // the resource in an uninitialized state.
+        let claim_guard = ClaimCreationGuard::from_key(self, &key);
+        let created = spec.create().await;
+        claim_guard.disarm();
+
+        let mut state = self.inner.lock().unwrap();
+        match created {
+            Ok(value) => {
+                let entry = state
+                    .entries
+                    .get_mut(&key)
+                    .expect("entry was inserted before creation and is only removed by this function");
+
+                entry.acquisitions += 1;
+                entry.state = EntryState::Leased(lease_info);
+
+                debug!(%key, %owner, "Created resource.");
+
+                Ok(ResourceLease {
+                    value: Some(value),
+                    registry: self.clone(),
+                    key,
+                })
+            }
+            Err(source) => {
+                // Drop the claim so that a later acquire can retry.
+                state.entries.remove(&key);
+                Err(AcquireError::CreationFailed {
+                    kind: S::KIND,
+                    key: key.key,
+                    source,
+                })
+            }
+        }
+    }
+
+    /// Returns a snapshot of every registered resource, ordered by key.
+    pub fn snapshot(&self) -> Vec<ResourceStatus> {
+        let state = self.inner.lock().unwrap();
+        state.snapshot()
+    }
+
+    /// Creates an API handler for reporting the state of all registered resources.
+    pub fn api_handler(&self) -> ResourceRegistryAPIHandler {
+        ResourceRegistryAPIHandler::from_registry(self.clone())
+    }
+
+    /// Creates a [`ResourceRegistryWorker`] that publishes the registry over the control plane.
+    pub fn worker(&self) -> ResourceRegistryWorker {
+        ResourceRegistryWorker::new(self.clone())
+    }
+
+    /// Returns a resource to the registry, marking its entry idle.
+    fn return_value(&self, key: &EntryKey, mut value: Box<dyn Any + Send>) {
+        let mut state = self.inner.lock().unwrap();
+        if let Some(entry) = state.entries.get_mut(key) {
+            debug!(%key, "Resource returned to registry.");
+
+            // Reset on the way in rather than on the way out, so the registry is never holding a half-consumed
+            // resource that a snapshot could observe.
+            (entry.reset)(&mut *value);
+            entry.state = EntryState::Idle(value);
+        }
+    }
+
+    /// Drops a resource instead of returning it, so that the next acquisition creates a fresh one.
+    fn discard_value(&self, key: &EntryKey) {
+        let mut state = self.inner.lock().unwrap();
+        if state.entries.remove(key).is_some() {
+            debug!(%key, "Resource discarded; it will be recreated on the next acquisition.");
+        }
+    }
+}
+
+/// Reported state of a single resource.
+#[derive(Clone, Debug, Serialize)]
+pub struct ResourceStatus {
+    /// Kind of the resource.
+    pub kind: ResourceKind,
+
+    /// Key the resource is registered under, unique within its kind.
+    pub key: String,
+
+    /// Rendered specification the resource was created from.
+    pub spec: String,
+
+    /// Lifecycle state of the resource: `idle`, `creating`, or `leased`.
+    pub state: &'static str,
+
+    /// Subsystem holding the resource, if any.
+    ///
+    /// This is the authoritative answer to who holds the resource.
+    pub owner: Option<String>,
+
+    /// Process that acquired the resource, if any.
+    ///
+    /// This is the process that ran the acquisition, which is not necessarily the one using the resource now: a
+    /// component acquires while it is being built, and only afterwards does it get a process of its own.
+    ///
+    /// Use [`owner`][Self::owner] to identify the holder.
+    pub acquisition_process_id: Option<usize>,
+
+    /// Number of times the resource has been acquired.
+    pub acquisitions: u64,
+}
+
+/// An exclusive lease on a resource.
+///
+/// Dereferences to the resource itself. Dropping the lease returns the resource to the registry still live, so a lease
+/// is a loan, never ownership. See [`ResourceRegistry`] for the full model.
+pub struct ResourceLease<R: Send + 'static> {
+    value: Option<R>,
+    registry: ResourceRegistry,
+    key: EntryKey,
+}
+
+impl<R: Send + 'static> ResourceLease<R> {
+    /// Returns the kind of this resource.
+    pub fn kind(&self) -> ResourceKind {
+        self.key.kind
+    }
+
+    /// Returns the key this resource is registered under, unique within its kind.
+    pub fn key(&self) -> &MetaString {
+        &self.key.key
+    }
+
+    /// Returns the resource to the registry.
+    ///
+    /// Equivalent to dropping the lease; useful where the return should be obvious at the call site.
+    pub fn release(self) {}
+
+    /// Drops the resource instead of returning it, so the next acquisition creates a fresh one.
+    ///
+    /// Use this when the resource has hit an error it can't recover from and handing it to the next acquirer would pass
+    /// the problem along.
+    pub fn discard(mut self) {
+        // Dropping the value here is the point: it is what releases the underlying resource.
+        let _ = self.value.take();
+        self.registry.discard_value(&self.key);
+    }
+}
+
+impl<R: Send + 'static> Deref for ResourceLease<R> {
+    type Target = R;
+
+    fn deref(&self) -> &Self::Target {
+        self.value.as_ref().expect("lease holds its value until dropped")
+    }
+}
+
+impl<R: Send + 'static> DerefMut for ResourceLease<R> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.value.as_mut().expect("lease holds its value until dropped")
+    }
+}
+
+impl<R: Send + 'static> Drop for ResourceLease<R> {
+    fn drop(&mut self) {
+        if let Some(value) = self.value.take() {
+            self.registry.return_value(&self.key, Box::new(value));
+        }
+    }
+}
+
+impl<R: Send + fmt::Debug + 'static> fmt::Debug for ResourceLease<R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ResourceLease")
+            .field("key", &self.key)
+            .field("value", &self.value)
+            .finish()
+    }
+}

--- a/lib/saluki-core/src/runtime/state/resources/tests.rs
+++ b/lib/saluki-core/src/runtime/state/resources/tests.rs
@@ -1,0 +1,599 @@
+use std::{
+    sync::atomic::{AtomicUsize, Ordering::Relaxed},
+    time::Duration,
+};
+
+use saluki_error::generic_error;
+
+use super::*;
+
+/// Hands every created instance a process-unique serial.
+///
+/// Tests assert on serials rather than on a creation count, so they stay correct when the test binary runs them in
+/// parallel: a serial identifies one specific instance no matter what else is happening in the process.
+static NEXT_SERIAL: AtomicUsize = AtomicUsize::new(0);
+
+fn next_serial() -> usize {
+    NEXT_SERIAL.fetch_add(1, Relaxed)
+}
+
+#[derive(Debug)]
+struct Counter {
+    serial: usize,
+}
+
+#[derive(Debug)]
+struct Widget;
+
+/// A resource that is internally several handles, standing in for something like a set of sockets bound to one address
+/// with `SO_REUSEPORT`. The registry knows nothing about the multiplicity.
+#[derive(Debug)]
+struct Bundle {
+    serials: Vec<usize>,
+}
+
+const BUNDLE_HANDLES: usize = 4;
+
+#[derive(Clone, Debug)]
+struct CounterSpec {
+    key: MetaString,
+    fail: bool,
+    create_delay: Option<Duration>,
+    setting: u32,
+}
+
+impl CounterSpec {
+    fn new(key: &str) -> Self {
+        Self {
+            key: MetaString::from(key),
+            fail: false,
+            create_delay: None,
+            setting: 0,
+        }
+    }
+
+    fn failing(mut self) -> Self {
+        self.fail = true;
+        self
+    }
+
+    fn with_create_delay(mut self, delay: Duration) -> Self {
+        self.create_delay = Some(delay);
+        self
+    }
+
+    fn with_setting(mut self, setting: u32) -> Self {
+        self.setting = setting;
+        self
+    }
+}
+
+#[async_trait]
+impl ResourceSpecification for CounterSpec {
+    type Resource = Counter;
+
+    const KIND: ResourceKind = ResourceKind::Socket;
+
+    fn key(&self) -> MetaString {
+        self.key.clone()
+    }
+
+    async fn create(&self) -> Result<Self::Resource, GenericError> {
+        if let Some(delay) = self.create_delay {
+            tokio::time::sleep(delay).await;
+        }
+
+        if self.fail {
+            return Err(generic_error!("creation deliberately failed"));
+        }
+
+        Ok(Counter { serial: next_serial() })
+    }
+}
+
+/// Identical in kind and key to [`CounterSpec`], but naming a different resource type, so that the two collide.
+#[derive(Clone, Debug)]
+struct WidgetSpec {
+    key: MetaString,
+}
+
+impl WidgetSpec {
+    fn new(key: &str) -> Self {
+        Self {
+            key: MetaString::from(key),
+        }
+    }
+}
+
+#[async_trait]
+impl ResourceSpecification for WidgetSpec {
+    type Resource = Widget;
+
+    const KIND: ResourceKind = ResourceKind::Socket;
+
+    fn key(&self) -> MetaString {
+        self.key.clone()
+    }
+
+    async fn create(&self) -> Result<Self::Resource, GenericError> {
+        Ok(Widget)
+    }
+}
+
+/// Shares [`CounterSpec`]'s keys but sits under a different kind, so the two must never collide.
+#[derive(Clone, Debug)]
+struct OtherKindSpec {
+    key: MetaString,
+}
+
+impl OtherKindSpec {
+    fn new(key: &str) -> Self {
+        Self {
+            key: MetaString::from(key),
+        }
+    }
+}
+
+#[async_trait]
+impl ResourceSpecification for OtherKindSpec {
+    type Resource = Widget;
+
+    const KIND: ResourceKind = ResourceKind::Test;
+
+    fn key(&self) -> MetaString {
+        self.key.clone()
+    }
+
+    async fn create(&self) -> Result<Self::Resource, GenericError> {
+        Ok(Widget)
+    }
+}
+
+/// A resource carrying state that accumulates within a single lease, standing in for a listener's cursor over the
+/// sockets it has handed out.
+#[derive(Debug)]
+struct Dispenser {
+    serial: usize,
+    handed_out: usize,
+}
+
+#[derive(Clone, Debug)]
+struct DispenserSpec {
+    key: MetaString,
+}
+
+impl DispenserSpec {
+    fn new(key: &str) -> Self {
+        Self {
+            key: MetaString::from(key),
+        }
+    }
+}
+
+#[async_trait]
+impl ResourceSpecification for DispenserSpec {
+    type Resource = Dispenser;
+
+    const KIND: ResourceKind = ResourceKind::Socket;
+
+    fn key(&self) -> MetaString {
+        self.key.clone()
+    }
+
+    async fn create(&self) -> Result<Self::Resource, GenericError> {
+        Ok(Dispenser {
+            serial: next_serial(),
+            handed_out: 0,
+        })
+    }
+
+    fn reset(resource: &mut Self::Resource) {
+        resource.handed_out = 0;
+    }
+}
+
+#[derive(Clone, Debug)]
+struct BundleSpec {
+    key: MetaString,
+}
+
+impl BundleSpec {
+    fn new(key: &str) -> Self {
+        Self {
+            key: MetaString::from(key),
+        }
+    }
+}
+
+#[async_trait]
+impl ResourceSpecification for BundleSpec {
+    type Resource = Bundle;
+
+    const KIND: ResourceKind = ResourceKind::Socket;
+
+    fn key(&self) -> MetaString {
+        self.key.clone()
+    }
+
+    async fn create(&self) -> Result<Self::Resource, GenericError> {
+        Ok(Bundle {
+            serials: (0..BUNDLE_HANDLES).map(|_| next_serial()).collect(),
+        })
+    }
+}
+
+fn owner(name: &str) -> SubsystemIdentifier {
+    SubsystemIdentifier::from_segments(["test", name])
+}
+
+#[tokio::test]
+async fn acquire_creates_and_leases() {
+    let registry = ResourceRegistry::new();
+    let lease = registry
+        .acquire(&owner("dsd_in"), CounterSpec::new("counter://a"))
+        .await
+        .expect("should acquire");
+
+    assert_eq!(lease.key().as_ref(), "counter://a");
+
+    let snapshot = registry.snapshot();
+    assert_eq!(snapshot.len(), 1);
+    assert_eq!(snapshot[0].key, "counter://a");
+    assert_eq!(snapshot[0].kind, ResourceKind::Socket);
+    assert_eq!(snapshot[0].state, "leased");
+    assert_eq!(snapshot[0].owner.as_deref(), Some("test.dsd_in"));
+    assert_eq!(
+        snapshot[0].acquisition_process_id,
+        Some(ProcessId::current().as_usize())
+    );
+    assert_eq!(snapshot[0].acquisitions, 1);
+}
+
+#[tokio::test]
+async fn second_acquire_while_leased_is_refused() {
+    let registry = ResourceRegistry::new();
+    let _held = registry
+        .acquire(&owner("first"), CounterSpec::new("counter://b"))
+        .await
+        .expect("should acquire");
+
+    let err = registry
+        .acquire(&owner("second"), CounterSpec::new("counter://b"))
+        .await
+        .expect_err("should be refused while leased");
+
+    match err {
+        AcquireError::AlreadyLeased { kind, key, owner, .. } => {
+            assert_eq!(kind, ResourceKind::Socket);
+            assert_eq!(key.as_ref(), "counter://b");
+            assert_eq!(owner.as_ref(), "test.first");
+        }
+        other => panic!("expected AlreadyLeased, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn reacquire_returns_the_same_resource() {
+    let registry = ResourceRegistry::new();
+    let spec = CounterSpec::new("counter://c");
+
+    let first = registry
+        .acquire(&owner("first"), spec.clone())
+        .await
+        .expect("should acquire");
+    let original = first.serial;
+    drop(first);
+
+    // The resource is back in the registry, so this must hand out the very same one rather than creating a new one.
+    // This is the property the whole registry exists for.
+    let second = registry
+        .acquire(&owner("second"), spec)
+        .await
+        .expect("should reacquire");
+    assert_eq!(second.serial, original);
+
+    let snapshot = registry.snapshot();
+    assert_eq!(snapshot[0].acquisitions, 2);
+    assert_eq!(snapshot[0].owner.as_deref(), Some("test.second"));
+}
+
+#[tokio::test]
+async fn returning_a_resource_marks_it_idle() {
+    let registry = ResourceRegistry::new();
+    let spec = CounterSpec::new("counter://d");
+
+    let lease = registry
+        .acquire(&owner("first"), spec.clone())
+        .await
+        .expect("should acquire");
+    drop(lease);
+
+    let snapshot = registry.snapshot();
+    assert_eq!(snapshot[0].state, "idle");
+    assert!(snapshot[0].owner.is_none());
+    assert!(snapshot[0].acquisition_process_id.is_none());
+}
+
+#[tokio::test]
+async fn a_resource_of_many_handles_is_leased_as_one() {
+    let registry = ResourceRegistry::new();
+    let spec = BundleSpec::new("bundle://a");
+
+    let first = registry
+        .acquire(&owner("first"), spec.clone())
+        .await
+        .expect("should acquire");
+    assert_eq!(first.serials.len(), BUNDLE_HANDLES);
+    let original = first.serials.clone();
+
+    // Multiplicity lives inside the resource, so the registry still reports exactly one entry and refuses a second
+    // acquirer on the strength of a single lease.
+    assert_eq!(registry.snapshot().len(), 1);
+    assert!(registry.acquire(&owner("second"), spec.clone()).await.is_err());
+
+    drop(first);
+
+    let second = registry
+        .acquire(&owner("second"), spec)
+        .await
+        .expect("should reacquire");
+    assert_eq!(second.serials, original);
+}
+
+#[tokio::test]
+async fn the_same_key_under_two_kinds_does_not_collide() {
+    let registry = ResourceRegistry::new();
+
+    // Identical key strings, different kinds. A kind namespaces its own keys, so neither of these can block the other
+    // and a specification author only has to keep keys unique within their own kind.
+    let socket = registry
+        .acquire(&owner("first"), CounterSpec::new("shared-key"))
+        .await
+        .expect("socket-kind resource should acquire");
+    let other = registry
+        .acquire(&owner("second"), OtherKindSpec::new("shared-key"))
+        .await
+        .expect("test-kind resource should acquire alongside it");
+
+    assert_eq!(socket.kind(), ResourceKind::Socket);
+    assert_eq!(other.kind(), ResourceKind::Test);
+    assert_eq!(socket.key(), other.key());
+
+    let snapshot = registry.snapshot();
+    assert_eq!(snapshot.len(), 2);
+    assert_eq!(snapshot[0].kind, ResourceKind::Socket);
+    assert_eq!(snapshot[1].kind, ResourceKind::Test);
+}
+
+#[tokio::test]
+async fn creation_failure_leaves_no_entry_behind() {
+    let registry = ResourceRegistry::new();
+
+    let err = registry
+        .acquire(&owner("first"), CounterSpec::new("counter://e").failing())
+        .await
+        .expect_err("creation should fail");
+    assert!(matches!(err, AcquireError::CreationFailed { .. }));
+
+    // A failed creation must not leave the key claimed, otherwise a transient failure would block it forever.
+    assert!(registry.snapshot().is_empty());
+    registry
+        .acquire(&owner("second"), CounterSpec::new("counter://e"))
+        .await
+        .expect("retry should succeed");
+}
+
+#[tokio::test]
+async fn same_key_with_a_different_resource_type_is_refused() {
+    let registry = ResourceRegistry::new();
+    let _held = registry
+        .acquire(&owner("first"), CounterSpec::new("counter://g"))
+        .await
+        .expect("should acquire");
+
+    let err = registry
+        .acquire(&owner("second"), WidgetSpec::new("counter://g"))
+        .await
+        .expect_err("a different type on the same key should be refused");
+
+    match err {
+        AcquireError::TypeMismatch {
+            kind,
+            key,
+            existing_type,
+            requested_type,
+        } => {
+            assert_eq!(kind, ResourceKind::Socket);
+            assert_eq!(key.as_ref(), "counter://g");
+            assert!(existing_type.ends_with("Counter"), "got {existing_type}");
+            assert!(requested_type.ends_with("Widget"), "got {requested_type}");
+        }
+        other => panic!("expected TypeMismatch, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn type_mismatch_is_detected_even_when_idle() {
+    let registry = ResourceRegistry::new();
+    drop(
+        registry
+            .acquire(&owner("first"), CounterSpec::new("counter://h"))
+            .await
+            .expect("should acquire"),
+    );
+
+    let err = registry
+        .acquire(&owner("second"), WidgetSpec::new("counter://h"))
+        .await
+        .expect_err("a different type on the same key should be refused");
+    assert!(matches!(err, AcquireError::TypeMismatch { .. }));
+}
+
+#[tokio::test]
+async fn concurrent_acquire_during_creation_does_not_double_create() {
+    let registry = ResourceRegistry::new();
+    let spec = CounterSpec::new("counter://i").with_create_delay(Duration::from_millis(100));
+
+    let first = tokio::spawn({
+        let registry = registry.clone();
+        let spec = spec.clone();
+        async move { registry.acquire(&owner("first"), spec).await }
+    });
+
+    // Give the first acquire time to stake its claim on the key, but not to finish creating.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let second = registry.acquire(&owner("second"), spec).await;
+    assert!(
+        matches!(second, Err(AcquireError::AlreadyLeased { .. })),
+        "an in-flight creation should be visible to a concurrent acquirer"
+    );
+
+    let first = first.await.expect("task should not panic").expect("should acquire");
+    let snapshot = registry.snapshot();
+    assert_eq!(snapshot.len(), 1);
+    assert_eq!(snapshot[0].acquisitions, 1);
+    drop(first);
+}
+
+#[tokio::test]
+async fn cancelling_an_acquisition_releases_its_claim() {
+    let registry = ResourceRegistry::new();
+    let spec = CounterSpec::new("counter://r").with_create_delay(Duration::from_secs(30));
+
+    // Drop the acquisition while creation is still pending, the way a supervisor aborts a worker that is still
+    // initializing when shutdown arrives.
+    let timed_out = tokio::time::timeout(Duration::from_millis(50), registry.acquire(&owner("first"), spec)).await;
+    assert!(timed_out.is_err(), "the acquisition should still have been creating");
+
+    // The claim must not outlive the acquisition that staked it, or the key would be blocked for the life of the
+    // process and no later caller could ever bind it.
+    assert!(registry.snapshot().is_empty());
+
+    let lease = registry
+        .acquire(&owner("second"), CounterSpec::new("counter://r"))
+        .await
+        .expect("should acquire after the cancelled attempt");
+    assert_eq!(lease.key().as_ref(), "counter://r");
+}
+
+#[tokio::test]
+async fn discard_recreates_on_the_next_acquire() {
+    let registry = ResourceRegistry::new();
+    let spec = CounterSpec::new("counter://j");
+
+    let lease = registry
+        .acquire(&owner("first"), spec.clone())
+        .await
+        .expect("should acquire");
+    let original = lease.serial;
+    lease.discard();
+
+    // A discarded resource is gone entirely, so the next acquire builds a fresh one.
+    assert!(registry.snapshot().is_empty());
+
+    let rebuilt = registry.acquire(&owner("second"), spec).await.expect("should acquire");
+    assert_ne!(rebuilt.serial, original);
+}
+
+#[tokio::test]
+async fn release_returns_the_resource_immediately() {
+    let registry = ResourceRegistry::new();
+    let spec = CounterSpec::new("counter://l");
+
+    let lease = registry
+        .acquire(&owner("first"), spec.clone())
+        .await
+        .expect("should acquire");
+    lease.release();
+
+    assert_eq!(registry.snapshot()[0].state, "idle");
+    registry
+        .acquire(&owner("second"), spec)
+        .await
+        .expect("should acquire after release");
+}
+
+#[tokio::test]
+async fn differing_settings_reuse_the_existing_resource() {
+    let registry = ResourceRegistry::new();
+
+    let first = registry
+        .acquire(&owner("first"), CounterSpec::new("counter://m").with_setting(1))
+        .await
+        .expect("should acquire");
+    let original = first.serial;
+    drop(first);
+
+    // The key identifies the resource, so a setting that isn't part of the key can't cause a rebuild.
+    let second = registry
+        .acquire(&owner("second"), CounterSpec::new("counter://m").with_setting(99))
+        .await
+        .expect("should acquire");
+    assert_eq!(second.serial, original);
+}
+
+#[tokio::test]
+async fn mutations_through_a_lease_survive_the_round_trip() {
+    let registry = ResourceRegistry::new();
+    let spec = CounterSpec::new("counter://n");
+
+    let mut lease = registry
+        .acquire(&owner("first"), spec.clone())
+        .await
+        .expect("should acquire");
+    lease.serial = 4242;
+    drop(lease);
+
+    let reacquired = registry
+        .acquire(&owner("second"), spec)
+        .await
+        .expect("should reacquire");
+    assert_eq!(reacquired.serial, 4242);
+}
+
+#[tokio::test]
+async fn per_lease_state_is_reset_when_the_resource_returns() {
+    let registry = ResourceRegistry::new();
+    let spec = DispenserSpec::new("dispenser://a");
+
+    let mut lease = registry
+        .acquire(&owner("first"), spec.clone())
+        .await
+        .expect("should acquire");
+    let serial = lease.serial;
+    lease.handed_out = 3;
+    drop(lease);
+
+    let lease = registry
+        .acquire(&owner("second"), spec)
+        .await
+        .expect("should reacquire");
+
+    // The resource itself survives -- that is the whole point of the registry ...
+    assert_eq!(lease.serial, serial);
+
+    // ... but state that only made sense to the previous holder starts clean, so a re-acquired listener hands out its
+    // sockets again rather than looking exhausted.
+    assert_eq!(lease.handed_out, 0);
+}
+
+#[tokio::test]
+async fn snapshot_is_ordered_by_key() {
+    let registry = ResourceRegistry::new();
+    for key in ["counter://q_c", "counter://q_a", "counter://q_b"] {
+        drop(
+            registry
+                .acquire(&owner("first"), CounterSpec::new(key))
+                .await
+                .expect("should acquire"),
+        );
+    }
+
+    let keys = registry
+        .snapshot()
+        .into_iter()
+        .map(|status| status.key)
+        .collect::<Vec<_>>();
+    assert_eq!(keys, vec!["counter://q_a", "counter://q_b", "counter://q_c"]);
+}

--- a/lib/saluki-core/src/runtime/state/resources/worker.rs
+++ b/lib/saluki-core/src/runtime/state/resources/worker.rs
@@ -1,0 +1,71 @@
+use async_trait::async_trait;
+use saluki_api::{DynamicRoute, EndpointType};
+use saluki_common::sync::shutdown::ShutdownHandle;
+use saluki_error::generic_error;
+use tracing::warn;
+
+use super::ResourceRegistry;
+use crate::{
+    diagnostic::DiagnosticsEmitter,
+    runtime::{state::DataspaceRegistry, InitializationError, Supervisable, SupervisorFuture},
+    support::SubsystemIdentifier,
+};
+
+/// A worker that exposes the resource registry over the control plane.
+///
+/// The registry itself needs no event loop -- it only does work when a resource is acquired or returned -- so this
+/// worker exists purely to publish it: it asserts the resource API routes as a [`DynamicRoute`] on the unprivileged
+/// endpoint and registers a diagnostic artifact, then idles until shutdown. Both registrations are retracted when the
+/// worker's process exits.
+pub struct ResourceRegistryWorker {
+    resource_registry: ResourceRegistry,
+}
+
+impl ResourceRegistryWorker {
+    pub(super) fn new(resource_registry: ResourceRegistry) -> Self {
+        Self { resource_registry }
+    }
+}
+
+#[async_trait]
+impl Supervisable for ResourceRegistryWorker {
+    fn name(&self) -> &str {
+        "resource-registry"
+    }
+
+    async fn initialize(&self, process_shutdown: ShutdownHandle) -> Result<SupervisorFuture, InitializationError> {
+        let resource_routes = DynamicRoute::http(EndpointType::Unprivileged, self.resource_registry.api_handler());
+
+        let resource_registry = self.resource_registry.clone();
+
+        Ok(Box::pin(async move {
+            let dataspace =
+                DataspaceRegistry::try_current().ok_or_else(|| generic_error!("Dataspace not available."))?;
+
+            // Register our API routes before we actually start running.
+            dataspace.assert(resource_routes, "resource-registry-api");
+
+            // Expose our diagnostic artifact via the diagnostics control surface.
+            let diagnostics = DiagnosticsEmitter::from_dataspace(
+                SubsystemIdentifier::from_segments(["resource-registry"]),
+                dataspace,
+            );
+            diagnostics.register_collector("resources.json", move || {
+                let snapshot = resource_registry.snapshot();
+                let snapshot_pretty = match serde_json::to_string_pretty(&snapshot) {
+                    Ok(json) => json,
+                    Err(e) => {
+                        warn!(error = %e, "Failed to serialize resource registry snapshot during diagnostics collection.");
+                        String::from(r#"{"error": "failed to serialize"}"#)
+                    },
+                };
+
+                snapshot_pretty
+            });
+
+            process_shutdown.await;
+
+            Ok(())
+        }))
+    }
+}

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -18,11 +18,14 @@ use crate::{
     components::{
         decoders::DecoderBuilder, destinations::DestinationBuilder, encoders::EncoderBuilder,
         forwarders::ForwarderBuilder, relays::RelayBuilder, sources::SourceBuilder, transforms::TransformBuilder,
-        ComponentContext, ComponentType,
+        BuildContext, ComponentContext, ComponentType,
     },
     data_model::event::Event,
     health::HealthRegistry,
-    runtime::{state::DataspaceRegistry, InitializationError, ShutdownStrategy, Supervisable, SupervisorFuture},
+    runtime::{
+        state::{DataspaceRegistry, ResourceRegistry},
+        InitializationError, ShutdownStrategy, Supervisable, SupervisorFuture,
+    },
     support::SubsystemIdentifier,
     topology::{ids::AsComponentIds, topology_identifier, EventsBuffer, DEFAULT_EVENTS_BUFFER_CAPACITY},
 };
@@ -61,6 +64,7 @@ pub struct TopologyBlueprint {
     build_state: Mutex<Option<TopologyBuildState>>,
     health_registry: Option<HealthRegistry>,
     memory_limiter: Option<MemoryLimiter>,
+    resource_registry: Option<ResourceRegistry>,
 }
 
 /// The consumable build state of a [`TopologyBlueprint`].
@@ -113,6 +117,7 @@ impl TopologyBlueprint {
             build_state: Mutex::new(Some(build_state)),
             health_registry: None,
             memory_limiter: None,
+            resource_registry: None,
         }
     }
 
@@ -162,6 +167,18 @@ impl TopologyBlueprint {
     /// This must be set before the blueprint is added to a supervisor; initialization fails otherwise.
     pub fn with_memory_limiter(&mut self, memory_limiter: MemoryLimiter) -> &mut Self {
         self.memory_limiter = Some(memory_limiter);
+        self
+    }
+
+    /// Sets the resource registry used when the topology is built and spawned.
+    ///
+    /// Components acquire scarce resources, such as bound network sockets, from this registry rather than creating
+    /// them directly, so that the registry outlives them and can hand the same resource back when a component is
+    /// rebuilt.
+    ///
+    /// This must be set before the blueprint is added to a supervisor; initialization fails otherwise.
+    pub fn with_resource_registry(&mut self, resource_registry: ResourceRegistry) -> &mut Self {
+        self.resource_registry = Some(resource_registry);
         self
     }
 
@@ -657,7 +674,7 @@ impl TopologyBuildState {
     /// # Errors
     ///
     /// If any of the components couldn't be built, an error is returned.
-    async fn build(self, name: String) -> Result<BuiltTopology, GenericError> {
+    async fn build(self, name: String, resource_registry: &ResourceRegistry) -> Result<BuiltTopology, GenericError> {
         self.graph.validate().error_context("Failed to build topology graph.")?;
 
         let mut sources = HashMap::new();
@@ -667,7 +684,7 @@ impl TopologyBuildState {
                 .component_registry
                 .get_resource_group_token(&component_context.identity());
             let source = builder
-                .build(component_context.clone())
+                .build(BuildContext::new(component_context.clone(), resource_registry.clone()))
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build source '{}'.", id))?;
@@ -682,7 +699,7 @@ impl TopologyBuildState {
                 .component_registry
                 .get_resource_group_token(&component_context.identity());
             let relay = builder
-                .build(component_context.clone())
+                .build(BuildContext::new(component_context.clone(), resource_registry.clone()))
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build relay '{}'.", id))?;
@@ -697,7 +714,7 @@ impl TopologyBuildState {
                 .component_registry
                 .get_resource_group_token(&component_context.identity());
             let decoder = builder
-                .build(component_context.clone())
+                .build(BuildContext::new(component_context.clone(), resource_registry.clone()))
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build decoder '{}'.", id))?;
@@ -712,7 +729,7 @@ impl TopologyBuildState {
                 .component_registry
                 .get_resource_group_token(&component_context.identity());
             let transform = builder
-                .build(component_context.clone())
+                .build(BuildContext::new(component_context.clone(), resource_registry.clone()))
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build transform '{}'.", id))?;
@@ -727,7 +744,7 @@ impl TopologyBuildState {
                 .component_registry
                 .get_resource_group_token(&component_context.identity());
             let destination = builder
-                .build(component_context.clone())
+                .build(BuildContext::new(component_context.clone(), resource_registry.clone()))
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build destination '{}'.", id))?;
@@ -742,7 +759,7 @@ impl TopologyBuildState {
                 .component_registry
                 .get_resource_group_token(&component_context.identity());
             let encoder = builder
-                .build(component_context.clone())
+                .build(BuildContext::new(component_context.clone(), resource_registry.clone()))
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build encoder '{}'.", id))?;
@@ -757,7 +774,7 @@ impl TopologyBuildState {
                 .component_registry
                 .get_resource_group_token(&component_context.identity());
             let forwarder = builder
-                .build(component_context.clone())
+                .build(BuildContext::new(component_context.clone(), resource_registry.clone()))
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build forwarder '{}'.", id))?;
@@ -817,6 +834,11 @@ impl Supervisable for TopologyBlueprint {
             .clone()
             .ok_or_else(|| generic_error!("Topology blueprint is missing its memory limiter."))?;
 
+        let resource_registry = self
+            .resource_registry
+            .clone()
+            .ok_or_else(|| generic_error!("Topology blueprint is missing its resource registry."))?;
+
         let dataspace = DataspaceRegistry::try_current()
             .ok_or_else(|| generic_error!("Topology must be initialized within a supervised process context."))?;
 
@@ -830,7 +852,7 @@ impl Supervisable for TopologyBlueprint {
         let environment_ready = build_state.environment_ready.take();
         let ready_signal = build_state.ready_signal.take();
         let shutdown_timeout = build_state.shutdown_timeout;
-        let built = build_state.build(self.name.clone()).await?;
+        let built = build_state.build(self.name.clone(), &resource_registry).await?;
 
         Ok(Box::pin(async move {
             pin!(shutdown);
@@ -895,8 +917,9 @@ mod tests {
 
     use super::{TopologyBlueprint, TopologyReady, WorkerPoolConfiguration};
     use crate::accounting::{ComponentRegistry, MemoryBounds, MemoryBoundsBuilder, MemoryLimiter};
+    use crate::components::BuildContext;
     use crate::data_model::event::Event;
-    use crate::runtime::Name;
+    use crate::runtime::{state::ResourceRegistry, Name};
     use crate::test_support::wait_until;
     use crate::topology::{ids::get_component_relative_identifier, topology_identifier, ComponentId};
     use crate::topology::{EventsBuffer, DEFAULT_EVENTS_BUFFER_CAPACITY};
@@ -990,7 +1013,7 @@ mod tests {
             &self.outputs
         }
 
-        async fn build(&self, _: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError> {
+        async fn build(&self, _: BuildContext) -> Result<Box<dyn Source + Send>, GenericError> {
             Ok(Box::new(ControlSource {
                 started: Arc::clone(&self.started),
                 spawned_child: self.spawned_child.clone(),
@@ -1023,7 +1046,7 @@ mod tests {
             self.input_event_ty
         }
 
-        async fn build(&self, _: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
+        async fn build(&self, _: BuildContext) -> Result<Box<dyn Destination + Send>, GenericError> {
             Ok(Box::new(DrainingDestination))
         }
     }
@@ -1059,7 +1082,7 @@ mod tests {
             self.input_event_ty
         }
 
-        async fn build(&self, _: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
+        async fn build(&self, _: BuildContext) -> Result<Box<dyn Destination + Send>, GenericError> {
             Ok(Box::new(StuckDestination {
                 started: Arc::clone(&self.started),
             }))
@@ -1099,7 +1122,8 @@ mod tests {
             .expect("should not fail to connect components");
         blueprint
             .with_health_registry(HealthRegistry::new())
-            .with_memory_limiter(MemoryLimiter::noop());
+            .with_memory_limiter(MemoryLimiter::noop())
+            .with_resource_registry(ResourceRegistry::new());
         (blueprint, source_started)
     }
 
@@ -1132,6 +1156,7 @@ mod tests {
         blueprint
             .with_health_registry(HealthRegistry::new())
             .with_memory_limiter(MemoryLimiter::noop())
+            .with_resource_registry(ResourceRegistry::new())
             .with_shutdown_timeout(shutdown_timeout);
         (blueprint, destination_started)
     }
@@ -1364,7 +1389,8 @@ mod tests {
         let mut blueprint = connected_blueprint();
         blueprint
             .with_health_registry(HealthRegistry::new())
-            .with_memory_limiter(MemoryLimiter::noop());
+            .with_memory_limiter(MemoryLimiter::noop())
+            .with_resource_registry(ResourceRegistry::new());
 
         let result = run_blueprint_until_exit(
             blueprint,
@@ -1384,7 +1410,8 @@ mod tests {
         let mut blueprint = connected_blueprint();
         blueprint
             .with_health_registry(HealthRegistry::new())
-            .with_memory_limiter(MemoryLimiter::noop());
+            .with_memory_limiter(MemoryLimiter::noop())
+            .with_resource_registry(ResourceRegistry::new());
 
         let result = run_blueprint_until_exit(blueprint, RestartStrategy::default()).await;
 
@@ -1412,6 +1439,7 @@ mod tests {
         blueprint
             .with_health_registry(HealthRegistry::new())
             .with_memory_limiter(MemoryLimiter::noop())
+            .with_resource_registry(ResourceRegistry::new())
             .with_environment_readiness(gate);
 
         let (tx, handle) = spawn_supervised_blueprint(blueprint);

--- a/lib/saluki-core/src/topology/test_util.rs
+++ b/lib/saluki-core/src/topology/test_util.rs
@@ -5,8 +5,7 @@ use super::OutputDefinition;
 use crate::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use crate::{
     components::{
-        decoders::*, destinations::*, encoders::*, forwarders::*, relays::*, sources::*, transforms::*,
-        ComponentContext,
+        decoders::*, destinations::*, encoders::*, forwarders::*, relays::*, sources::*, transforms::*, BuildContext,
     },
     data_model::{event::EventType, payload::PayloadType},
 };
@@ -38,7 +37,7 @@ impl SourceBuilder for TestSourceBuilder {
         &self.outputs
     }
 
-    async fn build(&self, _: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError> {
+    async fn build(&self, _: BuildContext) -> Result<Box<dyn Source + Send>, GenericError> {
         Ok(Box::new(TestSource))
     }
 }
@@ -85,7 +84,7 @@ impl RelayBuilder for TestRelayBuilder {
         &self.outputs
     }
 
-    async fn build(&self, _: ComponentContext) -> Result<Box<dyn Relay + Send>, GenericError> {
+    async fn build(&self, _: BuildContext) -> Result<Box<dyn Relay + Send>, GenericError> {
         Ok(Box::new(TestRelay))
     }
 }
@@ -127,7 +126,7 @@ impl DecoderBuilder for TestDecoderBuilder {
         self.output_event_ty
     }
 
-    async fn build(&self, _: ComponentContext) -> Result<Box<dyn Decoder + Send>, GenericError> {
+    async fn build(&self, _: BuildContext) -> Result<Box<dyn Decoder + Send>, GenericError> {
         Ok(Box::new(TestDecoder))
     }
 }
@@ -183,7 +182,7 @@ impl TransformBuilder for TestTransformBuilder {
         &self.outputs
     }
 
-    async fn build(&self, _: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
+    async fn build(&self, _: BuildContext) -> Result<Box<dyn Transform + Send>, GenericError> {
         Ok(Box::new(TestTransform))
     }
 }
@@ -225,7 +224,7 @@ impl EncoderBuilder for TestEncoderBuilder {
         self.output_payload_ty
     }
 
-    async fn build(&self, _: ComponentContext) -> Result<Box<dyn Encoder + Send>, GenericError> {
+    async fn build(&self, _: BuildContext) -> Result<Box<dyn Encoder + Send>, GenericError> {
         Ok(Box::new(TestEncoder))
     }
 }
@@ -259,7 +258,7 @@ impl ForwarderBuilder for TestForwarderBuilder {
         self.input_payload_ty
     }
 
-    async fn build(&self, _: ComponentContext) -> Result<Box<dyn Forwarder + Send>, GenericError> {
+    async fn build(&self, _: BuildContext) -> Result<Box<dyn Forwarder + Send>, GenericError> {
         Ok(Box::new(TestForwarder))
     }
 }
@@ -293,7 +292,7 @@ impl DestinationBuilder for TestDestinationBuilder {
         self.input_event_ty
     }
 
-    async fn build(&self, _: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
+    async fn build(&self, _: BuildContext) -> Result<Box<dyn Destination + Send>, GenericError> {
         Ok(Box::new(TestDestination))
     }
 }


### PR DESCRIPTION
## Summary

This PR introduces `ResourceRegistry`, a new centralized mechanism for coordinating the acquisition of external resources, such as network sockets, between components.

When a data plane starts up, it goes through the process of configuring itself, which generally involves things like binding network sockets to expose API endpoints for administrative purposes, or accepting data, and so on. These network sockets, or "external" resources, are very cut-and-dry: if we can't bind a port we need, we exit. This currently works well enough because we construct our topology once, and if it succeeds, then process runs and we don't have to worry about issues with binding sockets again at runtime because they're already bound.

However, in order to support a future where components can recover from failure, or even be intentionally added/removed/replaced dynamically at runtime, we have to contend with a new reality: we might need to destroy the object that holds an acquired external resource before creating our new component, and in doing so, introduce a risk that something else comes along and takes that resource.

This PR introduces a new mechanism for managing these resources at a higher level, `ResourceRegistry`, that is designed to solve these issues. `ResourceRegistry` provides a way to define "specifications" for types of resources -- a way to uniquely identify the resource, and how to create it -- and then is exposed to callers that need to create such resources. The registry owns resources for the lifetime of the process (or until the resource is manually discarded) and provides "leases" to callers, such that one instance of a component can hold temporary ownership of the resource, and then the resource is automatically returned when the component goes away. When the component comes back, it can reacquire the resource without the resource having ever been destroyed. This ensures that another external process cannot _steal_ a resource the data plane depends on, and it also keeps it alive for the purposes of zero-downtime changes to the topology.

Initially, the goal is to use this for network sockets, but the design can be scaled to anything, really, that we deem as a unique, mutually exclusive resource that we want to create and hold long-term, beyond the lifecycle of a single component task.

In terms of this PR, we've done the following:

- introduced `ResourceRegistry` and the various directly related types (`ResourceSpecification`, `ResourceLease`, `AcquireError`, etc etc)
- created a new `BuildContext` type that holds both `ComponentContext` and `ResourceRegistry`, and replaces the `ComponentContext` we provide to `build` methods in component builder traits to expose the ability to acquire resources from the registry when building a component
- exposed a new API endpoint, `/resources/status`, to query the state of the resource registry in terms of all registered resources, which process owns them, and so on

The vastly majority of changed files are simply related to the `build` method signature change to take `BuildContext`, while the rest are related to adding `ResourceRegistry` itself. This PR does not yet migrate anything to actually use it, and that will happen in a follow-up PR.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

New and existing tests.

## References

DADP-2
