### PR TITLE
chore(config): migrate TagFilterlistConfiguration to typed config

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -801,9 +801,12 @@ async fn add_dsd_pipeline_to_blueprint(
         DogStatsDMapperConfiguration::new(mapper.string_interner_size_bytes, mapper.cache_size, mapper_profiles);
     let dsd_enrich_config =
         ChainedConfiguration::default().with_transform_builder("dogstatsd_mapper", dsd_mapper_config);
-    let dogstatsd_config = config_system.live(|config| &config.domains.dogstatsd);
-    let dsd_tag_filterlist_config = TagFilterlistConfiguration::from_configuration(dogstatsd_config)
-        .error_context("Failed to configure metric tag filterlist transform.")?;
+    let dsd_tag_filterlist_config = TagFilterlistConfiguration::new(
+        config_system.live(|config| &config.domains.dogstatsd.tag_filterlist),
+        &typed.domains.dogstatsd.tag_value_allowlist,
+        typed.domains.dogstatsd.aggregation.aggregator_tag_filter_cache_capacity,
+    )
+    .error_context("Failed to configure metric tag filterlist transform.")?;
     let aggregation = &typed.domains.dogstatsd.aggregation;
     let histogram = &typed.shared.metrics_encoding.histogram;
     let dsd_hist_config = HistogramConfiguration::try_new(
@@ -1017,8 +1020,7 @@ mod tests {
 
     use agent_data_plane_config::{
         domains::dogstatsd::{
-            Domain as DogStatsDDomain, FilterAction, MetricTagFilterEntry, MetricTagValueAllowlistEntry,
-            TagValueMismatchAction,
+            FilterAction, MetricTagFilterEntry, MetricTagValueAllowlistEntry, TagValueMismatchAction,
         },
         Live,
     };
@@ -1091,23 +1093,22 @@ mod tests {
             let mapper_chain = ChainedConfiguration::default().with_transform_builder("dogstatsd_mapper", mapper);
             let prefix_filter = DogStatsDPrefixFilterConfiguration::from_configuration(&config)
                 .expect("prefix filter configuration should parse");
-            let dogstatsd_config = DogStatsDDomain {
-                tag_filterlist: vec![MetricTagFilterEntry {
+            let tag_filter = TagFilterlistConfiguration::new(
+                Live::new_fixed(vec![MetricTagFilterEntry {
                     metric_name: "tenant.mapped.requests".to_string(),
                     action: FilterAction::Exclude,
                     tags: vec!["remove".to_string()],
-                }],
-                tag_value_allowlist: vec![MetricTagValueAllowlistEntry {
+                }]),
+                &[MetricTagValueAllowlistEntry {
                     metric_prefix: "tenant.mapped.".to_string(),
                     tag_name: "customer_id".to_string(),
                     values: vec!["top-1".to_string()],
                     on_miss: TagValueMismatchAction::Remove,
                     replacement: "other".to_string(),
                 }],
-                ..Default::default()
-            };
-            let tag_filter = TagFilterlistConfiguration::from_configuration(Live::new_fixed(dogstatsd_config))
-                .expect("tag filter configuration should be valid");
+                0,
+            )
+            .expect("tag filter configuration should be valid");
             let hist_config = HistogramConfiguration::try_new(
                 &[
                     "max".to_string(),

--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -13,8 +13,8 @@ use std::{collections::hash_map::Entry, num::NonZeroUsize, time::Duration};
 
 use agent_data_plane_config::{
     domains::dogstatsd::{
-        validate_metric_tag_value_allowlists, Domain as DogStatsDDomain, FilterAction, MetricTagFilterEntry,
-        MetricTagValueAllowlistEntry, TagValueMismatchAction,
+        validate_metric_tag_value_allowlists, FilterAction, MetricTagFilterEntry, MetricTagValueAllowlistEntry,
+        TagValueMismatchAction,
     },
     Live,
 };
@@ -258,18 +258,20 @@ pub struct TagFilterlistConfiguration {
 }
 
 impl TagFilterlistConfiguration {
-    /// Creates a new `TagFilterlistConfiguration` from typed DogStatsD configuration.
+    /// Creates a new `TagFilterlistConfiguration`.
     ///
     /// # Errors
     ///
     /// Returns an error when the initial value allow-list rules are invalid.
-    pub fn from_configuration(config: Live<DogStatsDDomain>) -> Result<Self, GenericError> {
-        let entries = config.project(|config| &config.tag_filterlist);
-        let value_prefix_filters = compile_all_filters(&[], &config.tag_value_allowlist)?.value_prefix_filters;
+    pub fn new(
+        entries: Live<Vec<MetricTagFilterEntry>>, value_allowlists: &[MetricTagValueAllowlistEntry],
+        context_cache_capacity: usize,
+    ) -> Result<Self, GenericError> {
+        let value_prefix_filters = compile_all_filters(&[], value_allowlists)?.value_prefix_filters;
         Ok(Self {
             entries,
             value_prefix_filters,
-            context_cache_capacity: config.aggregation.aggregator_tag_filter_cache_capacity,
+            context_cache_capacity,
         })
     }
 }
@@ -1080,15 +1082,6 @@ mod tests {
     }
 
     #[test]
-    fn context_cache_capacity_comes_from_typed_dogstatsd_configuration() {
-        let mut config = DogStatsDDomain::default();
-        config.aggregation.aggregator_tag_filter_cache_capacity = 512;
-        let builder = TagFilterlistConfiguration::from_configuration(Live::new_fixed(config))
-            .expect("typed configuration should be valid");
-        assert_eq!(builder.context_cache_capacity, 512);
-    }
-
-    #[test]
     fn origin_tags_preserved_after_filtering() {
         let context = Context::from_static_parts("my.dist", &["env:prod", "host:h1"]);
         let tag_set: TagSet = [Tag::from("service:web")].into_iter().collect();
@@ -1389,21 +1382,19 @@ mod tests {
         //      that share a (name, tags) context resolve to a single cache entry, and every metric sharing that
         //      context is filtered identically (the second and later occurrences take the cache-hit branch).
 
-        let mut config = DogStatsDDomain::default();
-        config.aggregation.aggregator_tag_filter_cache_capacity = 100_000;
-        config.tag_filterlist = vec![MetricTagFilterEntry {
+        let entries = vec![MetricTagFilterEntry {
             metric_name: "svc.latency".to_string(),
             action: FilterAction::Exclude,
             tags: vec!["host".to_string()],
         }];
-        config.tag_value_allowlist = vec![value_allowlist(
+        let value_allowlists = vec![value_allowlist(
             "svc.",
             "customer_id",
             &[],
             TagValueMismatchAction::Replace,
             "other",
         )];
-        let builder = TagFilterlistConfiguration::from_configuration(Live::new_fixed(config))
+        let builder = TagFilterlistConfiguration::new(Live::new_fixed(entries), &value_allowlists, 100_000)
             .expect("typed configuration should be valid");
 
         let component_context = ComponentContext::test_transform("tag_filterlist");

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -167,66 +167,40 @@ fn parse_mapper_profile(key: &str, raw: serde_json::Value) -> Result<MapperProfi
     })
 }
 
-/// The result of parsing one `metric_tag_filterlist` object.
-///
-/// The two failure modes differ in whether the entry can still be used, and the caller relies on
-/// that difference to honor the system's opposite stances on translation errors (strict at startup,
-/// lenient at runtime). A [`Recovered`][Self::Recovered] entry is still usable, so a runtime update
-/// keeps filtering with it while startup still rejects the config on the recorded error. A
-/// [`Malformed`][Self::Malformed] object yields no value, so it is skipped.
-enum TagFilterEntry {
-    /// The object parsed and its `action` was recognized.
-    Valid(MetricTagFilterEntry),
-    /// The object parsed but its `action` was not `include`, `exclude`, or empty. The entry is kept
-    /// with `action` defaulted to `exclude`, matching the component's own tolerance, and the error
-    /// is recorded so a strict startup still rejects the config.
-    Recovered(MetricTagFilterEntry, TranslateError),
-    /// The object could not be deserialized into an entry; no value is recoverable.
-    Malformed(TranslateError),
-}
-
-/// Parses one `metric_tag_filterlist` object into a [`TagFilterEntry`].
+/// Parses one `metric_tag_filterlist` object into a [`MetricTagFilterEntry`].
 ///
 /// Like `parse_mapper_profile`, this imposes the typed model shape on a free-form schema object via
-/// a local `#[derive(Deserialize)]` shim. Unlike it, an unrecognized `action` does not discard the
-/// entry: the schema lets any string through, so the component tolerates typos by defaulting to
-/// `exclude`, and this preserves that behavior while still surfacing the error.
-fn parse_tag_filter_entry(key: &str, raw: serde_json::Value) -> TagFilterEntry {
+/// a local `#[derive(Deserialize)]` shim.
+fn parse_tag_filter_entry(key: &str, raw: serde_json::Value) -> Result<MetricTagFilterEntry> {
     #[derive(serde::Deserialize)]
     struct RawEntry {
         metric_name: String,
         #[serde(default)]
-        action: String,
+        action: Option<String>,
+        // The Agent decodes an entry with `mapstructure`, so an absent `tags` yields an empty list
+        // and keeps the entry. Requiring it here would reject a configuration the Agent runs with.
         #[serde(default)]
         tags: Vec<String>,
     }
 
-    let parsed: RawEntry = match serde_json::from_value(raw).map_err(|error| TranslateError::new(key, error)) {
-        Ok(parsed) => parsed,
-        Err(error) => return TagFilterEntry::Malformed(error),
+    let parsed: RawEntry = serde_json::from_value(raw).map_err(|error| TranslateError::new(key, error))?;
+    let action = match parsed.action.as_deref() {
+        Some("include") => FilterAction::Include,
+        None | Some("") | Some("exclude") => FilterAction::Exclude,
+        Some(other) => {
+            warn!(
+                action = %other,
+                "`metric_tag_filterlist.*.action` should be either `include` or `exclude`; defaulting to `exclude`."
+            );
+            FilterAction::Exclude
+        }
     };
 
-    let (action, action_error) = match parsed.action.as_str() {
-        "include" => (FilterAction::Include, None),
-        "" | "exclude" => (FilterAction::Exclude, None),
-        other => (
-            FilterAction::Exclude,
-            Some(TranslateError::new_with_message(
-                key,
-                format!("unknown filter action `{other}`"),
-            )),
-        ),
-    };
-
-    let entry = MetricTagFilterEntry {
+    Ok(MetricTagFilterEntry {
         metric_name: parsed.metric_name,
         action,
         tags: parsed.tags,
-    };
-    match action_error {
-        Some(error) => TagFilterEntry::Recovered(entry, error),
-        None => TagFilterEntry::Valid(entry),
-    }
+    })
 }
 
 impl DatadogConfigWitness for DatadogTranslator<'_> {
@@ -429,11 +403,19 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_data_plane_dogstatsd_aggregator_tag_filter_cache_capacity(&mut self, value: i64) {
-        self.config
-            .domains
-            .dogstatsd
-            .aggregation
-            .aggregator_tag_filter_cache_capacity = value.max(0) as usize;
+        match usize::try_from(value) {
+            Ok(capacity) => {
+                self.config
+                    .domains
+                    .dogstatsd
+                    .aggregation
+                    .aggregator_tag_filter_cache_capacity = capacity;
+            }
+            Err(_) => self.record_error(TranslateError::new_with_message(
+                "data_plane.dogstatsd.aggregator_tag_filter_cache_capacity",
+                format!("tag filter cache capacity must be greater than or equal to 0, got {value}"),
+            )),
+        }
     }
 
     fn consume_data_plane_dogstatsd_enabled(&mut self, value: bool) {
@@ -865,19 +847,11 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_metric_tag_filterlist(&mut self, value: Vec<serde_json::Value>) {
-        // A single bad entry must not empty the whole list: startup rejects the config on any
-        // recorded error, but a runtime update stores what translated, so dropping the list here
-        // would silently disable all tag filtering. Keep every entry we can build and record the
-        // errors alongside them.
         let mut entries = Vec::with_capacity(value.len());
         for raw in value {
             match parse_tag_filter_entry("metric_tag_filterlist", raw) {
-                TagFilterEntry::Valid(entry) => entries.push(entry),
-                TagFilterEntry::Recovered(entry, error) => {
-                    self.record_error(error);
-                    entries.push(entry);
-                }
-                TagFilterEntry::Malformed(error) => self.record_error(error),
+                Ok(entry) => entries.push(entry),
+                Err(error) => self.record_error(error),
             }
         }
         self.config.domains.dogstatsd.tag_filterlist = entries;
@@ -1818,34 +1792,93 @@ mod tests {
     }
 
     #[test]
-    fn bad_tag_filter_action_keeps_the_whole_list() {
+    fn tag_filter_actions_preserve_tolerant_parsing() {
         use agent_data_plane_config::domains::dogstatsd::FilterAction;
 
-        // One entry has a typo'd action between two valid entries. The bad action must not discard
-        // the list: the entry is kept with `action` defaulted to `exclude`, an error is recorded
-        // (so a strict startup rejects the config), and the surrounding valid entries survive (so a
-        // lenient runtime update keeps filtering).
         let (config, errors) = translate_explicit(json!({
             "metric_tag_filterlist": [
-                { "metric_name": "a", "action": "include", "tags": ["x"] },
-                { "metric_name": "b", "action": "exlude", "tags": ["y"] },
-                { "metric_name": "c", "action": "exclude", "tags": ["z"] },
+                { "metric_name": "missing", "tags": ["a"] },
+                { "metric_name": "null", "action": null, "tags": ["b"] },
+                { "metric_name": "empty", "action": "", "tags": ["c"] },
+                { "metric_name": "include", "action": "include", "tags": ["d"] },
+                { "metric_name": "exclude", "action": "exclude", "tags": ["e"] },
+                { "metric_name": "unknown", "action": "exlude", "tags": ["f"] },
             ],
         }));
 
+        assert!(errors.is_none());
         let entries = &config.domains.dogstatsd.tag_filterlist;
-        assert_eq!(entries.len(), 3, "a bad action must not drop the other entries");
-        assert_eq!(entries[0].action, FilterAction::Include);
+        let actions: Vec<_> = entries.iter().map(|entry| entry.action).collect();
         assert_eq!(
-            entries[1].action,
-            FilterAction::Exclude,
-            "unknown action defaults to exclude"
+            actions,
+            vec![
+                FilterAction::Exclude,
+                FilterAction::Exclude,
+                FilterAction::Exclude,
+                FilterAction::Include,
+                FilterAction::Exclude,
+                FilterAction::Exclude,
+            ]
         );
-        assert_eq!(entries[1].metric_name, "b");
-        assert_eq!(entries[2].action, FilterAction::Exclude);
+        assert_eq!(entries[0].metric_name, "missing");
+        assert_eq!(entries[5].tags, ["f"]);
+    }
 
-        // The error is still surfaced, so startup's strict gate rejects the config.
-        assert!(errors.is_some(), "an unknown action must record a translation error");
+    #[test]
+    fn tag_filter_entry_without_tags_is_kept_with_no_tags() {
+        let (config, errors) = translate_explicit(json!({
+            "metric_tag_filterlist": [{ "metric_name": "svc.latency" }],
+        }));
+
+        assert!(errors.is_none(), "the Agent accepts an entry without tags");
+        let entries = &config.domains.dogstatsd.tag_filterlist;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].metric_name, "svc.latency");
+        assert!(entries[0].tags.is_empty());
+    }
+
+    #[test]
+    fn malformed_tag_filter_entry_does_not_drop_valid_neighbors() {
+        let (config, errors) = translate_explicit(json!({
+            "metric_tag_filterlist": [
+                { "metric_name": "before", "tags": ["a"] },
+                { "tags": ["orphan"] },
+                { "metric_name": "after", "tags": ["b"] },
+            ],
+        }));
+
+        let names: Vec<_> = config
+            .domains
+            .dogstatsd
+            .tag_filterlist
+            .iter()
+            .map(|entry| entry.metric_name.as_str())
+            .collect();
+        assert_eq!(names, ["before", "after"]);
+        assert!(
+            errors.is_some(),
+            "an entry without a metric name must record a translation error"
+        );
+    }
+
+    #[test]
+    fn negative_tag_filter_cache_capacity_is_rejected() {
+        let (config, errors) = translate_explicit(json!({
+            "data_plane": { "dogstatsd": { "aggregator_tag_filter_cache_capacity": -1 } },
+        }));
+
+        assert_eq!(
+            config
+                .domains
+                .dogstatsd
+                .aggregation
+                .aggregator_tag_filter_cache_capacity,
+            0
+        );
+        let errors = errors.expect("a negative cache capacity must record a translation error");
+        assert!(errors
+            .to_string()
+            .contains("data_plane.dogstatsd.aggregator_tag_filter_cache_capacity"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace `TagFilterlistConfiguration::from_configuration` with `new(...)`.
- Pass a narrow `Live<Vec<MetricTagFilterEntry>>` to the component instead of the full DogStatsD domain.
- Pass value allowlists and context cache capacity as static component inputs.
- Warn on an unrecognized `action` and fall back to `exclude` without recording a translation error.
- This matches the core Agent recovery behavior and avoids rejecting a configuration the Agent runs with.
- Keep an entry without `tags` with an empty tag list, matching the Agent's `mapstructure` decode.
- Reject and drop an entry without `metric_name` while retaining valid neighboring entries.
- Reject negative `data_plane.dogstatsd.aggregator_tag_filter_cache_capacity` values during translation instead of clamping them.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make fmt`
- `make check-docs`
- `make check-clippy`
- Targeted `cargo nextest` runs for the configuration system, `datadog-agent-config`, and the tag-filterlist / DogStatsD pipeline tests

## References

- Progresses: #2293
