### PR TITLE
chore(config): declare object-array element types

### DIFF
--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -7,7 +7,9 @@
 //! to its `SalukiConfiguration` destination.
 //!
 //! Most keys assign a single field directly. The endpoint keys (`api_key`, `dd_url`, `site`,
-//! `additional_endpoints`) are copied into the model without selecting a primary endpoint here.
+//! `additional_endpoints`) are copied into the model without selecting a primary endpoint here. An
+//! object array without an `items` schema arrives as `Vec<serde_json::Value>`; the translator
+//! deserializes each value using [`array_objects`] before mapping it to the ADP model.
 //!
 //! A key whose meaning depends on whether its value was set explicitly or set by default is typed
 //! as a [`ConfigValue`] which preserves that provenance.
@@ -33,7 +35,7 @@ use agent_data_plane_config::shared::{ForwarderHttpProtocol, V3SeriesMode};
 use agent_data_plane_config::{ConfigValue, SalukiConfiguration};
 use bytesize::ByteSize;
 use datadog_agent_config::{
-    cast_to_string, drive, DatadogConfigWitness, DatadogConfiguration, TranslateError, TranslateErrors,
+    array_objects, cast_to_string, drive, DatadogConfigWitness, DatadogConfiguration, TranslateError, TranslateErrors,
 };
 use tracing::warn;
 
@@ -125,88 +127,14 @@ fn to_port(value: i64) -> u16 {
     value.clamp(0, u16::MAX as i64) as u16
 }
 
-/// Parses one `dogstatsd_mapper_profiles` object into a [`MapperProfile`].
+/// Classifies a `metric_tag_filterlist` element's `action` string.
 ///
-/// The vendored Datadog schema declares `dogstatsd_mapper_profiles` (and `metric_tag_filterlist`)
-/// as arrays of free-form objects, so the generated witness can only surface them as
-/// `Vec<serde_json::Value>`. This parser imposes the typed model shape at the configuration
-/// boundary via a local `#[derive(Deserialize)]` shim.
-fn parse_mapper_profile(key: &str, raw: serde_json::Value) -> Result<MapperProfile> {
-    #[derive(serde::Deserialize)]
-    struct RawMapping {
-        #[serde(rename = "match")]
-        metric_match: String,
-        #[serde(default)]
-        match_type: String,
-        name: String,
-        #[serde(default)]
-        tags: HashMap<String, String>,
-    }
-    #[derive(serde::Deserialize)]
-    struct RawProfile {
-        name: String,
-        prefix: String,
-        #[serde(default)]
-        mappings: Vec<RawMapping>,
-    }
-
-    let parsed: RawProfile = serde_json::from_value(raw).map_err(|error| TranslateError::new(key, error))?;
-    Ok(MapperProfile {
-        name: parsed.name,
-        prefix: parsed.prefix,
-        mappings: parsed
-            .mappings
-            .into_iter()
-            .map(|m| MetricMapping {
-                metric_match: m.metric_match,
-                match_type: m.match_type,
-                name: m.name,
-                tags: m.tags,
-            })
-            .collect(),
-    })
-}
-
-/// The result of parsing one `metric_tag_filterlist` object.
-///
-/// The two failure modes differ in whether the entry can still be used, and the caller relies on
-/// that difference to honor the system's opposite stances on translation errors (strict at startup,
-/// lenient at runtime). A [`Recovered`][Self::Recovered] entry is still usable, so a runtime update
-/// keeps filtering with it while startup still rejects the config on the recorded error. A
-/// [`Malformed`][Self::Malformed] object yields no value, so it is skipped.
-enum TagFilterEntry {
-    /// The object parsed and its `action` was recognized.
-    Valid(MetricTagFilterEntry),
-    /// The object parsed but its `action` was not `include`, `exclude`, or empty. The entry is kept
-    /// with `action` defaulted to `exclude`, matching the component's own tolerance, and the error
-    /// is recorded so a strict startup still rejects the config.
-    Recovered(MetricTagFilterEntry, TranslateError),
-    /// The object could not be deserialized into an entry; no value is recoverable.
-    Malformed(TranslateError),
-}
-
-/// Parses one `metric_tag_filterlist` object into a [`TagFilterEntry`].
-///
-/// Like `parse_mapper_profile`, this imposes the typed model shape on a free-form schema object via
-/// a local `#[derive(Deserialize)]` shim. Unlike it, an unrecognized `action` does not discard the
-/// entry: the schema lets any string through, so the component tolerates typos by defaulting to
-/// `exclude`, and this preserves that behavior while still surfacing the error.
-fn parse_tag_filter_entry(key: &str, raw: serde_json::Value) -> TagFilterEntry {
-    #[derive(serde::Deserialize)]
-    struct RawEntry {
-        metric_name: String,
-        #[serde(default)]
-        action: String,
-        #[serde(default)]
-        tags: Vec<String>,
-    }
-
-    let parsed: RawEntry = match serde_json::from_value(raw).map_err(|error| TranslateError::new(key, error)) {
-        Ok(parsed) => parsed,
-        Err(error) => return TagFilterEntry::Malformed(error),
-    };
-
-    let (action, action_error) = match parsed.action.as_str() {
+/// The schema types `action` as a free string, and the Agent defaults an unrecognized value to
+/// `exclude` instead of rejecting the entry, so the entry stays usable. The error is still returned
+/// so a strict startup rejects the configuration while a lenient runtime update keeps filtering with
+/// the recovered entry.
+fn parse_filter_action(key: &str, action: &str) -> (FilterAction, Option<TranslateError>) {
+    match action {
         "include" => (FilterAction::Include, None),
         "" | "exclude" => (FilterAction::Exclude, None),
         other => (
@@ -216,16 +144,6 @@ fn parse_tag_filter_entry(key: &str, raw: serde_json::Value) -> TagFilterEntry {
                 format!("unknown filter action `{other}`"),
             )),
         ),
-    };
-
-    let entry = MetricTagFilterEntry {
-        metric_name: parsed.metric_name,
-        action,
-        tags: parsed.tags,
-    };
-    match action_error {
-        Some(error) => TagFilterEntry::Recovered(entry, error),
-        None => TagFilterEntry::Valid(entry),
     }
 }
 
@@ -564,13 +482,28 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     fn consume_dogstatsd_mapper_profiles(&mut self, value: Vec<serde_json::Value>) {
         let mut profiles = Vec::with_capacity(value.len());
         for raw in value {
-            match parse_mapper_profile("dogstatsd_mapper_profiles", raw) {
-                Ok(profile) => profiles.push(profile),
+            let profile: array_objects::MapperProfile = match serde_json::from_value(raw) {
+                Ok(profile) => profile,
                 Err(error) => {
-                    self.record_error(error);
+                    self.record_error(TranslateError::new("dogstatsd_mapper_profiles", error));
                     return;
                 }
-            }
+            };
+
+            profiles.push(MapperProfile {
+                name: profile.name,
+                prefix: profile.prefix,
+                mappings: profile
+                    .mappings
+                    .into_iter()
+                    .map(|mapping| MetricMapping {
+                        metric_match: mapping.metric_match,
+                        match_type: mapping.match_type,
+                        name: mapping.name,
+                        tags: mapping.tags,
+                    })
+                    .collect(),
+            });
         }
         self.config.domains.dogstatsd.mapper.profiles = profiles;
     }
@@ -863,14 +796,23 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
         // errors alongside them.
         let mut entries = Vec::with_capacity(value.len());
         for raw in value {
-            match parse_tag_filter_entry("metric_tag_filterlist", raw) {
-                TagFilterEntry::Valid(entry) => entries.push(entry),
-                TagFilterEntry::Recovered(entry, error) => {
-                    self.record_error(error);
-                    entries.push(entry);
+            let entry: array_objects::MetricTagFilterlistEntry = match serde_json::from_value(raw) {
+                Ok(entry) => entry,
+                Err(error) => {
+                    self.record_error(TranslateError::new("metric_tag_filterlist", error));
+                    continue;
                 }
-                TagFilterEntry::Malformed(error) => self.record_error(error),
+            };
+
+            let (action, action_error) = parse_filter_action("metric_tag_filterlist", &entry.action);
+            if let Some(error) = action_error {
+                self.record_error(error);
             }
+            entries.push(MetricTagFilterEntry {
+                metric_name: entry.metric_name,
+                action,
+                tags: entry.tags,
+            });
         }
         self.config.domains.dogstatsd.tag_filterlist = entries;
     }

--- a/lib/datadog-agent/config/build/datadog_config_gen.rs
+++ b/lib/datadog-agent/config/build/datadog_config_gen.rs
@@ -16,7 +16,7 @@
 //! bare number from reaching the translator as an ambiguous unit.
 //!
 //! List fields also get shape-tolerant decoders. String lists accept the Agent's scalar forms, and
-//! free-form object arrays accept either sequences or JSON-encoded strings. Handling these shapes at
+//! object arrays without an `items` schema accept either sequences or JSON-encoded strings. Handling these shapes at
 //! the deserialization boundary keeps downstream types consistent; see `listize` and
 //! `crate::list_de`.
 //!
@@ -385,7 +385,7 @@ fn duration_defaults_module(durations: &BTreeMap<String, u64>) -> String {
 /// String lists arrive as a real sequence from a file or the remote Agent stream, but as a single
 /// space-separated string from an environment variable (`DD_DOGSTATSD_TAGS="a b"`), so each field
 /// must accept both. Map values containing string lists may likewise arrive as either one scalar or
-/// a sequence. Free-form object arrays also accept a JSON-encoded string.
+/// a sequence. Object arrays without an `items` schema also accept a JSON-encoded string.
 ///
 /// We push an extra `#[serde(deserialize_with = ...)]` attribute rather than replacing the field's
 /// existing serde attributes: serde merges multiple `#[serde(...)]`, so the field keeps its

--- a/lib/datadog-agent/config/src/array_objects.rs
+++ b/lib/datadog-agent/config/src/array_objects.rs
@@ -1,0 +1,115 @@
+//! Source types for object arrays without `items` schemas.
+//!
+//! The generated configuration model exposes these arrays as `Vec<serde_json::Value>`. The
+//! translator deserializes each value into a type in this module before mapping it to the ADP model.
+//!
+//! These types mirror the core Agent's `MappingProfileConfig`, `MetricMappingConfig`, and
+//! `MetricTagListEntry` structs.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+/// One `dogstatsd_mapper_profiles` element.
+#[derive(Clone, Debug, Deserialize)]
+pub struct MapperProfile {
+    /// Name of the profile.
+    pub name: String,
+
+    /// Metric-name prefix that selects this profile.
+    pub prefix: String,
+
+    /// Mapping rules the profile applies to a matching metric name.
+    #[serde(default)]
+    pub mappings: Vec<MetricMapping>,
+}
+
+/// One `mappings` element of a [`MapperProfile`].
+#[derive(Clone, Debug, Deserialize)]
+pub struct MetricMapping {
+    /// Pattern the metric name is matched against.
+    ///
+    /// Renamed because the schema spells this field `match`, a Rust keyword.
+    #[serde(rename = "match")]
+    pub metric_match: String,
+
+    /// How `metric_match` is interpreted, such as `wildcard` or `regex`.
+    #[serde(default)]
+    pub match_type: String,
+
+    /// Name the matched metric is rewritten to.
+    pub name: String,
+
+    /// Tags added to the matched metric, with capture-group references allowed in the values.
+    #[serde(default)]
+    pub tags: HashMap<String, String>,
+}
+
+/// One `metric_tag_filterlist` element.
+#[derive(Clone, Debug, Deserialize)]
+pub struct MetricTagFilterlistEntry {
+    /// Metric name the entry applies to.
+    pub metric_name: String,
+
+    /// Whether `tags` is an include or an exclude list.
+    ///
+    /// The schema types this as a free string, so the value is carried verbatim and classified by
+    /// the consumer.
+    #[serde(default)]
+    pub action: String,
+
+    /// Tags the action applies to.
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{MapperProfile, MetricTagFilterlistEntry};
+
+    #[test]
+    fn mapper_profile_defaults_its_optional_fields() {
+        let profile: MapperProfile = serde_json::from_value(json!({ "name": "p", "prefix": "svc." }))
+            .expect("a profile without mappings is valid");
+        assert!(profile.mappings.is_empty());
+
+        let profile: MapperProfile = serde_json::from_value(json!({
+            "name": "p",
+            "prefix": "svc.",
+            "mappings": [{ "match": "svc.*.latency", "name": "svc.latency" }],
+        }))
+        .expect("a mapping without match_type or tags is valid");
+        let mapping = &profile.mappings[0];
+        assert_eq!(mapping.metric_match, "svc.*.latency");
+        assert_eq!(mapping.name, "svc.latency");
+        assert_eq!(mapping.match_type, "");
+        assert!(mapping.tags.is_empty());
+    }
+
+    #[test]
+    fn mapper_profile_requires_its_identifying_fields() {
+        assert!(serde_json::from_value::<MapperProfile>(json!({ "prefix": "svc." })).is_err());
+        assert!(serde_json::from_value::<MapperProfile>(json!({ "name": "p" })).is_err());
+        assert!(serde_json::from_value::<MapperProfile>(json!({
+            "name": "p",
+            "prefix": "svc.",
+            "mappings": [{ "name": "svc.latency" }],
+        }))
+        .is_err());
+    }
+
+    #[test]
+    fn tag_filterlist_entry_defaults_action_and_tags() {
+        let entry: MetricTagFilterlistEntry = serde_json::from_value(json!({ "metric_name": "svc.latency" }))
+            .expect("an entry with only a metric name is valid");
+        assert_eq!(entry.action, "");
+        assert!(entry.tags.is_empty());
+    }
+
+    #[test]
+    fn tag_filterlist_entry_requires_a_metric_name() {
+        assert!(serde_json::from_value::<MetricTagFilterlistEntry>(json!({ "tags": ["host"] })).is_err());
+    }
+}

--- a/lib/datadog-agent/config/src/lib.rs
+++ b/lib/datadog-agent/config/src/lib.rs
@@ -7,6 +7,9 @@ mod duration_de;
 
 /// Decoders that turn a raw environment-variable string into the JSON shape a schema leaf declares.
 pub mod env_decode;
+
+/// Source types for object arrays without `items` schemas.
+pub mod array_objects;
 mod list_de;
 
 /// A Figment provider that reads the schema's environment variables into their canonical shape.

--- a/lib/datadog-agent/config/src/list_de.rs
+++ b/lib/datadog-agent/config/src/list_de.rs
@@ -1,8 +1,8 @@
 //! Serde deserialization for list schema fields with multiple source shapes.
 //!
 //! String lists can arrive as sequences or space-separated environment strings. Map values
-//! containing string lists can likewise arrive as scalars or sequences. Free-form object arrays can
-//! arrive as sequences or JSON-encoded strings. These adapters normalize each form at the boundary.
+//! containing string lists can likewise arrive as scalars or sequences. JSON arrays can arrive as
+//! sequences or JSON-encoded strings. These adapters normalize each form at the boundary.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -44,7 +44,7 @@ where
     deserializer.deserialize_any(SpaceSeparatedOrSeq)
 }
 
-/// Deserialize a free-form JSON array from either a sequence or a JSON-encoded string.
+/// Deserialize a JSON array from either a sequence or a JSON-encoded string.
 pub(crate) fn deserialize_json_array_or_string<'de, D>(deserializer: D) -> Result<Vec<Value>, D::Error>
 where
     D: Deserializer<'de>,


### PR DESCRIPTION
## Human Summary

TODO

## AI Summary

Declare source types for `dogstatsd_mapper_profiles` and
`metric_tag_filterlist` in `datadog-agent-config::array_objects`.

The core schema declares both arrays without `items` schemas, so generated
config exposes `Vec<serde_json::Value>`. The translator now deserializes each
value into a named source type instead of declaring local shims.

Field defaults and action handling are unchanged. Tests cover required and
defaulted source fields.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make fmt`
- `make check-docs`
- `make check-clippy`
- `cargo nextest run -p datadog-agent-config -p agent-data-plane-config-system -p agent-data-plane-config`
- `cargo nextest run -p agent-data-plane -E 'test(mapper) + test(tag_filter) + test(filterlist)'`

## References

- Progresses: #2293
