### PR TITLE
chore(deps): stop renovate from re-proposing the pinned aws-lc-rs bump

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -109,6 +109,17 @@
     {
       "matchManagers": ["rust-toolchain"],
       "enabled": false
+    },
+    // aws-lc-rs is intentionally pinned below 1.18 in Cargo.toml to stay on the
+    // NIST CMVP validated FIPS 140-3 module (AWS-LC-FIPS 3.x); 1.18.0 switches
+    // the `fips` feature to the not-yet-certified AWS-LC-FIPS 4.x module. Without
+    // this rule Renovate keeps proposing to widen the `<1.18` upper bound in the
+    // weekly non-major group PR. Remove once AWS-LC-FIPS 4.x is certified (see
+    // the pin comment next to the `aws-lc-rs` workspace dependency).
+    {
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["aws-lc-rs"],
+      "allowedVersions": "<1.18"
     }
   ],
 


### PR DESCRIPTION
## Summary
Renovate keeps proposing to widen the `aws-lc-rs` version pin in the weekly non-major bump PR (most recently #2467), even though it's intentionally pinned below 1.18 to stay on the NIST CMVP validated FIPS 140-3 module — 1.18.0 switches to the not-yet-certified AWS-LC-FIPS 4.x module. This adds a `packageRules` entry telling Renovate to respect that ceiling until the pin comment in `Cargo.toml` is lifted.

## Test plan
- [ ] renovate.json5 changes take effect on the next scheduled Renovate run (no aws-lc-rs bump proposed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)