### PR TITLE
chore(config): model run_path in typed configuration

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -30,11 +30,10 @@ use saluki_components::{
     relays::otlp::OtlpRelayConfiguration,
     sources::{ChecksIPCConfiguration, DogStatsDConfiguration, OtlpConfiguration},
     transforms::{
-        aggregate_context_snapshot_channel, AggregateConfiguration, AggregateContextSnapshotHandle,
-        ApmStatsTransformConfiguration, AutoscalingFailoverGatewayConfiguration, ChainedConfiguration,
-        DogStatsDMapperConfiguration, DogStatsDMapperProfile, DogStatsDMetricMapping, HistogramConfiguration,
-        HostEnrichmentConfiguration, MrfMetricsGatewayConfiguration, TraceObfuscationConfiguration,
-        TraceSamplerConfiguration,
+        aggregate_context_snapshot_channel, AggregateConfiguration, ApmStatsTransformConfiguration,
+        AutoscalingFailoverGatewayConfiguration, ChainedConfiguration, DogStatsDMapperConfiguration,
+        DogStatsDMapperProfile, DogStatsDMetricMapping, HistogramConfiguration, HostEnrichmentConfiguration,
+        MrfMetricsGatewayConfiguration, TraceObfuscationConfiguration, TraceSamplerConfiguration,
     },
 };
 use saluki_config::GenericConfiguration;
@@ -583,7 +582,7 @@ fn add_autoscaling_failover_metrics_pipeline_to_blueprint(
     let af_gateway_config = AutoscalingFailoverGatewayConfiguration::new(af_config);
     let af_metrics_config = DatadogMetricsConfiguration::from_configuration(shared).with_v2_series_only();
     let cluster_agent_forwarder_config =
-        ClusterAgentForwarderConfiguration::from_configuration(shared, config, ca_url, ca_token)
+        ClusterAgentForwarderConfiguration::from_configuration(shared, ca_url, ca_token)
             .error_context("Failed to configure Cluster Agent forwarder.")?;
 
     blueprint
@@ -707,22 +706,8 @@ async fn add_baseline_traces_pipeline_to_blueprint(
     Ok(())
 }
 
-fn build_dogstatsd_context_dump_api_handler(
-    config: &GenericConfiguration, snapshot_handle: AggregateContextSnapshotHandle,
-) -> Result<DogStatsDContextDumpAPIHandler, GenericError> {
-    let run_path = config
-        .try_get_typed::<PathBuf>("run_path")
-        .error_context("Failed to read configured `run_path` for DogStatsD context dumps.")?
-        .unwrap_or_default();
-
-    Ok(DogStatsDContextDumpAPIHandler::new(vec![snapshot_handle], run_path))
-}
-
 async fn add_dsd_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint,
-    config: &GenericConfiguration,
-    // Supplies the typed configuration used to resolve source-wide static tags.
-    config_system: &ConfigurationSystem,
+    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration, config_system: &ConfigurationSystem,
     env_provider: &ADPEnvironmentProvider,
 ) -> Result<DogStatsDControlSurface, GenericError> {
     // We're creating the "front half" of the DogStatsD pipeline, which deals solely with accepting DogStatsD payloads,
@@ -771,7 +756,7 @@ async fn add_dsd_pipeline_to_blueprint(
         &typed.shared.tags,
         features::is_ecs_fargate(),
     );
-    let dsd_config = DogStatsDConfiguration::from_configuration(config)
+    let dsd_config = DogStatsDConfiguration::from_configuration(config, &typed.shared.run_path)
         .error_context("Failed to configure DogStatsD source.")?
         .with_static_tags(static_tags)
         .with_default_hostname(default_hostname)
@@ -872,7 +857,10 @@ async fn add_dsd_pipeline_to_blueprint(
     let stats_api_handler = dsd_stats_config.api_handler();
     let capture_api_handler = dsd_config.capture_api_handler();
     let replay_api_handler = dsd_config.replay_api_handler();
-    let context_dump_api_handler = build_dogstatsd_context_dump_api_handler(config, dsd_context_snapshot_handle)?;
+    let context_dump_api_handler = DogStatsDContextDumpAPIHandler::new(
+        vec![dsd_context_snapshot_handle],
+        typed.shared.run_path.clone().unwrap_or_default(),
+    );
 
     blueprint
         // Components.
@@ -1043,7 +1031,6 @@ mod tests {
         AggregateContextSnapshotEntry, AggregateMetricType, ChainedConfiguration, DogStatsDMapperConfiguration,
         DogStatsDMapperProfile, DogStatsDMetricMapping, HistogramConfiguration,
     };
-    use saluki_config::{config_from, GenericConfiguration};
     use saluki_context::Context;
     use saluki_core::{
         accounting::{ComponentRegistry, MemoryBounds, MemoryBoundsBuilder, MemoryLimiter},
@@ -1058,12 +1045,10 @@ mod tests {
         topology::{OutputDefinition, TopologyBlueprint},
     };
     use saluki_error::{generic_error, GenericError};
-    use serde_json::json;
     use stringtheory::MetaString;
     use tokio::sync::{mpsc, oneshot};
     use tower::ServiceExt as _;
 
-    use super::build_dogstatsd_context_dump_api_handler;
     use crate::{
         components::{
             dogstatsd_prefix_filter::DogStatsDPrefixFilterConfiguration, tag_filterlist::TagFilterlistConfiguration,
@@ -1265,13 +1250,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn context_dump_handler_reads_configured_run_path_and_uses_supplied_owner() {
+    async fn context_dump_handler_uses_supplied_run_path_and_owner() {
         let run_directory = tempfile::tempdir().expect("run directory should be created");
-        let config = context_dump_config(Some(run_directory.path())).await;
         let (snapshot_handle, mut snapshot_responder) = aggregate_context_snapshot_channel_for_test();
 
-        let handler = build_dogstatsd_context_dump_api_handler(&config, snapshot_handle)
-            .expect("configured handler should build");
+        let handler = DogStatsDContextDumpAPIHandler::new(vec![snapshot_handle], run_directory.path());
         let owner = tokio::spawn(async move {
             snapshot_responder
                 .respond(vec![snapshot_entry("from.supplied.aggregate")])
@@ -1291,15 +1274,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn context_dump_handler_keeps_missing_and_empty_run_path_empty_until_publication() {
+    async fn context_dump_handler_keeps_empty_run_path_empty_until_publication() {
         let cwd_artifact = std::env::current_dir().unwrap().join(CONTEXT_DUMP_FILENAME);
         assert!(!cwd_artifact.exists(), "test requires no pre-existing cwd artifact");
 
         for run_path in [None, Some(Path::new(""))] {
-            let config = context_dump_config(run_path).await;
+            let run_path = run_path.map(Path::to_path_buf).unwrap_or_default();
             let (snapshot_handle, mut snapshot_responder) = aggregate_context_snapshot_channel_for_test();
-            let handler = build_dogstatsd_context_dump_api_handler(&config, snapshot_handle)
-                .expect("empty run path should reach publication");
+            let handler = DogStatsDContextDumpAPIHandler::new(vec![snapshot_handle], run_path);
             let owner = tokio::spawn(async move { snapshot_responder.respond(Vec::new()).await });
 
             let response = send(&handler, context_dump_post()).await;
@@ -1385,14 +1367,6 @@ mod tests {
 
     impl MemoryBounds for DrainingMetricDestinationBuilder {
         fn specify_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
-    }
-
-    async fn context_dump_config(run_path: Option<&Path>) -> GenericConfiguration {
-        let mut values = json!({});
-        if let Some(run_path) = run_path {
-            values["run_path"] = json!(run_path);
-        }
-        config_from(values).await
     }
 
     fn context_dump_post() -> Request<Empty<Bytes>> {

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -865,6 +865,7 @@ Both commands scrub recognized secret values before writing JSON to standard out
 | `proxy.http`                                                   | HTTP proxy URL                                     |
 | `proxy.https`                                                  | HTTPS proxy URL                                    |
 | `proxy.no_proxy`                                               | Hosts bypassing proxy                              |
+| `run_path`                                                     | Runtime state directory                            |
 | `serializer_compressor_kind`                                   | Payload compression algorithm                      |
 | `serializer_experimental_use_v3_api.compression_level`         | V3 API zstd compression level                      |
 | `serializer_experimental_use_v3_api.series.endpoints`          | Endpoints enabled for V3 series API                |

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -1104,6 +1104,23 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
         self.config.shared.endpoints.proxy.no_proxy = value;
     }
 
+    fn consume_run_path(&mut self, value: String) {
+        // In the vendored schema, run_path is defaulted to the placeholder ${run_path}. Though it
+        // seems highly unlikely this could slip through to ADP, we check for it, warn and treat
+        // the value as unset.
+        //
+        // Note that for this config, we do not care whether provenance is explicit or default. We
+        // just want to know whether we have a value or not.
+        if value == "${run_path}" {
+            warn!("`run_path` contains the unresolved schema placeholder '${{run_path}}'. Treating it as unset.");
+            self.config.shared.run_path = None;
+        } else if value.is_empty() {
+            self.config.shared.run_path = None;
+        } else {
+            self.config.shared.run_path = Some(PathBuf::from(value))
+        }
+    }
+
     fn consume_serializer_compressor_kind(&mut self, value: String) {
         self.config.shared.endpoints.compression.compressor_kind = value;
     }

--- a/lib/agent-data-plane-config/src/shared.rs
+++ b/lib/agent-data-plane-config/src/shared.rs
@@ -37,6 +37,13 @@ pub struct SharedConfiguration {
     /// Verbosity of the internal telemetry emitted about the runtime itself. (not in Datadog Agent
     /// config schema)
     pub metrics_level: String,
+
+    /// Base directory for runtime-state files.
+    ///
+    /// ADP uses this to derive default locations for forwarder retry data, DogStatsD captures, and
+    /// DogStatsD context dumps. Defaults to unset when configuration does not provide a concrete
+    /// `run_path`.
+    pub run_path: Option<PathBuf>,
 }
 
 /// Inputs used to derive deployment-wide static tags.

--- a/lib/datadog-agent/config-testing/src/config_registry/shared.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/shared.rs
@@ -49,4 +49,15 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Otlp]),
     };
+    /// `run_path`-Runtime state directory
+    RUN_PATH = SalukiAnnotation {
+        schema: &schema::RUN_PATH,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
 }

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -2734,6 +2734,15 @@ inventory:
       additional_attributes:
         config_registry_filename: proxy.rs
 
+  run_path:
+    support: full
+    pipelines: [cross_cutting]
+    description: "Runtime state directory"
+    test_support:
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: shared.rs
+
   serializer_compressor_kind:
     support: full
     pipelines: [cross_cutting]
@@ -4565,7 +4574,6 @@ excluded:
   reverse_dns_enrichment.rate_limiter.recovery_intervals: "ignored in initial audit 2026-04-23"
   reverse_dns_enrichment.rate_limiter.throttle_error_threshold: "ignored in initial audit 2026-04-23"
   reverse_dns_enrichment.workers: "ignored in initial audit 2026-04-23"
-  run_path: "ignored in second bulk edit 2026-05-06"
   runtime_security_config.activity_dump.remote_storage.endpoints.additional_endpoints: "ignored in initial audit 2026-04-23"
   runtime_security_config.activity_dump.remote_storage.endpoints.batch_max_concurrent_send: "ignored in initial audit 2026-04-23"
   runtime_security_config.activity_dump.remote_storage.endpoints.batch_max_content_size: "ignored in initial audit 2026-04-23"

--- a/lib/datadog-agent/config/src/generated/datadog_configuration.rs
+++ b/lib/datadog-agent/config/src/generated/datadog_configuration.rs
@@ -436,6 +436,10 @@ pub struct DatadogConfiguration {
     #[serde(default)]
     pub proxy: Proxy,
 
+    #[serde(default = "defaults::datadog_configuration_run_path")]
+    #[serde(deserialize_with = "crate::cast_de::deserialize_string")]
+    pub run_path: String,
+
     #[serde(default = "defaults::datadog_configuration_serializer_compressor_kind")]
     #[serde(deserialize_with = "crate::cast_de::deserialize_string")]
     pub serializer_compressor_kind: String,
@@ -655,6 +659,7 @@ impl Default for DatadogConfiguration {
             otlp_config: Default::default(),
             provider_kind: Default::default(),
             proxy: Default::default(),
+            run_path: defaults::datadog_configuration_run_path(),
             serializer_compressor_kind: defaults::datadog_configuration_serializer_compressor_kind(),
             serializer_experimental_use_v3_api: Default::default(),
             serializer_max_payload_size: defaults::default_u64::<i64, 2621440>(),
@@ -2036,6 +2041,9 @@ pub mod defaults {
     }
     pub(super) fn datadog_configuration_min_tls_version() -> String {
         "tlsv1.2".to_string()
+    }
+    pub(super) fn datadog_configuration_run_path() -> String {
+        "${run_path}".to_string()
     }
     pub(super) fn datadog_configuration_serializer_compressor_kind() -> String {
         "zstd".to_string()

--- a/lib/datadog-agent/config/src/generated/env_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_keys.rs
@@ -957,6 +957,11 @@ pub static DATADOG_ENV_KEYS: &[EnvKey] = &[
         decode: EnvDecode::StringList,
     },
     EnvKey {
+        env_vars: &["DD_RUN_PATH"],
+        path: &["run_path"],
+        decode: EnvDecode::RawString,
+    },
+    EnvKey {
         env_vars: &["DD_SERIALIZER_COMPRESSOR_KIND"],
         path: &["serializer_compressor_kind"],
         decode: EnvDecode::RawString,

--- a/lib/datadog-agent/config/src/generated/witness.rs
+++ b/lib/datadog-agent/config/src/generated/witness.rs
@@ -197,6 +197,7 @@ pub trait DatadogConfigWitness {
     fn consume_proxy_http(&mut self, value: String);
     fn consume_proxy_https(&mut self, value: String);
     fn consume_proxy_no_proxy(&mut self, value: Vec<String>);
+    fn consume_run_path(&mut self, value: String);
     fn consume_serializer_compressor_kind(&mut self, value: String);
     fn consume_serializer_experimental_use_v3_api_compression_level(&mut self, value: i64);
     fn consume_serializer_experimental_use_v3_api_series_endpoints(&mut self, value: Vec<String>);
@@ -526,6 +527,7 @@ pub fn drive(config: &DatadogConfiguration, consumer: &mut impl DatadogConfigWit
     consumer.consume_proxy_http(config.proxy.http.clone());
     consumer.consume_proxy_https(config.proxy.https.clone());
     consumer.consume_proxy_no_proxy(config.proxy.no_proxy.clone());
+    consumer.consume_run_path(config.run_path.clone());
     consumer.consume_serializer_compressor_kind(config.serializer_compressor_kind.clone());
     consumer.consume_serializer_experimental_use_v3_api_compression_level(
         config.serializer_experimental_use_v3_api.compression_level.clone(),

--- a/lib/saluki-components/src/common/datadog/config.rs
+++ b/lib/saluki-components/src/common/datadog/config.rs
@@ -297,7 +297,7 @@ struct ForwarderRouting {
 
 impl ForwarderConfiguration {
     /// Creates a new `ForwarderConfiguration` from the resolved shared configuration.
-    pub fn from_configuration(shared: &SharedConfiguration, config: &GenericConfiguration) -> Self {
+    pub fn from_configuration(shared: &SharedConfiguration) -> Self {
         let endpoints = &shared.endpoints;
         let routing = ForwarderRouting {
             endpoint: EndpointConfiguration::from_configuration(endpoints),
@@ -308,7 +308,7 @@ impl ForwarderConfiguration {
             },
         };
 
-        Self::from_routing(shared, config, routing)
+        Self::from_routing(shared, routing)
     }
 
     /// Creates a new `ForwarderConfiguration` that forwards only to a single destination.
@@ -316,9 +316,7 @@ impl ForwarderConfiguration {
     /// The destination replaces the configured primary endpoint, and neither dual shipping nor the
     /// alternate metrics intakes apply to it. Because the destination is part of construction, no
     /// later step can overwrite it.
-    pub(crate) fn for_single_destination(
-        shared: &SharedConfiguration, config: &GenericConfiguration, destination: &SingleDestination,
-    ) -> Self {
+    pub(crate) fn for_single_destination(shared: &SharedConfiguration, destination: &SingleDestination) -> Self {
         let mut v3_api: V3ApiConfig = (&shared.metrics_encoding.v3_api).into();
         let mut series_mode: UseV3ApiSeriesConfig = (&shared.metrics_encoding).into();
 
@@ -337,12 +335,12 @@ impl ForwarderConfiguration {
             use_v3_api: UseV3ApiConfig { series: series_mode },
         };
 
-        Self::from_routing(shared, config, routing)
+        Self::from_routing(shared, routing)
     }
 
     /// Builds the forwarder configuration from its destination-specific routing plus the settings
     /// every forwarder reads the same way.
-    fn from_routing(shared: &SharedConfiguration, config: &GenericConfiguration, routing: ForwarderRouting) -> Self {
+    fn from_routing(shared: &SharedConfiguration, routing: ForwarderRouting) -> Self {
         let endpoints = &shared.endpoints;
         let forwarder = &endpoints.forwarder;
 
@@ -352,7 +350,7 @@ impl ForwarderConfiguration {
             request_timeout_secs: forwarder.timeout,
             endpoint_buffer_size: forwarder.high_prio_buffer_size,
             endpoint: routing.endpoint,
-            retry: RetryConfiguration::from_configuration(forwarder, config),
+            retry: RetryConfiguration::from_configuration(forwarder, shared.run_path.as_deref()),
             proxy: ProxyConfiguration::from_configuration(&endpoints.proxy),
             opw_metrics: routing.opw_metrics,
             http_protocol: forwarder.http_protocol.into(),
@@ -569,7 +567,7 @@ mod tests {
     }
 
     async fn forwarder_config_from(shared: SharedConfiguration) -> ForwarderConfiguration {
-        ForwarderConfiguration::from_configuration(&shared, &empty_config().await)
+        ForwarderConfiguration::from_configuration(&shared)
     }
 
     fn endpoint_urls_by_route(config: &ForwarderConfiguration, route: EndpointRoute) -> Vec<String> {
@@ -901,7 +899,7 @@ mod tests {
             HashMap::from([(ADDITIONAL_URL.to_string(), vec!["extra-api-key".to_string()])]);
 
         let live_config = empty_config().await;
-        let config = ForwarderConfiguration::from_configuration(&shared, &live_config);
+        let config = ForwarderConfiguration::from_configuration(&shared);
         let endpoints = config
             .build_routable_endpoints(Some(live_config))
             .expect("endpoints should resolve");
@@ -954,7 +952,7 @@ mod tests {
             api_key_refresh_config_path: Some("multi_region_failover.api_key"),
             accepts_v3_series: false,
         };
-        let config = ForwarderConfiguration::for_single_destination(&shared, &empty_config().await, &destination);
+        let config = ForwarderConfiguration::for_single_destination(&shared, &destination);
 
         let endpoints = config.build_routable_endpoints(None).expect("endpoint should resolve");
         assert_eq!(1, endpoints.len());
@@ -978,7 +976,7 @@ mod tests {
             api_key_refresh_config_path: Some("multi_region_failover.api_key"),
             accepts_v3_series: true,
         };
-        let config = ForwarderConfiguration::for_single_destination(&shared, &empty_config().await, &destination);
+        let config = ForwarderConfiguration::for_single_destination(&shared, &destination);
 
         assert_eq!(V3SeriesMode::Enabled, config.use_v3_api_series().enabled);
     }

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -1127,7 +1127,7 @@ mod tests {
     use http_body_util::Empty;
     use rustls::{version::TLS12, RootCertStore, ServerConfig};
     use saluki_common::buf::FrozenChunkedBytesBuffer;
-    use saluki_config::{config_from, ConfigurationLoader};
+    use saluki_config::config_from;
     use saluki_core::{
         observability::ComponentMetricsExt as _,
         runtime::state::{DataspaceRegistry, DataspaceUpdate, IdentifierFilter},
@@ -1166,8 +1166,7 @@ mod tests {
     }
 
     async fn forwarder_config_from(shared: SharedConfiguration) -> ForwarderConfiguration {
-        let (config, _) = ConfigurationLoader::for_tests(None, None, false).await;
-        ForwarderConfiguration::from_configuration(&shared, &config)
+        ForwarderConfiguration::from_configuration(&shared)
     }
 
     #[test]

--- a/lib/saluki-components/src/common/datadog/retry.rs
+++ b/lib/saluki-components/src/common/datadog/retry.rs
@@ -92,7 +92,7 @@ impl RetryConfiguration {
     /// When no retry-queue storage path is configured, one is derived from `run_path`, matching the
     /// Datadog Agent's own layout. Both may be absent, in which case there is no storage path and
     /// disk persistence cannot be used.
-    pub(super) fn from_configuration(forwarder: &shared::Forwarder, config: &GenericConfiguration) -> Self {
+    pub(super) fn from_configuration(forwarder: &shared::Forwarder, run_path: Option<&Path>) -> Self {
         Self {
             backoff_factor: forwarder.backoff_factor,
             backoff_base: forwarder.backoff_base,
@@ -102,7 +102,7 @@ impl RetryConfiguration {
             queue_max_size_bytes: forwarder.effective_retry_queue_max_size_bytes(),
             storage_max_size_bytes: forwarder.storage_max_size_in_bytes,
             flush_to_disk_mem_ratio: forwarder.flush_to_disk_mem_ratio,
-            storage_path: resolve_storage_path(&forwarder.storage_path, config),
+            storage_path: resolve_storage_path(&forwarder.storage_path, run_path),
             storage_max_disk_ratio: forwarder.storage_max_disk_ratio,
             outdated_file_in_days: forwarder.outdated_file_in_days,
             capacity_time_interval_secs: forwarder
@@ -178,26 +178,16 @@ impl RetryConfiguration {
 /// Resolves the directory where retry payloads are persisted to disk.
 ///
 /// A configured `forwarder_storage_path` is used as-is. Otherwise the path is derived from
-/// `run_path`, which has no typed home: its schema default is an unresolved placeholder, so
-/// promoting it to the typed model would put that placeholder in the model.
-///
-/// TODO: read `run_path` from typed configuration once the placeholder default is resolved.
-fn resolve_storage_path(configured: &Path, config: &GenericConfiguration) -> PathBuf {
+/// `run_path`. If neither is configured, no storage path is available.
+fn resolve_storage_path(configured: &Path, run_path: Option<&Path>) -> PathBuf {
     if configured.parent().is_some() {
         return configured.to_path_buf();
     }
 
-    match config.try_get_typed::<PathBuf>("run_path") {
-        Ok(Some(mut run_path)) => {
-            run_path.push(RETRY_TXN_DIR);
-            run_path
-        }
-        Ok(None) => {
+    match run_path {
+        Some(run_path) => run_path.join(RETRY_TXN_DIR),
+        None => {
             debug!("`forwarder_storage_path` and `run_path` were empty. Cannot calculate default storage path for forwarder.");
-            PathBuf::new()
-        }
-        Err(e) => {
-            debug!(error = %e, "Failed to read `run_path` from configuration. Cannot calculate default storage path for forwarder.");
             PathBuf::new()
         }
     }
@@ -222,6 +212,8 @@ mod tests {
     type TestRequest = Request<()>;
     type TestResponse = Result<Response<()>, BoxError>;
 
+    const RUN_PATH: &str = "/my/little/run_path";
+
     fn ok_response(status: StatusCode) -> TestResponse {
         Ok(Response::builder().status(status).body(()).unwrap())
     }
@@ -239,21 +231,7 @@ mod tests {
         Policy::<TestRequest, Response<()>, BoxError>::retry(policy, &mut request, &mut response).is_some()
     }
 
-    async fn empty_config() -> GenericConfiguration {
-        let (config, _) = ConfigurationLoader::for_tests(None, None, false).await;
-        config
-    }
-
-    async fn config_from(values: serde_json::Value) -> GenericConfiguration {
-        let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
-        config
-    }
-
-    async fn retry_config_from(forwarder: shared::Forwarder, config: &GenericConfiguration) -> RetryConfiguration {
-        RetryConfiguration::from_configuration(&forwarder, config)
-    }
-
-    async fn test_retry_config() -> RetryConfiguration {
+    fn test_retry_config() -> RetryConfiguration {
         // Use small backoffs so that any returned `Sleep` futures are cheap; we never await them, but build them.
         let forwarder = shared::Forwarder {
             backoff_base: 0.001,
@@ -262,44 +240,40 @@ mod tests {
             ..Default::default()
         };
 
-        retry_config_from(forwarder, &empty_config().await).await
+        RetryConfiguration::from_configuration(&forwarder, None)
     }
 
-    #[tokio::test]
-    async fn storage_path_is_derived_from_run_path_when_not_configured() {
-        const RUN_PATH: &str = "/my/little/run_path";
+    #[test]
+    fn storage_path_is_derived_from_run_path_when_not_configured() {
+        let retry_config =
+            RetryConfiguration::from_configuration(&shared::Forwarder::default(), Some(Path::new(RUN_PATH)));
 
-        let config = config_from(json!({ "run_path": RUN_PATH })).await;
-        let retry_config = retry_config_from(shared::Forwarder::default(), &config).await;
-
-        assert_eq!(PathBuf::from(RUN_PATH).join(RETRY_TXN_DIR), retry_config.storage_path());
+        assert_eq!(Path::new(RUN_PATH).join(RETRY_TXN_DIR), retry_config.storage_path());
     }
 
-    #[tokio::test]
-    async fn a_configured_storage_path_wins_over_run_path() {
-        const RUN_PATH: &str = "/my/little/run_path";
+    #[test]
+    fn a_configured_storage_path_wins_over_run_path() {
         const FORWARDER_STORAGE_PATH: &str = "/custom/path/to/storage";
 
-        let config = config_from(json!({ "run_path": RUN_PATH })).await;
         let forwarder = shared::Forwarder {
             storage_path: PathBuf::from(FORWARDER_STORAGE_PATH),
             ..Default::default()
         };
-        let retry_config = retry_config_from(forwarder, &config).await;
+        let retry_config = RetryConfiguration::from_configuration(&forwarder, Some(Path::new(RUN_PATH)));
 
         assert_eq!(PathBuf::from(FORWARDER_STORAGE_PATH), retry_config.storage_path());
     }
 
-    #[tokio::test]
-    async fn there_is_no_storage_path_without_a_run_path() {
+    #[test]
+    fn there_is_no_storage_path_without_a_run_path() {
         // With neither setting, no valid path can be constructed, so disk persistence has nowhere to go.
-        let retry_config = retry_config_from(shared::Forwarder::default(), &empty_config().await).await;
+        let retry_config = RetryConfiguration::from_configuration(&shared::Forwarder::default(), None);
 
         assert_eq!(PathBuf::new(), retry_config.storage_path());
     }
 
-    #[tokio::test]
-    async fn queue_max_size_bytes_carries_the_resolved_size() {
+    #[test]
+    fn queue_max_size_bytes_carries_the_resolved_size() {
         // Which of the two retry-queue settings applies is resolved by the configuration layer; the
         // forwarder stores only the outcome.
         let forwarder = shared::Forwarder {
@@ -307,13 +281,13 @@ mod tests {
             retry_queue_max_size: ConfigValue::explicit(1024),
             ..Default::default()
         };
-        let retry_config = retry_config_from(forwarder, &empty_config().await).await;
+        let retry_config = RetryConfiguration::from_configuration(&forwarder, None);
 
         assert_eq!(1024, retry_config.queue_max_size_bytes());
     }
 
-    #[tokio::test]
-    async fn capacity_time_interval_secs_is_clamped_to_the_bucket_size() {
+    #[test]
+    fn capacity_time_interval_secs_is_clamped_to_the_bucket_size() {
         let cases = [
             (900, 900),
             (60, 60),
@@ -325,15 +299,15 @@ mod tests {
                 retry_queue_capacity_time_interval_sec: configured,
                 ..Default::default()
             };
-            let retry_config = retry_config_from(forwarder, &empty_config().await).await;
+            let retry_config = RetryConfiguration::from_configuration(&forwarder, None);
 
             assert_eq!(expected, retry_config.capacity_time_interval_secs(), "{configured}");
         }
     }
 
-    #[tokio::test]
-    async fn policy_without_config_does_not_retry_403() {
-        let retry_config = test_retry_config().await;
+    #[test]
+    fn policy_without_config_does_not_retry_403() {
+        let retry_config = test_retry_config();
         let mut policy = retry_config.to_default_http_retry_policy(None);
 
         assert!(!would_retry(&mut policy, ok_response(StatusCode::FORBIDDEN)));
@@ -342,7 +316,7 @@ mod tests {
     #[tokio::test]
     async fn policy_with_config_but_no_secrets_does_not_retry_403() {
         let (config, _) = ConfigurationLoader::for_tests(None, None, false).await;
-        let retry_config = test_retry_config().await;
+        let retry_config = test_retry_config();
         let mut policy = retry_config.to_default_http_retry_policy(Some(config));
 
         assert!(!would_retry(&mut policy, ok_response(StatusCode::FORBIDDEN)));
@@ -352,7 +326,7 @@ mod tests {
     async fn policy_with_secrets_retries_403() {
         let values = json!({ "secret_backend_command": "/bin/true" });
         let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
-        let retry_config = test_retry_config().await;
+        let retry_config = test_retry_config();
         let mut policy = retry_config.to_default_http_retry_policy(Some(config));
 
         assert!(would_retry(&mut policy, ok_response(StatusCode::FORBIDDEN)));
@@ -362,7 +336,7 @@ mod tests {
     async fn policy_secrets_does_not_affect_other_status_codes() {
         let values = json!({ "secret_backend_command": "/bin/true" });
         let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
-        let retry_config = test_retry_config().await;
+        let retry_config = test_retry_config();
         let mut policy = retry_config.to_default_http_retry_policy(Some(config));
 
         assert!(!would_retry(&mut policy, ok_response(StatusCode::OK)));
@@ -389,7 +363,7 @@ mod tests {
             .expect("should send initial snapshot");
         config.ready().await;
 
-        let retry_config = test_retry_config().await;
+        let retry_config = test_retry_config();
         let mut policy = retry_config.to_default_http_retry_policy(Some(config.clone()));
 
         // Before secrets are configured, 403 must not be retried.

--- a/lib/saluki-components/src/common/datadog/validation.rs
+++ b/lib/saluki-components/src/common/datadog/validation.rs
@@ -500,7 +500,7 @@ mod tests {
             url: "http://opw.example.com".to_string(),
             use_v3_series: false,
         };
-        let forwarder_config = ForwarderConfiguration::from_configuration(&shared, &config);
+        let forwarder_config = ForwarderConfiguration::from_configuration(&shared);
         let mut endpoints = forwarder_config
             .build_routable_endpoints(Some(config))
             .expect("endpoints should resolve");
@@ -547,7 +547,7 @@ mod tests {
             "http://additional.example.com".to_string(),
             vec!["old-additional-key".to_string()],
         )]);
-        let forwarder_config = ForwarderConfiguration::from_configuration(&shared, &config);
+        let forwarder_config = ForwarderConfiguration::from_configuration(&shared);
         let mut endpoints = forwarder_config
             .build_routable_endpoints(Some(config.clone()))
             .expect("endpoints should resolve");
@@ -626,8 +626,7 @@ mod tests {
         // A validation server that rejects the key with a 403, so validation concludes it is invalid.
         let invalid_url = start_validation_server(StatusCode::FORBIDDEN).await;
         let (config, _) = ConfigurationLoader::for_tests(Some(json!({ "api_key": "primary-key" })), None, false).await;
-        let forwarder_config =
-            ForwarderConfiguration::from_configuration(&shared_configuration_for(&invalid_url), &config);
+        let forwarder_config = ForwarderConfiguration::from_configuration(&shared_configuration_for(&invalid_url));
         let mut endpoints = forwarder_config
             .build_routable_endpoints(Some(config))
             .expect("endpoints should resolve");
@@ -663,8 +662,7 @@ mod tests {
         // A validation server that accepts the key, so validation concludes it is valid.
         let valid_url = start_validation_server(StatusCode::OK).await;
         let (config, _) = ConfigurationLoader::for_tests(Some(json!({ "api_key": "primary-key" })), None, false).await;
-        let forwarder_config =
-            ForwarderConfiguration::from_configuration(&shared_configuration_for(&valid_url), &config);
+        let forwarder_config = ForwarderConfiguration::from_configuration(&shared_configuration_for(&valid_url));
         let mut endpoints = forwarder_config
             .build_routable_endpoints(Some(config))
             .expect("endpoints should resolve");

--- a/lib/saluki-components/src/forwarders/cluster_agent/mod.rs
+++ b/lib/saluki-components/src/forwarders/cluster_agent/mod.rs
@@ -8,7 +8,6 @@ use http::{
     HeaderName, HeaderValue, Request, Uri,
 };
 use saluki_common::buf::FrozenChunkedBytesBuffer;
-use saluki_config::GenericConfiguration;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder, UsageExpr};
 use saluki_core::{
     components::{forwarders::*, BuildContext},
@@ -55,7 +54,7 @@ impl ClusterAgentForwarderConfiguration {
     ///
     /// Returns an error if the bearer token cannot be represented in an HTTP header.
     pub fn from_configuration(
-        shared: &SharedConfiguration, config: &GenericConfiguration, endpoint_url: String, auth_token: String,
+        shared: &SharedConfiguration, endpoint_url: String, auth_token: String,
     ) -> Result<Self, GenericError> {
         let auth_header_value = bearer_auth_header_value(&auth_token)?;
         let destination = SingleDestination {
@@ -64,8 +63,8 @@ impl ClusterAgentForwarderConfiguration {
             api_key_refresh_config_path: None,
             accepts_v3_series: false,
         };
-        let forwarder_config = ForwarderConfiguration::for_single_destination(shared, config, &destination)
-            .with_allow_arbitrary_tags(false);
+        let forwarder_config =
+            ForwarderConfiguration::for_single_destination(shared, &destination).with_allow_arbitrary_tags(false);
 
         Ok(Self {
             forwarder_config,
@@ -215,7 +214,6 @@ mod tests {
         ConfigValue,
     };
     use http::Method;
-    use saluki_config::ConfigurationLoader;
 
     use super::*;
     use crate::common::datadog::{endpoints::EndpointRoute, test_util::shared_configuration};
@@ -257,7 +255,6 @@ mod tests {
         // Every configured Datadog intake setting here conflicts with the Cluster Agent destination:
         // a different API key, an explicit `dd_url`, a `site`, an additional endpoint, an alternate
         // metrics intake, and V3 series routing. None of them may reach the built forwarder.
-        let (raw_config, _) = ConfigurationLoader::for_tests(None, None, false).await;
         let mut shared = shared_configuration();
         shared.endpoints.api_key = "primary-api-key".to_string();
         shared.endpoints.site = ConfigValue::explicit("datadoghq.eu".to_string());
@@ -276,12 +273,11 @@ mod tests {
             HashMap::from([("https://app.datadoghq.com".to_string(), V3SeriesMode::Enabled)]);
 
         // The same configuration drives a plain Datadog forwarder, which does honor all of it.
-        let datadog_forwarder = ForwarderConfiguration::from_configuration(&shared, &raw_config);
+        let datadog_forwarder = ForwarderConfiguration::from_configuration(&shared);
         assert_eq!(V3SeriesMode::Enabled, datadog_forwarder.use_v3_api_series().enabled);
 
         let config = ClusterAgentForwarderConfiguration::from_configuration(
             &shared,
-            &raw_config,
             "https://cluster-agent.example.com".to_string(),
             "secret-token".to_string(),
         )

--- a/lib/saluki-components/src/forwarders/datadog/mod.rs
+++ b/lib/saluki-components/src/forwarders/datadog/mod.rs
@@ -48,7 +48,7 @@ impl DatadogForwarderConfiguration {
     /// `config` is retained so that endpoints can refresh their API keys as configuration changes.
     pub fn from_configuration(shared: &SharedConfiguration, config: &GenericConfiguration) -> Self {
         Self {
-            forwarder_config: ForwarderConfiguration::from_configuration(shared, config),
+            forwarder_config: ForwarderConfiguration::from_configuration(shared),
             configuration: config.clone(),
         }
     }
@@ -70,7 +70,7 @@ impl DatadogForwarderConfiguration {
         };
 
         Self {
-            forwarder_config: ForwarderConfiguration::for_single_destination(shared, config, &destination),
+            forwarder_config: ForwarderConfiguration::for_single_destination(shared, &destination),
             configuration: config.clone(),
         }
     }

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -703,9 +703,9 @@ async fn resolve_bind_host(host: &str) -> Result<std::net::IpAddr, Error> {
 
 impl DogStatsDConfiguration {
     /// Creates a new `DogStatsDConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+    pub fn from_configuration(config: &GenericConfiguration, run_path: &Option<PathBuf>) -> Result<Self, GenericError> {
         let mut dogstatsd_config: Self = config.as_typed()?;
-        dogstatsd_config.fix_empty_capture_path(config);
+        dogstatsd_config.fix_empty_capture_path(run_path);
         dogstatsd_config.fix_capture_depth();
         Ok(dogstatsd_config)
     }
@@ -866,26 +866,16 @@ impl DogStatsDConfiguration {
         DogStatsDReplayAPIHandler::new(self.replay_control.clone())
     }
 
-    fn fix_empty_capture_path(&mut self, config: &GenericConfiguration) {
+    fn fix_empty_capture_path(&mut self, run_path: &Option<PathBuf>) {
         if self.capture_path.parent().is_some() {
             return;
         }
 
-        let capture_path = match config.try_get_typed::<PathBuf>("run_path") {
-            Ok(Some(mut run_path)) => {
-                run_path.push(DOGSTATSD_CAPTURE_DIR);
-                run_path
-            }
-            Ok(None) => {
+        let capture_path = match run_path {
+            Some(found_it) => found_it.join(DOGSTATSD_CAPTURE_DIR),
+            None => {
                 debug!(
                     "`dogstatsd_capture_path` and `run_path` were empty. Default DogStatsD capture path is unavailable."
-                );
-                return;
-            }
-            Err(e) => {
-                debug!(
-                    error = %e,
-                    "Failed to read `run_path` from configuration. Default DogStatsD capture path is unavailable."
                 );
                 return;
             }
@@ -4510,10 +4500,11 @@ mod tests {
     async fn fix_empty_capture_path_sets_path_from_run_path() {
         const RUN_PATH: &str = "/my/little/run_path";
 
-        let base_config_values = json!({ "run_path": RUN_PATH });
+        let base_config_values = json!({});
         let (config, _) = ConfigurationLoader::for_tests(Some(base_config_values), None, false).await;
 
-        let dogstatsd_config = DogStatsDConfiguration::from_configuration(&config).expect("should deserialize");
+        let dogstatsd_config = DogStatsDConfiguration::from_configuration(&config, &Some(PathBuf::from(RUN_PATH)))
+            .expect("should deserialize");
 
         let expected = PathBuf::from(RUN_PATH).join(DOGSTATSD_CAPTURE_DIR);
         assert_eq!(expected, dogstatsd_config.capture_path);
@@ -4524,10 +4515,11 @@ mod tests {
         const RUN_PATH: &str = "/my/little/run_path";
         const CAPTURE_PATH: &str = "/custom/path/to/capture";
 
-        let base_config_values = json!({ "run_path": RUN_PATH, "dogstatsd_capture_path": CAPTURE_PATH });
+        let base_config_values = json!({ "dogstatsd_capture_path": CAPTURE_PATH });
         let (config, _) = ConfigurationLoader::for_tests(Some(base_config_values), None, false).await;
 
-        let dogstatsd_config = DogStatsDConfiguration::from_configuration(&config).expect("should deserialize");
+        let dogstatsd_config = DogStatsDConfiguration::from_configuration(&config, &Some(PathBuf::from(RUN_PATH)))
+            .expect("should deserialize");
 
         assert_eq!(PathBuf::from(CAPTURE_PATH), dogstatsd_config.capture_path);
     }
@@ -4542,7 +4534,8 @@ mod tests {
 
         for (base_config_values, expected_depth) in cases {
             let (config, _) = ConfigurationLoader::for_tests(Some(base_config_values), None, false).await;
-            let dogstatsd_config = DogStatsDConfiguration::from_configuration(&config).expect("should deserialize");
+            let dogstatsd_config =
+                DogStatsDConfiguration::from_configuration(&config, &None).expect("should deserialize");
 
             assert_eq!(expected_depth, dogstatsd_config.capture_depth);
         }


### PR DESCRIPTION
## Human Summary

The state directory, `run_path`, was being read directly by key in a few places. Now we read this from typed configuration preserving existing `unset` behavior by using an `Option<PathBuf>` as the type. The coding agent noticed that the schema has a placeholder, `${run_path}` as a literal default string, so we check for that literal, warn, and discard it in the highly unlikely case that an Agent bug passes it to us.

## AI Summary

- Model `run_path` in typed configuration.
- Use it for retry storage, DogStatsD captures, and context dumps.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make fmt`
- `make check-clippy`
- `make check-docs`
- Targeted `cargo nextest` tests for retry, DogStatsD capture, and context dumps

## References

- Progresses: #2293
