### PR TITLE
feat(otlp): downgrade unsupported exponential histogram temporality t…

### DIFF
--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -688,7 +688,7 @@ impl OtlpMetricsTranslator {
                             &context,
                         ),
                         _ => {
-                            warn!(
+                            debug!(
                                 metric_name = base_dims.name,
                                 temporality = exponential_histogram.aggregation_temporality,
                                 "Unknown or unsupported aggregation temporality"
@@ -1637,8 +1637,9 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use otlp_protos::opentelemetry::proto::metrics::v1::{
-        number_data_point::Value as OtlpNumberDataPointValue, summary_data_point::ValueAtQuantile, Gauge,
-        NumberDataPoint as OtlpNumberDataPoint, ScopeMetrics, Sum,
+        number_data_point::Value as OtlpNumberDataPointValue, summary_data_point::ValueAtQuantile,
+        ExponentialHistogram as OtlpExponentialHistogram, Gauge, NumberDataPoint as OtlpNumberDataPoint, ScopeMetrics,
+        Sum,
     };
     use saluki_context::tags::Tag;
 
@@ -4558,6 +4559,35 @@ mod tests {
         let events = run_exponential_histogram(&mut translator, "otlp.exphist", vec![dp], false, &metrics);
 
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn exponential_histogram_cumulative_temporality_is_dropped_via_translate_metrics() {
+        // Exercises the `map_to_dd_format` dispatch path (not `map_exponential_histogram_metrics`
+        // directly): a Cumulative-temporality exponential histogram must produce no events. The
+        // drop is logged at debug level, not warn, to avoid operator noise for unsupported input
+        // that is handled as expected. See issue #2073.
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        let metric = OtlpMetric {
+            name: "otlp.exphist.cumulative".to_string(),
+            data: Some(OtlpMetricData::ExponentialHistogram(OtlpExponentialHistogram {
+                aggregation_temporality: AggregationTemporality::Cumulative as i32,
+                data_points: vec![exp_histogram_dp(3, 6.0, None, None)],
+            })),
+            ..Default::default()
+        };
+
+        let events = translator
+            .translate_metrics(resource_metrics_with_metric(metric), &metrics)
+            .expect("translation should succeed")
+            .collect::<Vec<_>>();
+
+        assert!(
+            events.is_empty(),
+            "cumulative exponential histogram must be dropped with no events emitted"
+        );
     }
 
     // -----------------------------------------------------------------------------------------------

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -4563,10 +4563,6 @@ mod tests {
 
     #[test]
     fn exponential_histogram_cumulative_temporality_is_dropped_via_translate_metrics() {
-        // Exercises the `map_to_dd_format` dispatch path (not `map_exponential_histogram_metrics`
-        // directly): a Cumulative-temporality exponential histogram must produce no events. The
-        // drop is logged at debug level, not warn, to avoid operator noise for unsupported input
-        // that is handled as expected. See issue #2073.
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
 

--- a/test/correctness/cases/otlp-metrics-histogram-nobuckets/config.yaml
+++ b/test/correctness/cases/otlp-metrics-histogram-nobuckets/config.yaml
@@ -1,0 +1,23 @@
+type: correctness
+runtime: docker
+analysis_mode: metrics
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=true
+    - DD_DATA_PLANE_OTLP_ENABLED=true
+    # ADP must bind the generator's `4317` target; container initialization moves the Core Agent.
+    # TODO(#2177): Replace this ADP-only override with the canonical schema-provided endpoint key
+    # once endpoint ownership prevents both processes from attempting to bind the same port.
+    - ADP_DD_DATA_PLANE_OTLP_RECEIVER_GRPC_ENDPOINT_TEMPORARY=0.0.0.0:4317
+    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/cases/otlp-metrics-histogram-nobuckets/datadog.yaml
+++ b/test/correctness/cases/otlp-metrics-histogram-nobuckets/datadog.yaml
@@ -1,0 +1,14 @@
+hostname: "correctness-testing"
+api_key: dummy-api-key-correctness-testing
+health_port: 5555
+dd_url: "http://datadog-intake:2049"
+
+otlp_config:
+  metrics:
+    histograms:
+      mode: nobuckets
+      send_aggregation_metrics: true
+  receiver:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"

--- a/test/correctness/cases/otlp-metrics-histogram-nobuckets/millstone.yaml
+++ b/test/correctness/cases/otlp-metrics-histogram-nobuckets/millstone.yaml
@@ -1,0 +1,11 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "grpc://$GROUP:4317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export"
+aggregation_bucket_width_secs: 10
+volume: 1
+corpus:
+  size: 1
+  payload:
+    # One valid delta histogram with two explicit bounds and three bucket counts. In `nobuckets`
+    # mode with aggregation metrics enabled, the translator emits the `.count`/`.sum` aggregation
+    # series and omits the per-bucket series.
+    static_base64: "CmoSaBJmCg5vdGxwLmhpc3RvZ3JhbUpUClARAMqaOwAAAAAZAJQ1dwAAAAAhBgAAAAAAAAApAAAAAACAN0AyGAEAAAAAAAAAAgAAAAAAAAADAAAAAAAAADoQAAAAAAAA8D8AAAAAAAAkQBAB"


### PR DESCRIPTION
…o debug and test cumulative drop

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Logs unsupported OTLP exponential-histogram temporality at debug level and rejects invalid OTLP histogram configuration

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

Unit test and correctness test

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->
- Closes: https://github.com/DataDog/saluki/issues/2073 https://github.com/DataDog/saluki/issues/2087

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
