### PR TITLE
fix(otlp): publish ephemeral server addresses

### DIFF
--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -33,6 +33,8 @@ use prost::Message;
 use saluki_core::accounting::MemoryLimiter;
 use saluki_core::components::{ComponentContext, ComponentSpawner};
 use saluki_core::observability::ComponentMetricsExt;
+#[cfg(test)]
+use saluki_core::runtime::state::Identifier;
 use saluki_error::{ErrorContext as _, GenericError};
 use saluki_io::net::server::{grpc::GrpcServer, http::HttpServer};
 use saluki_io::net::util::hyper::TowerToHyperService;
@@ -187,6 +189,10 @@ pub struct OtlpServerConfiguration {
     cors: CorsConfiguration,
     http_tls: Option<OtlpTlsConfiguration>,
     grpc_tls: Option<OtlpTlsConfiguration>,
+    #[cfg(test)]
+    http_bound_address_id: Option<Identifier>,
+    #[cfg(test)]
+    grpc_bound_address_id: Option<Identifier>,
 }
 
 impl OtlpServerConfiguration {
@@ -201,7 +207,19 @@ impl OtlpServerConfiguration {
             cors: CorsConfiguration::default(),
             http_tls: None,
             grpc_tls: None,
+            #[cfg(test)]
+            http_bound_address_id: None,
+            #[cfg(test)]
+            grpc_bound_address_id: None,
         }
+    }
+
+    /// Sets the identifiers used to publish the bound HTTP and gRPC addresses.
+    #[cfg(test)]
+    fn with_bound_address_ids(mut self, http_id: impl Into<Identifier>, grpc_id: impl Into<Identifier>) -> Self {
+        self.http_bound_address_id = Some(http_id.into());
+        self.grpc_bound_address_id = Some(grpc_id.into());
+        self
     }
 
     /// Sets the CORS configuration for the HTTP receiver.
@@ -268,6 +286,10 @@ impl OtlpServerConfiguration {
             .add_service(grpc_logs_server)
             .add_service(grpc_traces_server);
 
+        #[cfg(test)]
+        if let Some(id) = self.grpc_bound_address_id {
+            grpc_server = grpc_server.with_bound_address_id(id);
+        }
         if let Some(tls_config) = grpc_tls_config {
             grpc_server = grpc_server.with_tls_config(tls_config);
         }
@@ -297,6 +319,10 @@ impl OtlpServerConfiguration {
 
         let mut http_server = HttpServer::from_listen_address(self.http_endpoint, service);
 
+        #[cfg(test)]
+        if let Some(id) = self.http_bound_address_id {
+            http_server = http_server.with_bound_address_id(id);
+        }
         if let Some(tls_config) = http_tls_config {
             http_server = http_server.with_tls_config(tls_config);
         }
@@ -534,9 +560,7 @@ impl<H: OtlpHandler> TraceService for GrpcServiceImpl<H> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-    #[cfg(unix)]
-    use std::time::Duration;
+    use std::{sync::Arc, time::Duration};
 
     use axum::{
         body::Body,
@@ -551,7 +575,9 @@ mod tests {
     use saluki_core::{
         accounting::MemoryLimiter,
         components::{test_util::TestComponentSupervisor, ComponentContext},
+        runtime::state::{DataspaceUpdate, IdentifierFilter},
     };
+    use saluki_io::net::server::BoundServerAddress;
     use saluki_metrics::test::TestRecorder;
     use saluki_tls::test_util::SelfSignedCert;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -559,6 +585,9 @@ mod tests {
     use tower::ServiceExt;
 
     use super::*;
+
+    const HTTP_BOUND_ADDRESS_ID: &str = "test-otlp-http-bound-address";
+    const GRPC_BOUND_ADDRESS_ID: &str = "test-otlp-grpc-bound-address";
 
     struct NoopHandler;
 
@@ -916,17 +945,9 @@ mod tests {
         let supervisor = TestComponentSupervisor::start("otlp-tls-test").await;
         let spawner = supervisor.spawner();
 
-        // Bind listeners ourselves first to get ephemeral ports, then drop them and let the builder re-bind.
-        let http_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let grpc_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let http_port = http_listener.local_addr().unwrap().port();
-        let grpc_port = grpc_listener.local_addr().unwrap().port();
-        drop(http_listener);
-        drop(grpc_listener);
-
         let cert = SelfSignedCert::localhost();
-        let http_endpoint = ListenAddress::Tcp(format!("127.0.0.1:{}", http_port).parse().unwrap());
-        let grpc_endpoint = ListenAddress::Tcp(format!("127.0.0.1:{}", grpc_port).parse().unwrap());
+        let http_endpoint = ListenAddress::Tcp("127.0.0.1:0".parse().unwrap());
+        let grpc_endpoint = ListenAddress::Tcp("127.0.0.1:0".parse().unwrap());
 
         // Write the cert and key to temp files so OtlpTlsConfiguration can load them.
         let tempdir = tempfile::tempdir().expect("temp dir should be created");
@@ -937,6 +958,7 @@ mod tests {
 
         let tls_config = OtlpTlsConfiguration::new(cert_path, key_path);
         let server_config = OtlpServerConfiguration::new(http_endpoint, grpc_endpoint, 4 * 1024 * 1024)
+            .with_bound_address_ids(HTTP_BOUND_ADDRESS_ID, GRPC_BOUND_ADDRESS_ID)
             .with_http_tls(tls_config.clone())
             .with_grpc_tls(tls_config);
 
@@ -945,7 +967,21 @@ mod tests {
             .await
             .expect("OTLP server with TLS should start");
 
+        let http_port = bound_port(&supervisor, HTTP_BOUND_ADDRESS_ID).await;
+        let grpc_port = bound_port(&supervisor, GRPC_BOUND_ADDRESS_ID).await;
+
         (http_port, grpc_port, cert, supervisor)
+    }
+
+    async fn bound_port(supervisor: &TestComponentSupervisor, id: &str) -> u16 {
+        let mut subscription = supervisor
+            .dataspace()
+            .subscribe::<BoundServerAddress>(IdentifierFilter::exact(id));
+
+        match tokio::time::timeout(Duration::from_secs(5), subscription.recv()).await {
+            Ok(Some(DataspaceUpdate::Asserted(_, BoundServerAddress(address)))) => address.port(),
+            update => panic!("expected a bound address assertion for '{id}', got {update:?}"),
+        }
     }
 
     #[tokio::test]

--- a/lib/saluki-core/src/components/test_util.rs
+++ b/lib/saluki-core/src/components/test_util.rs
@@ -10,10 +10,13 @@
 
 use std::time::Duration;
 
-use tokio::{runtime::Handle, sync::oneshot, task::JoinHandle};
+use saluki_common::sync::shutdown::{ShutdownCoordinator, ShutdownHandle};
+use tokio::{runtime::Handle, task::JoinHandle};
 
 use crate::components::ComponentSpawner;
-use crate::runtime::{AutoShutdown, ShutdownMode, Supervisor, SupervisorError, SupervisorHandle};
+use crate::runtime::{
+    state::DataspaceRegistry, AutoShutdown, ShutdownMode, Supervisor, SupervisorError, SupervisorHandle,
+};
 
 /// Shutdown budget for the test supervisor.
 ///
@@ -35,7 +38,8 @@ const POLL_TIMEOUT: Duration = Duration::from_secs(5);
 /// component directly.
 pub struct TestComponentSupervisor {
     handle: SupervisorHandle,
-    shutdown_tx: Option<oneshot::Sender<()>>,
+    dataspace: DataspaceRegistry,
+    shutdown_coordinator: Option<ShutdownCoordinator>,
     task: JoinHandle<Result<(), SupervisorError>>,
 }
 
@@ -59,6 +63,7 @@ impl TestComponentSupervisor {
     ///
     /// Panics if `id` isn't a valid supervisor name, or if the supervisor doesn't start within a few seconds.
     pub async fn start_with_budget(id: &str, budget: Duration) -> Self {
+        let dataspace = DataspaceRegistry::default();
         let mut supervisor = Supervisor::new(id)
             .expect("test supervisor name should be valid")
             .with_auto_shutdown(AutoShutdown::AnySignificant)
@@ -69,12 +74,18 @@ impl TestComponentSupervisor {
         // is how we observe that it has.
         let handle = supervisor.handle();
 
-        let (shutdown_tx, shutdown_rx) = oneshot::channel();
-        let task = tokio::spawn(async move { supervisor.run_with_shutdown(shutdown_rx).await });
+        let task_dataspace = dataspace.clone();
+        let (shutdown_coordinator, process_shutdown) = ShutdownHandle::paired();
+        let task = tokio::spawn(async move {
+            supervisor
+                .run_with_shutdown_inner(process_shutdown, Some(task_dataspace))
+                .await
+        });
 
         let supervisor = Self {
             handle,
-            shutdown_tx: Some(shutdown_tx),
+            dataspace,
+            shutdown_coordinator: Some(shutdown_coordinator),
             task,
         };
         supervisor
@@ -89,6 +100,11 @@ impl TestComponentSupervisor {
     /// The current runtime stands in for the shared worker pool.
     pub fn spawner(&self) -> ComponentSpawner {
         ComponentSpawner::new(self.handle.clone(), Handle::current())
+    }
+
+    /// Returns the dataspace shared by the supervisor and its children.
+    pub fn dataspace(&self) -> &DataspaceRegistry {
+        &self.dataspace
     }
 
     /// Returns the number of dynamic children currently running.
@@ -117,9 +133,8 @@ impl TestComponentSupervisor {
     ///
     /// Panics if the supervisor task panicked.
     pub async fn shutdown(mut self) -> Result<(), SupervisorError> {
-        // The receiver only goes away if the run already ended, in which case shutdown is moot.
-        if let Some(shutdown_tx) = self.shutdown_tx.take() {
-            let _ = shutdown_tx.send(());
+        if let Some(shutdown_coordinator) = self.shutdown_coordinator.take() {
+            shutdown_coordinator.shutdown();
         }
 
         (&mut self.task).await.expect("test supervisor task should not panic")
@@ -144,7 +159,7 @@ impl TestComponentSupervisor {
 impl Drop for TestComponentSupervisor {
     fn drop(&mut self) {
         // A test that returns (or panics) without calling `shutdown` shouldn't leak a supervisor and its children into
-        // the rest of the run. Dropping the sender signals shutdown; the task tears itself down from there.
-        self.shutdown_tx.take();
+        // the rest of the run. Dropping the coordinator signals shutdown; the task tears itself down from there.
+        self.shutdown_coordinator.take();
     }
 }

--- a/lib/saluki-io/src/net/server/grpc.rs
+++ b/lib/saluki-io/src/net/server/grpc.rs
@@ -1,6 +1,7 @@
 use std::{
     convert::Infallible,
     io,
+    net::SocketAddr,
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -11,7 +12,10 @@ use async_trait::async_trait;
 use http::Request;
 use rustls::ServerConfig;
 use saluki_common::sync::shutdown::ShutdownHandle;
-use saluki_core::runtime::{InitializationError, ShutdownStrategy, Supervisable, SupervisorFuture};
+use saluki_core::runtime::{
+    state::{DataspaceRegistry, Identifier},
+    InitializationError, ShutdownStrategy, Supervisable, SupervisorFuture,
+};
 use saluki_error::ErrorContext as _;
 use saluki_tls::ensure_server_config_fips_compliant;
 use tokio::{
@@ -36,7 +40,7 @@ use tracing::{debug, warn};
 
 #[cfg(unix)]
 use crate::net::unix::{ensure_unix_socket_free, set_unix_socket_write_only};
-use crate::net::ListenAddress;
+use crate::net::{server::BoundServerAddress, ListenAddress};
 
 /// A gRPC server.
 ///
@@ -59,6 +63,7 @@ pub struct GrpcServer {
     routes: Option<Routes>,
     graceful_shutdown_timeout: Option<Duration>,
     tls_config: Option<ServerConfig>,
+    bound_address_id: Option<Identifier>,
 }
 
 impl GrpcServer {
@@ -69,7 +74,16 @@ impl GrpcServer {
             routes: None,
             graceful_shutdown_timeout: None,
             tls_config: None,
+            bound_address_id: None,
         }
+    }
+
+    /// Sets the identifier used to publish the bound TCP address.
+    ///
+    /// Defaults to not publishing the address. Unix listen addresses never publish an address.
+    pub fn with_bound_address_id(mut self, id: impl Into<Identifier>) -> Self {
+        self.bound_address_id = Some(id.into());
+        self
     }
 
     /// Sets the graceful shutdown timeout for this server.
@@ -94,6 +108,23 @@ impl GrpcServer {
     pub fn with_tls_config(mut self, config: ServerConfig) -> Self {
         self.tls_config = Some(config);
         self
+    }
+
+    fn publish_bound_address<F>(&self, local_addr: F, configured_addr: &SocketAddr) -> Result<(), InitializationError>
+    where
+        F: FnOnce() -> io::Result<SocketAddr>,
+    {
+        let Some(id) = self.bound_address_id.clone() else {
+            return Ok(());
+        };
+
+        let bound_address = local_addr()
+            .with_error_context(|| format!("Failed to query bound address for gRPC server ({}).", configured_addr))?;
+        let dataspace = DataspaceRegistry::try_current()
+            .ok_or_else(|| saluki_error::generic_error!("Dataspace not available for gRPC server."))?;
+        dataspace.assert(BoundServerAddress(bound_address), id);
+
+        Ok(())
     }
 
     /// Adds a new service to this server.
@@ -146,6 +177,7 @@ impl Supervisable for GrpcServer {
                     let listener = tokio::net::TcpListener::bind(*addr)
                         .await
                         .with_error_context(|| format!("Failed to bind listener for gRPC server ({}).", addr))?;
+                    self.publish_bound_address(|| listener.local_addr(), addr)?;
 
                     // Spawn each TLS handshake concurrently so a stalled client cannot block the accept loop.
                     let incoming = spawn_tls_handshake_loop(listener, acceptor);
@@ -178,6 +210,7 @@ impl Supervisable for GrpcServer {
                 } else {
                     let listener = TcpIncoming::bind(*addr)
                         .with_error_context(|| format!("Failed to bind listener for gRPC server ({}).", addr))?;
+                    self.publish_bound_address(|| listener.local_addr(), addr)?;
 
                     Ok(Box::pin(async move {
                         let (drain_tx, drain_rx) = oneshot::channel();
@@ -384,11 +417,19 @@ mod tests {
     use std::net::{SocketAddr, TcpListener as StdTcpListener};
 
     use saluki_common::sync::shutdown::ShutdownCoordinator;
+    #[cfg(unix)]
+    use saluki_core::runtime::state::IdentifierFilter;
+    use saluki_tls::test_util::SelfSignedCert;
+    #[cfg(unix)]
+    use tokio::io::AsyncReadExt as _;
     use tokio::io::AsyncWriteExt as _;
     use tokio::net::TcpStream;
     use tokio::time::timeout;
 
     use super::*;
+    use crate::net::server::test_util::ServerTestHarness;
+    #[cfg(unix)]
+    use crate::net::server::{test_util::connect_unix, BoundServerAddress};
 
     /// Bound on any server await in these tests, so a hang fails rather than stalling the suite.
     const TEST_TIMEOUT: Duration = Duration::from_secs(10);
@@ -399,6 +440,86 @@ mod tests {
         let addr = listener.local_addr().expect("should have a local address");
         drop(listener);
         addr
+    }
+
+    #[tokio::test]
+    async fn publishes_bound_tcp_address() {
+        let harness = ServerTestHarness::start("grpc-bound-address", |supervisor| {
+            let listen_address = ListenAddress::Tcp("127.0.0.1:0".parse().expect("address should parse"));
+            let server = GrpcServer::new(listen_address).with_bound_address_id("grpc-bound-address");
+            supervisor.add_worker(server);
+        })
+        .await;
+
+        let address = harness.bound_address("grpc-bound-address").await;
+        assert_ne!(address.port(), 0);
+        let stream = TcpStream::connect(address)
+            .await
+            .expect("should connect to published address");
+        drop(stream);
+
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn tls_server_publishes_bound_tcp_address() {
+        let _ = saluki_tls::initialize_default_crypto_provider();
+        let cert = SelfSignedCert::localhost();
+        let tls_config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(cert.cert_chain(), cert.private_key())
+            .expect("should build TLS config");
+        let harness = ServerTestHarness::start("grpc-tls-bound-address", move |supervisor| {
+            let listen_address = ListenAddress::Tcp("127.0.0.1:0".parse().expect("address should parse"));
+            let server = GrpcServer::new(listen_address)
+                .with_tls_config(tls_config)
+                .with_bound_address_id("grpc-tls-bound-address");
+            supervisor.add_worker(server);
+        })
+        .await;
+
+        let address = harness.bound_address("grpc-tls-bound-address").await;
+        assert_ne!(address.port(), 0);
+        let stream = TcpStream::connect(address)
+            .await
+            .expect("should connect to published address");
+        drop(stream);
+
+        harness.shutdown().await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unix_listener_does_not_publish_bound_address() {
+        let tempdir = tempfile::tempdir().expect("should create temp dir");
+        let socket_path = tempdir.path().join("grpc.sock");
+        let listen_address = ListenAddress::Unix(socket_path.clone());
+        let harness = ServerTestHarness::start("grpc-unix-bound-address", move |supervisor| {
+            let server = GrpcServer::new(listen_address).with_bound_address_id("grpc-unix-bound-address");
+            supervisor.add_worker(server);
+        })
+        .await;
+
+        let mut stream = connect_unix(&socket_path).await;
+        stream
+            .write_all(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+            .await
+            .expect("should write HTTP/2 preface");
+        let mut response = [0; 1];
+        timeout(TEST_TIMEOUT, stream.read_exact(&mut response))
+            .await
+            .expect("server should respond over Unix listener")
+            .expect("should read server response");
+        assert!(
+            harness
+                .dataspace
+                .current_values::<BoundServerAddress>(IdentifierFilter::all())
+                .is_empty(),
+            "Unix listener should not publish a bound address"
+        );
+        drop(stream);
+
+        harness.shutdown().await;
     }
 
     #[tokio::test]

--- a/lib/saluki-io/src/net/server/http.rs
+++ b/lib/saluki-io/src/net/server/http.rs
@@ -29,14 +29,17 @@ use saluki_common::{
     sync::shutdown::{ShutdownCoordinator, ShutdownHandle},
     task::{spawn_traced_named, HandleExt as _},
 };
-use saluki_core::runtime::{InitializationError, ShutdownStrategy, Supervisable, SupervisorFuture};
+use saluki_core::runtime::{
+    state::{DataspaceRegistry, Identifier},
+    InitializationError, ShutdownStrategy, Supervisable, SupervisorFuture,
+};
 use saluki_error::{ErrorContext as _, GenericError};
 use saluki_tls::ensure_server_config_fips_compliant;
 use tokio::{pin, runtime::Handle, select, sync::oneshot, time::timeout};
 use tokio_rustls::TlsAcceptor;
 use tracing::{debug, error, info, warn};
 
-use crate::net::{listener::ConnectionOrientedListener, ListenAddress};
+use crate::net::{listener::ConnectionOrientedListener, server::BoundServerAddress, ListenAddress};
 
 fn build_conn_builder() -> Builder<TokioExecutor> {
     let mut builder = Builder::new(TokioExecutor::new());
@@ -65,6 +68,7 @@ pub struct HttpServer<S> {
     tls_config: Option<ServerConfig>,
     conn_builder: Builder<TokioExecutor>,
     graceful_shutdown_timeout: Option<Duration>,
+    bound_address_id: Option<Identifier>,
     service: S,
 }
 
@@ -76,8 +80,17 @@ impl<S> HttpServer<S> {
             tls_config: None,
             conn_builder: build_conn_builder(),
             graceful_shutdown_timeout: None,
+            bound_address_id: None,
             service,
         }
+    }
+
+    /// Sets the identifier used to publish the bound TCP address.
+    ///
+    /// Defaults to not publishing the address. Unix listen addresses never publish an address.
+    pub fn with_bound_address_id(mut self, id: impl Into<Identifier>) -> Self {
+        self.bound_address_id = Some(id.into());
+        self
     }
 
     /// Sets the graceful shutdown timeout for this server.
@@ -129,6 +142,18 @@ where
         let listener = ConnectionOrientedListener::from_listen_address(self.listen_address.clone())
             .await
             .with_error_context(|| format!("Failed to bind listener for HTTP server ({}).", self.listen_address))?;
+
+        if let (Some(id), ListenAddress::Tcp(_)) = (&self.bound_address_id, &self.listen_address) {
+            let bound_address = listener.local_addr().with_error_context(|| {
+                format!(
+                    "Failed to query bound address for HTTP server ({}).",
+                    self.listen_address
+                )
+            })?;
+            let dataspace = DataspaceRegistry::try_current()
+                .ok_or_else(|| saluki_error::generic_error!("Dataspace not available for HTTP server."))?;
+            dataspace.assert(BoundServerAddress(bound_address), id.clone());
+        }
 
         let conn_builder = self.conn_builder.clone();
         let service = self.service.clone();
@@ -392,11 +417,16 @@ mod tests {
     use http_body_util::Full;
     use hyper::service::service_fn;
     use saluki_common::sync::shutdown::ShutdownCoordinator;
+    #[cfg(unix)]
+    use saluki_core::runtime::state::IdentifierFilter;
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
     use tokio::net::TcpStream;
     use tokio::time::timeout;
 
     use super::*;
+    use crate::net::server::test_util::ServerTestHarness;
+    #[cfg(unix)]
+    use crate::net::server::{test_util::connect_unix, BoundServerAddress};
 
     /// Bound on any server await in these tests, so a hang fails rather than stalling the suite.
     const TEST_TIMEOUT: Duration = Duration::from_secs(5);
@@ -414,7 +444,7 @@ mod tests {
 
     /// Builds a server whose handler runs `f` for every request.
     fn server_with<F, Fut>(
-        addr: SocketAddr, f: F,
+        listen_address: ListenAddress, f: F,
     ) -> HttpServer<
         impl Service<
                 Request<Incoming>,
@@ -431,7 +461,7 @@ mod tests {
         Fut: Future<Output = Result<Response<Full<bytes::Bytes>>, std::convert::Infallible>> + Send + 'static,
     {
         let service = service_fn(move |_req: Request<Incoming>| f());
-        HttpServer::from_listen_address(ListenAddress::Tcp(addr), service)
+        HttpServer::from_listen_address(listen_address, service)
     }
 
     /// A handler that responds immediately.
@@ -440,11 +470,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn publishes_bound_tcp_address() {
+        let harness = ServerTestHarness::start("http-bound-address", |supervisor| {
+            let server = server_with(
+                ListenAddress::Tcp("127.0.0.1:0".parse().expect("address should parse")),
+                ok_response,
+            )
+            .with_bound_address_id("http-bound-address");
+            supervisor.add_worker(server);
+        })
+        .await;
+
+        let address = harness.bound_address("http-bound-address").await;
+        assert_ne!(address.port(), 0);
+        let stream = TcpStream::connect(address)
+            .await
+            .expect("should connect to published address");
+        drop(stream);
+
+        harness.shutdown().await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unix_listener_does_not_publish_bound_address() {
+        let tempdir = tempfile::tempdir().expect("should create temp dir");
+        let socket_path = tempdir.path().join("http.sock");
+        let listen_address = ListenAddress::Unix(socket_path.clone());
+        let harness = ServerTestHarness::start("http-unix-bound-address", move |supervisor| {
+            let server = server_with(listen_address, ok_response).with_bound_address_id("http-unix-bound-address");
+            supervisor.add_worker(server);
+        })
+        .await;
+
+        let mut stream = connect_unix(&socket_path).await;
+        stream
+            .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+            .await
+            .expect("should write request");
+        let mut response = Vec::new();
+        timeout(TEST_TIMEOUT, stream.read_to_end(&mut response))
+            .await
+            .expect("server should respond over Unix listener")
+            .expect("should read response");
+        assert!(response.ends_with(b"ok"));
+        assert!(
+            harness
+                .dataspace
+                .current_values::<BoundServerAddress>(IdentifierFilter::all())
+                .is_empty(),
+            "Unix listener should not publish a bound address"
+        );
+
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn binds_during_initialization() {
         // The listener is bound by `initialize`, not by the worker future, so the port is already taken before anything
         // starts serving. That is what makes a bind failure a non-restartable initialization error.
         let addr = free_local_addr();
-        let server = server_with(addr, ok_response);
+        let server = server_with(ListenAddress::Tcp(addr), ok_response);
 
         let run = server
             .initialize(ShutdownHandle::noop())
@@ -466,7 +552,7 @@ mod tests {
         let addr = free_local_addr();
         let _held = StdTcpListener::bind(addr).expect("should hold the address");
 
-        let server = server_with(addr, ok_response);
+        let server = server_with(ListenAddress::Tcp(addr), ok_response);
         match server.initialize(ShutdownHandle::noop()).await {
             Ok(_) => panic!("initialization should have failed to bind {addr}"),
             Err(e) => {
@@ -481,7 +567,7 @@ mod tests {
         // The whole reason for supervising the server: when its worker stops, the socket is gone. Previously the
         // acceptor was a detached task that outlived whatever spawned it.
         let addr = free_local_addr();
-        let server = server_with(addr, ok_response);
+        let server = server_with(ListenAddress::Tcp(addr), ok_response);
 
         let mut coordinator = ShutdownCoordinator::default();
         let run = server
@@ -508,7 +594,8 @@ mod tests {
         // deadline, one such socket stalled shutdown indefinitely -- for the OTLP receivers that meant every ADP
         // shutdown hanging until the component budget forced an abort.
         let addr = free_local_addr();
-        let server = server_with(addr, ok_response).with_graceful_shutdown_timeout(Duration::from_secs(1));
+        let server =
+            server_with(ListenAddress::Tcp(addr), ok_response).with_graceful_shutdown_timeout(Duration::from_secs(1));
 
         let mut coordinator = ShutdownCoordinator::default();
         let run = server
@@ -543,7 +630,7 @@ mod tests {
 
         let handler_started = Arc::new(AtomicBool::new(false));
         let started = Arc::clone(&handler_started);
-        let server = server_with(addr, move || {
+        let server = server_with(ListenAddress::Tcp(addr), move || {
             let started = Arc::clone(&started);
             async move {
                 started.store(true, Ordering::SeqCst);

--- a/lib/saluki-io/src/net/server/mod.rs
+++ b/lib/saluki-io/src/net/server/mod.rs
@@ -1,3 +1,14 @@
+use std::net::SocketAddr;
+
 pub mod grpc;
 pub mod http;
 pub mod multiplex_service;
+
+#[cfg(test)]
+pub(crate) mod test_util;
+
+/// The socket address bound by a running server.
+///
+/// Servers assert this value only when configured with an identifier.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BoundServerAddress(pub SocketAddr);

--- a/lib/saluki-io/src/net/server/test_util.rs
+++ b/lib/saluki-io/src/net/server/test_util.rs
@@ -1,0 +1,130 @@
+#[cfg(unix)]
+use std::{io::ErrorKind, path::Path};
+use std::{sync::Mutex, time::Duration};
+
+use async_trait::async_trait;
+use saluki_common::sync::shutdown::ShutdownHandle;
+use saluki_core::runtime::{
+    state::{DataspaceRegistry, DataspaceUpdate, IdentifierFilter},
+    InitializationError, Supervisable, Supervisor, SupervisorError, SupervisorFuture,
+};
+use saluki_error::generic_error;
+#[cfg(unix)]
+use tokio::{net::UnixStream, time::sleep};
+use tokio::{sync::oneshot, task::JoinHandle, time::timeout};
+
+use super::BoundServerAddress;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[cfg(unix)]
+pub async fn connect_unix(path: &Path) -> UnixStream {
+    timeout(TEST_TIMEOUT, async {
+        loop {
+            match UnixStream::connect(path).await {
+                Ok(stream) => return stream,
+                Err(error) if matches!(error.kind(), ErrorKind::NotFound | ErrorKind::ConnectionRefused) => {
+                    sleep(Duration::from_millis(5)).await;
+                }
+                Err(error) => panic!("should connect to Unix listener: {error}"),
+            }
+        }
+    })
+    .await
+    .expect("should connect to Unix listener before timeout")
+}
+
+pub struct ServerTestHarness {
+    pub dataspace: DataspaceRegistry,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    task: JoinHandle<Result<(), SupervisorError>>,
+}
+
+impl ServerTestHarness {
+    pub async fn start(id: &str, configure: impl FnOnce(&mut Supervisor)) -> Self {
+        let (capture, dataspace_rx) = DataspaceCapture::new();
+        let mut supervisor = Supervisor::new(id).expect("test supervisor name should be valid");
+        configure(&mut supervisor);
+        supervisor.add_worker(capture);
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let task = tokio::spawn(async move { supervisor.run_with_shutdown(shutdown_rx).await });
+        let dataspace = timeout(TEST_TIMEOUT, dataspace_rx)
+            .await
+            .expect("should capture the supervisor dataspace")
+            .expect("dataspace capture worker should send the registry");
+
+        Self {
+            dataspace,
+            shutdown_tx: Some(shutdown_tx),
+            task,
+        }
+    }
+
+    pub async fn bound_address(&self, id: &str) -> std::net::SocketAddr {
+        let mut subscription = self
+            .dataspace
+            .subscribe::<BoundServerAddress>(IdentifierFilter::exact(id));
+
+        match timeout(TEST_TIMEOUT, subscription.recv()).await {
+            Ok(Some(DataspaceUpdate::Asserted(_, BoundServerAddress(address)))) => address,
+            update => panic!("expected a bound address assertion for '{id}', got {update:?}"),
+        }
+    }
+
+    pub async fn shutdown(mut self) {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+
+        (&mut self.task)
+            .await
+            .expect("test supervisor task should not panic")
+            .expect("test supervisor should stop cleanly");
+    }
+}
+
+impl Drop for ServerTestHarness {
+    fn drop(&mut self) {
+        self.shutdown_tx.take();
+    }
+}
+
+struct DataspaceCapture {
+    dataspace_tx: Mutex<Option<oneshot::Sender<DataspaceRegistry>>>,
+}
+
+impl DataspaceCapture {
+    fn new() -> (Self, oneshot::Receiver<DataspaceRegistry>) {
+        let (dataspace_tx, dataspace_rx) = oneshot::channel();
+        (
+            Self {
+                dataspace_tx: Mutex::new(Some(dataspace_tx)),
+            },
+            dataspace_rx,
+        )
+    }
+}
+
+#[async_trait]
+impl Supervisable for DataspaceCapture {
+    fn name(&self) -> &str {
+        "dataspace_capture"
+    }
+
+    async fn initialize(&self, process_shutdown: ShutdownHandle) -> Result<SupervisorFuture, InitializationError> {
+        let dataspace = DataspaceRegistry::try_current().ok_or_else(|| generic_error!("Dataspace not available."))?;
+        let dataspace_tx = self
+            .dataspace_tx
+            .lock()
+            .unwrap()
+            .take()
+            .ok_or_else(|| generic_error!("DataspaceCapture can only be initialized once."))?;
+        let _ = dataspace_tx.send(dataspace);
+
+        Ok(Box::pin(async move {
+            process_shutdown.await;
+            Ok(())
+        }))
+    }
+}


### PR DESCRIPTION
## Human Summary

There was a race in this test due to binding a port `0`, capturing the value, then releasing it and using that value to start the server. Instead we now send zero into the test server and it publishes its bound port back using dataspaces. All of that is under cfg(test), for now, which is a little ugly, pending a more unified way of doing this in production.

## AI Summary

- Publish the actual TCP address from supervised HTTP and gRPC servers when the caller provides an identifier.
- Bind the OTLP TLS test servers to port `0` and read their distinct addresses from the test supervisor dataspace.
- Cover plaintext and TLS address publication, plus Unix listeners that publish no address.

## Change Type

- [x] Bug fix

## How did you test this PR?

- `make check-fmt`
- `make check-clippy`
- `make check-docs`
- `make test`
- `make test-property`
- `make test-docs`
- Ran `common::otlp::tests` 10 times in a row.
- Confirmed the Unix-endpoint OTLP tests pass.

## References

- Related: #2459
