### PR TITLE
chore(config): migrate remote agent client configuration to typed config

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -13,7 +13,7 @@ use agent_data_plane_config::{
 use agent_data_plane_config_system::{ConfigurationSystem, LoadedConfiguration};
 use argh::FromArgs;
 use bytesize::ByteSize;
-use datadog_agent_commons::platform::PlatformSettings;
+use datadog_agent_commons::{ipc::config::RemoteAgentClientConfiguration, platform::PlatformSettings};
 use datadog_agent_config::classifier::{ConfigClassifier, Pipeline, PipelineAffinity, Severity, SupportLevel};
 use saluki_app::{
     accounting::{initialize_memory_bounds, MemoryBoundsConfiguration},
@@ -73,7 +73,10 @@ use crate::{
         DogStatsDControlSurface, TopologyControlSurfaces,
     },
 };
-use crate::{config::DataPlaneConfiguration, internal::env::ADPEnvironmentProvider};
+use crate::{
+    config::{remote_agent_client_configuration, DataPlaneConfiguration},
+    internal::env::ADPEnvironmentProvider,
+};
 
 /// Runs the data plane.
 #[derive(FromArgs, Debug)]
@@ -115,7 +118,8 @@ pub async fn handle_run_command(
         (config_sys, None)
     } else {
         // Blocks until the Core Agent acknowledges registration.
-        let ra_bootstrap = RemoteAgentBootstrap::from_configuration(&local_config.raw_config(), &bootstrap_dp_config)
+        let client_config = remote_agent_client_configuration(local_config.local(), &local_config.raw_config())?;
+        let ra_bootstrap = RemoteAgentBootstrap::new(&client_config, &bootstrap_dp_config)
             .await
             .error_context("Failed to bootstrap remote agent state.")?;
 
@@ -167,6 +171,15 @@ pub async fn handle_run_command(
 
     check_and_warn_config(&config_sys, &active_pipelines).error_context("Incompatible configuration detected.")?;
 
+    let remote_agent_client_config = if standalone {
+        None
+    } else {
+        Some(remote_agent_client_configuration(
+            &config_sys.config(),
+            &config_sys.raw_map(),
+        )?)
+    };
+
     // Set up all of the building blocks for building our topologies and launching internal processes.
     let component_registry = ComponentRegistry::default();
     let health_registry = HealthRegistry::new();
@@ -174,13 +187,20 @@ pub async fn handle_run_command(
     let (env_provider, maybe_env_supervisor) = ADPEnvironmentProvider::from_configuration(
         standalone,
         &config_sys.raw_map(),
+        remote_agent_client_config.as_ref(),
         &component_registry,
         &health_registry,
     )
     .await?;
 
     // Create the blueprint for our primary topology.
-    let (mut blueprint, control_surfaces) = create_topology(&config_sys, &env_provider, &component_registry).await?;
+    let (mut blueprint, control_surfaces) = create_topology(
+        &config_sys,
+        remote_agent_client_config.as_ref(),
+        &env_provider,
+        &component_registry,
+    )
+    .await?;
 
     // Create the internal supervisor which drives our control plane and internal observability.
     let mut internal_supervisor = create_internal_supervisor(
@@ -365,7 +385,8 @@ fn is_a_pipeline_affected(active_pipelines: &HashSet<Pipeline>, pipeline_affinit
 }
 
 async fn create_topology(
-    config_system: &ConfigurationSystem, env_provider: &ADPEnvironmentProvider, component_registry: &ComponentRegistry,
+    config_system: &ConfigurationSystem, remote_agent_client_config: Option<&RemoteAgentClientConfiguration>,
+    env_provider: &ADPEnvironmentProvider, component_registry: &ComponentRegistry,
 ) -> Result<(TopologyBlueprint, TopologyControlSurfaces), GenericError> {
     let config = config_system.config();
     let dp = DataPlaneConfiguration::from_configuration(&config);
@@ -401,7 +422,14 @@ async fn create_topology(
     }
 
     if dp.metrics_pipeline_required() {
-        add_baseline_metrics_pipeline_to_blueprint(&mut blueprint, config_system, &shared, env_provider).await?;
+        add_baseline_metrics_pipeline_to_blueprint(
+            &mut blueprint,
+            config_system,
+            remote_agent_client_config,
+            &shared,
+            env_provider,
+        )
+        .await?;
     }
 
     if dp.logs_pipeline_required() {
@@ -482,7 +510,8 @@ async fn add_checks_pipeline_to_blueprint(
 }
 
 async fn add_baseline_metrics_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config_system: &ConfigurationSystem, shared: &SharedConfiguration,
+    blueprint: &mut TopologyBlueprint, config_system: &ConfigurationSystem,
+    remote_agent_client_config: Option<&RemoteAgentClientConfiguration>, shared: &SharedConfiguration,
     env_provider: &ADPEnvironmentProvider,
 ) -> Result<(), GenericError> {
     // Create the back half of the metrics processing pipeline.
@@ -493,7 +522,9 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
     let config = config_system.config();
     let dp = DataPlaneConfiguration::from_configuration(&config);
     if !dp.standalone_mode() {
-        let host_tags_config = HostTagsConfiguration::from_configuration(&config_system.raw_map())?;
+        let client_config = remote_agent_client_config
+            .ok_or_else(|| generic_error!("Remote Agent client configuration is required in connected mode."))?;
+        let host_tags_config = HostTagsConfiguration::new(client_config.clone(), shared.tags.expected_tags_duration);
         if host_tags_config.enabled() {
             metrics_enrich_config = metrics_enrich_config.with_transform_builder("host_tags", host_tags_config);
         }

--- a/bin/agent-data-plane/src/components/host_tags/mod.rs
+++ b/bin/agent-data-plane/src/components/host_tags/mod.rs
@@ -5,7 +5,6 @@ use std::{
 
 use async_trait::async_trait;
 use datadog_agent_commons::ipc::{client::RemoteAgentClient, config::RemoteAgentClientConfiguration};
-use saluki_config::{DurationString, GenericConfiguration};
 use saluki_context::tags::{SharedTagSet, Tag};
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{components::transforms::*, topology::EventsBuffer};
@@ -22,21 +21,15 @@ pub struct HostTagsConfiguration {
     expected_tags_duration: Duration,
 }
 
-const DEFAULT_EXPECTED_TAGS_DURATION: Duration = Duration::ZERO;
-
 impl HostTagsConfiguration {
-    /// Creates a new `HostTagsConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let client_config = RemoteAgentClientConfiguration::from_configuration(config)?;
-        let expected_tags_duration = config
-            .try_get_typed::<DurationString>("expected_tags_duration")?
-            .map(|ds| ds.as_duration())
-            .unwrap_or(DEFAULT_EXPECTED_TAGS_DURATION);
-
-        Ok(Self {
+    /// Creates a new `HostTagsConfiguration` that fetches host tags from the Core Agent over the given IPC client
+    /// configuration. A non-zero `expected_tags_duration` turns enrichment on and bounds how long the tags are
+    /// attached; the default of zero leaves the transform inert.
+    pub fn new(client_config: RemoteAgentClientConfiguration, expected_tags_duration: Duration) -> Self {
+        Self {
             client_config,
             expected_tags_duration,
-        })
+        }
     }
 
     /// Returns `true` if host tags enrichment is enabled.
@@ -56,7 +49,7 @@ impl SynchronousTransformBuilder for HostTagsConfiguration {
         // on the Core Agent's slow `GetHostTags` RPC, delaying DogStatsD draining and starving origin detection.
         let host_tags = if self.enabled() {
             // We only pay attention to the "system" tags, as the "google_cloud_platform" tags are not relevant here.
-            let client = RemoteAgentClient::from_client_configuration(&self.client_config).await?;
+            let client = RemoteAgentClient::connect(&self.client_config).await?;
             let host_tags_reply = client.get_host_tags().await?.into_inner();
             let host_tags = host_tags_reply
                 .system

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -2,9 +2,13 @@ use std::collections::HashSet;
 use std::time::Duration;
 
 use agent_data_plane_config::SalukiConfiguration;
+use datadog_agent_commons::ipc::config::{IpcAuthConfiguration, RemoteAgentClientConfiguration};
 use datadog_agent_config::classifier::Pipeline;
+use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, GenericError};
 use saluki_io::net::ListenAddress;
+#[cfg(not(target_os = "linux"))]
+use tracing::warn;
 
 /// General data plane configuration.
 ///
@@ -13,6 +17,38 @@ use saluki_io::net::ListenAddress;
 #[derive(Clone, Debug)]
 pub struct DataPlaneConfiguration<'a> {
     config: &'a SalukiConfiguration,
+}
+
+/// Translates typed IPC settings and the remaining raw authentication settings into client configuration.
+pub(crate) fn remote_agent_client_configuration(
+    config: &SalukiConfiguration, raw_map: &GenericConfiguration,
+) -> Result<RemoteAgentClientConfiguration, GenericError> {
+    #[cfg(target_os = "linux")]
+    let vsock_cid = match config.control.ipc.vsock_addr.as_str() {
+        "" => None,
+        "host" => Some(2),
+        "hypervisor" => Some(0),
+        "local" => Some(3),
+        other => {
+            return Err(generic_error!(
+                "invalid vsock address '{}'; expected one of: host, hypervisor, local",
+                other
+            ))
+        }
+    };
+
+    #[cfg(not(target_os = "linux"))]
+    if !config.control.ipc.vsock_addr.is_empty() {
+        warn!("`vsock_addr` is configured but vsock is only supported on Linux. Setting will be ignored.");
+    }
+
+    Ok(RemoteAgentClientConfiguration {
+        cmd_port: config.control.ipc.cmd_port,
+        auth: IpcAuthConfiguration::from_configuration(raw_map)?,
+        grpc_max_message_size: config.control.ipc.grpc_max_message_size,
+        #[cfg(target_os = "linux")]
+        vsock_cid,
+    })
 }
 
 impl<'a> DataPlaneConfiguration<'a> {
@@ -176,6 +212,51 @@ impl<'a> DataPlaneConfiguration<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "linux")]
+    async fn empty_raw_config() -> GenericConfiguration {
+        let (config, _) = saluki_config::ConfigurationLoader::for_tests(None, None, false).await;
+        config
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn remote_agent_client_configuration_resolves_vsock_addresses() {
+        let raw_map = empty_raw_config().await;
+
+        for (value, expected_cid) in [
+            ("", None),
+            ("host", Some(2)),
+            ("hypervisor", Some(0)),
+            ("local", Some(3)),
+        ] {
+            let mut config = SalukiConfiguration::default();
+            config.control.ipc.cmd_port = 5001;
+            config.control.ipc.grpc_max_message_size = 4 * 1024 * 1024;
+            config.control.ipc.vsock_addr = value.to_string();
+
+            let client_config = remote_agent_client_configuration(&config, &raw_map).expect("valid IPC configuration");
+            assert_eq!(client_config.vsock_cid, expected_cid);
+            assert_eq!(client_config.cmd_port, 5001);
+            assert_eq!(client_config.grpc_max_message_size, 4 * 1024 * 1024);
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn remote_agent_client_configuration_rejects_invalid_vsock_addresses() {
+        let raw_map = empty_raw_config().await;
+
+        for value in ["invalid", "2", "HOST", "host ", "vm0"] {
+            let mut config = SalukiConfiguration::default();
+            config.control.ipc.vsock_addr = value.to_string();
+
+            assert!(
+                remote_agent_client_configuration(&config, &raw_map).is_err(),
+                "expected error for input: {value:?}",
+            );
+        }
+    }
 
     fn pipeline_configuration(
         checks_enabled: bool, dogstatsd_enabled: bool, otlp_enabled: bool, otlp_proxy_enabled: bool,

--- a/bin/agent-data-plane/src/internal/env/autodiscovery.rs
+++ b/bin/agent-data-plane/src/internal/env/autodiscovery.rs
@@ -2,10 +2,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use datadog_agent_commons::ipc::client::RemoteAgentClient;
+use datadog_agent_commons::ipc::{client::RemoteAgentClient, config::RemoteAgentClientConfiguration};
 use futures::StreamExt;
 use saluki_common::sync::shutdown::ShutdownHandle;
-use saluki_config::GenericConfiguration;
 use saluki_core::runtime::{InitializationError, Supervisable, Supervisor, SupervisorFuture};
 use saluki_env::autodiscovery::AutodiscoveryEvent;
 use saluki_env::AutodiscoveryProvider;
@@ -36,8 +35,8 @@ impl RemoteAgentAutodiscoveryProvider {
     /// # Errors
     ///
     /// If the remote agent client couldn't be created, an error is returned.
-    pub async fn from_configuration(config: &GenericConfiguration) -> Result<(Self, Supervisor), GenericError> {
-        let client = RemoteAgentClient::from_configuration(config).await?;
+    pub async fn new(client_config: &RemoteAgentClientConfiguration) -> Result<(Self, Supervisor), GenericError> {
+        let client = RemoteAgentClient::connect(client_config).await?;
         let subscribers = Arc::new(Mutex::new(Vec::new()));
 
         let provider = Self {

--- a/bin/agent-data-plane/src/internal/env/host.rs
+++ b/bin/agent-data-plane/src/internal/env/host.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
-use datadog_agent_commons::ipc::client::RemoteAgentClient;
-use saluki_config::GenericConfiguration;
+use datadog_agent_commons::ipc::{client::RemoteAgentClient, config::RemoteAgentClientConfiguration};
 use saluki_core::accounting::{ComponentRegistry, MemoryBounds, MemoryBoundsBuilder};
 use saluki_env::HostProvider;
 use saluki_error::GenericError;
@@ -25,10 +24,10 @@ impl RemoteAgentHostProvider {
     ///
     /// If the Agent gRPC client can't be created (invalid API endpoint, missing authentication token, etc), or if the
     /// authentication token is invalid, an error will be returned.
-    pub async fn from_configuration(
-        config: &GenericConfiguration, component_registry: &ComponentRegistry,
+    pub async fn new(
+        client_config: &RemoteAgentClientConfiguration, component_registry: &ComponentRegistry,
     ) -> Result<Self, GenericError> {
-        let client = RemoteAgentClient::from_configuration(config).await?;
+        let client = RemoteAgentClient::connect(client_config).await?;
 
         let host_provider = Self {
             client,

--- a/bin/agent-data-plane/src/internal/env/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/mod.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 
+use datadog_agent_commons::ipc::config::RemoteAgentClientConfiguration;
 use saluki_config::GenericConfiguration;
 use saluki_core::accounting::ComponentRegistry;
 use saluki_core::health::HealthRegistry;
@@ -10,7 +11,7 @@ use saluki_env::{
     host::providers::{BoxedHostProvider, FixedHostProvider},
     EnvironmentProvider,
 };
-use saluki_error::GenericError;
+use saluki_error::{generic_error, GenericError};
 use tracing::warn;
 
 mod autodiscovery;
@@ -54,8 +55,8 @@ impl ADPEnvironmentProvider {
     /// In standalone mode, no supervisor is returned as all behavior/functionality is either provided via
     /// fixed configuration or operates in a no-op fashion.
     pub async fn from_configuration(
-        standalone: bool, raw_map: &GenericConfiguration, component_registry: &ComponentRegistry,
-        health_registry: &HealthRegistry,
+        standalone: bool, raw_map: &GenericConfiguration, client_config: Option<&RemoteAgentClientConfiguration>,
+        component_registry: &ComponentRegistry, health_registry: &HealthRegistry,
     ) -> Result<(Self, Option<Supervisor>), GenericError> {
         // When we're in standalone mode, all of our functionality is either fixed or a no-op.
         if standalone {
@@ -71,16 +72,23 @@ impl ADPEnvironmentProvider {
         }
 
         // Otherwise, construct our real providers that will interact directly with the Datadog Agent.
+        let client_config = client_config
+            .ok_or_else(|| generic_error!("Remote Agent client configuration is required in connected mode."))?;
         let mut env_supervisor = Supervisor::new("env-provider")?;
 
-        let host_provider = RemoteAgentHostProvider::from_configuration(raw_map, component_registry).await?;
+        let host_provider = RemoteAgentHostProvider::new(client_config, component_registry).await?;
 
-        let (workload_provider, workload_supervisor) =
-            RemoteAgentWorkloadProvider::from_configuration(raw_map, component_registry, health_registry).await?;
+        let (workload_provider, workload_supervisor) = RemoteAgentWorkloadProvider::from_configuration(
+            raw_map,
+            client_config,
+            component_registry,
+            health_registry,
+        )
+        .await?;
         env_supervisor.add_worker(workload_supervisor);
 
         let (autodiscovery_provider, autodiscovery_supervisor) =
-            RemoteAgentAutodiscoveryProvider::from_configuration(raw_map).await?;
+            RemoteAgentAutodiscoveryProvider::new(client_config).await?;
         env_supervisor.add_worker(autodiscovery_supervisor);
 
         let env = Self {

--- a/bin/agent-data-plane/src/internal/env/workload/collectors/tagger.rs
+++ b/bin/agent-data-plane/src/internal/env/workload/collectors/tagger.rs
@@ -1,8 +1,7 @@
 use async_trait::async_trait;
-use datadog_agent_commons::ipc::client::RemoteAgentClient;
+use datadog_agent_commons::ipc::{client::RemoteAgentClient, config::RemoteAgentClientConfiguration};
 use datadog_protos::agent::{EntityId as RemoteEntityId, EventType, TagCardinality as RemoteTagCardinality};
 use futures::{StreamExt as _, TryStreamExt as _};
-use saluki_config::GenericConfiguration;
 use saluki_context::{
     origin::OriginTagCardinality,
     tags::{Tag, TagSet},
@@ -85,10 +84,10 @@ impl RemoteAgentTaggerMetadataCollector {
     ///
     /// If the Agent gRPC client can't be created (invalid API endpoint, missing authentication token, etc), or if the
     /// authentication token is invalid, an error will be returned.
-    pub async fn from_configuration(
-        config: &GenericConfiguration, health: Health, interner: GenericMapInterner,
+    pub async fn new(
+        client_config: &RemoteAgentClientConfiguration, health: Health, interner: GenericMapInterner,
     ) -> Result<Self, GenericError> {
-        let client = RemoteAgentClient::from_configuration(config).await?;
+        let client = RemoteAgentClient::connect(client_config).await?;
 
         Ok(Self {
             client,

--- a/bin/agent-data-plane/src/internal/env/workload/collectors/workloadmeta.rs
+++ b/bin/agent-data-plane/src/internal/env/workload/collectors/workloadmeta.rs
@@ -1,8 +1,7 @@
 use async_trait::async_trait;
-use datadog_agent_commons::ipc::client::RemoteAgentClient;
+use datadog_agent_commons::ipc::{client::RemoteAgentClient, config::RemoteAgentClientConfiguration};
 use datadog_protos::agent::{Container, KubernetesPod, WorkloadmetaEventType};
 use futures::{StreamExt as _, TryStreamExt as _};
-use saluki_config::GenericConfiguration;
 use saluki_context::origin::ExternalData;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::health::Health;
@@ -49,10 +48,10 @@ impl RemoteAgentWorkloadMetadataCollector {
     ///
     /// If the Agent gRPC client can't be created (invalid API endpoint, missing authentication token, etc), or if the
     /// authentication token is invalid, an error will be returned.
-    pub async fn from_configuration(
-        config: &GenericConfiguration, health: Health, interner: GenericMapInterner,
+    pub async fn new(
+        client_config: &RemoteAgentClientConfiguration, health: Health, interner: GenericMapInterner,
     ) -> Result<Self, GenericError> {
-        let client = RemoteAgentClient::from_configuration(config).await?;
+        let client = RemoteAgentClient::connect(client_config).await?;
 
         Ok(Self {
             client,

--- a/bin/agent-data-plane/src/internal/env/workload/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/workload/mod.rs
@@ -2,6 +2,7 @@
 
 use std::{future::Future, num::NonZeroUsize, time::Duration};
 
+use datadog_agent_commons::ipc::config::RemoteAgentClientConfiguration;
 use saluki_config::GenericConfiguration;
 use saluki_context::{
     origin::{OriginTagCardinality, RawOrigin},
@@ -82,7 +83,8 @@ impl RemoteAgentWorkloadProvider {
     /// If there is an issue with any of the provider configuration, or creating the underlying metadata collectors, an
     /// error is returned.
     pub async fn from_configuration(
-        config: &GenericConfiguration, component_registry: &ComponentRegistry, health_registry: &HealthRegistry,
+        config: &GenericConfiguration, client_config: &RemoteAgentClientConfiguration,
+        component_registry: &ComponentRegistry, health_registry: &HealthRegistry,
     ) -> Result<(Self, Supervisor), GenericError> {
         let workload_provider_id = root_provider_id().child("workload").child("remote_agent");
         let mut provider_bounds = component_registry.bounds_builder(&workload_provider_id);
@@ -154,7 +156,7 @@ impl RemoteAgentWorkloadProvider {
             "remote_agent_tags",
             health_registry,
             &mut collector_bounds,
-            |health| RemoteAgentTaggerMetadataCollector::from_configuration(config, health, string_interner.clone()),
+            |health| RemoteAgentTaggerMetadataCollector::new(client_config, health, string_interner.clone()),
         )
         .await?;
 
@@ -165,7 +167,7 @@ impl RemoteAgentWorkloadProvider {
             "remote_agent_wmeta",
             health_registry,
             &mut collector_bounds,
-            |health| RemoteAgentWorkloadMetadataCollector::from_configuration(config, health, string_interner.clone()),
+            |health| RemoteAgentWorkloadMetadataCollector::new(client_config, health, string_interner.clone()),
         )
         .await?;
 

--- a/bin/agent-data-plane/src/internal/remote_agent.rs
+++ b/bin/agent-data-plane/src/internal/remote_agent.rs
@@ -4,8 +4,11 @@ use std::{collections::hash_map::Entry, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use datadog_agent_commons::ipc::client::RemoteAgentClient;
-use datadog_agent_commons::ipc::session::{SessionId, SessionIdHandle};
+use datadog_agent_commons::ipc::{
+    client::RemoteAgentClient,
+    config::RemoteAgentClientConfiguration,
+    session::{SessionId, SessionIdHandle},
+};
 use datadog_protos::agent::v1::{
     event::Details as RemoteAgentEventDetails, Event as RemoteAgentEvent, InvalidApiKeyEvent,
     ReportRemoteAgentEventRequest,
@@ -22,10 +25,7 @@ use process_memory::Querier as MemoryQuerier;
 use prost_types::value::Kind;
 use saluki_common::sync::shutdown::ShutdownHandle;
 use saluki_common::task::spawn_traced_named;
-use saluki_config::{
-    dynamic::{ConfigSetting, ConfigUpdate, Provenance},
-    GenericConfiguration,
-};
+use saluki_config::dynamic::{ConfigSetting, ConfigUpdate, Provenance};
 use saluki_core::{
     diagnostic::{subscribe_events, DiagnosticCollector, DiagnosticDetails, DiagnosticEvent},
     observability::metrics::{get_shared_metrics_state, AggregatedMetricsProcessor, Reflector, TelemetryProcessor},
@@ -88,8 +88,8 @@ impl RemoteAgentBootstrap {
     /// # Errors
     ///
     /// If the configuration is invalid, an error is returned.
-    pub async fn from_configuration<'a>(
-        config: &GenericConfiguration, dp_config: &DataPlaneConfiguration<'a>,
+    pub async fn new<'a>(
+        client_config: &RemoteAgentClientConfiguration, dp_config: &DataPlaneConfiguration<'a>,
     ) -> Result<Self, GenericError> {
         let secure_api_listen_address = dp_config.secure_api_listen_address()?;
         let api_listen_addr = GrpcTargetAddress::try_from_listen_addr(&secure_api_listen_address)
@@ -108,7 +108,7 @@ impl RemoteAgentBootstrap {
         // Create our client, and then immediately start the registration loop.
         //
         // Wait for the result of the initial registration attempt before proceeding.
-        let client = RemoteAgentClient::from_configuration(config).await?;
+        let client = RemoteAgentClient::connect(client_config).await?;
         spawn_traced_named(
             "adp-remote-agent-task",
             run_remote_agent_registration_loop(client.clone(), state),

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -163,11 +163,6 @@ fn non_empty_trimmed(s: String) -> Option<String> {
     }
 }
 
-/// Clamps a raw `i64` port into the `u16` range.
-fn to_port(value: i64) -> u16 {
-    value.clamp(0, u16::MAX as i64) as u16
-}
-
 /// Parses one `dogstatsd_mapper_profiles` object into a [`MapperProfile`].
 ///
 /// The vendored Datadog schema declares `dogstatsd_mapper_profiles` (and `metric_tag_filterlist`)
@@ -252,7 +247,13 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_agent_ipc_grpc_max_message_size(&mut self, value: i64) {
-        self.config.control.ipc.grpc_max_message_size = value;
+        match usize::try_from(value) {
+            Ok(max_message_size) => self.config.control.ipc.grpc_max_message_size = max_message_size,
+            Err(_) => self.record_error(TranslateError::new_with_message(
+                "agent_ipc.grpc_max_message_size",
+                "maximum message size must be greater than or equal to 0",
+            )),
+        }
     }
 
     fn consume_aggregator_stop_timeout(&mut self, value: i64) {
@@ -430,7 +431,9 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_cmd_port(&mut self, value: i64) {
-        self.config.control.ipc.cmd_port = to_port(value);
+        if let Some(port) = self.parse_port("cmd_port", value) {
+            self.config.control.ipc.cmd_port = port;
+        }
     }
 
     fn consume_cri_connection_timeout(&mut self, value: i64) {
@@ -2157,6 +2160,47 @@ mod tests {
             errors.is_some(),
             "an entry without a metric name must record a translation error"
         );
+    }
+
+    #[test]
+    fn ipc_settings_default_to_schema_values_when_unset() {
+        // The typed model derives `Default`, so a translation that silently skipped these keys would
+        // leave zeroes behind and still look healthy. Pin the schema defaults instead.
+        let (config, errors) = translate_explicit(json!({}));
+
+        assert!(errors.is_none());
+        assert_eq!(config.control.ipc.cmd_port, 5001);
+        assert_eq!(config.control.ipc.grpc_max_message_size, 128 * 1024 * 1024);
+        assert_eq!(config.control.ipc.vsock_addr, "");
+    }
+
+    #[test]
+    fn cmd_port_preserves_u16_validation() {
+        for value in [0, 5001, u16::MAX as i64] {
+            let (config, errors) = translate_explicit(json!({ "cmd_port": value }));
+
+            assert!(errors.is_none());
+            assert_eq!(config.control.ipc.cmd_port, value as u16);
+        }
+
+        for value in [-1, u16::MAX as i64 + 1] {
+            let (config, errors) = translate_explicit(json!({ "cmd_port": value }));
+
+            assert_eq!(config.control.ipc.cmd_port, 0);
+            let errors = errors.expect("an out-of-range port should record a translation error");
+            assert!(errors.to_string().contains("cmd_port"));
+        }
+    }
+
+    #[test]
+    fn negative_ipc_grpc_max_message_size_is_rejected() {
+        let (config, errors) = translate_explicit(json!({
+            "agent_ipc": { "grpc_max_message_size": -1 },
+        }));
+
+        assert_eq!(config.control.ipc.grpc_max_message_size, 0);
+        let errors = errors.expect("a negative maximum message size must record a translation error");
+        assert!(errors.to_string().contains("agent_ipc.grpc_max_message_size"));
     }
 
     #[test]

--- a/lib/agent-data-plane-config/src/control.rs
+++ b/lib/agent-data-plane-config/src/control.rs
@@ -109,17 +109,27 @@ pub struct Logging {
     pub file_max_size: u64,
 }
 
-/// Bootstrap IPC and remote-agent connection parameters, read before runtime authority exists.
+/// IPC and remote-agent connection parameters, read once at bootstrap before runtime authority
+/// exists and again from the authoritative configuration once it does.
+///
+/// The derived `Default` is all zeroes and serves only as the starting point for translation. The
+/// effective default of each field is the one the Datadog schema declares, noted per field below.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct ControlIpc {
     /// TCP port the command API listens on.
+    ///
+    /// Defaults to `5001`.
     pub cmd_port: u16,
 
     /// vsock address used for guest/host IPC.
+    ///
+    /// Defaults to empty, which reaches the Core Agent over TCP on localhost at `cmd_port`.
     pub vsock_addr: String,
 
     /// Maximum gRPC message size, in bytes, accepted over the remote-agent IPC channel.
-    pub grpc_max_message_size: i64,
+    ///
+    /// Defaults to `134217728` (128 MiB).
+    pub grpc_max_message_size: usize,
 
     /// Timeout for establishing a connection to the container runtime interface.
     pub cri_connection_timeout: i64,

--- a/lib/datadog-agent/commons/src/ipc/client/mod.rs
+++ b/lib/datadog-agent/commons/src/ipc/client/mod.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use backon::Retryable as _;
+use backon::{ConstantBuilder, Retryable as _};
 use datadog_protos::agent::v1::{
     RefreshRemoteAgentRequest, RegisterRemoteAgentRequest, RegisterRemoteAgentResponse, ReportRemoteAgentEventRequest,
     ReportRemoteAgentEventResponse,
@@ -13,7 +13,6 @@ use datadog_protos::agent::{
     StreamTagsRequest, StreamTagsResponse, TagCardinality, WorkloadmetaEventType, WorkloadmetaFilter, WorkloadmetaKind,
     WorkloadmetaSource, WorkloadmetaStreamRequest, WorkloadmetaStreamResponse,
 };
-use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use saluki_io::net::client::http::HttpsCapableConnectorBuilder;
 use tonic::{
@@ -31,6 +30,9 @@ use self::bearer_auth::BearerAuthInterceptor;
 mod streaming;
 pub use self::streaming::StreamingResponse;
 
+const CONNECT_RETRY_ATTEMPTS: usize = 10;
+const CONNECT_RETRY_BACKOFF: Duration = Duration::from_secs(2);
+
 /// A client for interacting with the Datadog Agent's internal gRPC-based API.
 #[derive(Clone)]
 pub struct RemoteAgentClient {
@@ -40,24 +42,13 @@ pub struct RemoteAgentClient {
 }
 
 impl RemoteAgentClient {
-    /// Creates a new `RemoteAgentClient` from the given configuration.
+    /// Connects to the Core Agent's gRPC IPC endpoint using the given client configuration.
     ///
     /// # Errors
     ///
-    /// If the Agent gRPC client can't be created (invalid API endpoint, missing authentication token, etc), or if the
-    /// authentication token is invalid, an error will be returned.
-    pub async fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let config = RemoteAgentClientConfiguration::from_configuration(config)?;
-        Self::from_client_configuration(&config).await
-    }
-
-    /// Creates a new `RemoteAgentClient` from the given client configuration.
-    ///
-    /// # Errors
-    ///
-    /// If the Agent gRPC client can't be created (invalid API endpoint, missing authentication token, etc), or if the
-    /// authentication token is invalid, an error will be returned.
-    pub async fn from_client_configuration(config: &RemoteAgentClientConfiguration) -> Result<Self, GenericError> {
+    /// If the connection can't be established, the authentication token or IPC certificate can't be read, or the
+    /// initial health-check RPC fails, an error will be returned. Each of these is retried first.
+    pub async fn connect(config: &RemoteAgentClientConfiguration) -> Result<Self, GenericError> {
         // TODO: We need to write a Tower middleware service that allows applying a backoff between failed calls,
         // specifically so that we can throttle reconnection attempts.
         //
@@ -69,18 +60,18 @@ impl RemoteAgentClient {
         // We could potentially just use a retry middleware, but Tonic does have its own reconnection logic, so we'd
         // have to test it out to make sure it behaves sensibly.
         let service_builder = || async {
-            let auth_interceptor = BearerAuthInterceptor::from_file(&config.auth().auth_token_file_path()).await?;
-            let ipc_cert_file_path = config.auth().ipc_cert_file_path();
+            let auth_interceptor = BearerAuthInterceptor::from_file(&config.auth.auth_token_file_path()).await?;
+            let ipc_cert_file_path = config.auth.ipc_cert_file_path();
             let client_tls_config = build_ipc_client_ipc_tls_config(ipc_cert_file_path).await?;
             let connector_builder = HttpsCapableConnectorBuilder::default();
             #[cfg(target_os = "linux")]
-            let connector_builder = if let Some(addr) = config.vsock_addr()? {
+            let connector_builder = if let Some(addr) = config.vsock_addr() {
                 connector_builder.with_vsock_addr(addr)
             } else {
                 connector_builder
             };
             let https_connector = connector_builder.build(client_tls_config)?;
-            let endpoint = config.endpoint()?;
+            let endpoint = config.endpoint();
             let channel = Endpoint::from(endpoint.clone())
                 .connect_timeout(Duration::from_secs(2))
                 .connect_with_connector(https_connector)
@@ -92,25 +83,29 @@ impl RemoteAgentClient {
             // Health check inside the retried region. A transient partition can let the TCP connect succeed but break
             // this first RPC stream, so retrying here keeps a boot-time blip from failing client construction.
             let mut secure_client =
-                AgentSecureClient::new(service.clone()).max_decoding_message_size(config.grpc_max_message_size());
+                AgentSecureClient::new(service.clone()).max_decoding_message_size(config.grpc_max_message_size);
             try_query_agent_api(&mut secure_client).await?;
 
             Ok::<_, GenericError>(service)
         };
 
         let service = service_builder
-            .retry(config)
+            .retry(
+                ConstantBuilder::default()
+                    .with_delay(CONNECT_RETRY_BACKOFF)
+                    .with_max_times(CONNECT_RETRY_ATTEMPTS),
+            )
             .notify(|e, delay| {
                 warn!(error = %e, "Failed to create Datadog Agent API client. Retrying in {:?}...", delay);
             })
             .await
             .error_context("Failed to create Datadog Agent API client.")?;
 
-        let client = AgentClient::new(service.clone()).max_decoding_message_size(config.grpc_max_message_size());
+        let client = AgentClient::new(service.clone()).max_decoding_message_size(config.grpc_max_message_size);
         let secure_client =
-            AgentSecureClient::new(service.clone()).max_decoding_message_size(config.grpc_max_message_size());
+            AgentSecureClient::new(service.clone()).max_decoding_message_size(config.grpc_max_message_size);
         let remote_agent_client =
-            RemoteAgentServiceClient::new(service).max_decoding_message_size(config.grpc_max_message_size());
+            RemoteAgentServiceClient::new(service).max_decoding_message_size(config.grpc_max_message_size);
 
         Ok(Self {
             client,

--- a/lib/datadog-agent/commons/src/ipc/config.rs
+++ b/lib/datadog-agent/commons/src/ipc/config.rs
@@ -1,55 +1,16 @@
 //! IPC configuration.
 
-use std::{path::PathBuf, time::Duration};
+use std::path::PathBuf;
 
-use backon::{BackoffBuilder, ConstantBuilder};
 use saluki_config::GenericConfiguration;
 use saluki_error::{ErrorContext as _, GenericError};
 use serde::Deserialize;
 use tonic::transport::Uri;
-#[cfg(not(target_os = "linux"))]
-use tracing::warn;
 
 use crate::platform::PlatformSettings;
 
-const DEFAULT_CMD_PORT: u16 = 5001;
-
-const fn default_cmd_port() -> u16 {
-    DEFAULT_CMD_PORT
-}
-
-const fn default_connect_retry_attempts() -> usize {
-    10
-}
-
-/// The Datadog Agent's `agent_ipc` configuration section.
-#[derive(Clone, Debug, Deserialize)]
-struct AgentIpcConfiguration {
-    /// Maximum message size for gRPC messages.
-    ///
-    /// Defaults to `128 * 1024 * 1024` (128 MB).
-    #[serde(default = "default_grpc_max_message_size")]
-    grpc_max_message_size: usize,
-}
-
-impl Default for AgentIpcConfiguration {
-    fn default() -> Self {
-        Self {
-            grpc_max_message_size: default_grpc_max_message_size(),
-        }
-    }
-}
-
-const fn default_grpc_max_message_size() -> usize {
-    128 * 1024 * 1024
-}
-
-const fn default_connect_retry_backoff() -> Duration {
-    Duration::from_secs(2)
-}
-
 /// Datadog Agent IPC bearer-token and exact shared-certificate mTLS configuration.
-#[derive(Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct IpcAuthConfiguration {
     /// Path to the Agent authentication token file.
@@ -124,141 +85,35 @@ impl Default for IpcAuthConfiguration {
 }
 
 /// Datadog Agent IPC client configuration.
-#[derive(Deserialize)]
+#[derive(Clone, Debug)]
 pub struct RemoteAgentClientConfiguration {
     /// Core Agent CMD API port used for remote-agent gRPC IPC on localhost.
-    ///
-    /// Defaults to `5001`.
-    #[serde(default = "default_cmd_port")]
-    cmd_port: u16,
+    pub cmd_port: u16,
 
     /// Authentication configuration for the IPC endpoint.
-    #[serde(flatten, default)]
-    auth: IpcAuthConfiguration,
+    pub auth: IpcAuthConfiguration,
 
-    /// Number of allowed retry attempts when initially connecting.
-    ///
-    /// Defaults to `10`.
-    #[serde(default = "default_connect_retry_attempts")]
-    connect_retry_attempts: usize,
+    /// Maximum message size for gRPC messages.
+    pub grpc_max_message_size: usize,
 
-    /// Amount of time to wait between connection attempts when initially connecting.
-    ///
-    /// Defaults to 2 seconds.
-    #[serde(default = "default_connect_retry_backoff")]
-    connect_retry_backoff: Duration,
-
-    /// The Agent's `agent_ipc` section.
-    #[serde(default)]
-    agent_ipc: AgentIpcConfiguration,
-
-    /// vsock address for connecting to the Agent IPC endpoint via AF_VSOCK.
-    ///
-    /// When set, the IPC client connects over a vsock socket using the resolved CID with the port
-    /// taken from the configured endpoint. This mirrors the Datadog Agent's `vsock_addr`
-    /// configuration, enabling communication from within a guest VM (for example, Nitro Enclaves)
-    /// to an Agent process running on the host or hypervisor.
-    ///
-    /// Accepted values:
-    /// - `host`: connect to the host (CID 2, `VMADDR_CID_HOST`)
-    /// - `hypervisor`: connect to the hypervisor (CID 0, `VMADDR_CID_HYPERVISOR`)
-    /// - `local`: connect to the local VM (CID 3, `VMADDR_CID_LOCAL`)
-    ///
-    /// Defaults to unset (TCP connection).
+    /// Resolved CID for connecting to the Agent IPC endpoint via AF_VSOCK.
     #[cfg(target_os = "linux")]
-    #[serde(default, deserialize_with = "deserialize_vsock_addr")]
-    vsock_addr: Option<u32>,
-
-    // Non-Linux: capture raw value solely to emit a warning when configured.
-    #[cfg(not(target_os = "linux"))]
-    #[serde(default)]
-    vsock_addr: String,
-}
-
-#[cfg(target_os = "linux")]
-fn deserialize_vsock_addr<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::de::Error as _;
-    match Option::<String>::deserialize(deserializer)?.as_deref() {
-        None | Some("") => Ok(None),
-        Some("host") => Ok(Some(2)),       // VMADDR_CID_HOST
-        Some("hypervisor") => Ok(Some(0)), // VMADDR_CID_HYPERVISOR
-        Some("local") => Ok(Some(3)),      // VMADDR_CID_LOCAL
-        Some(other) => Err(D::Error::custom(format!(
-            "invalid vsock address '{}'; expected one of: host, hypervisor, local",
-            other
-        ))),
-    }
+    pub vsock_cid: Option<u32>,
 }
 
 impl RemoteAgentClientConfiguration {
-    /// Creates a new `RemoteAgentClientConfiguration` from the given configuration.
-    ///
-    /// ## Errors
-    ///
-    /// If the configuration is invalid, an error is returned.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let this = config
-            .as_typed::<Self>()
-            .error_context("Failed to parse Datadog Agent IPC client configuration.")?;
-
-        #[cfg(not(target_os = "linux"))]
-        if !this.vsock_addr.is_empty() {
-            warn!("`vsock_addr` is configured but vsock is only supported on Linux. Setting will be ignored.");
-        }
-
-        Ok(this)
-    }
-
-    /// Returns a reference to the authentication configuration for the Remote Agent client.
-    pub fn auth(&self) -> &IpcAuthConfiguration {
-        &self.auth
-    }
-
     /// Returns the Core Agent CMD API gRPC endpoint URI.
-    pub fn endpoint(&self) -> Result<Uri, GenericError> {
+    pub fn endpoint(&self) -> Uri {
         format!("https://127.0.0.1:{}", self.cmd_port)
-            .parse::<Uri>()
-            .with_error_context(|| format!("failed to build URI from cmd_port {}", self.cmd_port))
-    }
-
-    /// Returns the maximum message size for gRPC.
-    pub fn grpc_max_message_size(&self) -> usize {
-        self.agent_ipc.grpc_max_message_size
+            .parse()
+            .expect("a URI built from a u16 port is valid")
     }
 
     /// Returns the vsock address to use for connecting to the IPC endpoint, if configured.
-    ///
-    /// Combines the CID from `vsock_addr` with the port resolved from `endpoint()`. Returns
-    /// an error if `vsock_addr` is set but the endpoint has no explicit port.
-    ///
-    /// # Errors
-    ///
-    /// If the configured endpoint has no explicit port.
     #[cfg(target_os = "linux")]
-    pub fn vsock_addr(&self) -> Result<Option<tokio_vsock::VsockAddr>, GenericError> {
-        let Some(cid) = self.vsock_addr else {
-            return Ok(None);
-        };
-        let port = self
-            .endpoint()?
-            .port_u16()
-            .map(u32::from)
-            .ok_or_else(|| saluki_error::generic_error!("vsock requires an explicit port in the IPC endpoint"))?;
-        Ok(Some(tokio_vsock::VsockAddr::new(cid, port)))
-    }
-}
-
-impl BackoffBuilder for &RemoteAgentClientConfiguration {
-    type Backoff = <ConstantBuilder as BackoffBuilder>::Backoff;
-
-    fn build(self) -> Self::Backoff {
-        ConstantBuilder::default()
-            .with_delay(self.connect_retry_backoff)
-            .with_max_times(self.connect_retry_attempts)
-            .build()
+    pub fn vsock_addr(&self) -> Option<tokio_vsock::VsockAddr> {
+        self.vsock_cid
+            .map(|cid| tokio_vsock::VsockAddr::new(cid, u32::from(self.cmd_port)))
     }
 }
 
@@ -268,14 +123,12 @@ mod tests {
 
     use saluki_config::ConfigurationLoader;
 
-    use super::RemoteAgentClientConfiguration;
+    use super::{IpcAuthConfiguration, RemoteAgentClientConfiguration};
     use crate::platform::PlatformSettings;
 
-    async fn get_remote_agent_config(
+    async fn get_auth_config(
         ipc_cert_file_path: Option<&Path>, auth_token_file_path: Option<&Path>,
-    ) -> RemoteAgentClientConfiguration {
-        // Set the values in the config map if provided, then defer to the shared loader helper so both
-        // entry points build the configuration the exact same way.
+    ) -> IpcAuthConfiguration {
         let mut values = serde_json::Map::new();
         if let Some(path) = ipc_cert_file_path {
             values.insert(
@@ -290,7 +143,9 @@ mod tests {
             );
         }
 
-        config_from_values(values).await
+        let (base_config, _) =
+            ConfigurationLoader::for_tests(Some(serde_json::Value::Object(values)), None, false).await;
+        IpcAuthConfiguration::from_configuration(&base_config).unwrap()
     }
 
     #[tokio::test]
@@ -299,13 +154,13 @@ mod tests {
 
         // When the auth token file path _and_ IPC cert file path are both unset, we should default to looking for the
         // IPC cert in the same directory as the auth token.
-        let config = get_remote_agent_config(None, None).await;
+        let config = get_auth_config(None, None).await;
         assert_eq!(
-            config.auth().ipc_cert_file_path().parent(),
+            config.ipc_cert_file_path().parent(),
             default_auth_token_path.as_path().parent()
         );
         assert_eq!(
-            config.auth().ipc_cert_file_path().file_name().map(Path::new),
+            config.ipc_cert_file_path().file_name().map(Path::new),
             Some(PlatformSettings::get_ipc_cert_filename())
         );
     }
@@ -316,13 +171,13 @@ mod tests {
 
         // When the IPC cert file path is not set, it should default to the same directory as the auth token file using
         // the default certificate file name.
-        let config = get_remote_agent_config(None, Some(&default_auth_token_path)).await;
+        let config = get_auth_config(None, Some(&default_auth_token_path)).await;
         assert_eq!(
-            config.auth().ipc_cert_file_path().parent(),
+            config.ipc_cert_file_path().parent(),
             default_auth_token_path.as_path().parent()
         );
         assert_eq!(
-            config.auth().ipc_cert_file_path().file_name().map(Path::new),
+            config.ipc_cert_file_path().file_name().map(Path::new),
             Some(PlatformSettings::get_ipc_cert_filename())
         );
     }
@@ -333,8 +188,8 @@ mod tests {
         let custom_ipc_cert_path = PathBuf::from("/tmp/custom_ipc_cert.pem");
 
         // When the IPC cert file path is explicitly set, it should be used.
-        let config = get_remote_agent_config(Some(&custom_ipc_cert_path), Some(&default_auth_token_path)).await;
-        assert_eq!(custom_ipc_cert_path, config.auth().ipc_cert_file_path());
+        let config = get_auth_config(Some(&custom_ipc_cert_path), Some(&default_auth_token_path)).await;
+        assert_eq!(custom_ipc_cert_path, config.ipc_cert_file_path());
     }
 
     #[tokio::test]
@@ -343,13 +198,13 @@ mod tests {
 
         // When the IPC cert file path is not set, but there's a custom auth token path (explicitly set, different from the default),
         // we should still look in the same directory as the auth token file using the default certificate file name.
-        let config = get_remote_agent_config(None, Some(&custom_auth_token_path)).await;
+        let config = get_auth_config(None, Some(&custom_auth_token_path)).await;
         assert_eq!(
-            config.auth().ipc_cert_file_path().parent(),
+            config.ipc_cert_file_path().parent(),
             custom_auth_token_path.as_path().parent()
         );
         assert_eq!(
-            config.auth().ipc_cert_file_path().file_name().map(Path::new),
+            config.ipc_cert_file_path().file_name().map(Path::new),
             Some(PlatformSettings::get_ipc_cert_filename())
         );
     }
@@ -360,74 +215,43 @@ mod tests {
 
         // If the auth token file path is somehow unset or invalid (for example, no parent directory), we should use the same
         // logic but with the default Datadog Agent configuration directory.
-        let config = get_remote_agent_config(None, Some(&invalid_auth_token_path)).await;
+        let config = get_auth_config(None, Some(&invalid_auth_token_path)).await;
         assert_eq!(
-            config.auth().ipc_cert_file_path().parent(),
+            config.ipc_cert_file_path().parent(),
             Some(PlatformSettings::get_config_dir_path())
         );
         assert_eq!(
-            config.auth().ipc_cert_file_path().file_name().map(Path::new),
+            config.ipc_cert_file_path().file_name().map(Path::new),
             Some(PlatformSettings::get_ipc_cert_filename())
         );
     }
 
-    async fn config_from_values(values: serde_json::Map<String, serde_json::Value>) -> RemoteAgentClientConfiguration {
-        let (base_config, _) =
-            ConfigurationLoader::for_tests(Some(serde_json::Value::Object(values)), None, false).await;
-        RemoteAgentClientConfiguration::from_configuration(&base_config).unwrap()
+    fn remote_agent_config(cmd_port: u16) -> RemoteAgentClientConfiguration {
+        RemoteAgentClientConfiguration {
+            cmd_port,
+            auth: IpcAuthConfiguration::default(),
+            grpc_max_message_size: 128 * 1024 * 1024,
+            #[cfg(target_os = "linux")]
+            vsock_cid: None,
+        }
     }
 
-    #[tokio::test]
-    async fn endpoint_defaults_to_port_5001() {
-        let config = config_from_values(serde_json::Map::new()).await;
-        assert_eq!(config.endpoint().unwrap().to_string(), "https://127.0.0.1:5001/");
-    }
-
-    #[tokio::test]
-    async fn endpoint_uses_cmd_port() {
-        let mut values = serde_json::Map::new();
-        values.insert("cmd_port".to_string(), 7777.into());
-        let config = config_from_values(values).await;
-        assert_eq!(config.endpoint().unwrap().to_string(), "https://127.0.0.1:7777/");
-    }
-
-    #[cfg(target_os = "linux")]
-    #[tokio::test]
-    async fn vsock_addr_valid_values() {
-        // (vsock_addr input, expected CID — port always comes from cmd_port=5001)
-        let cases: &[(&str, Option<u32>)] = &[
-            ("", None),
-            ("host", Some(2)),
-            ("hypervisor", Some(0)),
-            ("local", Some(3)),
-        ];
-
-        for (input, expected_cid) in cases {
-            let mut values = serde_json::Map::new();
-            values.insert("vsock_addr".to_string(), (*input).into());
-            values.insert("cmd_port".to_string(), 5001u16.into());
-            let config = config_from_values(values).await;
-            let result = config
-                .vsock_addr()
-                .expect("vsock_addr() should not error with cmd_port set");
-            assert_eq!(result.map(|a| a.cid()), *expected_cid, "input: {input:?}");
+    #[test]
+    fn endpoint_uses_cmd_port() {
+        for (cmd_port, expected) in [(5001, "https://127.0.0.1:5001/"), (7777, "https://127.0.0.1:7777/")] {
+            assert_eq!(remote_agent_config(cmd_port).endpoint().to_string(), expected);
         }
     }
 
     #[cfg(target_os = "linux")]
-    #[tokio::test]
-    async fn vsock_addr_invalid_values() {
-        let cases = &["invalid", "2", "HOST", "host ", "vm0"];
+    #[test]
+    fn vsock_addr_uses_resolved_cid_and_cmd_port() {
+        let mut config = remote_agent_config(5001);
+        assert_eq!(config.vsock_addr(), None);
 
-        for input in cases {
-            let mut values = serde_json::Map::new();
-            values.insert("vsock_addr".to_string(), (*input).into());
-            let (base_config, _) =
-                ConfigurationLoader::for_tests(Some(serde_json::Value::Object(values)), None, false).await;
-            assert!(
-                RemoteAgentClientConfiguration::from_configuration(&base_config).is_err(),
-                "expected error for input: {input:?}",
-            );
-        }
+        config.vsock_cid = Some(2);
+        let addr = config.vsock_addr().expect("vsock address should be configured");
+        assert_eq!(addr.cid(), 2);
+        assert_eq!(addr.port(), 5001);
     }
 }

--- a/lib/datadog-agent/config-overlay-model/src/smoke_test_support.rs
+++ b/lib/datadog-agent/config-overlay-model/src/smoke_test_support.rs
@@ -17,7 +17,6 @@ pub enum ConfigurationStruct {
     DogStatsDDebugLogConfiguration,
     DogStatsDMapperConfiguration,
     DogStatsDPrefixFilterConfiguration,
-    RemoteAgentClientConfiguration,
 
     /// Keys consumed through the typed configuration translation system.
     TypedConfigSystem,
@@ -48,7 +47,6 @@ impl ConfigurationStruct {
             ConfigurationStruct::DogStatsDDebugLogConfiguration => "DOGSTATSD_DEBUG_LOG_CONFIGURATION",
             ConfigurationStruct::DogStatsDMapperConfiguration => "DOGSTATSD_MAPPER_CONFIGURATION",
             ConfigurationStruct::DogStatsDPrefixFilterConfiguration => "DOGSTATSD_PREFIX_FILTER_CONFIGURATION",
-            ConfigurationStruct::RemoteAgentClientConfiguration => "REMOTE_AGENT_CLIENT_CONFIGURATION",
             ConfigurationStruct::TypedConfigSystem => "TYPED_CONFIG_SYSTEM",
             ConfigurationStruct::GetTyped => "GET_TYPED",
             ConfigurationStruct::NoSmoke => "NO_SMOKE",

--- a/lib/datadog-agent/config-testing/src/config_registry/data_plane.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/data_plane.rs
@@ -37,6 +37,17 @@ static DATA_PLANE_STOP_TIMEOUT_SCHEMA: SchemaEntry = SchemaEntry {
 };
 
 crate::declare_annotations! {
+    /// `agent_ipc.grpc_max_message_size`-Max inbound gRPC message size for IPC client
+    AGENT_IPC_GRPC_MAX_MESSAGE_SIZE = SalukiAnnotation {
+        schema: &schema::AGENT_IPC_GRPC_MAX_MESSAGE_SIZE,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: Some("4194304"),
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
     /// `basic_telemetry_add_container_tags`-Add container tags to basic telemetry signals
     BASIC_TELEMETRY_ADD_CONTAINER_TAGS = SalukiAnnotation {
         schema: &schema::BASIC_TELEMETRY_ADD_CONTAINER_TAGS,
@@ -46,6 +57,17 @@ crate::declare_annotations! {
         used_by: &[structs::TYPED_CONFIG_SYSTEM],
         value_type_override: None,
         test_json: Some("true"),
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
+    /// `cmd_port`-Core Agent CMD API port for ADP gRPC IPC
+    CMD_PORT = SalukiAnnotation {
+        schema: &schema::CMD_PORT,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: Some("5101"),
         pipeline_affinity: PipelineAffinity::CrossCutting,
     };
     /// `data_plane.api_listen_address`-Unprivileged API listen address
@@ -178,6 +200,17 @@ crate::declare_annotations! {
         used_by: &[structs::GET_TYPED],
         value_type_override: None,
         test_json: None,
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
+    /// `vsock_addr`-vsock address for Agent IPC endpoint
+    VSOCK_ADDR = SalukiAnnotation {
+        schema: &schema::VSOCK_ADDR,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: Some(r#""host""#),
         pipeline_affinity: PipelineAffinity::CrossCutting,
     };
 }

--- a/lib/datadog-agent/config-testing/src/config_registry/get_typed.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/get_typed.rs
@@ -16,28 +16,6 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::CrossCutting,
     };
-    /// `vsock_addr`-vsock address for Agent IPC endpoint
-    VSOCK_ADDR = SalukiAnnotation {
-        schema: &schema::VSOCK_ADDR,
-        support_level: SupportLevel::Full,
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[structs::REMOTE_AGENT_CLIENT_CONFIGURATION],
-        value_type_override: None,
-        test_json: Some(r#""host""#),
-        pipeline_affinity: PipelineAffinity::CrossCutting,
-    };
-    /// `cmd_port`-Core Agent CMD API port for ADP gRPC IPC
-    CMD_PORT = SalukiAnnotation {
-        schema: &schema::CMD_PORT,
-        support_level: SupportLevel::Full,
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[structs::REMOTE_AGENT_CLIENT_CONFIGURATION],
-        value_type_override: None,
-        test_json: Some("5101"),
-        pipeline_affinity: PipelineAffinity::CrossCutting,
-    };
     /// `log_format_rfc3339`-Use RFC 3339 timestamps in log output
     LOG_FORMAT_RFC3339 = SalukiAnnotation {
         schema: &schema::LOG_FORMAT_RFC3339,
@@ -80,17 +58,6 @@ crate::declare_annotations! {
         used_by: &[structs::GET_TYPED],
         value_type_override: Some(ValueType::Integer),
         test_json: None,
-        pipeline_affinity: PipelineAffinity::CrossCutting,
-    };
-    /// `agent_ipc.grpc_max_message_size`-Max inbound gRPC message size for IPC client
-    AGENT_IPC_GRPC_MAX_MESSAGE_SIZE = SalukiAnnotation {
-        schema: &schema::AGENT_IPC_GRPC_MAX_MESSAGE_SIZE,
-        support_level: SupportLevel::Full,
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[structs::REMOTE_AGENT_CLIENT_CONFIGURATION],
-        value_type_override: None,
-        test_json: Some("4194304"),
         pipeline_affinity: PipelineAffinity::CrossCutting,
     };
     /// `autoscaling.failover.enabled`-Enable autoscaling failover metric routing

--- a/lib/datadog-agent/config-testing/src/config_registry/shared.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/shared.rs
@@ -27,6 +27,17 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Otlp]),
     };
+    /// `expected_tags_duration`-How long startup host tags are attached
+    EXPECTED_TAGS_DURATION = SalukiAnnotation {
+        schema: &schema::EXPECTED_TAGS_DURATION,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
     /// `kubernetes_kubelet_nodename`-Kubernetes node name for EKS Fargate static tags
     KUBERNETES_KUBELET_NODENAME = SalukiAnnotation {
         schema: &schema::KUBERNETES_KUBELET_NODENAME,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -60,10 +60,10 @@ inventory:
     pipelines: [cross_cutting]
     description: "Max inbound gRPC message size for IPC client"
     test_support:
-      used_by: [RemoteAgentClientConfiguration]
+      used_by: [TypedConfigSystem]
       test_json: "4194304"
       additional_attributes:
-        config_registry_filename: get_typed.rs
+        config_registry_filename: data_plane.rs
 
   aggregator_buffer_size:
     support: none
@@ -539,10 +539,10 @@ inventory:
     pipelines: [cross_cutting]
     description: "Core Agent CMD API port for ADP gRPC IPC"
     test_support:
-      used_by: [RemoteAgentClientConfiguration]
+      used_by: [TypedConfigSystem]
       test_json: "5101"
       additional_attributes:
-        config_registry_filename: get_typed.rs
+        config_registry_filename: data_plane.rs
 
   config_id:
     support: none
@@ -1403,7 +1403,9 @@ inventory:
     pipelines: [cross_cutting]
     description: "How long startup host tags are attached"
     test_support:
-      used_by: [NO_SMOKE]
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: shared.rs
 
   extra_tags:
     support: full
@@ -3203,10 +3205,10 @@ inventory:
     pipelines: [cross_cutting]
     description: "vsock address for Agent IPC endpoint"
     test_support:
-      used_by: [RemoteAgentClientConfiguration]
+      used_by: [TypedConfigSystem]
       test_json: '"host"'
       additional_attributes:
-        config_registry_filename: get_typed.rs
+        config_registry_filename: data_plane.rs
 
 excluded:
   GUI_host: "ignored in initial audit 2026-04-23"

--- a/lib/datadog-agent/config/src/classifier/mod.rs
+++ b/lib/datadog-agent/config/src/classifier/mod.rs
@@ -52,8 +52,6 @@ pub mod structs {
     pub const DATADOG_EVENTS_CONFIGURATION: &str = "DatadogEventsConfiguration";
     /// Identifier for `DatadogServiceChecksConfiguration`.
     pub const DATADOG_SERVICE_CHECKS_CONFIGURATION: &str = "DatadogServiceChecksConfiguration";
-    /// Identifier for `RemoteAgentClientConfiguration`.
-    pub const REMOTE_AGENT_CLIENT_CONFIGURATION: &str = "RemoteAgentClientConfiguration";
     /// Keys consumed through the typed configuration translation system.
     pub const TYPED_CONFIG_SYSTEM: &str = "TypedConfigSystem";
     /// Keys read via `get_typed` / `try_get_typed` rather than struct deserialization.


### PR DESCRIPTION
## Human Summary

Migrates the `RemoteAgentClientConfiguration` struct to typed config. Slightly new case in that it exists in `datadog-agent/commons` rather than `saluki-components` or ADP. It was easy to avoid taking a new dependency the same way we have been in `saluki-components`: by make the fields pub and populating them at the construction site.

Note, the next PR, #2488, migrates `IpcAuthConfiguration` which fully removes the raw map from `RemoteAgentClient` construction.

## AI Summary

- Build remote Agent clients from typed command port, message size, and vsock settings.
- Validate IPC values at the configuration boundary and share one resolved client configuration across bootstrap, environment providers, and host tags.
- Mark the migrated IPC inventory keys as typed configuration consumers.
- Rename the client constructor to `RemoteAgentClient::connect`, and rename the wrappers that now take a typed client configuration to `new`. Only the builders that still read the raw map keep the `from_configuration` name.

### Vsock behavior

The transport behavior is unchanged. Vsock remains Linux-only: `host`, `hypervisor`, and `local` resolve to CIDs 2, 0, and 3, respectively, while an empty value uses TCP. On non-Linux platforms, a configured value is ignored with a warning. This PR moves CID resolution making that unchanged behavior harder to see in the diff.

## Behavior Notes

Validation is intentionally stricter here. Previously the translator narrowed an out-of-range `cmd_port` into the `u16` range with a `clamp(0, u16::MAX)` helper. That helper is deleted, and `cmd_port` now goes through the shared `parse_port` helper, which records a translation error. A negative `agent_ipc.grpc_max_message_size` is rejected the same way. Startup translation is a strict gate, so a recorded translation error fails the load and the process does not boot.

In connected mode this is the behavior we want: an out-of-range command port cannot produce a working IPC connection to the Core Agent, so failing at startup is better than silently connecting to a narrowed port. In standalone mode ADP does not open an IPC connection at all, so the gate is stricter there than that path strictly requires. We are accepting that: a command port outside the valid range is a configuration error worth surfacing in either mode. This also matches the precedent already set for the other migrated ports, where out-of-range DogStatsD ports are rejected rather than narrowed.

`connect_retry_attempts` and `connect_retry_backoff` are removed as configurable fields. Their former defaults, ten attempts and a two-second delay, are retained exactly as constants, so runtime behavior is unchanged. On the base branch both keys existed only as serde fields on the Rust struct. Neither appears in the vendored Datadog schema, the support inventory, the Saluki-only key list, or the generated configuration documentation. Nothing in the repository sets either key. `connect_retry_backoff` was not realistically settable in any case, since it deserialized as a `std::time::Duration`, whose serde representation requires a `{secs, nanos}` map rather than a duration string or a plain number. This was an owner decision to remove unused configurability rather than promote the two keys into the the support inventory.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make fmt`
- `cargo check --workspace --tests`
- `make check-all`
- Targeted `cargo nextest` tests for IPC configuration, translation, and host tags
- Added a translator test pinning the effective IPC defaults (`cmd_port` 5001, `agent_ipc.grpc_max_message_size` 128 MiB, `vsock_addr` unset) so a translation that skipped these keys could not pass by leaving the model's derived zero values in place

## References

- Progresses: #2293
- Related: #2197
