### PR TITLE
chore(config): migrate autoscaling failover to typed config

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -595,8 +595,10 @@ fn add_mrf_metrics_pipeline_to_blueprint(
 fn add_autoscaling_failover_metrics_pipeline_to_blueprint(
     blueprint: &mut TopologyBlueprint, config: &GenericConfiguration, shared: &SharedConfiguration,
 ) -> Result<(), GenericError> {
-    let af_config = AutoscalingFailoverConfiguration::from_configuration(config)
-        .error_context("Failed to configure autoscaling failover metrics pipeline.")?;
+    let af_config = AutoscalingFailoverConfiguration::new(
+        shared.autoscaling_failover.enabled,
+        shared.autoscaling_failover.metrics.clone(),
+    );
     let ca_config = ClusterAgentConfiguration::from_configuration(config)
         .error_context("Failed to configure Cluster Agent metrics forwarding.")?;
 

--- a/lib/agent-data-plane-config-system/src/system.rs
+++ b/lib/agent-data-plane-config-system/src/system.rs
@@ -526,6 +526,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unset_autoscaling_failover_keeps_its_schema_defaults() {
+        // Nothing is set here, so both fields must come back as the schema defaults; the component
+        // layer no longer supplies fallbacks of its own.
+        let system = standalone_system(Some(json!({})), None).await.expect("system builds");
+        let config = system.config();
+
+        assert!(!config.shared.autoscaling_failover.enabled);
+        assert_eq!(
+            config.shared.autoscaling_failover.metrics,
+            vec!["container.memory.usage".to_string(), "container.cpu.usage".to_string()]
+        );
+    }
+
+    #[tokio::test]
     async fn nested_saluki_only_key_seeds_the_model() {
         let system = standalone_system(Some(json!({ "data_plane": { "standalone_mode": true } })), None)
             .await

--- a/lib/agent-data-plane-config/src/shared.rs
+++ b/lib/agent-data-plane-config/src/shared.rs
@@ -539,10 +539,17 @@ pub struct ClusterAgent {
 /// Autoscaling failover, shared by checks, DogStatsD, and OTLP.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct AutoscalingFailover {
-    /// Whether autoscaling metrics failover is active.
+    /// Whether metrics designated for autoscaling failover are forwarded to the Cluster Agent.
+    ///
+    /// Defaults to `false`. Also needs `cluster_agent.enabled`, `cluster_agent.auth_token`, a resolvable Cluster Agent
+    /// endpoint, and a non-empty `metrics`; otherwise the branch is not built and primary forwarding continues.
     pub enabled: bool,
 
-    /// Metrics designated for failover.
+    /// Names of the metrics designated for autoscaling failover.
+    ///
+    /// Defaults to `container.memory.usage` and `container.cpu.usage`. An empty list turns the failover branch off even
+    /// when `enabled` is set, because there is nothing left to forward. Set this when autoscaling reads metrics other
+    /// than the two defaults.
     pub metrics: Vec<String>,
 }
 

--- a/lib/datadog-agent/config-testing/src/config_registry/get_typed.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/get_typed.rs
@@ -60,28 +60,6 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::CrossCutting,
     };
-    /// `autoscaling.failover.enabled`-Enable autoscaling failover metric routing
-    AUTOSCALING_FAILOVER_ENABLED = SalukiAnnotation {
-        schema: &schema::AUTOSCALING_FAILOVER_ENABLED,
-        support_level: SupportLevel::Full,
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[structs::GET_TYPED],
-        value_type_override: None,
-        test_json: Some("true"),
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD, Pipeline::Otlp]),
-    };
-    /// `autoscaling.failover.metrics`-Metric names forwarded to DCA for failover
-    AUTOSCALING_FAILOVER_METRICS = SalukiAnnotation {
-        schema: &schema::AUTOSCALING_FAILOVER_METRICS,
-        support_level: SupportLevel::Full,
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[structs::GET_TYPED],
-        value_type_override: None,
-        test_json: Some(r#"["container.memory.usage"]"#),
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD, Pipeline::Otlp]),
-    };
     /// `cluster_agent.auth_token`-Bearer token for Cluster Agent requests
     CLUSTER_AGENT_AUTH_TOKEN = SalukiAnnotation {
         schema: &schema::CLUSTER_AGENT_AUTH_TOKEN,

--- a/lib/datadog-agent/config-testing/src/config_registry/shared.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/shared.rs
@@ -5,6 +5,28 @@ use super::schema;
 use super::*;
 
 crate::declare_annotations! {
+    /// `autoscaling.failover.enabled`-Enable autoscaling failover metric routing
+    AUTOSCALING_FAILOVER_ENABLED = SalukiAnnotation {
+        schema: &schema::AUTOSCALING_FAILOVER_ENABLED,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: Some("true"),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD, Pipeline::Otlp]),
+    };
+    /// `autoscaling.failover.metrics`-Metric names forwarded to DCA for failover
+    AUTOSCALING_FAILOVER_METRICS = SalukiAnnotation {
+        schema: &schema::AUTOSCALING_FAILOVER_METRICS,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: Some(r#"["container.memory.usage"]"#),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD, Pipeline::Otlp]),
+    };
     /// `cluster_name`-EKS Fargate cluster name static tag
     CLUSTER_NAME = SalukiAnnotation {
         schema: &schema::CLUSTER_NAME,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -460,20 +460,20 @@ inventory:
     pipelines: [checks, dogstatsd, otlp]
     description: "Enable autoscaling failover metric routing"
     test_support:
-      used_by: [get_typed]
+      used_by: [TypedConfigSystem]
       test_json: "true"
       additional_attributes:
-        config_registry_filename: get_typed.rs
+        config_registry_filename: shared.rs
 
   autoscaling.failover.metrics:
     support: full
     pipelines: [checks, dogstatsd, otlp]
     description: "Metric names forwarded to DCA for failover"
     test_support:
-      used_by: [get_typed]
+      used_by: [TypedConfigSystem]
       test_json: '["container.memory.usage"]'
       additional_attributes:
-        config_registry_filename: get_typed.rs
+        config_registry_filename: shared.rs
 
   basic_telemetry_add_container_tags:
     support: full

--- a/lib/saluki-components/src/config/autoscaling_failover.rs
+++ b/lib/saluki-components/src/config/autoscaling_failover.rs
@@ -1,12 +1,5 @@
 //! Autoscaling failover configuration.
 
-use saluki_config::GenericConfiguration;
-use saluki_error::GenericError;
-
-fn default_metrics() -> Vec<String> {
-    vec!["container.memory.usage".to_string(), "container.cpu.usage".to_string()]
-}
-
 /// Autoscaling failover configuration for the metrics pipeline.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AutoscalingFailoverConfiguration {
@@ -15,14 +8,13 @@ pub struct AutoscalingFailoverConfiguration {
 }
 
 impl AutoscalingFailoverConfiguration {
-    /// Creates a new `AutoscalingFailoverConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        Ok(Self {
-            enabled: config.try_get_typed("autoscaling.failover.enabled")?.unwrap_or(false),
-            metrics: config
-                .try_get_typed("autoscaling.failover.metrics")?
-                .unwrap_or_else(default_metrics),
-        })
+    /// Creates a new `AutoscalingFailoverConfiguration`.
+    ///
+    /// `enabled` is whether autoscaling failover is requested (`is_branch_requested` also requires a non-empty
+    /// `metrics`), and `metrics` is the allowlist of metric names eligible for the failover branch. Both values arrive
+    /// already resolved: the configuration layer owns their defaults, so this constructor applies none of its own.
+    pub fn new(enabled: bool, metrics: Vec<String>) -> Self {
+        Self { enabled, metrics }
     }
 
     /// Returns whether the autoscaling failover branch is requested by configuration.
@@ -38,54 +30,27 @@ impl AutoscalingFailoverConfiguration {
 
 #[cfg(test)]
 mod tests {
-    use saluki_config::config_from;
-    use serde_json::json;
-
     use super::*;
 
-    async fn autoscaling_config_from(value: serde_json::Value) -> AutoscalingFailoverConfiguration {
-        AutoscalingFailoverConfiguration::from_configuration(&config_from(value).await)
-            .expect("autoscaling failover configuration should deserialize")
-    }
-
-    #[tokio::test]
-    async fn defaults_to_disabled_with_default_metric_allowlist() {
-        let config = autoscaling_config_from(json!({})).await;
+    #[test]
+    fn branch_is_not_requested_when_disabled() {
+        let config = AutoscalingFailoverConfiguration::new(false, vec!["custom.metric".to_string()]);
 
         assert!(!config.is_branch_requested());
-        assert_eq!(
-            config.metrics(),
-            ["container.memory.usage".to_string(), "container.cpu.usage".to_string()]
-        );
+        assert_eq!(config.metrics(), ["custom.metric".to_string()]);
     }
 
-    #[tokio::test]
-    async fn branch_is_requested_when_enabled_with_non_empty_metrics() {
-        let config = autoscaling_config_from(json!({
-            "autoscaling": {
-                "failover": {
-                    "enabled": true,
-                    "metrics": ["custom.metric"]
-                }
-            }
-        }))
-        .await;
+    #[test]
+    fn branch_is_requested_when_enabled_with_non_empty_metrics() {
+        let config = AutoscalingFailoverConfiguration::new(true, vec!["custom.metric".to_string()]);
 
         assert!(config.is_branch_requested());
         assert_eq!(config.metrics(), ["custom.metric".to_string()]);
     }
 
-    #[tokio::test]
-    async fn empty_metric_allowlist_disables_branch() {
-        let config = autoscaling_config_from(json!({
-            "autoscaling": {
-                "failover": {
-                    "enabled": true,
-                    "metrics": []
-                }
-            }
-        }))
-        .await;
+    #[test]
+    fn empty_metric_allowlist_disables_branch() {
+        let config = AutoscalingFailoverConfiguration::new(true, Vec::new());
 
         assert!(!config.is_branch_requested());
         assert!(config.metrics().is_empty());

--- a/lib/saluki-components/src/transforms/autoscaling_failover_gateway/mod.rs
+++ b/lib/saluki-components/src/transforms/autoscaling_failover_gateway/mod.rs
@@ -169,60 +169,35 @@ impl Transform for AutoscalingFailoverGateway {
 mod tests {
     use std::time::Duration;
 
-    use saluki_config::ConfigurationLoader;
     use saluki_core::data_model::event::{metric::Metric, Event};
-    use serde_json::json;
 
     use super::*;
 
-    async fn gateway_from_config(value: serde_json::Value) -> AutoscalingFailoverGateway {
-        let (config, _) = ConfigurationLoader::for_tests(Some(value), None, false).await;
-        let failover_config = AutoscalingFailoverConfiguration::from_configuration(&config)
-            .expect("autoscaling failover configuration should deserialize");
-        AutoscalingFailoverGateway::new(failover_config)
+    fn gateway_from_config(enabled: bool, metrics: &[&str]) -> AutoscalingFailoverGateway {
+        let metrics = metrics.iter().map(|name| (*name).to_string()).collect();
+        AutoscalingFailoverGateway::new(AutoscalingFailoverConfiguration::new(enabled, metrics))
     }
 
-    #[tokio::test]
-    async fn inactive_gateway_drops_everything() {
-        let gw = gateway_from_config(json!({
-            "autoscaling": {
-                "failover": {
-                    "enabled": false,
-                    "metrics": ["allowed.metric"]
-                }
-            }
-        }))
-        .await;
+    #[test]
+    fn inactive_gateway_drops_everything() {
+        let gw = gateway_from_config(false, &["allowed.metric"]);
 
         assert!(!gw.should_forward(&Event::Metric(Metric::counter("allowed.metric", 1.0))));
     }
 
-    #[tokio::test]
-    async fn empty_metric_allowlist_drops_everything() {
-        let gw = gateway_from_config(json!({
-            "autoscaling": {
-                "failover": {
-                    "enabled": true,
-                    "metrics": []
-                }
-            }
-        }))
-        .await;
+    #[test]
+    fn empty_metric_allowlist_drops_everything() {
+        let gw = gateway_from_config(true, &[]);
 
         assert!(!gw.should_forward(&Event::Metric(Metric::counter("allowed.metric", 1.0))));
     }
 
-    #[tokio::test]
-    async fn active_gateway_forwards_only_allowed_series_metrics() {
-        let gw = gateway_from_config(json!({
-            "autoscaling": {
-                "failover": {
-                    "enabled": true,
-                    "metrics": ["allowed.counter", "allowed.gauge", "allowed.rate", "allowed.set"]
-                }
-            }
-        }))
-        .await;
+    #[test]
+    fn active_gateway_forwards_only_allowed_series_metrics() {
+        let gw = gateway_from_config(
+            true,
+            &["allowed.counter", "allowed.gauge", "allowed.rate", "allowed.set"],
+        );
 
         assert!(gw.should_forward(&Event::Metric(Metric::counter("allowed.counter", 1.0))));
         assert!(gw.should_forward(&Event::Metric(Metric::gauge("allowed.gauge", 1.0))));
@@ -235,17 +210,9 @@ mod tests {
         assert!(!gw.should_forward(&Event::Metric(Metric::counter("blocked.counter", 1.0))));
     }
 
-    #[tokio::test]
-    async fn active_gateway_drops_sketch_metrics_even_when_allowed() {
-        let gw = gateway_from_config(json!({
-            "autoscaling": {
-                "failover": {
-                    "enabled": true,
-                    "metrics": ["allowed.histogram", "allowed.distribution"]
-                }
-            }
-        }))
-        .await;
+    #[test]
+    fn active_gateway_drops_sketch_metrics_even_when_allowed() {
+        let gw = gateway_from_config(true, &["allowed.histogram", "allowed.distribution"]);
 
         assert!(!gw.should_forward(&Event::Metric(Metric::histogram("allowed.histogram", [1.0, 2.0, 3.0]))));
         assert!(!gw.should_forward(&Event::Metric(Metric::distribution(


### PR DESCRIPTION
## Summary

Migrate `AutoscalingFailoverConfiguration` off the raw configuration map.

- Build it from the typed `shared.autoscaling_failover` slice in `run.rs`.
- Keep the effective default allowlist: the Datadog schema default for
  `autoscaling.failover.metrics` is the same list the component carried.
- Document the defaults and the empty-list behavior on the shared model fields.
- Add a translation test that pins both schema defaults.

### Behavioral Notes

Input validation for `autoscaling.failover.metrics` is relaxed. The component
used to read the key off the raw configuration map, where a string value failed
to deserialize as a sequence and aborted startup. The typed leaf instead splits
a string on whitespace, so `autoscaling.failover.metrics: "container.cpu.usage"`
is now accepted as a one-element allowlist rather than being a boot failure.

This is deliberate: it matches what the Datadog Agent accepts, and it is the
only form an environment variable can carry, so `DD_AUTOSCALING_FAILOVER_METRICS`
seemingly did not previously work. The string form is already pinned by an
existing test in the typed configuration layer.

The effective defaults do not change: `enabled` is `false` and the allowlist is
`container.memory.usage` and `container.cpu.usage`, before and after.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make build-schema-overlay`
- `make fmt`
- `make check-docs`
- `make check-clippy`
- `cargo nextest run` for the autoscaling failover config, the gateway transform,
  and the config system

## References

- Progresses: #2293
