### PR TITLE
chore(config): migrate cluster agent forwarding to typed config

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -542,7 +542,7 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
         shared,
         &config.domains.multi_region_failover,
     )?;
-    add_autoscaling_failover_metrics_pipeline_to_blueprint(blueprint, &config_system.raw_map(), shared)?;
+    add_autoscaling_failover_metrics_pipeline_to_blueprint(blueprint, shared)?;
 
     Ok(())
 }
@@ -593,14 +593,19 @@ fn add_mrf_metrics_pipeline_to_blueprint(
 }
 
 fn add_autoscaling_failover_metrics_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration, shared: &SharedConfiguration,
+    blueprint: &mut TopologyBlueprint, shared: &SharedConfiguration,
 ) -> Result<(), GenericError> {
     let af_config = AutoscalingFailoverConfiguration::new(
         shared.autoscaling_failover.enabled,
         shared.autoscaling_failover.metrics.clone(),
     );
-    let ca_config = ClusterAgentConfiguration::from_configuration(config)
-        .error_context("Failed to configure Cluster Agent metrics forwarding.")?;
+    let cluster_agent = &shared.cluster_agent;
+    let ca_config = ClusterAgentConfiguration {
+        enabled: cluster_agent.enabled,
+        url: cluster_agent.url.clone(),
+        auth_token: cluster_agent.auth_token.clone(),
+        kubernetes_service_name: cluster_agent.kubernetes_service_name.clone(),
+    };
 
     let Some((ca_url, ca_token)) = ca_config.endpoint_and_token() else {
         if af_config.is_branch_requested() {

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -796,7 +796,7 @@ Both commands scrub recognized secret values before writing JSON to standard out
 | `bind_host`                                                                                | Global listen host fallback                        |
 | `cluster_agent.auth_token`                                                                 | Bearer token for Cluster Agent requests            |
 | `cluster_agent.enabled`                                                                    | Enable Cluster Agent communication                 |
-| `cluster_agent.kubernetes_service_name`                                                    | Cluster Agent Kubernetes service name              |
+| `cluster_agent.kubernetes_service_name`                                                    | Cluster Agent service name; blank skips lookup     |
 | `cluster_agent.url`                                                                        | Cluster Agent HTTPS endpoint                       |
 | `cluster_name`                                                                             | EKS Fargate cluster name static tag                |
 | `cmd_port`                                                                                 | Core Agent CMD API port for ADP gRPC IPC           |

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -796,7 +796,7 @@ Both commands scrub recognized secret values before writing JSON to standard out
 | `bind_host`                                                                                | Global listen host fallback                        |
 | `cluster_agent.auth_token`                                                                 | Bearer token for Cluster Agent requests            |
 | `cluster_agent.enabled`                                                                    | Enable Cluster Agent communication                 |
-| `cluster_agent.kubernetes_service_name`                                                    | Cluster Agent service name; blank skips lookup     |
+| `cluster_agent.kubernetes_service_name`                                                    | Cluster Agent Kubernetes service name              |
 | `cluster_agent.url`                                                                        | Cluster Agent HTTPS endpoint                       |
 | `cluster_name`                                                                             | EKS Fargate cluster name static tag                |
 | `cmd_port`                                                                                 | Core Agent CMD API port for ADP gRPC IPC           |

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -415,7 +415,7 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_cluster_agent_auth_token(&mut self, value: String) {
-        self.config.shared.cluster_agent.auth_token = non_empty(value);
+        self.config.shared.cluster_agent.auth_token = non_empty_trimmed(value);
     }
 
     fn consume_cluster_agent_enabled(&mut self, value: bool) {
@@ -423,11 +423,13 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_cluster_agent_kubernetes_service_name(&mut self, value: String) {
-        self.config.shared.cluster_agent.kubernetes_service_name = non_empty(value);
+        // An empty name is meaningful here: it turns Kubernetes service discovery off, so the value is trimmed but
+        // kept rather than collapsed into the schema default.
+        self.config.shared.cluster_agent.kubernetes_service_name = value.trim().to_string();
     }
 
     fn consume_cluster_agent_url(&mut self, value: String) {
-        self.config.shared.cluster_agent.url = non_empty(value);
+        self.config.shared.cluster_agent.url = non_empty_trimmed(value);
     }
 
     fn consume_cluster_name(&mut self, value: String) {
@@ -2037,6 +2039,59 @@ mod tests {
         assert_eq!(None, mrf.site);
         assert_eq!(None, mrf.dd_url);
         assert_eq!(None, mrf.metrics_endpoint_url());
+    }
+
+    #[test]
+    fn cluster_agent_settings_default_to_schema_values_when_unset() {
+        let (config, errors) = translate_explicit(json!({}));
+
+        assert!(errors.is_none());
+        let cluster_agent = &config.shared.cluster_agent;
+        assert!(!cluster_agent.enabled);
+        assert_eq!(None, cluster_agent.url);
+        assert_eq!(None, cluster_agent.auth_token);
+        assert_eq!("datadog-cluster-agent", cluster_agent.kubernetes_service_name);
+    }
+
+    #[test]
+    fn padded_cluster_agent_settings_are_trimmed() {
+        // Whitespace around the endpoint would travel into the request URL, and whitespace around the
+        // token would be sent as part of the credential.
+        let (config, errors) = translate_explicit(json!({
+            "cluster_agent": {
+                "enabled": true,
+                "url": " https://cluster-agent.example.com ",
+                "auth_token": " cluster-agent-token ",
+                "kubernetes_service_name": " custom-cluster-agent "
+            }
+        }));
+
+        assert!(errors.is_none());
+        let cluster_agent = &config.shared.cluster_agent;
+        assert_eq!(Some("https://cluster-agent.example.com"), cluster_agent.url.as_deref());
+        assert_eq!(Some("cluster-agent-token"), cluster_agent.auth_token.as_deref());
+        assert_eq!("custom-cluster-agent", cluster_agent.kubernetes_service_name);
+    }
+
+    #[test]
+    fn a_blank_cluster_agent_setting_is_unset() {
+        // A blank URL or token says no more than an absent one. A blank service name is different: it
+        // is the way to ask that the injected Kubernetes environment variables be ignored, so it stays
+        // empty instead of falling back to the schema default.
+        let (config, errors) = translate_explicit(json!({
+            "cluster_agent": {
+                "enabled": true,
+                "url": "  ",
+                "auth_token": "\t",
+                "kubernetes_service_name": "   "
+            }
+        }));
+
+        assert!(errors.is_none());
+        let cluster_agent = &config.shared.cluster_agent;
+        assert_eq!(None, cluster_agent.url);
+        assert_eq!(None, cluster_agent.auth_token);
+        assert_eq!("", cluster_agent.kubernetes_service_name);
     }
 
     #[test]

--- a/lib/agent-data-plane-config/src/shared.rs
+++ b/lib/agent-data-plane-config/src/shared.rs
@@ -529,7 +529,7 @@ pub struct HistogramEncoding {
 pub struct ClusterAgent {
     /// Whether the Cluster Agent connection is used.
     ///
-    /// Defaults to `false`. When disabled, nothing talks to the Cluster Agent even if the remaining fields are set.
+    /// Defaults to `false`. Turn it on in a deployment that runs a Cluster Agent; while it is off, nothing talks to it.
     pub enabled: bool,
 
     /// URL of the Cluster Agent.
@@ -542,8 +542,8 @@ pub struct ClusterAgent {
 
     /// Token used to authenticate to the Cluster Agent.
     ///
-    /// Defaults to unset, which leaves the Cluster Agent unreachable: there is no anonymous access. A blank value is
-    /// normalized to unset, so padding a token with whitespace does not make it a different token.
+    /// Defaults to unset, which leaves the Cluster Agent unreachable: there is no anonymous access. Set it wherever the
+    /// Cluster Agent is enabled, to that Agent's own token; a blank value is normalized to unset.
     pub auth_token: Option<String>,
 
     /// Kubernetes service name used to discover the Cluster Agent.

--- a/lib/agent-data-plane-config/src/shared.rs
+++ b/lib/agent-data-plane-config/src/shared.rs
@@ -521,19 +521,38 @@ pub struct HistogramEncoding {
 }
 
 /// Cluster Agent connection, shared by checks, DogStatsD, and OTLP.
+///
+/// The defaults named on each field are the Datadog schema defaults, which translation writes whenever the key is
+/// absent. They are not the values `Default` produces: that is the zero value of each field, which for
+/// `kubernetes_service_name` is the empty string and therefore not the schema default.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct ClusterAgent {
     /// Whether the Cluster Agent connection is used.
+    ///
+    /// Defaults to `false`. When disabled, nothing talks to the Cluster Agent even if the remaining fields are set.
     pub enabled: bool,
 
     /// URL of the Cluster Agent.
+    ///
+    /// Defaults to unset, which leaves the endpoint to Kubernetes service discovery through
+    /// `kubernetes_service_name`. A blank value is normalized to unset. Set this in a deployment where the Cluster
+    /// Agent is not reachable through an injected Kubernetes service, and give an `https` endpoint: consumers use only
+    /// `https`.
     pub url: Option<String>,
 
     /// Token used to authenticate to the Cluster Agent.
+    ///
+    /// Defaults to unset, which leaves the Cluster Agent unreachable: there is no anonymous access. A blank value is
+    /// normalized to unset, so padding a token with whitespace does not make it a different token.
     pub auth_token: Option<String>,
 
     /// Kubernetes service name used to discover the Cluster Agent.
-    pub kubernetes_service_name: Option<String>,
+    ///
+    /// Defaults to `datadog-cluster-agent`. The name is turned into the `<NAME>_SERVICE_HOST` and
+    /// `<NAME>_SERVICE_PORT` environment variables that Kubernetes injects into the pod. Set this when the Cluster
+    /// Agent runs under a different service name, or set it to the empty string to turn the lookup off, which leaves
+    /// `url` as the only way to reach the Cluster Agent.
+    pub kubernetes_service_name: String,
 }
 
 /// Autoscaling failover, shared by checks, DogStatsD, and OTLP.

--- a/lib/datadog-agent/config-testing/src/config_registry/get_typed.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/get_typed.rs
@@ -60,50 +60,6 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::CrossCutting,
     };
-    /// `cluster_agent.auth_token`-Bearer token for Cluster Agent requests
-    CLUSTER_AGENT_AUTH_TOKEN = SalukiAnnotation {
-        schema: &schema::CLUSTER_AGENT_AUTH_TOKEN,
-        support_level: SupportLevel::Full,
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[structs::GET_TYPED],
-        value_type_override: None,
-        test_json: Some(r#""cluster-agent-token""#),
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD, Pipeline::Otlp]),
-    };
-    /// `cluster_agent.enabled`-Enable Cluster Agent communication
-    CLUSTER_AGENT_ENABLED = SalukiAnnotation {
-        schema: &schema::CLUSTER_AGENT_ENABLED,
-        support_level: SupportLevel::Full,
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[structs::GET_TYPED],
-        value_type_override: None,
-        test_json: Some("true"),
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD, Pipeline::Otlp]),
-    };
-    /// `cluster_agent.kubernetes_service_name`-Cluster Agent Kubernetes service name
-    CLUSTER_AGENT_KUBERNETES_SERVICE_NAME = SalukiAnnotation {
-        schema: &schema::CLUSTER_AGENT_KUBERNETES_SERVICE_NAME,
-        support_level: SupportLevel::Full,
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[structs::GET_TYPED],
-        value_type_override: None,
-        test_json: Some(r#""datadog-cluster-agent""#),
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD, Pipeline::Otlp]),
-    };
-    /// `cluster_agent.url`-Cluster Agent HTTPS endpoint
-    CLUSTER_AGENT_URL = SalukiAnnotation {
-        schema: &schema::CLUSTER_AGENT_URL,
-        support_level: SupportLevel::Full,
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[structs::GET_TYPED],
-        value_type_override: None,
-        test_json: Some(r#""https://cluster-agent.example.com""#),
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD, Pipeline::Otlp]),
-    };
     /// `log_level`-Log verbosity directives
     LOG_LEVEL = SalukiAnnotation {
         schema: &schema::LOG_LEVEL,

--- a/lib/datadog-agent/config-testing/src/config_registry/shared.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/shared.rs
@@ -49,7 +49,7 @@ crate::declare_annotations! {
         test_json: Some("true"),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD, Pipeline::Otlp]),
     };
-    /// `cluster_agent.kubernetes_service_name`-Cluster Agent service name; blank skips lookup
+    /// `cluster_agent.kubernetes_service_name`-Cluster Agent Kubernetes service name
     CLUSTER_AGENT_KUBERNETES_SERVICE_NAME = SalukiAnnotation {
         schema: &schema::CLUSTER_AGENT_KUBERNETES_SERVICE_NAME,
         support_level: SupportLevel::Full,

--- a/lib/datadog-agent/config-testing/src/config_registry/shared.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/shared.rs
@@ -27,6 +27,50 @@ crate::declare_annotations! {
         test_json: Some(r#"["container.memory.usage"]"#),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD, Pipeline::Otlp]),
     };
+    /// `cluster_agent.auth_token`-Bearer token for Cluster Agent requests
+    CLUSTER_AGENT_AUTH_TOKEN = SalukiAnnotation {
+        schema: &schema::CLUSTER_AGENT_AUTH_TOKEN,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: Some(r#""cluster-agent-token""#),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD, Pipeline::Otlp]),
+    };
+    /// `cluster_agent.enabled`-Enable Cluster Agent communication
+    CLUSTER_AGENT_ENABLED = SalukiAnnotation {
+        schema: &schema::CLUSTER_AGENT_ENABLED,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: Some("true"),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD, Pipeline::Otlp]),
+    };
+    /// `cluster_agent.kubernetes_service_name`-Cluster Agent service name; blank skips lookup
+    CLUSTER_AGENT_KUBERNETES_SERVICE_NAME = SalukiAnnotation {
+        schema: &schema::CLUSTER_AGENT_KUBERNETES_SERVICE_NAME,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: Some(r#""datadog-cluster-agent""#),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD, Pipeline::Otlp]),
+    };
+    /// `cluster_agent.url`-Cluster Agent HTTPS endpoint
+    CLUSTER_AGENT_URL = SalukiAnnotation {
+        schema: &schema::CLUSTER_AGENT_URL,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: Some(r#""https://cluster-agent.example.com""#),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD, Pipeline::Otlp]),
+    };
     /// `cluster_name`-EKS Fargate cluster name static tag
     CLUSTER_NAME = SalukiAnnotation {
         schema: &schema::CLUSTER_NAME,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -517,7 +517,7 @@ inventory:
   cluster_agent.kubernetes_service_name:
     support: full
     pipelines: [checks, dogstatsd, otlp]
-    description: "Cluster Agent service name; blank skips lookup"
+    description: "Cluster Agent Kubernetes service name"
     test_support:
       used_by: [TypedConfigSystem]
       test_json: '"datadog-cluster-agent"'

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -499,40 +499,40 @@ inventory:
     pipelines: [checks, dogstatsd, otlp]
     description: "Bearer token for Cluster Agent requests"
     test_support:
-      used_by: [get_typed]
+      used_by: [TypedConfigSystem]
       test_json: '"cluster-agent-token"'
       additional_attributes:
-        config_registry_filename: get_typed.rs
+        config_registry_filename: shared.rs
 
   cluster_agent.enabled:
     support: full
     pipelines: [checks, dogstatsd, otlp]
     description: "Enable Cluster Agent communication"
     test_support:
-      used_by: [get_typed]
+      used_by: [TypedConfigSystem]
       test_json: "true"
       additional_attributes:
-        config_registry_filename: get_typed.rs
+        config_registry_filename: shared.rs
 
   cluster_agent.kubernetes_service_name:
     support: full
     pipelines: [checks, dogstatsd, otlp]
-    description: "Cluster Agent Kubernetes service name"
+    description: "Cluster Agent service name; blank skips lookup"
     test_support:
-      used_by: [get_typed]
+      used_by: [TypedConfigSystem]
       test_json: '"datadog-cluster-agent"'
       additional_attributes:
-        config_registry_filename: get_typed.rs
+        config_registry_filename: shared.rs
 
   cluster_agent.url:
     support: full
     pipelines: [checks, dogstatsd, otlp]
     description: "Cluster Agent HTTPS endpoint"
     test_support:
-      used_by: [get_typed]
+      used_by: [TypedConfigSystem]
       test_json: '"https://cluster-agent.example.com"'
       additional_attributes:
-        config_registry_filename: get_typed.rs
+        config_registry_filename: shared.rs
 
   cluster_name:
     support: full

--- a/lib/saluki-components/src/config/cluster_agent.rs
+++ b/lib/saluki-components/src/config/cluster_agent.rs
@@ -2,32 +2,46 @@
 
 use std::net::IpAddr;
 
-use saluki_config::GenericConfiguration;
-use saluki_error::GenericError;
-
-const DEFAULT_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME: &str = "datadog-cluster-agent";
-
 /// Cluster Agent forwarding configuration.
+///
+/// Every field arrives already resolved: configuration owns the defaults, trims the string values, and turns a blank
+/// value into either `None` or an empty name. What is left here is the endpoint decision, which needs the process
+/// environment and so cannot be made at the configuration boundary.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ClusterAgentConfiguration {
-    enabled: bool,
-    url: Option<String>,
-    kubernetes_service_name: Option<String>,
-    auth_token: Option<String>,
+    /// Whether forwarding to the Cluster Agent is turned on.
+    ///
+    /// Defaults to `false` in configuration. When this is `false`, no endpoint is resolved and nothing is forwarded,
+    /// whatever the other fields hold.
+    pub enabled: bool,
+
+    /// Configured Cluster Agent URL.
+    ///
+    /// Defaults to unset in configuration. A value is preferred over Kubernetes service discovery, and it is used only
+    /// if it resolves to an `https` URL with a host: a URL without a scheme is completed to `https://`, and anything
+    /// else yields no endpoint rather than falling back to service discovery.
+    pub url: Option<String>,
+
+    /// Bearer token presented on Cluster Agent requests.
+    ///
+    /// Defaults to unset in configuration, which leaves nothing to forward with: the Cluster Agent has no anonymous
+    /// access, so an unset token yields no endpoint.
+    pub auth_token: Option<String>,
+
+    /// Kubernetes service name whose injected environment variables locate the Cluster Agent.
+    ///
+    /// Configuration defaults this to `datadog-cluster-agent`. The name is upper-cased, its dashes become underscores,
+    /// and the `<NAME>_SERVICE_HOST` and `<NAME>_SERVICE_PORT` variables Kubernetes injects into the pod supply the
+    /// endpoint. An empty name turns the lookup off, which is how a deployment asks that `url` be the only way to
+    /// reach the Cluster Agent.
+    pub kubernetes_service_name: String,
 }
 
 impl ClusterAgentConfiguration {
-    /// Creates a new `ClusterAgentConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        Ok(Self {
-            enabled: config.try_get_typed("cluster_agent.enabled")?.unwrap_or(false),
-            url: get_non_empty_string(config, "cluster_agent.url")?,
-            kubernetes_service_name: get_trimmed_string(config, "cluster_agent.kubernetes_service_name")?,
-            auth_token: get_non_empty_string(config, "cluster_agent.auth_token")?,
-        })
-    }
-
     /// Returns the Cluster Agent HTTPS endpoint and bearer token when forwarding can be configured.
+    ///
+    /// Returns `None` when forwarding is turned off, when no `https` endpoint resolves from either `url` or the
+    /// Kubernetes service environment, or when `auth_token` is unset.
     pub fn endpoint_and_token(&self) -> Option<(String, String)> {
         self.endpoint_and_token_with_env(|key| std::env::var(key).ok())
     }
@@ -53,26 +67,12 @@ impl ClusterAgentConfiguration {
             return normalize_cluster_agent_url(url);
         }
 
-        let service_name = self
-            .kubernetes_service_name
-            .as_deref()
-            .unwrap_or(DEFAULT_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME);
-        if service_name.is_empty() {
+        if self.kubernetes_service_name.is_empty() {
             return None;
         }
 
-        resolve_kubernetes_service_endpoint(service_name, env_lookup)
+        resolve_kubernetes_service_endpoint(&self.kubernetes_service_name, env_lookup)
     }
-}
-
-fn get_non_empty_string(config: &GenericConfiguration, key: &str) -> Result<Option<String>, GenericError> {
-    Ok(get_trimmed_string(config, key)?.filter(|value| !value.is_empty()))
-}
-
-fn get_trimmed_string(config: &GenericConfiguration, key: &str) -> Result<Option<String>, GenericError> {
-    Ok(config
-        .try_get_typed::<String>(key)?
-        .map(|value| value.trim().to_string()))
 }
 
 fn normalize_cluster_agent_url(url: &str) -> Option<String> {
@@ -116,70 +116,57 @@ fn join_host_port(host: &str, port: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use saluki_config::config_from;
-    use serde_json::json;
-
     use super::*;
 
-    async fn cluster_agent_config_from(value: serde_json::Value) -> ClusterAgentConfiguration {
-        ClusterAgentConfiguration::from_configuration(&config_from(value).await)
-            .expect("Cluster Agent configuration should deserialize")
+    /// The name the Datadog schema supplies when `cluster_agent.kubernetes_service_name` is absent.
+    const DEFAULT_SERVICE_NAME: &str = "datadog-cluster-agent";
+
+    fn enabled_config() -> ClusterAgentConfiguration {
+        ClusterAgentConfiguration {
+            enabled: true,
+            url: None,
+            auth_token: Some("secret-token".to_string()),
+            kubernetes_service_name: DEFAULT_SERVICE_NAME.to_string(),
+        }
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_requires_enabled_cluster_agent() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": false,
-                "url": "https://cluster-agent.example.com",
-                "auth_token": "secret-token"
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_requires_enabled_cluster_agent() {
+        let config = ClusterAgentConfiguration {
+            enabled: false,
+            url: Some("https://cluster-agent.example.com".to_string()),
+            ..enabled_config()
+        };
 
         assert_eq!(config.endpoint_and_token_with_env(env_lookup(&[])), None);
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_requires_resolvable_endpoint() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "auth_token": "secret-token"
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_requires_resolvable_endpoint() {
+        let config = enabled_config();
 
         assert_eq!(config.endpoint_and_token_with_env(env_lookup(&[])), None);
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_requires_https_url() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "url": "http://cluster-agent.example.com",
-                "auth_token": "secret-token"
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_requires_https_url() {
+        let config = ClusterAgentConfiguration {
+            url: Some("http://cluster-agent.example.com".to_string()),
+            ..enabled_config()
+        };
 
-        assert_eq!(config.endpoint_and_token(), None);
+        assert_eq!(config.endpoint_and_token_with_env(env_lookup(&[])), None);
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_adds_https_scheme_to_url() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "url": "cluster-agent.example.com:5005",
-                "auth_token": "secret-token"
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_adds_https_scheme_to_url() {
+        let config = ClusterAgentConfiguration {
+            url: Some("cluster-agent.example.com:5005".to_string()),
+            ..enabled_config()
+        };
 
         assert_eq!(
-            config.endpoint_and_token(),
+            config.endpoint_and_token_with_env(env_lookup(&[])),
             Some((
                 "https://cluster-agent.example.com:5005".to_string(),
                 "secret-token".to_string()
@@ -187,33 +174,26 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_requires_non_empty_token() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "url": "https://cluster-agent.example.com",
-                "auth_token": "  "
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_requires_a_token() {
+        let config = ClusterAgentConfiguration {
+            url: Some("https://cluster-agent.example.com".to_string()),
+            auth_token: None,
+            ..enabled_config()
+        };
 
-        assert_eq!(config.endpoint_and_token(), None);
+        assert_eq!(config.endpoint_and_token_with_env(env_lookup(&[])), None);
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_returns_https_url_and_token() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "url": " https://cluster-agent.example.com ",
-                "auth_token": " secret-token "
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_returns_https_url_and_token() {
+        let config = ClusterAgentConfiguration {
+            url: Some("https://cluster-agent.example.com".to_string()),
+            ..enabled_config()
+        };
 
         assert_eq!(
-            config.endpoint_and_token(),
+            config.endpoint_and_token_with_env(env_lookup(&[])),
             Some((
                 "https://cluster-agent.example.com".to_string(),
                 "secret-token".to_string()
@@ -221,15 +201,9 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_resolves_default_kubernetes_service_env() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "auth_token": "secret-token"
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_resolves_default_kubernetes_service_env() {
+        let config = enabled_config();
 
         assert_eq!(
             config.endpoint_and_token_with_env(env_lookup(&[
@@ -240,16 +214,12 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_resolves_configured_kubernetes_service_env() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "kubernetes_service_name": "custom-cluster-agent",
-                "auth_token": "secret-token"
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_resolves_configured_kubernetes_service_env() {
+        let config = ClusterAgentConfiguration {
+            kubernetes_service_name: "custom-cluster-agent".to_string(),
+            ..enabled_config()
+        };
 
         assert_eq!(
             config.endpoint_and_token_with_env(env_lookup(&[
@@ -260,15 +230,27 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_wraps_kubernetes_service_ipv6_host() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "auth_token": "secret-token"
-            }
-        }))
-        .await;
+    #[test]
+    fn an_empty_kubernetes_service_name_turns_discovery_off() {
+        // Configuration resolves an explicitly blank name to an empty string, which means the injected environment
+        // variables are ignored even when they are present.
+        let config = ClusterAgentConfiguration {
+            kubernetes_service_name: String::new(),
+            ..enabled_config()
+        };
+
+        assert_eq!(
+            config.endpoint_and_token_with_env(env_lookup(&[
+                ("DATADOG_CLUSTER_AGENT_SERVICE_HOST", "127.0.0.1"),
+                ("DATADOG_CLUSTER_AGENT_SERVICE_PORT", "443"),
+            ])),
+            None
+        );
+    }
+
+    #[test]
+    fn endpoint_and_token_wraps_kubernetes_service_ipv6_host() {
+        let config = enabled_config();
 
         assert_eq!(
             config.endpoint_and_token_with_env(env_lookup(&[
@@ -282,17 +264,13 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_prefers_configured_url_over_kubernetes_service_env() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "url": "https://configured-cluster-agent.example.com",
-                "kubernetes_service_name": "custom-cluster-agent",
-                "auth_token": "secret-token"
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_prefers_configured_url_over_kubernetes_service_env() {
+        let config = ClusterAgentConfiguration {
+            url: Some("https://configured-cluster-agent.example.com".to_string()),
+            kubernetes_service_name: "custom-cluster-agent".to_string(),
+            ..enabled_config()
+        };
 
         assert_eq!(
             config.endpoint_and_token_with_env(env_lookup(&[

--- a/lib/saluki-components/src/config/cluster_agent.rs
+++ b/lib/saluki-components/src/config/cluster_agent.rs
@@ -118,7 +118,7 @@ fn join_host_port(host: &str, port: &str) -> String {
 mod tests {
     use super::*;
 
-    /// The name the Datadog schema supplies when `cluster_agent.kubernetes_service_name` is absent.
+    /// The configuration default, owned by `cluster_agent_settings_default_to_schema_values_when_unset` upstream.
     const DEFAULT_SERVICE_NAME: &str = "datadog-cluster-agent";
 
     fn enabled_config() -> ClusterAgentConfiguration {


### PR DESCRIPTION
## Summary

Migrate `ClusterAgentConfiguration` off the raw configuration map. The four
`cluster_agent.*` keys now reach the component through the typed
`shared.cluster_agent` slice.

- Move the trimming and empty-value handling out of the component and into
  translation.
- Hold the resolved Kubernetes service name as a `String`: an absent key
  resolves to `datadog-cluster-agent` through the schema default, and an
  explicitly blank name turns the service lookup off, as before.
- Keep the endpoint decision in the component, because it reads the
  `<NAME>_SERVICE_HOST` and `<NAME>_SERVICE_PORT` variables Kubernetes injects.
- Component tests now build the struct by field and resolve the environment
  through an injected lookup, so they no longer depend on the ambient process
  environment.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make build-schema-overlay`
- `make fmt`
- `make check-docs`
- `make check-clippy`
- `cargo nextest run` for the Cluster Agent config, the Cluster Agent forwarder,
  and the translator

## References

- Progresses: #2293
