### PR TITLE
chore(config): migrate mrf metrics gateway to typed config

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -46,7 +46,6 @@ use saluki_components::{
         MrfMetricsGatewayConfiguration, TraceObfuscationConfiguration, TraceSamplerConfiguration,
     },
 };
-use saluki_config::GenericConfiguration;
 use saluki_context::origin::OriginTagCardinality;
 use saluki_core::accounting::{ComponentBounds, ComponentRegistry};
 use saluki_core::health::HealthRegistry;
@@ -536,19 +535,14 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
         // Metrics, then forwarding.
         .connect_components_in_order(["metrics_enrich", "dd_metrics_encode", "dd_out"])?;
 
-    add_mrf_metrics_pipeline_to_blueprint(
-        blueprint,
-        &config_system.raw_map(),
-        shared,
-        &config.domains.multi_region_failover,
-    )?;
+    add_mrf_metrics_pipeline_to_blueprint(blueprint, config_system, shared, &config.domains.multi_region_failover)?;
     add_autoscaling_failover_metrics_pipeline_to_blueprint(blueprint, shared)?;
 
     Ok(())
 }
 
 fn add_mrf_metrics_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration, shared: &SharedConfiguration,
+    blueprint: &mut TopologyBlueprint, config_system: &ConfigurationSystem, shared: &SharedConfiguration,
     mrf: &multi_region_failover::Domain,
 ) -> Result<(), GenericError> {
     let mrf_config = MrfConfiguration::from_configuration(mrf);
@@ -566,13 +560,16 @@ fn add_mrf_metrics_pipeline_to_blueprint(
         return Ok(());
     };
 
-    let mrf_gateway_config = MrfMetricsGatewayConfiguration::new(mrf_config.clone(), config.clone());
+    let mrf_gateway_config = MrfMetricsGatewayConfiguration::new(
+        mrf_config.is_enabled(),
+        config_system.live(|config| &config.domains.multi_region_failover.metric_mirroring),
+    );
     let mrf_metrics_config =
         DatadogMetricsConfiguration::from_configuration(shared).with_metrics_endpoint_override(mrf_dd_url.clone());
 
     let mrf_forwarder_config = DatadogForwarderConfiguration::for_endpoint_override(
         shared,
-        config,
+        &config_system.raw_map(),
         mrf_dd_url,
         mrf_api_key,
         "multi_region_failover.api_key",

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -958,11 +958,11 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_multi_region_failover_failover_metrics(&mut self, value: bool) {
-        self.config.domains.multi_region_failover.failover_metrics = value;
+        self.config.domains.multi_region_failover.metric_mirroring.enabled = value;
     }
 
     fn consume_multi_region_failover_metric_allowlist(&mut self, value: Vec<String>) {
-        self.config.domains.multi_region_failover.metric_allowlist = value;
+        self.config.domains.multi_region_failover.metric_mirroring.allowlist = value;
     }
 
     fn consume_multi_region_failover_site(&mut self, value: String) {

--- a/lib/agent-data-plane-config/src/domains/multi_region_failover.rs
+++ b/lib/agent-data-plane-config/src/domains/multi_region_failover.rs
@@ -10,13 +10,14 @@ const MRF_METRICS_ENDPOINT_PREFIX: &str = "https://app.mrf.";
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct Domain {
     /// Whether multi-region failover is active.
+    ///
+    /// Defaults to `false`. The failover pipeline is wired when the topology is built, so turning this on takes a
+    /// restart, and it takes a reachable failover region as well: an [`api_key`](Self::api_key), plus either a
+    /// [`site`](Self::site) or a [`dd_url`](Self::dd_url). Without those, the pipeline is not wired at all.
     pub enabled: bool,
 
-    /// Whether metrics are mirrored to the failover region.
-    pub failover_metrics: bool,
-
-    /// Metrics permitted to be sent to the failover region.
-    pub metric_allowlist: Vec<String>,
+    /// Which metrics are mirrored to the failover region.
+    pub metric_mirroring: MetricMirroring,
 
     /// API key used to authenticate to the failover region.
     pub api_key: Option<String>,
@@ -26,6 +27,28 @@ pub struct Domain {
 
     /// Explicit intake URL for the failover region, overriding the site.
     pub dd_url: Option<String>,
+}
+
+/// Which metrics are mirrored to the failover region.
+///
+/// The two settings are grouped because they are consumed together: the routing state of the failover metrics
+/// pipeline is derived from both at once. A consumer that watched them separately could rebuild that state from a
+/// fresh value of one and a stale value of the other, describing a configuration that was never published; a live
+/// view of this struct delivers both from one configuration version instead.
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct MetricMirroring {
+    /// Whether metrics are mirrored to the failover region.
+    ///
+    /// Defaults to `false`. Mirroring also requires [`Domain::enabled`], but unlike it this setting is read live,
+    /// which is the point of it: an operator starts and stops mirroring on a running process.
+    pub enabled: bool,
+
+    /// Metrics permitted to be sent to the failover region.
+    ///
+    /// Defaults to empty, which mirrors every metric rather than none: the list narrows mirroring, it does not enable
+    /// it. Names match exactly. Read live, alongside [`enabled`](Self::enabled), so an operator can restrict mirroring
+    /// to the metrics the failover region needs without restarting.
+    pub allowlist: Vec<String>,
 }
 
 impl Domain {

--- a/lib/saluki-components/src/config/mrf.rs
+++ b/lib/saluki-components/src/config/mrf.rs
@@ -3,11 +3,9 @@
 use agent_data_plane_config::domains::multi_region_failover;
 
 /// Multi-region failover configuration shared by signal-specific pipelines.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct MrfConfiguration {
     enabled: bool,
-    failover_metrics: bool,
-    metric_allowlist: Vec<String>,
     api_key: Option<String>,
     metrics_endpoint: Option<String>,
 }
@@ -17,8 +15,6 @@ impl MrfConfiguration {
     pub fn from_configuration(mrf: &multi_region_failover::Domain) -> Self {
         Self {
             enabled: mrf.enabled,
-            failover_metrics: mrf.failover_metrics,
-            metric_allowlist: mrf.metric_allowlist.clone(),
             api_key: mrf.api_key.clone(),
             metrics_endpoint: mrf.metrics_endpoint_url(),
         }
@@ -27,26 +23,6 @@ impl MrfConfiguration {
     /// Returns whether multi-region failover is enabled for this process.
     pub const fn is_enabled(&self) -> bool {
         self.enabled
-    }
-
-    /// Returns whether metrics forwarding to the failover region is requested by configuration.
-    pub const fn is_metrics_forwarding_requested(&self) -> bool {
-        self.enabled && self.failover_metrics
-    }
-
-    /// Updates whether metrics forwarding to the failover region is enabled.
-    pub(crate) const fn set_failover_metrics(&mut self, failover_metrics: bool) {
-        self.failover_metrics = failover_metrics;
-    }
-
-    /// Updates the metric allowlist.
-    pub(crate) fn set_metric_allowlist(&mut self, metric_allowlist: Vec<String>) {
-        self.metric_allowlist = metric_allowlist;
-    }
-
-    /// Returns the metric allowlist.
-    pub fn metric_allowlist(&self) -> &[String] {
-        &self.metric_allowlist
     }
 
     /// Returns the failover-region API key.
@@ -71,6 +47,8 @@ impl MrfConfiguration {
 
 #[cfg(test)]
 mod tests {
+    use agent_data_plane_config::domains::multi_region_failover::MetricMirroring;
+
     use super::*;
 
     fn mrf_config(mrf: multi_region_failover::Domain) -> MrfConfiguration {
@@ -81,15 +59,12 @@ mod tests {
     fn carries_the_resolved_multi_region_failover_configuration() {
         let config = mrf_config(multi_region_failover::Domain {
             enabled: true,
-            failover_metrics: true,
-            metric_allowlist: vec!["first.metric".to_string(), "second.metric".to_string()],
             api_key: Some("mrf-api-key".to_string()),
             site: Some("datadoghq.eu".to_string()),
-            dd_url: None,
+            ..Default::default()
         });
 
-        assert!(config.is_metrics_forwarding_requested());
-        assert_eq!(config.metric_allowlist(), ["first.metric", "second.metric"]);
+        assert!(config.is_enabled());
         assert_eq!(Some("mrf-api-key"), config.api_key());
         assert_eq!(Some("https://app.mrf.datadoghq.eu"), config.metrics_endpoint_url());
     }
@@ -98,7 +73,6 @@ mod tests {
     fn metrics_endpoint_override_requires_api_key_and_endpoint() {
         let missing_api_key = mrf_config(multi_region_failover::Domain {
             enabled: true,
-            failover_metrics: true,
             site: Some("datadoghq.eu".to_string()),
             ..Default::default()
         });
@@ -106,7 +80,6 @@ mod tests {
 
         let missing_endpoint = mrf_config(multi_region_failover::Domain {
             enabled: true,
-            failover_metrics: true,
             api_key: Some("mrf-api-key".to_string()),
             ..Default::default()
         });
@@ -114,7 +87,6 @@ mod tests {
 
         let ready = mrf_config(multi_region_failover::Domain {
             enabled: true,
-            failover_metrics: true,
             api_key: Some("mrf-api-key".to_string()),
             dd_url: Some("https://mrf.example.com".to_string()),
             ..Default::default()
@@ -127,15 +99,19 @@ mod tests {
 
     #[test]
     fn metrics_endpoint_override_does_not_require_failover_metrics() {
+        // The endpoint override is what wires the failover forwarder, and it is deliberately independent of
+        // `failover_metrics`: that setting can turn metric mirroring on later, without a restart.
         let config = mrf_config(multi_region_failover::Domain {
             enabled: true,
-            failover_metrics: false,
+            metric_mirroring: MetricMirroring {
+                enabled: false,
+                allowlist: Vec::new(),
+            },
             api_key: Some("mrf-api-key".to_string()),
             dd_url: Some("https://mrf.example.com".to_string()),
             ..Default::default()
         });
 
-        assert!(!config.is_metrics_forwarding_requested());
         assert_eq!(
             Some(("https://mrf.example.com".to_string(), "mrf-api-key".to_string())),
             config.metrics_endpoint_override()
@@ -148,7 +124,6 @@ mod tests {
         // when multi-region failover is disabled (the `if !self.enabled` guard at the top of the method).
         let config = mrf_config(multi_region_failover::Domain {
             enabled: false,
-            failover_metrics: true,
             api_key: Some("mrf-api-key".to_string()),
             dd_url: Some("https://mrf.example.com".to_string()),
             ..Default::default()

--- a/lib/saluki-components/src/transforms/mrf_gateway/mod.rs
+++ b/lib/saluki-components/src/transforms/mrf_gateway/mod.rs
@@ -2,8 +2,8 @@
 
 use std::collections::HashSet;
 
+use agent_data_plane_config::{domains::multi_region_failover::MetricMirroring, Live};
 use async_trait::async_trait;
-use saluki_config::GenericConfiguration;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
     components::{
@@ -17,31 +17,34 @@ use saluki_error::GenericError;
 use tokio::select;
 use tracing::{debug, error};
 
-use crate::config::MrfConfiguration;
-
-/// MRF metrics gateway transform configuration.
+/// Configuration for the MRF metrics gateway transform.
 ///
-/// This transform sits between the enrichment stage and the MRF-specific encoder/forwarder. It owns
-/// all routing and filtering decisions for the MRF metrics pipeline:
+/// This transform sits between the enrichment stage and the MRF-specific encoder/forwarder, and owns all routing and
+/// filtering decisions for the MRF metrics pipeline:
 ///
-/// - When MRF is disabled, all events are dropped.
-/// - When MRF is enabled with no allowlist, all events are forwarded.
-/// - When MRF is enabled with an allowlist, only matching events are forwarded.
-///
-/// The transform reads static MRF configuration from a snapshot taken at build time, and watches
-/// `multi_region_failover.failover_metrics` and `multi_region_failover.metric_allowlist` for
-/// dynamic updates.
+/// - When multi-region failover is off, or metric mirroring is off, all events are dropped.
+/// - When both are on and no allowlist is configured, all events are forwarded.
+/// - When both are on and an allowlist is configured, only events whose metric name is in the allowlist are forwarded.
 pub struct MrfMetricsGatewayConfiguration {
-    mrf_config: MrfConfiguration,
-    configuration: GenericConfiguration,
+    enabled: bool,
+    metric_mirroring: Live<MetricMirroring>,
 }
 
 impl MrfMetricsGatewayConfiguration {
-    /// Creates a new `MrfMetricsGatewayConfiguration` from the given [`MrfConfiguration`].
-    pub fn new(mrf_config: MrfConfiguration, configuration: GenericConfiguration) -> Self {
+    /// Creates a new `MrfMetricsGatewayConfiguration`.
+    ///
+    /// `enabled` is whether multi-region failover is on. It defaults to off in configuration and is read once, when
+    /// the topology is built, because the failover forwarder this transform feeds is wired at that point or not at all.
+    ///
+    /// `metric_mirroring` is whether metrics are mirrored to the failover region and which metric names are allowed to
+    /// be mirrored, defaulting to off and empty respectively. It is a live view: an operator can turn mirroring on, or
+    /// change the allowlist, without restarting, and the transform rebuilds its routing state from the new value. The
+    /// two settings arrive as one value, from one configuration version, so a rebuild cannot mix a fresh setting with a
+    /// stale one.
+    pub fn new(enabled: bool, metric_mirroring: Live<MetricMirroring>) -> Self {
         Self {
-            mrf_config,
-            configuration,
+            enabled,
+            metric_mirroring,
         }
     }
 }
@@ -49,52 +52,53 @@ impl MrfMetricsGatewayConfiguration {
 /// Routing and filtering state for the MRF metrics gateway.
 #[derive(Debug)]
 enum GatewayMode {
-    /// MRF is disabled or improperly configured; drop all events.
+    /// Multi-region failover is off, or metric mirroring is off; drop all events.
     Inactive,
-    /// MRF is active and no allowlist is configured; forward all events.
+    /// Mirroring is on and no allowlist is configured; forward all events.
     ForwardAll,
-    /// MRF is active and an allowlist is configured; forward only matching events.
+    /// Mirroring is on and an allowlist is configured; forward only matching events.
     FilteredForward { allowlist: HashSet<String> },
 }
 
-/// MRF metrics gateway transform.
-pub struct MrfMetricsGateway {
-    mrf_config: MrfConfiguration,
+/// The current settings, and the routing state they imply.
+///
+/// This holds the mirroring settings by value rather than as a view. The transform's run loop awaits the view and hands
+/// the new value here, so the routing state is always rebuilt from one configuration version: the two settings the mode
+/// is derived from cannot be a fresh value and a stale one.
+struct Routing {
+    enabled: bool,
+    metric_mirroring: MetricMirroring,
     mode: GatewayMode,
-    configuration: GenericConfiguration,
 }
 
-impl MrfMetricsGateway {
-    fn new(mrf_config: MrfConfiguration, configuration: GenericConfiguration) -> Self {
-        let mode = Self::mode_for_config(&mrf_config);
+impl Routing {
+    fn new(enabled: bool, metric_mirroring: MetricMirroring) -> Self {
+        let mut routing = Self {
+            enabled,
+            metric_mirroring,
+            mode: GatewayMode::Inactive,
+        };
+        routing.rebuild_mode();
 
-        Self {
-            mrf_config,
-            mode,
-            configuration,
-        }
+        routing
     }
 
-    fn mode_for_config(mrf_config: &MrfConfiguration) -> GatewayMode {
-        if !mrf_config.is_metrics_forwarding_requested() {
+    fn set_metric_mirroring(&mut self, metric_mirroring: MetricMirroring) {
+        self.metric_mirroring = metric_mirroring;
+        self.rebuild_mode();
+        debug!(mode = ?self.mode, "MRF metrics gateway routing state rebuilt.");
+    }
+
+    fn rebuild_mode(&mut self) {
+        self.mode = if !(self.enabled && self.metric_mirroring.enabled) {
             GatewayMode::Inactive
-        } else if mrf_config.metric_allowlist().is_empty() {
+        } else if self.metric_mirroring.allowlist.is_empty() {
             GatewayMode::ForwardAll
         } else {
             GatewayMode::FilteredForward {
-                allowlist: mrf_config.metric_allowlist().iter().cloned().collect(),
+                allowlist: self.metric_mirroring.allowlist.iter().cloned().collect(),
             }
-        }
-    }
-
-    fn update_failover_metrics(&mut self, failover_metrics: bool) {
-        self.mrf_config.set_failover_metrics(failover_metrics);
-        self.mode = Self::mode_for_config(&self.mrf_config);
-    }
-
-    fn update_metric_allowlist(&mut self, metric_allowlist: Vec<String>) {
-        self.mrf_config.set_metric_allowlist(metric_allowlist);
-        self.mode = Self::mode_for_config(&self.mrf_config);
+        };
     }
 
     fn should_forward(&self, event: &Event) -> bool {
@@ -129,13 +133,28 @@ impl MrfMetricsGateway {
     }
 }
 
+/// MRF metrics gateway transform.
+///
+/// Forwards the metrics permitted to reach the failover region and drops the rest, following the live mirroring
+/// settings it holds. It carries the view rather than a snapshot so that the run loop can await it.
+pub struct MrfMetricsGateway {
+    enabled: bool,
+    metric_mirroring: Live<MetricMirroring>,
+}
+
+impl MrfMetricsGateway {
+    fn new(config: &MrfMetricsGatewayConfiguration) -> Self {
+        Self {
+            enabled: config.enabled,
+            metric_mirroring: config.metric_mirroring.clone(),
+        }
+    }
+}
+
 #[async_trait]
 impl TransformBuilder for MrfMetricsGatewayConfiguration {
     async fn build(&self, _context: BuildContext) -> Result<Box<dyn Transform + Send>, GenericError> {
-        Ok(Box::new(MrfMetricsGateway::new(
-            self.mrf_config.clone(),
-            self.configuration.clone(),
-        )))
+        Ok(Box::new(MrfMetricsGateway::new(self)))
     }
 
     fn input_event_type(&self) -> EventType {
@@ -150,17 +169,19 @@ impl TransformBuilder for MrfMetricsGatewayConfiguration {
 
 impl MemoryBounds for MrfMetricsGatewayConfiguration {
     fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
-        let allowlist = self.mrf_config.metric_allowlist();
+        let allowlist = &self.metric_mirroring.allowlist;
         builder
             .minimum()
             .with_single_value::<MrfMetricsGateway>("component struct")
             .with_fixed_amount("hashset overhead", std::mem::size_of::<HashSet<String>>())
             .with_fixed_amount(
+                // Two copies: the live view's snapshot, and the copy the routing state is rebuilt from.
                 "allowlist strings",
                 allowlist
                     .iter()
                     .map(|name| name.len() + std::mem::size_of::<String>())
-                    .sum::<usize>(),
+                    .sum::<usize>()
+                    * 2,
             )
             .with_fixed_amount(
                 "hashset buckets",
@@ -171,24 +192,25 @@ impl MemoryBounds for MrfMetricsGatewayConfiguration {
 
 #[async_trait]
 impl Transform for MrfMetricsGateway {
-    async fn run(mut self: Box<Self>, mut context: TransformContext) -> Result<(), GenericError> {
+    async fn run(self: Box<Self>, mut context: TransformContext) -> Result<(), GenericError> {
         let mut health = context.take_health_handle();
-        let mut failover_metrics_watcher = self
-            .configuration
-            .watch_for_updates("multi_region_failover.failover_metrics");
-        let mut metric_allowlist_watcher = self
-            .configuration
-            .watch_for_updates("multi_region_failover.metric_allowlist");
+        // The view is moved out of the transform because `select!` awaits it while an arm body updates the routing
+        // state; keeping the two apart is what lets both happen without borrowing the same value.
+        let Self {
+            enabled,
+            mut metric_mirroring,
+        } = *self;
+        let mut routing = Routing::new(enabled, (*metric_mirroring).clone());
 
         health.mark_ready();
-        debug!(mode = ?self.mode, "MRF metrics gateway transform started.");
+        debug!(mode = ?routing.mode, "MRF metrics gateway transform started.");
 
         loop {
             select! {
                 _ = health.live() => continue,
                 maybe_events = context.events().next() => match maybe_events {
                     Some(events) => {
-                        if let Err(e) = self.process_event_batch(events, &mut context).await {
+                        if let Err(e) = routing.process_event_batch(events, &mut context).await {
                             error!(error = %e, "MRF metrics gateway failed to process event batch.");
                         }
                     }
@@ -197,15 +219,8 @@ impl Transform for MrfMetricsGateway {
                         break;
                     }
                 },
-                (_, maybe_failover_metrics) = failover_metrics_watcher.changed::<bool>() => {
-                    if let Some(failover_metrics) = maybe_failover_metrics {
-                        self.update_failover_metrics(failover_metrics);
-                    }
-                },
-                (_, maybe_metric_allowlist) = metric_allowlist_watcher.changed::<Vec<String>>() => {
-                    if let Some(metric_allowlist) = maybe_metric_allowlist {
-                        self.update_metric_allowlist(metric_allowlist);
-                    }
+                new_metric_mirroring = metric_mirroring.changed() => {
+                    routing.set_metric_mirroring(new_metric_mirroring);
                 },
             }
         }
@@ -217,133 +232,170 @@ impl Transform for MrfMetricsGateway {
 
 #[cfg(test)]
 mod tests {
-    use agent_data_plane_config::domains::multi_region_failover;
-    use saluki_config::{
-        dynamic::{ConfigSetting, ConfigUpdate},
-        ConfigurationLoader,
-    };
+    use std::sync::Arc;
+
+    use agent_data_plane_config::SalukiConfiguration;
+    use arc_swap::ArcSwap;
     use saluki_core::data_model::event::{metric::Metric, Event};
-    use serde_json::json;
+    use tokio::sync::watch;
 
     use super::*;
 
-    /// Builds a gateway from resolved failover configuration, plus the live configuration it watches.
+    /// A configuration the tests can replace, plus the live view projected out of it.
     ///
-    /// The gateway tracks `multi_region_failover.failover_metrics` and
-    /// `multi_region_failover.metric_allowlist` through the live configuration, so a test that exercises
-    /// an update needs both views to describe the same starting state.
-    async fn dynamic_gateway_from_config(
-        mrf: multi_region_failover::Domain, value: serde_json::Value,
-    ) -> (MrfMetricsGateway, tokio::sync::mpsc::Sender<ConfigUpdate>) {
-        let (config, sender) = ConfigurationLoader::for_tests(Some(value), None, true).await;
-        let sender = sender.expect("dynamic sender should exist");
-        sender
-            .send(ConfigUpdate::snapshot([]))
-            .await
-            .expect("initial dynamic snapshot should be sent");
-        config.ready().await;
+    /// This stands in for the configuration system: replacing the configuration and ticking the notification is what
+    /// the system does once it has translated an update.
+    struct LiveSource {
+        cell: Arc<ArcSwap<SalukiConfiguration>>,
+        tick: watch::Sender<()>,
+    }
 
-        let mrf_config = MrfConfiguration::from_configuration(&mrf);
-        (MrfMetricsGateway::new(mrf_config, config), sender)
+    impl LiveSource {
+        fn new(failover_metrics: bool, metric_allowlist: &[&str]) -> Self {
+            let (tick, _) = watch::channel(());
+
+            Self {
+                cell: Arc::new(ArcSwap::from_pointee(configuration(failover_metrics, metric_allowlist))),
+                tick,
+            }
+        }
+
+        fn metric_mirroring(&self) -> Live<MetricMirroring> {
+            Live::new_dynamic(Arc::clone(&self.cell), self.tick.subscribe(), |config| {
+                &config.domains.multi_region_failover.metric_mirroring
+            })
+        }
+
+        fn publish(&self, failover_metrics: bool, metric_allowlist: &[&str]) {
+            self.cell
+                .store(Arc::new(configuration(failover_metrics, metric_allowlist)));
+            self.tick.send(()).expect("a view still holds the receiver");
+        }
+    }
+
+    fn configuration(failover_metrics: bool, metric_allowlist: &[&str]) -> SalukiConfiguration {
+        let mut config = SalukiConfiguration::default();
+        let mirroring = &mut config.domains.multi_region_failover.metric_mirroring;
+        mirroring.enabled = failover_metrics;
+        mirroring.allowlist = metric_allowlist.iter().map(|name| (*name).to_string()).collect();
+
+        config
+    }
+
+    /// Builds the routing state the transform starts from, the way `run` does.
+    fn routing(enabled: bool, source: &LiveSource) -> Routing {
+        let config = MrfMetricsGatewayConfiguration::new(enabled, source.metric_mirroring());
+        let gateway = MrfMetricsGateway::new(&config);
+
+        Routing::new(gateway.enabled, (*gateway.metric_mirroring).clone())
+    }
+
+    fn counter(name: &'static str) -> Event {
+        Event::Metric(Metric::counter(name, 1.0))
+    }
+
+    /// Waits for `view` to process the published update, failing the test rather than hanging.
+    async fn await_update<T>(view: &mut Live<T>) -> T
+    where
+        T: Clone + PartialEq + 'static,
+    {
+        tokio::time::timeout(std::time::Duration::from_secs(2), view.changed())
+            .await
+            .expect("the published update should reach the view")
     }
 
     #[tokio::test]
-    async fn failover_metrics_dynamic_update_toggles_forwarding() {
-        let (mut gw, sender) = dynamic_gateway_from_config(
-            multi_region_failover::Domain {
-                enabled: true,
-                failover_metrics: false,
-                api_key: Some("mrf-api-key".to_string()),
-                dd_url: Some("https://mrf.example.com".to_string()),
-                ..Default::default()
-            },
-            json!({
-                "multi_region_failover": {
-                    "enabled": true,
-                    "failover_metrics": false,
-                    "api_key": "mrf-api-key",
-                    "dd_url": "https://mrf.example.com"
-                }
-            }),
-        )
-        .await;
-        let mut watcher = gw
-            .configuration
-            .watch_for_updates("multi_region_failover.failover_metrics");
+    async fn failover_that_is_off_drops_everything() {
+        let source = LiveSource::new(true, &[]);
+        let routing = routing(false, &source);
 
-        assert!(!gw.should_forward(&Event::Metric(Metric::counter("any.metric", 1.0))));
-
-        sender
-            .send(ConfigUpdate::Partial(ConfigSetting::explicit(
-                "multi_region_failover.failover_metrics",
-                json!(true),
-            )))
-            .await
-            .expect("dynamic update should be sent");
-        let (_, maybe_failover_metrics) =
-            tokio::time::timeout(std::time::Duration::from_secs(2), watcher.changed::<bool>())
-                .await
-                .expect("failover metrics update should be received");
-        gw.update_failover_metrics(maybe_failover_metrics.expect("update should have a new value"));
-        assert!(gw.should_forward(&Event::Metric(Metric::counter("any.metric", 1.0))));
-
-        sender
-            .send(ConfigUpdate::Partial(ConfigSetting::explicit(
-                "multi_region_failover.failover_metrics",
-                json!(false),
-            )))
-            .await
-            .expect("dynamic update should be sent");
-        let (_, maybe_failover_metrics) =
-            tokio::time::timeout(std::time::Duration::from_secs(2), watcher.changed::<bool>())
-                .await
-                .expect("failover metrics update should be received");
-        gw.update_failover_metrics(maybe_failover_metrics.expect("update should have a new value"));
-        assert!(!gw.should_forward(&Event::Metric(Metric::counter("any.metric", 1.0))));
+        assert!(!routing.should_forward(&counter("any.metric")));
     }
 
     #[tokio::test]
-    async fn metric_allowlist_dynamic_update_changes_filtering() {
-        let (mut gw, sender) = dynamic_gateway_from_config(
-            multi_region_failover::Domain {
-                enabled: true,
-                failover_metrics: true,
-                api_key: Some("mrf-api-key".to_string()),
-                dd_url: Some("https://mrf.example.com".to_string()),
-                ..Default::default()
-            },
-            json!({
-                "multi_region_failover": {
-                    "enabled": true,
-                    "failover_metrics": true,
-                    "api_key": "mrf-api-key",
-                    "dd_url": "https://mrf.example.com"
-                }
-            }),
-        )
-        .await;
-        let mut watcher = gw
-            .configuration
-            .watch_for_updates("multi_region_failover.metric_allowlist");
+    async fn mirroring_that_is_off_drops_everything() {
+        let source = LiveSource::new(false, &[]);
+        let routing = routing(true, &source);
 
-        assert!(gw.should_forward(&Event::Metric(Metric::counter("allowed.metric", 1.0))));
-        assert!(gw.should_forward(&Event::Metric(Metric::counter("also.allowed", 1.0))));
+        assert!(!routing.should_forward(&counter("any.metric")));
+    }
 
-        sender
-            .send(ConfigUpdate::Partial(ConfigSetting::explicit(
-                "multi_region_failover.metric_allowlist",
-                json!(["also.allowed"]),
-            )))
-            .await
-            .expect("dynamic update should be sent");
-        let (_, maybe_metric_allowlist) =
-            tokio::time::timeout(std::time::Duration::from_secs(2), watcher.changed::<Vec<String>>())
+    #[tokio::test]
+    async fn an_empty_allowlist_forwards_everything() {
+        let source = LiveSource::new(true, &[]);
+        let routing = routing(true, &source);
+
+        assert!(routing.should_forward(&counter("any.metric")));
+    }
+
+    #[tokio::test]
+    async fn an_allowlist_forwards_only_matching_metrics() {
+        let source = LiveSource::new(true, &["allowed.metric"]);
+        let routing = routing(true, &source);
+
+        assert!(routing.should_forward(&counter("allowed.metric")));
+        assert!(!routing.should_forward(&counter("blocked.metric")));
+    }
+
+    #[tokio::test]
+    async fn a_mirroring_update_toggles_forwarding() {
+        let source = LiveSource::new(false, &[]);
+        let mut routing = routing(true, &source);
+        let mut view = source.metric_mirroring();
+
+        assert!(!routing.should_forward(&counter("any.metric")));
+
+        source.publish(true, &[]);
+        routing.set_metric_mirroring(await_update(&mut view).await);
+        assert!(routing.should_forward(&counter("any.metric")));
+
+        source.publish(false, &[]);
+        routing.set_metric_mirroring(await_update(&mut view).await);
+        assert!(!routing.should_forward(&counter("any.metric")));
+    }
+
+    #[tokio::test]
+    async fn an_allowlist_update_changes_filtering() {
+        let source = LiveSource::new(true, &[]);
+        let mut routing = routing(true, &source);
+        let mut view = source.metric_mirroring();
+
+        assert!(routing.should_forward(&counter("allowed.metric")));
+        assert!(routing.should_forward(&counter("also.allowed")));
+
+        source.publish(true, &["also.allowed"]);
+        routing.set_metric_mirroring(await_update(&mut view).await);
+
+        assert!(!routing.should_forward(&counter("allowed.metric")));
+        assert!(routing.should_forward(&counter("also.allowed")));
+        assert!(!routing.should_forward(&counter("blocked.metric")));
+    }
+
+    #[tokio::test]
+    async fn a_change_to_both_settings_arrives_as_one_update() {
+        // The dangerous transition is mirroring turning off as the allowlist is cleared: taken one setting at a time,
+        // the cleared allowlist alone reads as "forward everything", which no published configuration asked for. The
+        // two settings share one view, so the transition arrives as a single value and the intermediate state cannot
+        // be observed.
+        let source = LiveSource::new(true, &["allowed.metric"]);
+        let mut routing = routing(true, &source);
+        let mut view = source.metric_mirroring();
+
+        assert!(routing.should_forward(&counter("allowed.metric")));
+        assert!(!routing.should_forward(&counter("other.metric")));
+
+        source.publish(false, &[]);
+        routing.set_metric_mirroring(await_update(&mut view).await);
+
+        assert!(!routing.should_forward(&counter("allowed.metric")));
+        assert!(!routing.should_forward(&counter("other.metric")));
+
+        // Nothing is left to deliver, which is what makes the assertions above the only state the transform sees.
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), view.changed())
                 .await
-                .expect("metric allowlist update should be received");
-        gw.update_metric_allowlist(maybe_metric_allowlist.expect("update should have a new value"));
-
-        assert!(!gw.should_forward(&Event::Metric(Metric::counter("allowed.metric", 1.0))));
-        assert!(gw.should_forward(&Event::Metric(Metric::counter("also.allowed", 1.0))));
-        assert!(!gw.should_forward(&Event::Metric(Metric::counter("blocked.metric", 1.0))));
+                .is_err(),
+            "both settings should have arrived in the update above"
+        );
     }
 }

--- a/lib/saluki-components/src/transforms/mrf_gateway/mod.rs
+++ b/lib/saluki-components/src/transforms/mrf_gateway/mod.rs
@@ -397,32 +397,4 @@ mod tests {
         assert!(routing.should_forward(&counter("also.allowed")));
         assert!(!routing.should_forward(&counter("blocked.metric")));
     }
-
-    #[tokio::test]
-    async fn a_change_to_both_settings_arrives_as_one_update() {
-        // The dangerous transition is mirroring turning off as the allowlist is cleared: taken one setting at a time,
-        // the cleared allowlist alone reads as "forward everything", which no published configuration asked for. The
-        // two settings share one view, so the transition arrives as a single value and the intermediate state cannot
-        // be observed.
-        let source = LiveSource::new(true, &["allowed.metric"]);
-        let mut routing = routing(true, &source);
-        let mut view = source.metric_mirroring();
-
-        assert!(routing.should_forward(&counter("allowed.metric")));
-        assert!(!routing.should_forward(&counter("other.metric")));
-
-        source.publish(false, &[]);
-        routing.set_metric_mirroring(await_update(&mut view).await);
-
-        assert!(!routing.should_forward(&counter("allowed.metric")));
-        assert!(!routing.should_forward(&counter("other.metric")));
-
-        // Nothing is left to deliver, which is what makes the assertions above the only state the transform sees.
-        assert!(
-            tokio::time::timeout(std::time::Duration::from_millis(50), view.changed())
-                .await
-                .is_err(),
-            "both settings should have arrived in the update above"
-        );
-    }
 }

--- a/lib/saluki-components/src/transforms/mrf_gateway/mod.rs
+++ b/lib/saluki-components/src/transforms/mrf_gateway/mod.rs
@@ -175,13 +175,13 @@ impl MemoryBounds for MrfMetricsGatewayConfiguration {
             .with_single_value::<MrfMetricsGateway>("component struct")
             .with_fixed_amount("hashset overhead", std::mem::size_of::<HashSet<String>>())
             .with_fixed_amount(
-                // Two copies: the live view's snapshot, and the copy the routing state is rebuilt from.
+                // Three copies: the live view's snapshot, routing state, and hash set.
                 "allowlist strings",
                 allowlist
                     .iter()
                     .map(|name| name.len() + std::mem::size_of::<String>())
                     .sum::<usize>()
-                    * 2,
+                    * 3,
             )
             .with_fixed_amount(
                 "hashset buckets",
@@ -232,11 +232,15 @@ impl Transform for MrfMetricsGateway {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{mem::size_of, sync::Arc};
 
     use agent_data_plane_config::SalukiConfiguration;
     use arc_swap::ArcSwap;
-    use saluki_core::data_model::event::{metric::Metric, Event};
+    use saluki_core::{
+        accounting::ComponentRegistry,
+        data_model::event::{metric::Metric, Event},
+        support::SubsystemIdentifier,
+    };
     use tokio::sync::watch;
 
     use super::*;
@@ -302,6 +306,29 @@ mod tests {
         tokio::time::timeout(std::time::Duration::from_secs(2), view.changed())
             .await
             .expect("the published update should reach the view")
+    }
+
+    #[test]
+    fn memory_bounds_include_all_allowlist_copies() {
+        let allowlist = ["allowed.metric", "also.allowed"];
+        let source = LiveSource::new(true, &allowlist);
+        let config = MrfMetricsGatewayConfiguration::new(true, source.metric_mirroring());
+
+        let registry = ComponentRegistry::default();
+        config.specify_bounds(&mut registry.bounds_builder(&SubsystemIdentifier::from_dotted("test")));
+        let bounds = registry.as_bounds();
+
+        let allowlist_strings = allowlist
+            .iter()
+            .map(|name| name.len() + size_of::<String>())
+            .sum::<usize>();
+        let expected = size_of::<MrfMetricsGateway>()
+            + size_of::<HashSet<String>>()
+            + allowlist_strings * 3
+            + allowlist.len() * size_of::<Option<String>>() * 2;
+
+        assert_eq!(bounds.total_minimum_required_bytes(), expected);
+        assert_eq!(bounds.total_firm_limit_bytes(), expected);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Human Summary

Migrate `MrfConfiguration` and `MrfMetricsGatewayConfiguration` to typed configuration. These were slightly more complex than other migrations due to dynamic configuration. An audit caught that a config stream change to both the allowlist and dynamic enablement flag in the same config stream commit could be torn at the component, so we bundled these together in a single `Live<T>`. That change led to a little bit of extra churn. While at it, `failover_metrics` was renamed to `metric_mirroring.enabled` internally which is a bit clearer.

## AI Summary

Migrate the MRF metrics gateway transform off the raw configuration map.

- Group `multi_region_failover.failover_metrics` and
  `multi_region_failover.metric_allowlist` into `multi_region_failover.metric_mirroring`
  on the typed model, and take one `Live<MetricMirroring>` instead of holding a
  cloned raw map and watching the two keys by name.
- Rebuild the gateway's routing state from that one value, so it is always
  derived from a single configuration version.
- Drop the `MrfConfiguration` fields and accessors that only the gateway used.
- Document the defaults and the empty-allowlist behavior on the typed model.

The one behavior change worth naming: updates now arrive through the typed
model, so a failed translation keeps the last known good values instead of
delivering a raw value the typed system rejected.

### Behavioral Notes

The gateway's routing state is derived from two settings at once: whether
metrics are mirrored, and which metric names are allowed. Watching them
separately — as the gateway did before this change, by key, and as an earlier
revision of this change did with one `Live` view each — means each update
rebuilds that state from one fresh value and one stale one, because a watcher
wakes for one setting at a time.

That can produce a routing state no configuration version ever described. Going
from mirroring-on with an allowlist to mirroring-off with an empty allowlist,
the cleared allowlist can be applied first, and an empty allowlist with
mirroring still on means "forward everything": every metric is mirrored to the
failover region until the second value lands, and a batch can be processed in
that window.

The fix is to make the pair the unit of observation. The two settings now live
in one struct on the typed model, `multi_region_failover.metric_mirroring`, and
the gateway takes a single live view of it, so one update carries both values
and the intermediate state is unobservable. `a_change_to_both_settings_arrives_as_one_update`
covers exactly that transition. The memory bound now counts the allowlist three times: the view's snapshot, the routing state, and the hash set.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make fmt`
- `make check-all`
- `cargo nextest run -p saluki-components -p agent-data-plane-config -p agent-data-plane-config-system -p agent-data-plane`

## References

- Progresses: #2293



