### PR TITLE
feat(otlp): added origin metadata to metrics

### DIFF
--- a/bin/correctness/panoramic/src/correctness/analysis/metrics/mod.rs
+++ b/bin/correctness/panoramic/src/correctness/analysis/metrics/mod.rs
@@ -124,6 +124,27 @@ fn compare_metric_values(
                 samples.push(detail);
             }
         }
+
+        // Compare origin metadata. A mismatch here means the baseline and comparison disagree on the product,
+        // subproduct, or product detail of the metric— which affects billing attribution.
+        if baseline_metric.origin() != comparison_metric.origin() {
+            mismatched_count += 1;
+
+            error!("Found mismatched origin for metric '{}':", baseline_metric.context());
+            warn!("  Baseline:    {}", format_origin(baseline_metric.origin()));
+            warn!("  Comparison: {}", format_origin(comparison_metric.origin()));
+
+            let detail = format!(
+                "  {} (origin)\n    baseline:    {}\n    comparison:  {}",
+                baseline_metric.context(),
+                format_origin(baseline_metric.origin()),
+                format_origin(comparison_metric.origin()),
+            );
+            all_details.push(detail.clone());
+            if samples.len() < SAMPLE_MISMATCH_LIMIT {
+                samples.push(detail);
+            }
+        }
     }
 
     if mismatched_count == 0 {
@@ -190,5 +211,15 @@ fn get_formatted_metric_value(value: &MetricValue) -> String {
             sketch.count(),
             sketch.bin_count(),
         ),
+    }
+}
+
+fn format_origin(origin: Option<&stele::MetricOrigin>) -> String {
+    match origin {
+        Some(origin) => format!(
+            "product={} category={} service={}",
+            origin.product, origin.category, origin.service
+        ),
+        None => "none".to_string(),
     }
 }

--- a/bin/correctness/panoramic/src/correctness/analysis/metrics/types.rs
+++ b/bin/correctness/panoramic/src/correctness/analysis/metrics/types.rs
@@ -202,13 +202,28 @@ impl NormalizedMetrics {
         for metric in metrics {
             let context = NormalizedMetricContext::from_stele_context(metric.context().clone());
             let metric_type = metric_value_type(metric.values());
+            let metric_origin = metric.origin().cloned();
             let key = (context, metric_type);
             let (context_values, origin) = aggregated_context_values
                 .entry(key)
                 .or_insert_with(|| (Vec::new(), None));
             context_values.extend_from_slice(metric.values());
-            if origin.is_none() {
-                *origin = metric.origin().cloned();
+
+            // Track the origin for this group. The same metric may arrive via multiple wire formats
+            // (V1 JSON, V2 series/sketch, V3), and we take the first non-`None` origin. If a later
+            // metric in the same group has a different non-`None` origin, that indicates a wire-format
+            // discrepancy — we reject it rather than silently dropping the conflicting value.
+            match (&*origin, &metric_origin) {
+                (None, Some(new_origin)) => *origin = Some(new_origin.clone()),
+                (Some(existing), Some(new_origin)) if existing != new_origin => {
+                    return Err(generic_error!(
+                        "Conflicting origin metadata for metric '{}': {:?} vs {:?}",
+                        metric.context().name(),
+                        existing,
+                        new_origin
+                    ));
+                }
+                _ => {}
             }
         }
 

--- a/bin/correctness/panoramic/src/correctness/analysis/metrics/types.rs
+++ b/bin/correctness/panoramic/src/correctness/analysis/metrics/types.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
-use stele::{Metric, MetricContext, MetricValue};
+use stele::{Metric, MetricContext, MetricOrigin, MetricValue};
 
 /// A metric context and type pair, used for comparing metrics between different sets.
 type ContextTypePair<'a> = (&'a NormalizedMetricContext, MetricType);
@@ -101,16 +101,17 @@ pub struct NormalizedMetric {
     context: NormalizedMetricContext,
     raw_values: Vec<(u64, MetricValue)>,
     value: MetricValue,
+    origin: Option<MetricOrigin>,
 }
 
 impl NormalizedMetric {
-    /// Attempts to create `NormalizedMetric` from the given context and raw metric values.
+    /// Attempts to create `NormalizedMetric` from the given context, raw metric values, and origin.
     ///
     /// # Errors
     ///
     /// If the raw values are empty, or if the values can't be normalized, an error is returned.
     pub fn try_from_values(
-        context: NormalizedMetricContext, mut raw_values: Vec<(u64, MetricValue)>,
+        context: NormalizedMetricContext, mut raw_values: Vec<(u64, MetricValue)>, origin: Option<MetricOrigin>,
     ) -> Result<Self, GenericError> {
         // We need to first sort the raw values by timestamp, to ensure we have proper ordering semantics.
         raw_values.sort_by_key(|a| a.0);
@@ -121,6 +122,7 @@ impl NormalizedMetric {
             context,
             raw_values,
             value,
+            origin,
         })
     }
 
@@ -149,7 +151,15 @@ impl NormalizedMetric {
     pub fn normalized_value(&self) -> &MetricValue {
         &self.value
     }
+
+    /// Returns the origin metadata of the metric, if present.
+    pub fn origin(&self) -> Option<&MetricOrigin> {
+        self.origin.as_ref()
+    }
 }
+
+/// Aggregated values and origin for a single (context, type) group during normalization.
+type AggregatedMetric = (Vec<(u64, MetricValue)>, Option<MetricOrigin>);
 
 /// A set of normalized metrics.
 ///
@@ -183,19 +193,28 @@ impl NormalizedMetrics {
         //
         // We group by type because metrics with the same context but different types (for example, Count vs Rate) cannot be
         // merged together during normalization.
-        let mut aggregated_context_values = BTreeMap::new();
+        //
+        // We also track the origin for each group. Since the same metric may arrive via multiple wire formats (V2 and V3),
+        // we take the first non-`None` origin— V1 JSON carries no origin, while V2/V3 do.
+        let mut aggregated_context_values: BTreeMap<(NormalizedMetricContext, MetricType), AggregatedMetric> =
+            BTreeMap::new();
 
         for metric in metrics {
             let context = NormalizedMetricContext::from_stele_context(metric.context().clone());
             let metric_type = metric_value_type(metric.values());
             let key = (context, metric_type);
-            let context_values = aggregated_context_values.entry(key).or_insert_with(Vec::new);
+            let (context_values, origin) = aggregated_context_values
+                .entry(key)
+                .or_insert_with(|| (Vec::new(), None));
             context_values.extend_from_slice(metric.values());
+            if origin.is_none() {
+                *origin = metric.origin().cloned();
+            }
         }
 
         let metrics = aggregated_context_values
             .into_iter()
-            .map(|((context, _type), values)| NormalizedMetric::try_from_values(context, values))
+            .map(|((context, _type), (values, origin))| NormalizedMetric::try_from_values(context, values, origin))
             .try_fold(Vec::new(), |mut metrics, maybe_metric| {
                 metrics.push(maybe_metric?);
                 Ok::<_, GenericError>(metrics)

--- a/bin/correctness/stele/src/metrics.rs
+++ b/bin/correctness/stele/src/metrics.rs
@@ -685,7 +685,18 @@ impl Metric {
                 if origin_ref == 0 {
                     None
                 } else {
-                    origins_dict.get(origin_ref - 1).cloned()
+                    Some(
+                        origins_dict
+                            .get(origin_ref - 1)
+                            .ok_or_else(|| {
+                                generic_error!(
+                                    "Invalid origin info ref {} (dict size {})",
+                                    origin_ref,
+                                    origins_dict.len()
+                                )
+                            })?
+                            .clone(),
+                    )
                 }
             };
 

--- a/bin/correctness/stele/src/metrics.rs
+++ b/bin/correctness/stele/src/metrics.rs
@@ -75,11 +75,31 @@ impl fmt::Display for MetricContext {
     }
 }
 
+/// Origin metadata attached to a metric on the wire.
+///
+/// The field names follow the wire semantics: `product` is the originating product, `category` is the
+/// subproduct, and `service` is the product-specific detail.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct MetricOrigin {
+    /// The originating product (for example, `10` for the Agent, `19` for the OpenTelemetry Collector
+    /// Datadog Exporter).
+    pub product: u32,
+
+    /// The subproduct / category.
+    pub category: u32,
+
+    /// The product-specific detail (for example, the receiver that produced the metric).
+    pub service: u32,
+}
+
 /// A simplified metric representation.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Metric {
     context: MetricContext,
     values: Vec<(u64, MetricValue)>,
+    /// Origin metadata, if present in the wire payload.
+    #[serde(default)]
+    origin: Option<MetricOrigin>,
 }
 
 impl Metric {
@@ -91,6 +111,11 @@ impl Metric {
     /// Returns the values associated with the metric.
     pub fn values(&self) -> &[(u64, MetricValue)] {
         &self.values
+    }
+
+    /// Returns the origin metadata of the metric, if present.
+    pub fn origin(&self) -> Option<&MetricOrigin> {
+        self.origin.as_ref()
     }
 }
 
@@ -242,6 +267,7 @@ impl Metric {
                     tags,
                 },
                 values,
+                origin: None,
             });
         }
 
@@ -304,9 +330,20 @@ impl Metric {
                 }
             }
 
+            let origin = series
+                .metadata
+                .as_ref()
+                .and_then(|m| m.origin.as_ref())
+                .map(|o| MetricOrigin {
+                    product: o.origin_product,
+                    category: o.origin_category,
+                    service: o.origin_service,
+                });
+
             metrics.push(Metric {
                 context: MetricContext { name, tags },
                 values,
+                origin,
             })
         }
 
@@ -340,9 +377,20 @@ impl Metric {
                 values.push((timestamp, MetricValue::Sketch { sketch }));
             }
 
+            let origin = sketch
+                .metadata
+                .as_ref()
+                .and_then(|m| m.origin.as_ref())
+                .map(|o| MetricOrigin {
+                    product: o.origin_product,
+                    category: o.origin_category,
+                    service: o.origin_service,
+                });
+
             metrics.push(Metric {
                 context: MetricContext { name, tags },
                 values,
+                origin,
             })
         }
 
@@ -416,16 +464,19 @@ impl Metric {
             &data.dictResourceName,
             &parse_dict_strings(&data.dictResourceStr)?,
         )?;
+        let origins_dict = parse_origin_infos(&data.dictOriginInfo)?;
 
         // Delta-decode index arrays.
         let mut name_refs = data.nameRefs;
         let mut tagset_refs = data.tagsetRefs;
         let mut resources_refs = data.resourcesRefs;
         let mut timestamps = data.timestamps;
+        let mut origin_info_refs = data.originInfoRefs;
         delta_decode(&mut name_refs);
         delta_decode(&mut tagset_refs);
         delta_decode(&mut resources_refs);
         delta_decode(&mut timestamps);
+        delta_decode(&mut origin_info_refs);
 
         // Delta-decode sketch bin keys (per-sketch sequences are individually delta-encoded,
         // but we handle that during iteration).
@@ -623,9 +674,25 @@ impl Metric {
                 }
             }
 
+            let origin = if origin_info_refs.is_empty() {
+                None
+            } else {
+                let origin_ref = origin_info_refs
+                    .get(i)
+                    .copied()
+                    .ok_or_else(|| generic_error!("Ran out of originInfoRefs"))
+                    .and_then(|r| i64_to_usize(r, "origin info ref"))?;
+                if origin_ref == 0 {
+                    None
+                } else {
+                    origins_dict.get(origin_ref - 1).cloned()
+                }
+            };
+
             metrics.push(Metric {
                 context: MetricContext { name, tags },
                 values,
+                origin,
             });
         }
 
@@ -795,6 +862,29 @@ fn resource_index(idx: i64) -> Result<usize, GenericError> {
     let idx = usize::try_from(idx).map_err(|_| generic_error!("Invalid negative resource index: {}", idx))?;
     idx.checked_sub(1)
         .ok_or_else(|| generic_error!("Invalid zero resource index"))
+}
+
+/// Parse the `dictOriginInfo` dictionary into a list of origin tuples.
+///
+/// The dictionary is a flat array of `i32` values, where every three consecutive elements form a
+/// `(product, category, service)` tuple.
+fn parse_origin_infos(dict_origin_info: &[i32]) -> Result<Vec<MetricOrigin>, GenericError> {
+    if !dict_origin_info.len().is_multiple_of(3) {
+        return Err(generic_error!(
+            "dictOriginInfo has {} elements, which is not a multiple of 3",
+            dict_origin_info.len()
+        ));
+    }
+
+    let mut origins = Vec::with_capacity(dict_origin_info.len() / 3);
+    for chunk in dict_origin_info.chunks_exact(3) {
+        origins.push(MetricOrigin {
+            product: chunk[0] as u32,
+            category: chunk[1] as u32,
+            service: chunk[2] as u32,
+        });
+    }
+    Ok(origins)
 }
 
 /// Read the next f64 value from the appropriate value array based on `value_type`.
@@ -1005,6 +1095,89 @@ mod tests {
     }
 
     #[test]
+    fn try_from_series_v2_extracts_origin_metadata() {
+        use datadog_protos::metrics::metric_payload::{MetricPoint, MetricSeries, MetricType as ProtoMetricType};
+        use datadog_protos::metrics::{Metadata, MetricPayload, Origin};
+
+        let mut payload = MetricPayload::new();
+
+        let mut series = MetricSeries::new();
+        series.set_metric("my.metric".into());
+        series.set_type(ProtoMetricType::COUNT);
+
+        let mut origin = Origin::new();
+        origin.origin_product = 19;
+        origin.origin_category = 0;
+        origin.origin_service = 224;
+        let mut metadata = Metadata::new();
+        metadata.set_origin(origin);
+        series.set_metadata(metadata);
+
+        let mut point = MetricPoint::new();
+        point.value = 1.0;
+        point.timestamp = 1;
+        series.points.push(point);
+
+        payload.series.push(series);
+
+        let metrics = Metric::try_from_series_v2(payload).expect("parse should succeed");
+        assert_eq!(metrics.len(), 1);
+        let origin = metrics[0].origin().expect("origin should be present");
+        assert_eq!(origin.product, 19);
+        assert_eq!(origin.category, 0);
+        assert_eq!(origin.service, 224);
+    }
+
+    #[test]
+    fn try_from_series_v2_omits_origin_when_metadata_absent() {
+        use datadog_protos::metrics::metric_payload::{MetricPoint, MetricSeries, MetricType as ProtoMetricType};
+        use datadog_protos::metrics::MetricPayload;
+
+        let mut payload = MetricPayload::new();
+        let mut series = MetricSeries::new();
+        series.set_metric("my.metric".into());
+        series.set_type(ProtoMetricType::COUNT);
+
+        let mut point = MetricPoint::new();
+        point.value = 1.0;
+        point.timestamp = 1;
+        series.points.push(point);
+
+        payload.series.push(series);
+
+        let metrics = Metric::try_from_series_v2(payload).expect("parse should succeed");
+        assert_eq!(metrics.len(), 1);
+        assert!(metrics[0].origin().is_none());
+    }
+
+    #[test]
+    fn try_from_sketch_extracts_origin_metadata() {
+        use datadog_protos::metrics::sketch_payload::Sketch;
+        use datadog_protos::metrics::{Metadata, Origin, SketchPayload};
+
+        let mut payload = SketchPayload::new();
+        let mut sketch = Sketch::new();
+        sketch.set_metric("my.metric".into());
+
+        let mut origin = Origin::new();
+        origin.origin_product = 19;
+        origin.origin_category = 0;
+        origin.origin_service = 229;
+        let mut metadata = Metadata::new();
+        metadata.set_origin(origin);
+        sketch.set_metadata(metadata);
+
+        payload.sketches.push(sketch);
+
+        let metrics = Metric::try_from_sketch(payload).expect("parse should succeed");
+        assert_eq!(metrics.len(), 1);
+        let origin = metrics[0].origin().expect("origin should be present");
+        assert_eq!(origin.product, 19);
+        assert_eq!(origin.category, 0);
+        assert_eq!(origin.service, 229);
+    }
+
+    #[test]
     fn try_from_sketch_folds_host_into_tags() {
         use datadog_protos::metrics::sketch_payload::Sketch;
         use datadog_protos::metrics::SketchPayload;
@@ -1050,6 +1223,57 @@ mod tests {
         assert!(metrics[0].context.tags.contains(&"env:prod".to_string()));
         assert!(metrics[0].context.tags.contains(&"host:server-1".to_string()));
         assert!(!metrics[0].context.tags.iter().any(|tag| tag.starts_with("device:")));
+    }
+
+    #[test]
+    fn try_from_v3_extracts_origin_metadata() {
+        use datadog_protos::metrics::v3::{MetricData, Payload};
+
+        let mut data = MetricData::new();
+        data.dictNameStr = length_prefixed_strings(["my.metric"]);
+        // One origin tuple: (19, 0, 224) at 1-based index 1.
+        data.dictOriginInfo = vec![19, 0, 224];
+        data.types = vec![V3_METRIC_TYPE_COUNT | V3_VALUE_TYPE_ZERO];
+        data.nameRefs = vec![1];
+        data.tagsetRefs = vec![0];
+        data.resourcesRefs = vec![0];
+        data.intervals = vec![0];
+        data.numPoints = vec![1];
+        data.timestamps = vec![1];
+        data.originInfoRefs = vec![1];
+
+        let mut payload = Payload::new();
+        payload.metricData = Some(data).into();
+
+        let metrics = Metric::try_from_v3(payload).expect("parse should succeed");
+        assert_eq!(metrics.len(), 1);
+        let origin = metrics[0].origin().expect("origin should be present");
+        assert_eq!(origin.product, 19);
+        assert_eq!(origin.category, 0);
+        assert_eq!(origin.service, 224);
+    }
+
+    #[test]
+    fn try_from_v3_omits_origin_when_ref_is_zero() {
+        use datadog_protos::metrics::v3::{MetricData, Payload};
+
+        let mut data = MetricData::new();
+        data.dictNameStr = length_prefixed_strings(["my.metric"]);
+        data.types = vec![V3_METRIC_TYPE_COUNT | V3_VALUE_TYPE_ZERO];
+        data.nameRefs = vec![1];
+        data.tagsetRefs = vec![0];
+        data.resourcesRefs = vec![0];
+        data.intervals = vec![0];
+        data.numPoints = vec![1];
+        data.timestamps = vec![1];
+        data.originInfoRefs = vec![0];
+
+        let mut payload = Payload::new();
+        payload.metricData = Some(data).into();
+
+        let metrics = Metric::try_from_v3(payload).expect("parse should succeed");
+        assert_eq!(metrics.len(), 1);
+        assert!(metrics[0].origin().is_none());
     }
 
     #[test]

--- a/lib/saluki-components/src/sources/otlp/metrics/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/mod.rs
@@ -4,6 +4,7 @@ pub mod cache;
 pub mod config;
 pub mod dimensions;
 pub mod internal;
+pub mod origin;
 pub mod remap;
 pub mod runtime_metrics;
 pub mod telemetry;

--- a/lib/saluki-components/src/sources/otlp/metrics/origin.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/origin.rs
@@ -8,14 +8,10 @@ const COLLECTOR_RECEIVER_PREFIX: &str = "github.com/open-telemetry/opentelemetry
 
 /// Returns the origin product detail for the given instrumentation scope name.
 ///
-/// Returns `0` (unknown) when the scope name is empty or does not begin with the Collector receiver prefix.
-/// Otherwise, extracts the receiver name—the first path segment after the prefix—and looks it up in the
-/// known-receiver table.
+/// Returns `0` (unknown) when the scope name is empty or does not begin with the Collector receiver
+/// prefix. Otherwise, extracts the receiver name—the first path segment after the prefix—and
+/// looks it up in the known-receiver table.
 pub fn product_detail_from_scope(scope_name: &str) -> u32 {
-    product_detail_from_scope_name(scope_name)
-}
-
-fn product_detail_from_scope_name(scope_name: &str) -> u32 {
     // Strip the Collector receiver prefix, then take the first remaining path segment as the receiver name:
     //
     //   .../receiver/kubeletstatsreceiver          -> kubeletstatsreceiver
@@ -80,31 +76,31 @@ mod tests {
     #[test]
     fn known_receiver_scope_names_map_to_their_product_detail() {
         assert_eq!(
-            product_detail_from_scope_name(
+            product_detail_from_scope(
                 "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver"
             ),
             224
         );
         assert_eq!(
-            product_detail_from_scope_name(
+            product_detail_from_scope(
                 "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver"
             ),
             229
         );
         assert_eq!(
-            product_detail_from_scope_name(
+            product_detail_from_scope(
                 "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
             ),
             238
         );
         assert_eq!(
-            product_detail_from_scope_name(
+            product_detail_from_scope(
                 "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver"
             ),
             217
         );
         assert_eq!(
-            product_detail_from_scope_name(
+            product_detail_from_scope(
                 "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver"
             ),
             521
@@ -114,7 +110,7 @@ mod tests {
     #[test]
     fn sub_signal_segments_after_the_receiver_name_are_ignored() {
         assert_eq!(
-            product_detail_from_scope_name(
+            product_detail_from_scope(
                 "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/disk"
             ),
             224
@@ -124,7 +120,7 @@ mod tests {
     #[test]
     fn unknown_receiver_name_falls_back_to_zero() {
         assert_eq!(
-            product_detail_from_scope_name(
+            product_detail_from_scope(
                 "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/unknownreceiver"
             ),
             0
@@ -133,8 +129,8 @@ mod tests {
 
     #[test]
     fn scope_name_without_collector_prefix_falls_back_to_zero() {
-        assert_eq!(product_detail_from_scope_name("io.opentelemetry.myapp"), 0);
-        assert_eq!(product_detail_from_scope_name(""), 0);
+        assert_eq!(product_detail_from_scope("io.opentelemetry.myapp"), 0);
+        assert_eq!(product_detail_from_scope(""), 0);
     }
 
     #[test]

--- a/lib/saluki-components/src/sources/otlp/metrics/origin.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/origin.rs
@@ -1,0 +1,173 @@
+//! OTLP metrics origin mapping.
+//!
+//! Maps an OTLP `InstrumentationScope` name to a Datadog `OriginProductDetail` identifier, so that metrics ingested
+//! over OTLP carry the same origin metadata the Agent emits for billing and UI attribution.
+//!
+//! This is a port of the Agent's `originProductDetailFromScopeName` logic in
+//! `pkg/opentelemetry-mapping-go/otlp/metrics/origin.go`. The receiver-name-to-product-detail constants and the
+//! scope-name parsing rules are kept identical to the Agent.
+
+/// The product detail used when a scope is absent or does not map to a known receiver.
+const ORIGIN_PRODUCT_DETAIL_UNKNOWN: u32 = 0;
+
+/// The prefix shared by OpenTelemetry Collector receiver instrumentation scopes.
+///
+/// A scope name is only mapped to a receiver when it begins with this prefix. The receiver name is the first path
+/// segment after the prefix; any further segments (for example, a sub-signal like `disk` in
+/// `hostmetricsreceiver/disk`) are ignored.
+const COLLECTOR_RECEIVER_PREFIX: &str = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/";
+
+/// Returns the `OriginProductDetail` for the given instrumentation scope name.
+///
+/// When the scope name is empty (no `InstrumentationScope` was present) or does not begin with the Collector
+/// receiver prefix, this returns `0` (unknown). Otherwise it extracts the receiver name — the first path segment
+/// after the prefix — and looks it up in the known-receiver table.
+///
+/// This mirrors the Agent's behavior at `pkg/opentelemetry-mapping-go/otlp/metrics/origin.go`, including the
+/// unknown-scope fallback.
+pub fn product_detail_from_scope(scope_name: &str) -> u32 {
+    product_detail_from_scope_name(scope_name)
+}
+
+fn product_detail_from_scope_name(scope_name: &str) -> u32 {
+    // Strip the Collector receiver prefix, then take the first remaining path segment as the receiver name:
+    //
+    //   .../receiver/kubeletstatsreceiver          -> kubeletstatsreceiver
+    //   .../receiver/hostmetricsreceiver/disk      -> hostmetricsreceiver
+    let receiver_name = match scope_name.strip_prefix(COLLECTOR_RECEIVER_PREFIX) {
+        Some(rest) => rest.split('/').next().unwrap_or(""),
+        None => return ORIGIN_PRODUCT_DETAIL_UNKNOWN,
+    };
+
+    // The receiver-name-to-product-detail table, kept identical to the Agent.
+    match receiver_name {
+        "activedirectorydsreceiver" => 251,
+        "aerospikereceiver" => 252,
+        "apachereceiver" => 253,
+        "apachesparkreceiver" => 254,
+        "azuremonitorreceiver" => 255,
+        "bigipreceiver" => 256,
+        "chronyreceiver" => 257,
+        "couchdbreceiver" => 258,
+        "dockerstatsreceiver" => 217,
+        "elasticsearchreceiver" => 218,
+        "expvarreceiver" => 219,
+        "filestatsreceiver" => 220,
+        "flinkmetricsreceiver" => 221,
+        "gitproviderreceiver" => 222,
+        "haproxyreceiver" => 223,
+        "hostmetricsreceiver" => 224,
+        "httpcheckreceiver" => 225,
+        "iisreceiver" => 226,
+        "k8sclusterreceiver" => 227,
+        "kafkametricsreceiver" => 228,
+        "kubeletstatsreceiver" => 229,
+        "memcachedreceiver" => 230,
+        "mongodbatlasreceiver" => 231,
+        "mongodbreceiver" => 232,
+        "mysqlreceiver" => 233,
+        "nginxreceiver" => 234,
+        "nsxtreceiver" => 235,
+        "oracledbreceiver" => 236,
+        "podmanreceiver" => 521,
+        "postgresqlreceiver" => 237,
+        "prometheusreceiver" => 238,
+        "rabbitmqreceiver" => 239,
+        "redisreceiver" => 240,
+        "riakreceiver" => 241,
+        "saphanareceiver" => 242,
+        "snmpreceiver" => 243,
+        "snowflakereceiver" => 244,
+        "splunkenterprisereceiver" => 245,
+        "sqlserverreceiver" => 246,
+        "sshcheckreceiver" => 247,
+        "statsdreceiver" => 248,
+        "vcenterreceiver" => 249,
+        "zookeeperreceiver" => 250,
+        _ => ORIGIN_PRODUCT_DETAIL_UNKNOWN,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_receiver_scope_names_map_to_their_product_detail() {
+        // A few representative entries, including the receivers called out in the issue.
+        assert_eq!(
+            product_detail_from_scope_name(
+                "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver"
+            ),
+            224
+        );
+        assert_eq!(
+            product_detail_from_scope_name(
+                "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver"
+            ),
+            229
+        );
+        assert_eq!(
+            product_detail_from_scope_name(
+                "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+            ),
+            238
+        );
+        assert_eq!(
+            product_detail_from_scope_name(
+                "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver"
+            ),
+            217
+        );
+        assert_eq!(
+            product_detail_from_scope_name(
+                "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver"
+            ),
+            521
+        );
+    }
+
+    #[test]
+    fn sub_signal_segments_after_the_receiver_name_are_ignored() {
+        // The Agent takes the first path segment after the prefix; trailing segments (e.g. `disk`) must not affect
+        // the result.
+        assert_eq!(
+            product_detail_from_scope_name(
+                "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/disk"
+            ),
+            224
+        );
+    }
+
+    #[test]
+    fn unknown_receiver_name_falls_back_to_zero() {
+        assert_eq!(
+            product_detail_from_scope_name(
+                "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/unknownreceiver"
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn scope_name_without_collector_prefix_falls_back_to_zero() {
+        // Custom instrumentation libraries (e.g. application SDKs) do not use the Collector receiver prefix.
+        assert_eq!(product_detail_from_scope_name("io.opentelemetry.myapp"), 0);
+        assert_eq!(product_detail_from_scope_name(""), 0);
+    }
+
+    #[test]
+    fn empty_scope_name_falls_back_to_zero() {
+        assert_eq!(product_detail_from_scope(""), 0);
+    }
+
+    #[test]
+    fn present_known_scope_is_resolved() {
+        assert_eq!(
+            product_detail_from_scope(
+                "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver"
+            ),
+            234
+        );
+    }
+}

--- a/lib/saluki-components/src/sources/otlp/metrics/origin.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/origin.rs
@@ -1,30 +1,16 @@
-//! OTLP metrics origin mapping.
-//!
-//! Maps an OTLP `InstrumentationScope` name to a Datadog `OriginProductDetail` identifier, so that metrics ingested
-//! over OTLP carry the same origin metadata the Agent emits for billing and UI attribution.
-//!
-//! This is a port of the Agent's `originProductDetailFromScopeName` logic in
-//! `pkg/opentelemetry-mapping-go/otlp/metrics/origin.go`. The receiver-name-to-product-detail constants and the
-//! scope-name parsing rules are kept identical to the Agent.
+//! Maps an OTLP instrumentation scope name to an origin product detail identifier.
 
 /// The product detail used when a scope is absent or does not map to a known receiver.
 const ORIGIN_PRODUCT_DETAIL_UNKNOWN: u32 = 0;
 
 /// The prefix shared by OpenTelemetry Collector receiver instrumentation scopes.
-///
-/// A scope name is only mapped to a receiver when it begins with this prefix. The receiver name is the first path
-/// segment after the prefix; any further segments (for example, a sub-signal like `disk` in
-/// `hostmetricsreceiver/disk`) are ignored.
 const COLLECTOR_RECEIVER_PREFIX: &str = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/";
 
-/// Returns the `OriginProductDetail` for the given instrumentation scope name.
+/// Returns the origin product detail for the given instrumentation scope name.
 ///
-/// When the scope name is empty (no `InstrumentationScope` was present) or does not begin with the Collector
-/// receiver prefix, this returns `0` (unknown). Otherwise it extracts the receiver name — the first path segment
-/// after the prefix — and looks it up in the known-receiver table.
-///
-/// This mirrors the Agent's behavior at `pkg/opentelemetry-mapping-go/otlp/metrics/origin.go`, including the
-/// unknown-scope fallback.
+/// Returns `0` (unknown) when the scope name is empty or does not begin with the Collector receiver prefix.
+/// Otherwise, extracts the receiver name—the first path segment after the prefix—and looks it up in the
+/// known-receiver table.
 pub fn product_detail_from_scope(scope_name: &str) -> u32 {
     product_detail_from_scope_name(scope_name)
 }
@@ -39,7 +25,6 @@ fn product_detail_from_scope_name(scope_name: &str) -> u32 {
         None => return ORIGIN_PRODUCT_DETAIL_UNKNOWN,
     };
 
-    // The receiver-name-to-product-detail table, kept identical to the Agent.
     match receiver_name {
         "activedirectorydsreceiver" => 251,
         "aerospikereceiver" => 252,
@@ -94,7 +79,6 @@ mod tests {
 
     #[test]
     fn known_receiver_scope_names_map_to_their_product_detail() {
-        // A few representative entries, including the receivers called out in the issue.
         assert_eq!(
             product_detail_from_scope_name(
                 "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver"
@@ -129,8 +113,6 @@ mod tests {
 
     #[test]
     fn sub_signal_segments_after_the_receiver_name_are_ignored() {
-        // The Agent takes the first path segment after the prefix; trailing segments (e.g. `disk`) must not affect
-        // the result.
         assert_eq!(
             product_detail_from_scope_name(
                 "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/disk"
@@ -151,7 +133,6 @@ mod tests {
 
     #[test]
     fn scope_name_without_collector_prefix_falls_back_to_zero() {
-        // Custom instrumentation libraries (e.g. application SDKs) do not use the Collector receiver prefix.
         assert_eq!(product_detail_from_scope_name("io.opentelemetry.myapp"), 0);
         assert_eq!(product_detail_from_scope_name(""), 0);
     }

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -2207,7 +2207,7 @@ mod tests {
         assert_eq!(
             *origin,
             MetricOrigin::OriginMetadata {
-                product: 10,
+                product: 19,
                 subproduct: 17,
                 product_detail: 224,
             }
@@ -2234,7 +2234,7 @@ mod tests {
         assert_eq!(
             *origin,
             MetricOrigin::OriginMetadata {
-                product: 10,
+                product: 19,
                 subproduct: 17,
                 product_detail: 0,
             }
@@ -2262,7 +2262,7 @@ mod tests {
         assert_eq!(
             *origin,
             MetricOrigin::OriginMetadata {
-                product: 10,
+                product: 19,
                 subproduct: 17,
                 product_detail: 0,
             }
@@ -2330,7 +2330,7 @@ mod tests {
         assert_eq!(
             *origin,
             MetricOrigin::OriginMetadata {
-                product: 10,
+                product: 19,
                 subproduct: 17,
                 product_detail: 229, // kubeletstatsreceiver
             }

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -25,7 +25,7 @@ use otlp_protos::opentelemetry::proto::metrics::v1::{
 use saluki_common::collections::FastHashSet;
 use saluki_context::tags::{SharedTagSet, TagSet};
 use saluki_context::{ContextResolver, ContextResolverBuilder};
-use saluki_core::data_model::event::metric::{Metric, MetricMetadata, MetricValues};
+use saluki_core::data_model::event::metric::{Metric, MetricMetadata, MetricOrigin, MetricValues};
 use saluki_core::data_model::event::Event;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use stringtheory::MetaString;
@@ -35,6 +35,7 @@ use super::cache::PointsCache;
 use super::config::OtlpMetricsTranslatorConfig;
 use super::dimensions::Dimensions;
 use super::internal::{instrumentationlibrary, instrumentationscope};
+use super::origin;
 use super::remap;
 use super::runtime_metrics::{RuntimeMetricMapping, RUNTIME_METRICS_MAPPINGS, RUNTIME_METRIC_PREFIX_LANGUAGE_MAP};
 use super::telemetry::OtlpMetricsTranslatorMetrics;
@@ -89,6 +90,12 @@ enum MetricTypeOverrideWarningKind {
 struct TranslationContext<'a> {
     resource_attributes: &'a [OtlpKeyValue],
     metrics: &'a Metrics,
+    /// The `InstrumentationScope` name of the enclosing `ScopeMetrics`, or an empty string when no scope was
+    /// present.
+    ///
+    /// Used to derive the metric origin's product detail. An empty
+    /// name falls back to `0` (unknown).
+    scope_name: &'a str,
 }
 
 /// A translator for converting OTLP metrics into Saluki `Event::Metric`s.
@@ -559,6 +566,11 @@ impl OtlpMetricsTranslator {
             let mut tags = resource_tags.clone();
             tags.extend_from_shared(&scope_tags);
 
+            // Derive the metric origin's product detail from the instrumentation scope name. The scope is read once
+            // per `ScopeMetrics` and threaded through the translation context to the metric and sketch emission
+            // sites.
+            let scope_name = scope_metrics.scope.as_ref().map_or("", |scope| scope.name.as_str());
+
             let mut new_metrics: Vec<OtlpMetric> = Vec::new();
             for mut metric in scope_metrics.metrics {
                 if let Some(mappings) = RUNTIME_METRICS_MAPPINGS.get(metric.name.as_str()) {
@@ -605,13 +617,13 @@ impl OtlpMetricsTranslator {
                 }
 
                 let mut translated_events =
-                    self.map_to_dd_format(metric, &tags, host.clone(), &resource.attributes, metrics);
+                    self.map_to_dd_format(metric, &tags, host.clone(), &resource.attributes, metrics, scope_name);
                 events.append(&mut translated_events);
             }
 
             for metric in new_metrics {
                 let mut translated_events =
-                    self.map_to_dd_format(metric, &tags, host.clone(), &resource.attributes, metrics);
+                    self.map_to_dd_format(metric, &tags, host.clone(), &resource.attributes, metrics, scope_name);
                 events.append(&mut translated_events);
             }
         }
@@ -710,7 +722,7 @@ impl OtlpMetricsTranslator {
     /// Translates a single OTLP `Metric` into a collection of Saluki `Event`s.
     fn map_to_dd_format(
         &mut self, metric: OtlpMetric, attribute_tags: &SharedTagSet, host: Option<MetaString>,
-        resource_attributes: &[OtlpKeyValue], metrics: &Metrics,
+        resource_attributes: &[OtlpKeyValue], metrics: &Metrics, scope_name: &str,
     ) -> Vec<Event> {
         let origin_id = self.attribute_translator.origin_id_from_attributes(resource_attributes);
         let base_dims = Dimensions {
@@ -723,6 +735,7 @@ impl OtlpMetricsTranslator {
         let context = TranslationContext {
             resource_attributes,
             metrics,
+            scope_name,
         };
 
         if let Some(data) = metric.data {
@@ -832,7 +845,10 @@ impl OtlpMetricsTranslator {
                     DataType::Rate => MetricValues::rate((timestamp_s, value), Duration::ZERO),
                 };
 
-                let metric = Metric::from_parts(resolved_context, values, MetricMetadata::default());
+                let metadata = MetricMetadata::default().with_origin(Some(MetricOrigin::otlp(
+                    origin::product_detail_from_scope(context.scope_name),
+                )));
+                let metric = Metric::from_parts(resolved_context, values, metadata);
                 events.push(Event::Metric(metric));
             }
             None => {
@@ -1198,7 +1214,10 @@ impl OtlpMetricsTranslator {
                 }
                 let timestamp_s = timestamp_ns / 1_000_000_000;
                 let values = MetricValues::distribution((timestamp_s, sketch));
-                let metric = Metric::from_parts(resolved_context, values, MetricMetadata::default());
+                let metadata = MetricMetadata::default().with_origin(Some(MetricOrigin::otlp(
+                    origin::product_detail_from_scope(context.scope_name),
+                )));
+                let metric = Metric::from_parts(resolved_context, values, metadata);
                 events.push(Event::Metric(metric));
             }
             None => {
@@ -1777,6 +1796,7 @@ mod tests {
         translator.config.hist_mode = mode;
         let context = TranslationContext {
             resource_attributes: &[],
+            scope_name: "",
             metrics: &metrics,
         };
         let dims = Dimensions {
@@ -1805,6 +1825,7 @@ mod tests {
         let metrics = Metrics::for_tests();
         let context = TranslationContext {
             resource_attributes: &[],
+            scope_name: "",
             metrics: &metrics,
         };
         let dims = Dimensions {
@@ -1872,6 +1893,7 @@ mod tests {
         let metrics = Metrics::for_tests();
         let context = TranslationContext {
             resource_attributes: &[],
+            scope_name: "",
             metrics: &metrics,
         };
         let dims = Dimensions {
@@ -1929,6 +1951,7 @@ mod tests {
         let metrics = Metrics::for_tests();
         let context = TranslationContext {
             resource_attributes: &[],
+            scope_name: "",
             metrics: &metrics,
         };
         let dims = Dimensions {
@@ -1987,6 +2010,7 @@ mod tests {
         };
         let context = TranslationContext {
             resource_attributes: &[],
+            scope_name: "",
             metrics,
         };
         translator.map_number_monotonic_metrics(dims, data_points, &context)
@@ -2000,6 +2024,7 @@ mod tests {
     ) -> Vec<Event> {
         let context = TranslationContext {
             resource_attributes: &[],
+            scope_name: "",
             metrics,
         };
         translator.map_number_metrics(dims, data_points, data_type, &context)
@@ -2133,6 +2158,187 @@ mod tests {
         assert_eq!(metric.context().host(), Some("resource-host"));
     }
 
+    fn single_gauge_resource_metrics_with_scope(scope_name: Option<&str>) -> OtlpResourceMetrics {
+        let scope = scope_name.map(
+            |name| otlp_protos::opentelemetry::proto::common::v1::InstrumentationScope {
+                name: name.to_string(),
+                ..Default::default()
+            },
+        );
+
+        OtlpResourceMetrics {
+            resource: None,
+            scope_metrics: vec![otlp_protos::opentelemetry::proto::metrics::v1::ScopeMetrics {
+                scope,
+                metrics: vec![OtlpMetric {
+                    name: "otlp.host.metric".to_string(),
+                    data: Some(OtlpMetricData::Gauge(
+                        otlp_protos::opentelemetry::proto::metrics::v1::Gauge {
+                            data_points: vec![OtlpNumberDataPoint {
+                                value: Some(OtlpNumberDataPointValue::AsDouble(1.0)),
+                                time_unix_nano: nanos_from_seconds(1),
+                                ..Default::default()
+                            }],
+                        },
+                    )),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn translate_metrics_attaches_otlp_origin_for_known_receiver_scope() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        // The hostmetricsreceiver is one of the ~40 known Collector receivers in the Agent's mapping table.
+        let scope = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver";
+        let (events, _) = translator
+            .translate_metrics(single_gauge_resource_metrics_with_scope(Some(scope)), &metrics)
+            .expect("translation should succeed");
+        let events = events.collect::<Vec<_>>();
+
+        let metric = events[0].try_as_metric().expect("metric event");
+        let origin = metric
+            .metadata()
+            .origin()
+            .expect("OTLP metrics should carry origin metadata");
+        assert_eq!(
+            *origin,
+            MetricOrigin::OriginMetadata {
+                product: 10,
+                subproduct: 17,
+                product_detail: 224,
+            }
+        );
+    }
+
+    #[test]
+    fn translate_metrics_attaches_otlp_origin_with_unknown_detail_for_absent_scope() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        let (events, _) = translator
+            .translate_metrics(single_gauge_resource_metrics_with_scope(None), &metrics)
+            .expect("translation should succeed");
+        let events = events.collect::<Vec<_>>();
+
+        let metric = events[0].try_as_metric().expect("metric event");
+        // The Agent always sets product 10 and the OTLP subproduct 17, even when no scope is present; the product
+        // detail then falls back to 0 (unknown).
+        let origin = metric
+            .metadata()
+            .origin()
+            .expect("OTLP metrics should carry origin metadata even without a scope");
+        assert_eq!(
+            *origin,
+            MetricOrigin::OriginMetadata {
+                product: 10,
+                subproduct: 17,
+                product_detail: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn translate_metrics_attaches_otlp_origin_with_unknown_detail_for_unmapped_scope() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        // A custom instrumentation library that does not use the Collector receiver prefix must not map to a known
+        // receiver; the product detail falls back to 0 (unknown).
+        let scope = "io.opentelemetry.myapp";
+        let (events, _) = translator
+            .translate_metrics(single_gauge_resource_metrics_with_scope(Some(scope)), &metrics)
+            .expect("translation should succeed");
+        let events = events.collect::<Vec<_>>();
+
+        let metric = events[0].try_as_metric().expect("metric event");
+        let origin = metric
+            .metadata()
+            .origin()
+            .expect("OTLP metrics should carry origin metadata");
+        assert_eq!(
+            *origin,
+            MetricOrigin::OriginMetadata {
+                product: 10,
+                subproduct: 17,
+                product_detail: 0,
+            }
+        );
+    }
+
+    fn single_histogram_resource_metrics_with_scope(scope_name: Option<&str>) -> OtlpResourceMetrics {
+        let scope = scope_name.map(
+            |name| otlp_protos::opentelemetry::proto::common::v1::InstrumentationScope {
+                name: name.to_string(),
+                ..Default::default()
+            },
+        );
+
+        OtlpResourceMetrics {
+            resource: None,
+            scope_metrics: vec![otlp_protos::opentelemetry::proto::metrics::v1::ScopeMetrics {
+                scope,
+                metrics: vec![OtlpMetric {
+                    name: "otlp.histogram".to_string(),
+                    data: Some(OtlpMetricData::Histogram(
+                        otlp_protos::opentelemetry::proto::metrics::v1::Histogram {
+                            aggregation_temporality: AggregationTemporality::Delta as i32,
+                            data_points: vec![OtlpHistogramDataPoint {
+                                count: 6,
+                                sum: Some(10.0),
+                                bucket_counts: vec![1, 2, 3],
+                                explicit_bounds: vec![1.0, 2.0],
+                                time_unix_nano: nanos_from_seconds(1),
+                                ..Default::default()
+                            }],
+                        },
+                    )),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn translate_metrics_attaches_otlp_origin_to_sketch_events() {
+        let metrics = Metrics::for_tests();
+        // `for_tests` defaults to `HistogramMode::Distributions`, so a delta histogram emits a single sketch.
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        let scope = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver";
+        let (events, _) = translator
+            .translate_metrics(single_histogram_resource_metrics_with_scope(Some(scope)), &metrics)
+            .expect("translation should succeed");
+        let events = events.collect::<Vec<_>>();
+
+        assert_eq!(events.len(), 1, "distributions mode emits a single sketch");
+        let metric = events[0].try_as_metric().expect("metric event");
+        assert!(
+            matches!(metric.values(), MetricValues::Distribution(_)),
+            "expected a sketch (distribution) metric"
+        );
+
+        let origin = metric
+            .metadata()
+            .origin()
+            .expect("OTLP sketch metrics should carry origin metadata");
+        assert_eq!(
+            *origin,
+            MetricOrigin::OriginMetadata {
+                product: 10,
+                subproduct: 17,
+                product_detail: 229, // kubeletstatsreceiver
+            }
+        );
+    }
+
     #[test]
     fn translate_metrics_leaves_fargate_resource_host_unset() {
         let metrics = Metrics::for_tests();
@@ -2262,6 +2468,7 @@ mod tests {
             None,
             &[],
             &metrics,
+            "",
         );
 
         assert_eq!(events.len(), 1);
@@ -2300,6 +2507,7 @@ mod tests {
             None,
             &[],
             metrics,
+            "",
         )
     }
 
@@ -2388,6 +2596,7 @@ mod tests {
             None,
             &[],
             &metrics,
+            "",
         );
 
         assert_eq!(events.len(), 1);
@@ -2412,7 +2621,7 @@ mod tests {
         };
         sum.data_points.push(sum.data_points[0].clone());
 
-        let events = translator.map_to_dd_format(metric, &SharedTagSet::default(), None, &[], &metrics);
+        let events = translator.map_to_dd_format(metric, &SharedTagSet::default(), None, &[], &metrics, "");
 
         assert_eq!(events.len(), 2);
         assert!(translator
@@ -2432,6 +2641,7 @@ mod tests {
                 None,
                 &[],
                 &metrics,
+                "",
             );
 
             assert_eq!(events.len(), 1, "expected one event for {as_type}");
@@ -2453,7 +2663,7 @@ mod tests {
         };
         sum.data_points.push(sum.data_points[0].clone());
 
-        let events = translator.map_to_dd_format(metric, &SharedTagSet::default(), None, &[], &metrics);
+        let events = translator.map_to_dd_format(metric, &SharedTagSet::default(), None, &[], &metrics, "");
 
         assert_eq!(events.len(), 2);
         assert!(translator
@@ -2484,6 +2694,7 @@ mod tests {
             None,
             &[],
             &metrics,
+            "",
         );
 
         assert_eq!(events.len(), 1);
@@ -2842,6 +3053,7 @@ mod tests {
         };
         let context = TranslationContext {
             resource_attributes: &[],
+            scope_name: "",
             metrics: &metrics,
         };
         let start_ts = translator.process_start_time_ns + 1;
@@ -4340,6 +4552,7 @@ mod tests {
         };
         let context = TranslationContext {
             resource_attributes: &[],
+            scope_name: "",
             metrics,
         };
         translator.map_histogram_metrics(dims, data_points, delta, &context)
@@ -4494,6 +4707,7 @@ mod tests {
         };
         let context = TranslationContext {
             resource_attributes: &[],
+            scope_name: "",
             metrics,
         };
         translator.map_summary_metrics(dims, data_points, &context)
@@ -4595,6 +4809,7 @@ mod tests {
         };
         let context = TranslationContext {
             resource_attributes: &[],
+            scope_name: "",
             metrics,
         };
         translator.map_exponential_histogram_metrics(dims, data_points, delta, &context)

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -2208,7 +2208,7 @@ mod tests {
             *origin,
             MetricOrigin::OriginMetadata {
                 product: 19,
-                subproduct: 17,
+                subproduct: 0,
                 product_detail: 224,
             }
         );
@@ -2235,7 +2235,7 @@ mod tests {
             *origin,
             MetricOrigin::OriginMetadata {
                 product: 19,
-                subproduct: 17,
+                subproduct: 0,
                 product_detail: 0,
             }
         );
@@ -2263,7 +2263,7 @@ mod tests {
             *origin,
             MetricOrigin::OriginMetadata {
                 product: 19,
-                subproduct: 17,
+                subproduct: 0,
                 product_detail: 0,
             }
         );
@@ -2331,7 +2331,7 @@ mod tests {
             *origin,
             MetricOrigin::OriginMetadata {
                 product: 19,
-                subproduct: 17,
+                subproduct: 0,
                 product_detail: 229, // kubeletstatsreceiver
             }
         );

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -566,9 +566,7 @@ impl OtlpMetricsTranslator {
             let mut tags = resource_tags.clone();
             tags.extend_from_shared(&scope_tags);
 
-            // Derive the metric origin's product detail from the instrumentation scope name. The scope is read once
-            // per `ScopeMetrics` and threaded through the translation context to the metric and sketch emission
-            // sites.
+            // Derive the metric origin's product detail from the instrumentation scope name.
             let scope_name = scope_metrics.scope.as_ref().map_or("", |scope| scope.name.as_str());
 
             let mut new_metrics: Vec<OtlpMetric> = Vec::new();
@@ -2194,7 +2192,7 @@ mod tests {
         let metrics = Metrics::for_tests();
         let mut translator = OtlpMetricsTranslator::for_tests();
 
-        // The hostmetricsreceiver is one of the ~40 known Collector receivers in the Agent's mapping table.
+        // The hostmetricsreceiver is one of the known Collector receivers in the mapping table.
         let scope = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver";
         let (events, _) = translator
             .translate_metrics(single_gauge_resource_metrics_with_scope(Some(scope)), &metrics)

--- a/lib/saluki-core/src/data_model/event/metric/metadata.rs
+++ b/lib/saluki-core/src/data_model/event/metric/metadata.rs
@@ -3,6 +3,7 @@ use std::{fmt, sync::Arc};
 use stringtheory::MetaString;
 
 const ORIGIN_PRODUCT_AGENT: u32 = 10;
+const ORIGIN_PRODUCT_DATADOG_EXPORTER: u32 = 19;
 const ORIGIN_SUBPRODUCT_DOGSTATSD: u32 = 10;
 const ORIGIN_SUBPRODUCT_INTEGRATION: u32 = 11;
 const ORIGIN_SUBPRODUCT_OTLP: u32 = 17;
@@ -162,12 +163,12 @@ impl MetricOrigin {
 
     /// Creates a `MetricOrigin` for any metric ingested via OTLP.
     ///
-    /// OTLP metrics always use product `10` and the OTLP subproduct (`17`). The product detail is provided by the
+    /// OTLP metrics use product `19` and the OTLP subproduct (`17`). The product detail is provided by the
     /// caller— typically derived from the instrumentation scope name— and falls back to `0` (unknown) when the
     /// scope is absent or does not map to a known receiver.
     pub fn otlp(product_detail: u32) -> Self {
         Self::OriginMetadata {
-            product: ORIGIN_PRODUCT_AGENT,
+            product: ORIGIN_PRODUCT_DATADOG_EXPORTER,
             subproduct: ORIGIN_SUBPRODUCT_OTLP,
             product_detail,
         }

--- a/lib/saluki-core/src/data_model/event/metric/metadata.rs
+++ b/lib/saluki-core/src/data_model/event/metric/metadata.rs
@@ -2,8 +2,15 @@ use std::{fmt, sync::Arc};
 
 use stringtheory::MetaString;
 
+// Origin product identifies the software that emitted the metric. The Agent product (`10`) covers
+// metrics collected by the agent process itself, while the Datadog Exporter product (`19`) covers
+// metrics translated from OpenTelemetry Protocol.
 const ORIGIN_PRODUCT_AGENT: u32 = 10;
 const ORIGIN_PRODUCT_DATADOG_EXPORTER: u32 = 19;
+
+// Origin subproduct identifies the ingestion channel within a product. DogStatsD (`10`) covers
+// statsd protocol metrics, integration (`11`) covers check-based metrics, and OTLP (`0`) covers
+// metrics ingested via the OpenTelemetry Protocol.
 const ORIGIN_SUBPRODUCT_DOGSTATSD: u32 = 10;
 const ORIGIN_SUBPRODUCT_INTEGRATION: u32 = 11;
 const ORIGIN_SUBPRODUCT_OTLP: u32 = 0;
@@ -164,8 +171,8 @@ impl MetricOrigin {
     /// Creates a `MetricOrigin` for any metric ingested via OTLP.
     ///
     /// OTLP metrics use product `19` and subproduct `0`. The product detail is provided by the
-    /// caller— typically derived from the instrumentation scope name— and falls back to `0` (unknown) when the
-    /// scope is absent or does not map to a known receiver.
+    /// caller, typically derived from the instrumentation scope name, and falls back to `0`
+    /// (unknown) when the scope is absent or does not map to a known receiver.
     pub fn otlp(product_detail: u32) -> Self {
         Self::OriginMetadata {
             product: ORIGIN_PRODUCT_DATADOG_EXPORTER,

--- a/lib/saluki-core/src/data_model/event/metric/metadata.rs
+++ b/lib/saluki-core/src/data_model/event/metric/metadata.rs
@@ -163,7 +163,7 @@ impl MetricOrigin {
     /// Creates a `MetricOrigin` for any metric ingested via OTLP.
     ///
     /// OTLP metrics always use product `10` and the OTLP subproduct (`17`). The product detail is provided by the
-    /// caller — typically derived from the instrumentation scope name — and falls back to `0` (unknown) when the
+    /// caller— typically derived from the instrumentation scope name— and falls back to `0` (unknown) when the
     /// scope is absent or does not map to a known receiver.
     pub fn otlp(product_detail: u32) -> Self {
         Self::OriginMetadata {

--- a/lib/saluki-core/src/data_model/event/metric/metadata.rs
+++ b/lib/saluki-core/src/data_model/event/metric/metadata.rs
@@ -5,6 +5,7 @@ use stringtheory::MetaString;
 const ORIGIN_PRODUCT_AGENT: u32 = 10;
 const ORIGIN_SUBPRODUCT_DOGSTATSD: u32 = 10;
 const ORIGIN_SUBPRODUCT_INTEGRATION: u32 = 11;
+const ORIGIN_SUBPRODUCT_OTLP: u32 = 17;
 const ORIGIN_PRODUCT_DETAIL_NONE: u32 = 0;
 
 /// Metric metadata.
@@ -159,6 +160,19 @@ impl MetricOrigin {
         }
     }
 
+    /// Creates a `MetricOrigin` for any metric ingested via OTLP.
+    ///
+    /// OTLP metrics always use product `10` and the OTLP subproduct (`17`). The product detail is provided by the
+    /// caller — typically derived from the instrumentation scope name — and falls back to `0` (unknown) when the
+    /// scope is absent or does not map to a known receiver.
+    pub fn otlp(product_detail: u32) -> Self {
+        Self::OriginMetadata {
+            product: ORIGIN_PRODUCT_AGENT,
+            subproduct: ORIGIN_SUBPRODUCT_OTLP,
+            product_detail,
+        }
+    }
+
     /// Returns `true` if the origin of the metric is DogStatsD.
     pub fn is_dogstatsd(&self) -> bool {
         matches!(self, Self::OriginMetadata { subproduct, .. } if *subproduct == ORIGIN_SUBPRODUCT_DOGSTATSD)
@@ -219,6 +233,7 @@ fn subproduct_id_to_str(subproduct_id: u32) -> &'static str {
     match subproduct_id {
         ORIGIN_SUBPRODUCT_DOGSTATSD => "dogstatsd",
         ORIGIN_SUBPRODUCT_INTEGRATION => "integration",
+        ORIGIN_SUBPRODUCT_OTLP => "otlp",
         _ => "unknown_subproduct",
     }
 }

--- a/lib/saluki-core/src/data_model/event/metric/metadata.rs
+++ b/lib/saluki-core/src/data_model/event/metric/metadata.rs
@@ -6,7 +6,7 @@ const ORIGIN_PRODUCT_AGENT: u32 = 10;
 const ORIGIN_PRODUCT_DATADOG_EXPORTER: u32 = 19;
 const ORIGIN_SUBPRODUCT_DOGSTATSD: u32 = 10;
 const ORIGIN_SUBPRODUCT_INTEGRATION: u32 = 11;
-const ORIGIN_SUBPRODUCT_OTLP: u32 = 17;
+const ORIGIN_SUBPRODUCT_OTLP: u32 = 0;
 const ORIGIN_PRODUCT_DETAIL_NONE: u32 = 0;
 
 /// Metric metadata.
@@ -163,7 +163,7 @@ impl MetricOrigin {
 
     /// Creates a `MetricOrigin` for any metric ingested via OTLP.
     ///
-    /// OTLP metrics use product `19` and the OTLP subproduct (`17`). The product detail is provided by the
+    /// OTLP metrics use product `19` and subproduct `0`. The product detail is provided by the
     /// caller— typically derived from the instrumentation scope name— and falls back to `0` (unknown) when the
     /// scope is absent or does not map to a known receiver.
     pub fn otlp(product_detail: u32) -> Self {


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Adds origin metadata (`originProduct`, `originSubProduct`, and `originProductDetail`) for OTLP Ingest metrics. 

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

Unit tests

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->
- Closes: #2078 

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
