### PR TITLE
fix(dogstatsd): normalize invalid UTF-8 tag blocks

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -2065,7 +2065,7 @@ fn handle_metric_packet(
     packet: MetricPacket, context_resolvers: &mut ContextResolvers, process_origin: Option<&ProcessOrigin>,
     additional_tags: &[String], default_hostname: &MetaString,
 ) -> Option<Metric> {
-    let well_known_tags = WellKnownTags::from_raw_tags(packet.tags.clone());
+    let well_known_tags = WellKnownTags::from_raw_tags(&packet.tags);
 
     let origin = origin_from_metric_packet(&packet, &well_known_tags);
     let origin_tags = context_resolvers.resolve_origin_tags(origin, process_origin);
@@ -2077,7 +2077,7 @@ fn handle_metric_packet(
         context_resolvers.primary()
     };
 
-    let tags = get_filtered_tags_iterator(packet.tags, additional_tags);
+    let tags = get_filtered_tags_iterator(&packet.tags, additional_tags);
 
     let hostname = well_known_tags.hostname.unwrap_or(default_hostname);
 
@@ -2106,12 +2106,12 @@ fn handle_event_packet(
     packet: EventPacket, context_resolvers: &mut ContextResolvers, process_origin: Option<&ProcessOrigin>,
     additional_tags: &[String],
 ) -> Option<EventD> {
-    let well_known_tags = WellKnownTags::from_raw_tags(packet.tags.clone());
+    let well_known_tags = WellKnownTags::from_raw_tags(&packet.tags);
 
     let origin = origin_from_event_packet(&packet, &well_known_tags);
     let origin_tags = context_resolvers.resolve_origin_tags(origin, process_origin);
 
-    let tags = get_filtered_tags_iterator(packet.tags, additional_tags);
+    let tags = get_filtered_tags_iterator(&packet.tags, additional_tags);
     let tags_resolver = context_resolvers.tags();
     let tags = tags_resolver.create_tag_set(tags)?;
 
@@ -2149,12 +2149,12 @@ fn handle_service_check_packet(
     packet: ServiceCheckPacket, context_resolvers: &mut ContextResolvers, process_origin: Option<&ProcessOrigin>,
     additional_tags: &[String],
 ) -> Option<ServiceCheck> {
-    let well_known_tags = WellKnownTags::from_raw_tags(packet.tags.clone());
+    let well_known_tags = WellKnownTags::from_raw_tags(&packet.tags);
 
     let origin = origin_from_service_check_packet(&packet, &well_known_tags);
     let origin_tags = context_resolvers.resolve_origin_tags(origin, process_origin);
 
-    let tags = get_filtered_tags_iterator(packet.tags, additional_tags);
+    let tags = get_filtered_tags_iterator(&packet.tags, additional_tags);
     let tags_resolver = context_resolvers.tags();
     let tags = tags_resolver.create_tag_set(tags)?;
 
@@ -2176,7 +2176,7 @@ fn handle_service_check_packet(
 }
 
 fn get_filtered_tags_iterator<'a>(
-    raw_tags: RawTags<'a>, additional_tags: &'a [String],
+    raw_tags: &'a RawTags<'_>, additional_tags: &'a [String],
 ) -> impl Iterator<Item = &'a str> + Clone {
     // This filters out "well-known" tags from the raw tags in the DogStatsD packet, and then chains on any additional tags
     // that were configured on the source.

--- a/lib/saluki-components/src/sources/dogstatsd/origin.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/origin.rs
@@ -277,9 +277,12 @@ impl OriginTagsResolver for DogStatsDOriginTagResolver {
 }
 
 /// Builds an `RawOrigin` object from the given metric packet.
-pub fn origin_from_metric_packet<'packet>(
-    packet: &MetricPacket<'packet>, well_known_tags: &WellKnownTags<'packet>,
-) -> RawOrigin<'packet> {
+pub fn origin_from_metric_packet<'packet, 'tags>(
+    packet: &'tags MetricPacket<'packet>, well_known_tags: &'tags WellKnownTags<'tags>,
+) -> RawOrigin<'tags>
+where
+    'packet: 'tags,
+{
     let cardinality = packet.cardinality.or(well_known_tags.cardinality);
 
     let mut origin = RawOrigin::default();
@@ -291,9 +294,12 @@ pub fn origin_from_metric_packet<'packet>(
 }
 
 /// Builds an `RawOrigin` object from the given event packet.
-pub fn origin_from_event_packet<'packet>(
-    packet: &EventPacket<'packet>, well_known_tags: &WellKnownTags<'packet>,
-) -> RawOrigin<'packet> {
+pub fn origin_from_event_packet<'packet, 'tags>(
+    packet: &'tags EventPacket<'packet>, well_known_tags: &'tags WellKnownTags<'tags>,
+) -> RawOrigin<'tags>
+where
+    'packet: 'tags,
+{
     let cardinality = packet.cardinality.or(well_known_tags.cardinality);
 
     let mut origin = RawOrigin::default();
@@ -305,9 +311,12 @@ pub fn origin_from_event_packet<'packet>(
 }
 
 /// Builds an `RawOrigin` object from the given service check packet.
-pub fn origin_from_service_check_packet<'packet>(
-    packet: &ServiceCheckPacket<'packet>, well_known_tags: &WellKnownTags<'packet>,
-) -> RawOrigin<'packet> {
+pub fn origin_from_service_check_packet<'packet, 'tags>(
+    packet: &'tags ServiceCheckPacket<'packet>, well_known_tags: &'tags WellKnownTags<'tags>,
+) -> RawOrigin<'tags>
+where
+    'packet: 'tags,
+{
     let cardinality = packet.cardinality.or(well_known_tags.cardinality);
 
     let mut origin = RawOrigin::default();
@@ -392,7 +401,7 @@ mod tests {
         let raw_tags_input = "dd.internal.card:high";
         let raw_tags = RawTags::new(raw_tags_input, usize::MAX, usize::MAX);
 
-        let well_known_tags = WellKnownTags::from_raw_tags(raw_tags.clone());
+        let well_known_tags = WellKnownTags::from_raw_tags(&raw_tags);
         assert_eq!(well_known_tags.cardinality, Some(OriginTagCardinality::High));
 
         let packet_with_card = MetricPacket {
@@ -435,7 +444,7 @@ mod tests {
         let raw_tags_input = "dd.internal.card:low";
         let raw_tags = RawTags::new(raw_tags_input, usize::MAX, usize::MAX);
 
-        let well_known_tags = WellKnownTags::from_raw_tags(raw_tags.clone());
+        let well_known_tags = WellKnownTags::from_raw_tags(&raw_tags);
         assert_eq!(well_known_tags.cardinality, Some(OriginTagCardinality::Low));
 
         let packet_with_card = EventPacket {
@@ -484,7 +493,7 @@ mod tests {
         let raw_tags_input = "dd.internal.card:orchestrator";
         let raw_tags = RawTags::new(raw_tags_input, usize::MAX, usize::MAX);
 
-        let well_known_tags = WellKnownTags::from_raw_tags(raw_tags.clone());
+        let well_known_tags = WellKnownTags::from_raw_tags(&raw_tags);
         assert_eq!(well_known_tags.cardinality, Some(OriginTagCardinality::Orchestrator));
 
         let packet_with_card = ServiceCheckPacket {

--- a/lib/saluki-components/src/sources/dogstatsd/tags.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/tags.rs
@@ -34,7 +34,7 @@ impl<'a> WellKnownTags<'a> {
     /// Extracts well-known tags from the raw tags of a DogStatsD payload.
     ///
     /// All fields default to `None`.
-    pub fn from_raw_tags(tags: RawTags<'a>) -> Self {
+    pub fn from_raw_tags(tags: &'a RawTags<'_>) -> Self {
         let mut well_known_tags = Self {
             hostname: None,
             pod_uid: None,
@@ -77,7 +77,7 @@ mod tests {
     #[test]
     fn well_known_tags_empty() {
         let tags = RawTags::new("", usize::MAX, usize::MAX);
-        let wkt = WellKnownTags::from_raw_tags(tags);
+        let wkt = WellKnownTags::from_raw_tags(&tags);
 
         assert_eq!(wkt.cardinality, None);
         assert_eq!(wkt.hostname, None);
@@ -105,7 +105,7 @@ mod tests {
         for (tag_value, expected) in cases {
             let card_tag = format!("{}:{}", CARDINALITY_TAG_KEY, tag_value);
             let tags = RawTags::new(&card_tag, usize::MAX, usize::MAX);
-            let wkt = WellKnownTags::from_raw_tags(tags);
+            let wkt = WellKnownTags::from_raw_tags(&tags);
 
             assert_eq!(wkt.cardinality, expected);
         }
@@ -118,7 +118,7 @@ mod tests {
         for (tag_value, expected) in cases {
             let host_tag = format!("{}:{}", HOST_TAG_KEY, tag_value);
             let tags = RawTags::new(&host_tag, usize::MAX, usize::MAX);
-            let wkt = WellKnownTags::from_raw_tags(tags);
+            let wkt = WellKnownTags::from_raw_tags(&tags);
 
             assert_eq!(wkt.hostname, expected);
         }
@@ -131,7 +131,7 @@ mod tests {
         for (tag_value, expected) in cases {
             let jmx_tag = format!("{}:{}", JMX_CHECK_NAME_TAG_KEY, tag_value);
             let tags = RawTags::new(&jmx_tag, usize::MAX, usize::MAX);
-            let wkt = WellKnownTags::from_raw_tags(tags);
+            let wkt = WellKnownTags::from_raw_tags(&tags);
 
             assert_eq!(wkt.jmx_check_name, expected);
         }
@@ -144,7 +144,7 @@ mod tests {
         for (tag_value, expected) in cases {
             let pod_tag = format!("{}:{}", ENTITY_ID_TAG_KEY, tag_value);
             let tags = RawTags::new(&pod_tag, usize::MAX, usize::MAX);
-            let wkt = WellKnownTags::from_raw_tags(tags);
+            let wkt = WellKnownTags::from_raw_tags(&tags);
 
             assert_eq!(wkt.pod_uid, expected);
         }

--- a/lib/saluki-context/src/tags/raw.rs
+++ b/lib/saluki-context/src/tags/raw.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 /// A wrapper over raw tags in their unprocessed form.
 ///
 /// This type is meant to handle raw tags that have been extracted from network payloads, such as DogStatsD, where the
@@ -11,17 +13,17 @@
 ///
 /// ## Cloning
 ///
-/// `RawTags` can be cloned to create a new iterator with its own iteration state. The same underlying input byte slice
-/// is retained.
+/// `RawTags` can be cloned to create a new iterator with its own iteration state. Borrowed tags retain their input
+/// slice, while normalized tags retain their owned backing string.
 #[derive(Clone)]
 pub struct RawTags<'a> {
-    raw_tags: &'a str,
+    raw_tags: Cow<'a, str>,
     max_tag_count: usize,
     max_tag_len: usize,
 }
 
 impl<'a> RawTags<'a> {
-    /// Creates a new `RawTags` from the given input byte slice.
+    /// Creates `RawTags` from a borrowed tag block.
     ///
     /// The maximum tag count and maximum tag length control how many tags are returned from the iterator and their
     /// length. If the iterator encounters more tags than the maximum count, it will simply stop returning tags. If the
@@ -29,7 +31,16 @@ impl<'a> RawTags<'a> {
     /// length, or to a smaller length, whichever is closer to a valid UTF-8 character boundary.
     pub const fn new(raw_tags: &'a str, max_tag_count: usize, max_tag_len: usize) -> Self {
         Self {
-            raw_tags,
+            raw_tags: Cow::Borrowed(raw_tags),
+            max_tag_count,
+            max_tag_len,
+        }
+    }
+
+    /// Creates `RawTags` from an owned, normalized tag block.
+    pub fn from_owned(raw_tags: String, max_tag_count: usize, max_tag_len: usize) -> Self {
+        Self {
+            raw_tags: Cow::Owned(raw_tags),
             max_tag_count,
             max_tag_len,
         }
@@ -38,28 +49,20 @@ impl<'a> RawTags<'a> {
     /// Creates an empty `RawTags`.
     pub const fn empty() -> Self {
         Self {
-            raw_tags: "",
+            raw_tags: Cow::Borrowed(""),
             max_tag_count: 0,
             max_tag_len: 0,
         }
     }
 
-    fn tags_iter(&self) -> RawTagsIter<'a> {
+    /// Returns an iterator over the individual tags.
+    pub fn iter(&self) -> RawTagsIter<'_> {
         RawTagsIter {
-            raw_tags: self.raw_tags,
+            raw_tags: &self.raw_tags,
             parsed_tags: 0,
             max_tag_len: self.max_tag_len,
             max_tag_count: self.max_tag_count,
         }
-    }
-}
-
-impl<'a> IntoIterator for RawTags<'a> {
-    type Item = &'a str;
-    type IntoIter = RawTagsIter<'a>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.tags_iter()
     }
 }
 
@@ -120,18 +123,18 @@ pub struct RawTagsFilter<'a, F> {
 
 impl<'a, F> RawTagsFilter<'a, F> {
     /// Creates a new `RawTagsFilter` that includes only the tags that match the given predicate.
-    pub fn include(raw: RawTags<'a>, predicate: F) -> RawTagsFilter<'a, F> {
+    pub fn include(raw: &'a RawTags<'_>, predicate: F) -> RawTagsFilter<'a, F> {
         Self {
-            raw: raw.into_iter(),
+            raw: raw.iter(),
             predicate,
             include: true,
         }
     }
 
     /// Creates a new `RawTagsFilter` that excludes any tags that match the given predicate.
-    pub fn exclude(raw: RawTags<'a>, predicate: F) -> RawTagsFilter<'a, F> {
+    pub fn exclude(raw: &'a RawTags<'_>, predicate: F) -> RawTagsFilter<'a, F> {
         Self {
-            raw: raw.into_iter(),
+            raw: raw.iter(),
             predicate,
             include: false,
         }
@@ -240,7 +243,7 @@ mod tests {
     fn raw_tags_filter_include() {
         let raw_tags_input = "key1:value1,key2:value2,key3:value3";
         let raw_tags = RawTags::new(raw_tags_input, usize::MAX, usize::MAX);
-        let filtered_raw_tags = RawTagsFilter::include(raw_tags, filter_key2_tag);
+        let filtered_raw_tags = RawTagsFilter::include(&raw_tags, filter_key2_tag);
 
         let filtered_tags = filtered_raw_tags.into_iter().collect::<Vec<_>>();
         assert_eq!(filtered_tags.len(), 1);
@@ -251,7 +254,7 @@ mod tests {
     fn raw_tags_filter_include_duplicates() {
         let raw_tags_input = "key1:value1,key2:value2,key3:value3,key2:value4";
         let raw_tags = RawTags::new(raw_tags_input, usize::MAX, usize::MAX);
-        let filtered_raw_tags = RawTagsFilter::include(raw_tags, filter_key2_tag);
+        let filtered_raw_tags = RawTagsFilter::include(&raw_tags, filter_key2_tag);
 
         let filtered_tags = filtered_raw_tags.into_iter().collect::<Vec<_>>();
         assert_eq!(filtered_tags.len(), 2);
@@ -263,7 +266,7 @@ mod tests {
     fn raw_tags_filter_exclude() {
         let raw_tags_input = "key1:value1,key2:value2,key3:value3";
         let raw_tags = RawTags::new(raw_tags_input, usize::MAX, usize::MAX);
-        let filtered_raw_tags = RawTagsFilter::exclude(raw_tags, filter_key2_tag);
+        let filtered_raw_tags = RawTagsFilter::exclude(&raw_tags, filter_key2_tag);
 
         let filtered_tags = filtered_raw_tags.into_iter().collect::<Vec<_>>();
         assert_eq!(filtered_tags.len(), 2);
@@ -275,7 +278,7 @@ mod tests {
     fn raw_tags_filter_exclude_duplicates() {
         let raw_tags_input = "key1:value1,key2:value2,key3:value3,key1:value9,key2:value6";
         let raw_tags = RawTags::new(raw_tags_input, usize::MAX, usize::MAX);
-        let filtered_raw_tags = RawTagsFilter::exclude(raw_tags, filter_key2_tag);
+        let filtered_raw_tags = RawTagsFilter::exclude(&raw_tags, filter_key2_tag);
 
         let filtered_tags = filtered_raw_tags.into_iter().collect::<Vec<_>>();
         assert_eq!(filtered_tags.len(), 3);
@@ -292,17 +295,15 @@ mod tests {
             // This is because we may have duplicate tags in the input, and so we need to discard all of those duplicates
             // when ensuring that the resulting filtered sets are disjoint, and that they both add up to the original
             // set of raw tags.
-
-            let raw_tags = RawTags::new(&inputs, usize::MAX, usize::MAX)
-                .into_iter()
-                .collect::<HashSet<_>>();
+            let raw_tags_input = RawTags::new(&inputs, usize::MAX, usize::MAX);
+            let raw_tags = raw_tags_input.iter().collect::<HashSet<_>>();
             let predicate = |tag: &str| filters.iter().any(|filter| tag.starts_with(filter));
 
             let raw_tags_include = RawTags::new(&inputs, usize::MAX, usize::MAX);
-            let filtered_raw_tags_include = RawTagsFilter::include(raw_tags_include, predicate);
+            let filtered_raw_tags_include = RawTagsFilter::include(&raw_tags_include, predicate);
 
             let raw_tags_exclude = RawTags::new(&inputs, usize::MAX, usize::MAX);
-            let filtered_raw_tags_exclude = RawTagsFilter::exclude(raw_tags_exclude, predicate);
+            let filtered_raw_tags_exclude = RawTagsFilter::exclude(&raw_tags_exclude, predicate);
 
             let filtered_tags_include = filtered_raw_tags_include.into_iter().collect::<HashSet<_>>();
             let filtered_tags_exclude = filtered_raw_tags_exclude.into_iter().collect::<HashSet<_>>();

--- a/lib/saluki-io/src/deser/codec/dogstatsd/event.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/event.rs
@@ -277,6 +277,20 @@ mod tests {
     }
 
     #[test]
+    fn event_tags_with_invalid_utf8_are_normalized() {
+        let mut input = b"_e{5,4}:title|text|#env:prod,tag:".to_vec();
+        input.extend_from_slice(&[0xff, 0xfe]);
+
+        let tags = ["env:prod", "tag:\u{FFFD}"];
+        let expected = EventD::new("title", "text").with_tags(SharedTagSet::from(TagSet::from_iter(
+            tags.iter().map(|&tag| tag.into()),
+        )));
+        let actual = parse_dsd_eventd(&input).expect("event with invalid tag bytes should parse");
+
+        check_basic_eventd_eq(expected, actual);
+    }
+
+    #[test]
     fn eventd_priority() {
         let event_title = "my event";
         let event_text = "text";

--- a/lib/saluki-io/src/deser/codec/dogstatsd/event.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/event.rs
@@ -208,7 +208,7 @@ mod tests {
         assert!(remaining.is_empty());
 
         let mut event_tags = TagSet::default();
-        for tag in packet.tags.into_iter() {
+        for tag in packet.tags.iter() {
             event_tags.insert_tag(tag);
         }
 
@@ -411,6 +411,6 @@ mod tests {
         assert_eq!(packet.local_data, None);
         assert_eq!(packet.external_data, None);
         assert_eq!(packet.cardinality, None);
-        assert!(packet.tags.into_iter().next().is_none());
+        assert!(packet.tags.iter().next().is_none());
     }
 }

--- a/lib/saluki-io/src/deser/codec/dogstatsd/helpers.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/helpers.rs
@@ -101,12 +101,9 @@ pub fn ascii_alphanum_and_seps(input: &[u8]) -> IResult<&[u8], &str> {
 
 /// Extracts as many raw tags from the input slice as possible, up to the configured limit.
 ///
-/// Tags can be limited by length as well as count. If any tags exceed the maximum length, they're dropped. If the number
-/// of tags exceeds the maximum count, the excess tags are dropped. The remaining slice doesn't contain any dropped tags.
-///
-/// # Errors
-///
-/// If the input slice isn't at least one byte long, or if it's not valid UTF-8, an error is returned.
+/// Tags can be limited by length as well as count. If a tag exceeds the maximum length, it is truncated. If the number
+/// of tags exceeds the maximum count, the excess tags are dropped. Invalid UTF-8 is replaced with one U+FFFD character
+/// per contiguous invalid byte run so downstream tag handling operates exclusively on valid UTF-8.
 #[inline]
 pub fn tags(config: &DogStatsDCodecConfiguration) -> impl Fn(&[u8]) -> IResult<&[u8], RawTags<'_>> {
     let max_tag_count = config.maximum_tag_count;
@@ -114,8 +111,31 @@ pub fn tags(config: &DogStatsDCodecConfiguration) -> impl Fn(&[u8]) -> IResult<&
 
     move |input| match simdutf8::basic::from_utf8(input) {
         Ok(tags) => Ok((&[], RawTags::new(tags, max_tag_count, max_tag_len))),
-        Err(_) => Err(nom::Err::Error(Error::new(input, ErrorKind::Verify))),
+        Err(_) => Ok((
+            &[],
+            RawTags::from_owned(to_valid_utf8(input), max_tag_count, max_tag_len),
+        )),
     }
+}
+
+fn to_valid_utf8(bytes: &[u8]) -> String {
+    let mut output = String::with_capacity(bytes.len());
+    let mut previous_chunk_was_invalid = false;
+
+    for chunk in bytes.utf8_chunks() {
+        if !chunk.valid().is_empty() {
+            output.push_str(chunk.valid());
+            previous_chunk_was_invalid = false;
+        }
+        if !chunk.invalid().is_empty() {
+            if !previous_chunk_was_invalid {
+                output.push('\u{FFFD}');
+            }
+            previous_chunk_was_invalid = true;
+        }
+    }
+
+    output
 }
 
 /// Parses a Unix timestamp from the input slice.

--- a/lib/saluki-io/src/deser/codec/dogstatsd/helpers.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/helpers.rs
@@ -221,10 +221,25 @@ pub fn cardinality(input: &[u8]) -> IResult<&[u8], Option<OriginTagCardinality>>
 mod tests {
     use saluki_context::origin::OriginTagCardinality;
 
-    use super::{cardinality, CARDINALITY_PREFIX};
+    use super::{cardinality, to_valid_utf8, CARDINALITY_PREFIX};
 
     fn card(s: &str) -> Vec<u8> {
         format!("{}{}", simdutf8::basic::from_utf8(CARDINALITY_PREFIX).unwrap(), s).into_bytes()
+    }
+
+    #[test]
+    fn to_valid_utf8_replaces_each_contiguous_invalid_run_once() {
+        let cases = [
+            (b"ok".as_slice(), "ok"),
+            (b"a\xff\xfeb".as_slice(), "a\u{FFFD}b"),
+            (b"\xff\xff\xff".as_slice(), "\u{FFFD}"),
+            (b"a\xffb\xffc".as_slice(), "a\u{FFFD}b\u{FFFD}c"),
+            ("café".as_bytes(), "café"),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(to_valid_utf8(input), expected, "failed for {input:?}");
+        }
     }
 
     #[test]

--- a/lib/saluki-io/src/deser/codec/dogstatsd/metric.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/metric.rs
@@ -421,6 +421,17 @@ mod tests {
     }
 
     #[test]
+    fn metric_tags_with_invalid_utf8_are_normalized() {
+        let mut input = b"my.gauge:1|g|#env:prod,tag:".to_vec();
+        input.extend_from_slice(&[0xff, 0xfe]);
+
+        let expected = Metric::gauge(("my.gauge", &["env:prod", "tag:\u{FFFD}"][..]), 1.0);
+        let actual = parse_dsd_metric(&input).expect("metric with invalid tag bytes should parse");
+
+        check_basic_metric_eq(expected, actual);
+    }
+
+    #[test]
     fn metric_sample_rate() {
         let name = "my.counter";
         let value = 1.0;

--- a/lib/saluki-io/src/deser/codec/dogstatsd/metric.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/metric.rs
@@ -331,7 +331,7 @@ mod tests {
         let (remaining, packet) = parse_dogstatsd_metric(input, config)?;
         assert!(remaining.is_empty());
 
-        let tags = packet.tags.into_iter().map(Tag::from).collect::<SharedTagSet>();
+        let tags = packet.tags.iter().map(Tag::from).collect::<SharedTagSet>();
         let context = Context::from_parts(packet.metric_name, tags);
 
         Ok(Some(Metric::from_parts(

--- a/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
@@ -95,7 +95,8 @@ impl DogStatsDCodecConfiguration {
     /// aren't within ASCII bounds, etc) such that the data plane can attempt to process them further.
     ///
     /// Permissive mode doesn't allow for decoding payloads with structural errors (for example, missing delimiters, etc) or
-    /// that can't be safely handled internally (for example, invalid UTF-8 characters for the metric name or tags).
+    /// that can't be safely handled internally (for example, invalid UTF-8 characters in a metric name). Invalid UTF-8 tag
+    /// bytes are normalized to U+FFFD before further processing.
     ///
     /// Defaults to `false`.
     pub fn with_permissive_mode(mut self, permissive: bool) -> Self {

--- a/lib/saluki-io/src/deser/codec/dogstatsd/service_check.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/service_check.rs
@@ -154,7 +154,7 @@ mod tests {
         assert!(remaining.is_empty());
 
         let mut service_check_tags = TagSet::default();
-        for tag in packet.tags.into_iter() {
+        for tag in packet.tags.iter() {
             service_check_tags.insert_tag(tag);
         }
 

--- a/lib/saluki-io/src/deser/codec/dogstatsd/service_check.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/service_check.rs
@@ -212,6 +212,20 @@ mod tests {
     }
 
     #[test]
+    fn service_check_tags_with_invalid_utf8_are_normalized() {
+        let mut input = b"_sc|testsvc|0|#env:prod,tag:".to_vec();
+        input.extend_from_slice(&[0xff, 0xfe]);
+
+        let tags = ["env:prod", "tag:\u{FFFD}"];
+        let expected = ServiceCheck::new("testsvc", CheckStatus::Ok).with_tags(SharedTagSet::from(TagSet::from_iter(
+            tags.iter().map(|&tag| tag.into()),
+        )));
+        let actual = parse_dsd_service_check(&input).expect("service check with invalid tag bytes should parse");
+
+        check_basic_service_check_eq(expected, actual);
+    }
+
+    #[test]
     fn service_check_message() {
         let name = "testsvc";
         let sc_status = CheckStatus::Ok;


### PR DESCRIPTION
## Summary

- Normalize invalid UTF-8 in every DogStatsD `#` tag block to one U+FFFD per contiguous invalid byte run, matching the backend behavior modeled for Agent-originated v2 series.
- Retain borrowed, zero-copy tag storage for valid inputs; use owned backing storage only after normalization is required.
- Refactor raw-tag iteration and DogStatsD well-known-tag extraction to borrow the backing representation, allowing metrics, events, and service checks to handle either storage form safely.
- Add regression coverage for the normalizer and for metric, event, and service-check tag blocks.

## Scope

This implements DADP-77 / #1634. It intentionally does not add recovery telemetry, an error subtype, or a user-facing configuration policy.

## Validation

- [x] Test-driven red phase: disabling recovery causes the invalid-tag event regression test to fail with the previous `Verify` parser error.
- [x] `cargo nextest run -p saluki-io` — 166 passed.
- [x] `make fmt`
- [x] `cargo check --workspace`
- [x] `cargo check --workspace --tests`
- [x] `make check-all`
- [x] `make test-all`
- [x] Repository pre-commit hooks.

## Self-review

A fresh-context review found and the follow-up commit corrected the permissive-decoding documentation, which still claimed invalid UTF-8 tag bytes were rejected. No remaining correctness, lifetime-safety, normalization, special-tag/origin, allocation-path, telemetry-scope, or configuration-scope defects were identified.
