### PR TITLE
feat(otlp): new error, drop, and latency telemetry for metrics

### DIFF
--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -70,6 +70,9 @@ pub struct Metrics {
     logs_received: Counter,
     bytes_received: Counter,
     spans_received: Counter,
+    metrics_errors_decode: Counter,
+    metrics_errors_dispatch: Counter,
+    metrics_errors_flush: Counter,
 }
 
 impl Metrics {
@@ -89,6 +92,18 @@ impl Metrics {
         &self.bytes_received
     }
 
+    pub fn metrics_errors_decode(&self) -> &Counter {
+        &self.metrics_errors_decode
+    }
+
+    pub fn metrics_errors_dispatch(&self) -> &Counter {
+        &self.metrics_errors_dispatch
+    }
+
+    pub fn metrics_errors_flush(&self) -> &Counter {
+        &self.metrics_errors_flush
+    }
+
     /// Test-only helper to construct a `Metrics` instance.
     #[cfg(test)]
     pub fn for_tests() -> Self {
@@ -97,6 +112,9 @@ impl Metrics {
             logs_received: Counter::noop(),
             bytes_received: Counter::noop(),
             spans_received: Counter::noop(),
+            metrics_errors_decode: Counter::noop(),
+            metrics_errors_dispatch: Counter::noop(),
+            metrics_errors_flush: Counter::noop(),
         }
     }
 }
@@ -113,6 +131,10 @@ pub fn build_metrics(component_context: &ComponentContext) -> Metrics {
         bytes_received: builder.register_counter_with_tags("component_bytes_received_total", [("source", "otlp")]),
         spans_received: builder
             .register_counter_with_tags("component_events_received_total", [("message_type", "otlp_spans")]),
+        metrics_errors_decode: builder.register_counter_with_tags("otlp_metrics_errors_total", [("reason", "decode")]),
+        metrics_errors_dispatch: builder
+            .register_counter_with_tags("otlp_metrics_errors_total", [("reason", "dispatch")]),
+        metrics_errors_flush: builder.register_counter_with_tags("otlp_metrics_errors_total", [("reason", "flush")]),
     }
 }
 
@@ -457,6 +479,7 @@ async fn http_metrics_handler<H: OtlpHandler>(
         Ok(()) => (StatusCode::OK, "OK"),
         Err(e) => {
             error!(error = %e, "Failed to handle OTLP metrics.");
+            metrics.metrics_errors_decode().increment(1);
             (StatusCode::INTERNAL_SERVER_ERROR, "Internal processing error")
         }
     }
@@ -537,6 +560,7 @@ impl<H: OtlpHandler> MetricsService for GrpcServiceImpl<H> {
             Ok(()) => Ok(Response::new(ExportMetricsServiceResponse { partial_success: None })),
             Err(e) => {
                 error!(error = %e, "Failed to handle OTLP metrics.");
+                self.metrics.metrics_errors_decode().increment(1);
                 Err(Status::internal("Internal processing error"))
             }
         }
@@ -600,6 +624,7 @@ mod tests {
         components::{test_util::TestComponentSupervisor, ComponentContext},
         runtime::state::{DataspaceUpdate, IdentifierFilter},
     };
+    use saluki_error::generic_error;
     use saluki_io::net::server::BoundServerAddress;
     use saluki_metrics::test::TestRecorder;
     use saluki_tls::test_util::SelfSignedCert;
@@ -618,6 +643,24 @@ mod tests {
     impl OtlpHandler for NoopHandler {
         async fn handle_metrics(&self, _body: Bytes) -> Result<(), GenericError> {
             Ok(())
+        }
+
+        async fn handle_logs(&self, _body: Bytes) -> Result<(), GenericError> {
+            Ok(())
+        }
+
+        async fn handle_traces(&self, _body: Bytes) -> Result<(), GenericError> {
+            Ok(())
+        }
+    }
+
+    /// A handler that always fails for metrics, used to test the decode error counter.
+    struct FailingHandler;
+
+    #[async_trait]
+    impl OtlpHandler for FailingHandler {
+        async fn handle_metrics(&self, _body: Bytes) -> Result<(), GenericError> {
+            Err(generic_error!("simulated decode failure"))
         }
 
         async fn handle_logs(&self, _body: Bytes) -> Result<(), GenericError> {
@@ -664,6 +707,29 @@ mod tests {
             .unwrap();
 
         assert_bytes_received(&recorder, expected_size);
+    }
+
+    #[tokio::test]
+    async fn grpc_metrics_export_failure_increments_decode_error_counter() {
+        let recorder = TestRecorder::default();
+        let _local = metrics::set_default_local_recorder(&recorder);
+
+        let metrics = Arc::new(build_metrics(&test_component_context()));
+        let service = GrpcServiceImpl::new(Arc::new(FailingHandler), MemoryLimiter::noop(), metrics);
+        let request = ExportMetricsServiceRequest {
+            resource_metrics: vec![otlp_protos::opentelemetry::proto::metrics::v1::ResourceMetrics::default()],
+        };
+
+        // The handler returns an error, so the export should return a gRPC error status.
+        let result = MetricsService::export(&service, TonicRequest::new(request)).await;
+        assert!(result.is_err(), "export with a failing handler should return an error");
+
+        let tags: &[(&str, &str)] = &[
+            ("component_id", "otlp_test"),
+            ("component_type", "source"),
+            ("reason", "decode"),
+        ];
+        assert_eq!(recorder.counter(("otlp_metrics_errors_total", tags)), Some(1));
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -137,12 +137,12 @@ pub fn build_metrics(component_context: &ComponentContext) -> Metrics {
         bytes_received: builder.register_counter_with_tags("component_bytes_received_total", [("source", "otlp")]),
         spans_received: builder
             .register_counter_with_tags("component_events_received_total", [("message_type", "otlp_spans")]),
-        metrics_errors_decode: builder.register_counter_with_tags("otlp_metrics_errors_total", [("reason", "decode")]),
+        metrics_errors_decode: builder.register_counter_with_tags("component_errors_total", [("reason", "decode")]),
         metrics_errors_channel: builder
-            .register_counter_with_tags("otlp_metrics_errors_total", [("reason", "channel")]),
+            .register_counter_with_tags("component_errors_total", [("reason", "channel")]),
         metrics_errors_dispatch: builder
-            .register_counter_with_tags("otlp_metrics_errors_total", [("reason", "dispatch")]),
-        metrics_errors_flush: builder.register_counter_with_tags("otlp_metrics_errors_total", [("reason", "flush")]),
+            .register_counter_with_tags("component_errors_total", [("reason", "dispatch")]),
+        metrics_errors_flush: builder.register_counter_with_tags("component_errors_total", [("reason", "flush")]),
     }
 }
 

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -138,10 +138,8 @@ pub fn build_metrics(component_context: &ComponentContext) -> Metrics {
         spans_received: builder
             .register_counter_with_tags("component_events_received_total", [("message_type", "otlp_spans")]),
         metrics_errors_decode: builder.register_counter_with_tags("component_errors_total", [("reason", "decode")]),
-        metrics_errors_channel: builder
-            .register_counter_with_tags("component_errors_total", [("reason", "channel")]),
-        metrics_errors_dispatch: builder
-            .register_counter_with_tags("component_errors_total", [("reason", "dispatch")]),
+        metrics_errors_channel: builder.register_counter_with_tags("component_errors_total", [("reason", "channel")]),
+        metrics_errors_dispatch: builder.register_counter_with_tags("component_errors_total", [("reason", "dispatch")]),
         metrics_errors_flush: builder.register_counter_with_tags("component_errors_total", [("reason", "flush")]),
     }
 }

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -71,6 +71,7 @@ pub struct Metrics {
     bytes_received: Counter,
     spans_received: Counter,
     metrics_errors_decode: Counter,
+    metrics_errors_channel: Counter,
     metrics_errors_dispatch: Counter,
     metrics_errors_flush: Counter,
 }
@@ -96,6 +97,10 @@ impl Metrics {
         &self.metrics_errors_decode
     }
 
+    pub fn metrics_errors_channel(&self) -> &Counter {
+        &self.metrics_errors_channel
+    }
+
     pub fn metrics_errors_dispatch(&self) -> &Counter {
         &self.metrics_errors_dispatch
     }
@@ -113,6 +118,7 @@ impl Metrics {
             bytes_received: Counter::noop(),
             spans_received: Counter::noop(),
             metrics_errors_decode: Counter::noop(),
+            metrics_errors_channel: Counter::noop(),
             metrics_errors_dispatch: Counter::noop(),
             metrics_errors_flush: Counter::noop(),
         }
@@ -132,6 +138,8 @@ pub fn build_metrics(component_context: &ComponentContext) -> Metrics {
         spans_received: builder
             .register_counter_with_tags("component_events_received_total", [("message_type", "otlp_spans")]),
         metrics_errors_decode: builder.register_counter_with_tags("otlp_metrics_errors_total", [("reason", "decode")]),
+        metrics_errors_channel: builder
+            .register_counter_with_tags("otlp_metrics_errors_total", [("reason", "channel")]),
         metrics_errors_dispatch: builder
             .register_counter_with_tags("otlp_metrics_errors_total", [("reason", "dispatch")]),
         metrics_errors_flush: builder.register_counter_with_tags("otlp_metrics_errors_total", [("reason", "flush")]),
@@ -479,7 +487,6 @@ async fn http_metrics_handler<H: OtlpHandler>(
         Ok(()) => (StatusCode::OK, "OK"),
         Err(e) => {
             error!(error = %e, "Failed to handle OTLP metrics.");
-            metrics.metrics_errors_decode().increment(1);
             (StatusCode::INTERNAL_SERVER_ERROR, "Internal processing error")
         }
     }
@@ -560,7 +567,6 @@ impl<H: OtlpHandler> MetricsService for GrpcServiceImpl<H> {
             Ok(()) => Ok(Response::new(ExportMetricsServiceResponse { partial_success: None })),
             Err(e) => {
                 error!(error = %e, "Failed to handle OTLP metrics.");
-                self.metrics.metrics_errors_decode().increment(1);
                 Err(Status::internal("Internal processing error"))
             }
         }
@@ -624,7 +630,6 @@ mod tests {
         components::{test_util::TestComponentSupervisor, ComponentContext},
         runtime::state::{DataspaceUpdate, IdentifierFilter},
     };
-    use saluki_error::generic_error;
     use saluki_io::net::server::BoundServerAddress;
     use saluki_metrics::test::TestRecorder;
     use saluki_tls::test_util::SelfSignedCert;
@@ -643,24 +648,6 @@ mod tests {
     impl OtlpHandler for NoopHandler {
         async fn handle_metrics(&self, _body: Bytes) -> Result<(), GenericError> {
             Ok(())
-        }
-
-        async fn handle_logs(&self, _body: Bytes) -> Result<(), GenericError> {
-            Ok(())
-        }
-
-        async fn handle_traces(&self, _body: Bytes) -> Result<(), GenericError> {
-            Ok(())
-        }
-    }
-
-    /// A handler that always fails for metrics, used to test the decode error counter.
-    struct FailingHandler;
-
-    #[async_trait]
-    impl OtlpHandler for FailingHandler {
-        async fn handle_metrics(&self, _body: Bytes) -> Result<(), GenericError> {
-            Err(generic_error!("simulated decode failure"))
         }
 
         async fn handle_logs(&self, _body: Bytes) -> Result<(), GenericError> {
@@ -707,29 +694,6 @@ mod tests {
             .unwrap();
 
         assert_bytes_received(&recorder, expected_size);
-    }
-
-    #[tokio::test]
-    async fn grpc_metrics_export_failure_increments_decode_error_counter() {
-        let recorder = TestRecorder::default();
-        let _local = metrics::set_default_local_recorder(&recorder);
-
-        let metrics = Arc::new(build_metrics(&test_component_context()));
-        let service = GrpcServiceImpl::new(Arc::new(FailingHandler), MemoryLimiter::noop(), metrics);
-        let request = ExportMetricsServiceRequest {
-            resource_metrics: vec![otlp_protos::opentelemetry::proto::metrics::v1::ResourceMetrics::default()],
-        };
-
-        // The handler returns an error, so the export should return a gRPC error status.
-        let result = MetricsService::export(&service, TonicRequest::new(request)).await;
-        assert!(result.is_err(), "export with a failing handler should return an error");
-
-        let tags: &[(&str, &str)] = &[
-            ("component_id", "otlp_test"),
-            ("component_type", "source"),
-            ("reason", "decode"),
-        ];
-        assert_eq!(recorder.counter(("otlp_metrics_errors_total", tags)), Some(1));
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/sources/otlp/metrics/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/mod.rs
@@ -6,4 +6,5 @@ pub mod dimensions;
 pub mod internal;
 pub mod remap;
 pub mod runtime_metrics;
+pub mod telemetry;
 pub mod translator;

--- a/lib/saluki-components/src/sources/otlp/metrics/telemetry.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/telemetry.rs
@@ -1,18 +1,11 @@
-//! Self-telemetry for the OTLP metrics translator.
-//!
-//! These metrics are distinct from the server-level volume counters in [`crate::common::otlp::Metrics`], which
-//! track bytes and events received. All counters use a bounded `reason` tag:
-//!
-//! - `translate`: the translator returned an error for an entire resource batch.
-//! - `unsupported_temporality`: a metric point was dropped because its aggregation temporality is not supported.
-//! - `histogram_conversion`: a histogram or exponential histogram data point could not be converted.
-//! - `invalid_value`: a metric point was dropped because its value was `NaN` or `Infinity`.
-
 use ::metrics::{Counter, Histogram};
 use saluki_core::components::ComponentContext;
 use saluki_core::observability::ComponentMetricsExt;
 use saluki_metrics::MetricsBuilder;
 
+/// Self-telemetry for the OTLP metrics translator.
+///
+/// Holds translation-specific error and dropped-point counters, plus a processing-latency histogram.
 #[derive(Clone)]
 pub struct OtlpMetricsTranslatorMetrics {
     errors_translate: Counter,
@@ -23,6 +16,7 @@ pub struct OtlpMetricsTranslatorMetrics {
 }
 
 impl OtlpMetricsTranslatorMetrics {
+    /// Builds the translator telemetry from the given component context.
     pub fn from_component_context(component_context: &ComponentContext) -> Self {
         let builder = MetricsBuilder::from_component_context(component_context);
 
@@ -43,6 +37,7 @@ impl OtlpMetricsTranslatorMetrics {
         }
     }
 
+    /// Creates a no-op instance for use in tests where real metric recording is not needed.
     pub fn for_tests() -> Self {
         Self {
             errors_translate: Counter::noop(),
@@ -53,22 +48,27 @@ impl OtlpMetricsTranslatorMetrics {
         }
     }
 
+    /// Returns the counter for batch-level translation errors.
     pub fn errors_translate(&self) -> &Counter {
         &self.errors_translate
     }
 
+    /// Returns the counter for points dropped due to unsupported aggregation temporality.
     pub fn dropped_unsupported_temporality(&self) -> &Counter {
         &self.dropped_unsupported_temporality
     }
 
+    /// Returns the counter for points dropped due to histogram conversion failures.
     pub fn dropped_histogram_conversion(&self) -> &Counter {
         &self.dropped_histogram_conversion
     }
 
+    /// Returns the counter for points dropped due to invalid values (`NaN` or `Infinity`).
     pub fn dropped_invalid_value(&self) -> &Counter {
         &self.dropped_invalid_value
     }
 
+    /// Returns the histogram for OTLP metrics processing latency.
     pub fn processing_duration(&self) -> &Histogram {
         &self.processing_duration
     }

--- a/lib/saluki-components/src/sources/otlp/metrics/telemetry.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/telemetry.rs
@@ -21,16 +21,13 @@ impl OtlpMetricsTranslatorMetrics {
         let builder = MetricsBuilder::from_component_context(component_context);
 
         Self {
-            errors_translate: builder
-                .register_counter_with_tags("component_errors_total", [("reason", "translate")]),
+            errors_translate: builder.register_counter_with_tags("component_errors_total", [("reason", "translate")]),
             dropped_unsupported_temporality: builder.register_counter_with_tags(
                 "component_events_dropped_total",
                 [("reason", "unsupported_temporality")],
             ),
-            dropped_histogram_conversion: builder.register_counter_with_tags(
-                "component_events_dropped_total",
-                [("reason", "histogram_conversion")],
-            ),
+            dropped_histogram_conversion: builder
+                .register_counter_with_tags("component_events_dropped_total", [("reason", "histogram_conversion")]),
             dropped_invalid_value: builder
                 .register_counter_with_tags("component_events_dropped_total", [("reason", "invalid_value")]),
             processing_duration: builder.register_histogram("component_processing_duration_seconds"),

--- a/lib/saluki-components/src/sources/otlp/metrics/telemetry.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/telemetry.rs
@@ -22,18 +22,18 @@ impl OtlpMetricsTranslatorMetrics {
 
         Self {
             errors_translate: builder
-                .register_counter_with_tags("otlp_metrics_errors_total", [("reason", "translate")]),
+                .register_counter_with_tags("component_errors_total", [("reason", "translate")]),
             dropped_unsupported_temporality: builder.register_counter_with_tags(
-                "otlp_metrics_dropped_points_total",
+                "component_events_dropped_total",
                 [("reason", "unsupported_temporality")],
             ),
             dropped_histogram_conversion: builder.register_counter_with_tags(
-                "otlp_metrics_dropped_points_total",
+                "component_events_dropped_total",
                 [("reason", "histogram_conversion")],
             ),
             dropped_invalid_value: builder
-                .register_counter_with_tags("otlp_metrics_dropped_points_total", [("reason", "invalid_value")]),
-            processing_duration: builder.register_histogram("otlp_metrics_processing_duration_seconds"),
+                .register_counter_with_tags("component_events_dropped_total", [("reason", "invalid_value")]),
+            processing_duration: builder.register_histogram("component_processing_duration_seconds"),
         }
     }
 

--- a/lib/saluki-components/src/sources/otlp/metrics/telemetry.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/telemetry.rs
@@ -1,0 +1,129 @@
+//! Self-telemetry for the OTLP metrics translator.
+//!
+//! Holds counters and histograms that measure translation errors, dropped metric points, and processing latency for
+//! OTLP metrics batches. These metrics are distinct from the server-level volume counters in
+//! [`crate::common::otlp::Metrics`], which track bytes and events received.
+//!
+//! All counters use a bounded `reason` tag so that the cardinality of emitted series stays fixed regardless of input.
+//! The supported reasons are:
+//!
+//! - `translate`: a batch-level translation failure (the translator returned an error for the entire resource).
+//! - `unsupported_temporality`: a metric point was dropped because its aggregation temporality is not supported.
+//! - `histogram_conversion`: a histogram or exponential histogram data point could not be converted.
+//! - `invalid_value`: a metric point was dropped because its value was `NaN` or `Infinity`.
+
+use std::time::Duration;
+
+use ::metrics::{Counter, Histogram};
+use saluki_core::components::ComponentContext;
+use saluki_core::observability::ComponentMetricsExt;
+use saluki_metrics::MetricsBuilder;
+
+/// The counter name for OTLP metrics translation errors.
+const OTLP_METRICS_ERRORS_TOTAL: &str = "otlp_metrics_errors_total";
+
+/// The counter name for OTLP metric points dropped during translation.
+const OTLP_METRICS_DROPPED_POINTS_TOTAL: &str = "otlp_metrics_dropped_points_total";
+
+/// The histogram name for OTLP metrics processing latency, in seconds.
+const OTLP_METRICS_PROCESSING_DURATION_SECONDS: &str = "otlp_metrics_processing_duration_seconds";
+
+/// Reason tag value for a batch-level translation error.
+const REASON_TRANSLATE: &str = "translate";
+
+/// Reason tag value for an unsupported aggregation temporality drop.
+const REASON_UNSUPPORTED_TEMPORALITY: &str = "unsupported_temporality";
+
+/// Reason tag value for a histogram or exponential histogram conversion failure.
+const REASON_HISTOGRAM_CONVERSION: &str = "histogram_conversion";
+
+/// Reason tag value for a metric point with an invalid value (`NaN` or `Infinity`).
+const REASON_INVALID_VALUE: &str = "invalid_value";
+
+/// Self-telemetry for the OTLP metrics translator.
+///
+/// Holds translation-specific error and dropped-point counters, plus a processing-latency histogram. The counters
+/// use a bounded `reason` tag so the cardinality of emitted series is fixed.
+#[derive(Clone)]
+pub struct OtlpMetricsTranslatorMetrics {
+    errors_translate: Counter,
+    dropped_unsupported_temporality: Counter,
+    dropped_histogram_conversion: Counter,
+    dropped_invalid_value: Counter,
+    processing_duration: Histogram,
+}
+
+impl OtlpMetricsTranslatorMetrics {
+    /// Builds the translator telemetry from the given component context.
+    ///
+    /// Each counter is pre-registered with its fixed `reason` tag so that the emitted series cardinality is bounded
+    /// and does not grow with input.
+    pub fn from_component_context(component_context: &ComponentContext) -> Self {
+        let builder = MetricsBuilder::from_component_context(component_context);
+
+        Self {
+            errors_translate: builder
+                .register_counter_with_tags(OTLP_METRICS_ERRORS_TOTAL, [("reason", REASON_TRANSLATE)]),
+            dropped_unsupported_temporality: builder.register_counter_with_tags(
+                OTLP_METRICS_DROPPED_POINTS_TOTAL,
+                [("reason", REASON_UNSUPPORTED_TEMPORALITY)],
+            ),
+            dropped_histogram_conversion: builder.register_counter_with_tags(
+                OTLP_METRICS_DROPPED_POINTS_TOTAL,
+                [("reason", REASON_HISTOGRAM_CONVERSION)],
+            ),
+            dropped_invalid_value: builder
+                .register_counter_with_tags(OTLP_METRICS_DROPPED_POINTS_TOTAL, [("reason", REASON_INVALID_VALUE)]),
+            processing_duration: builder.register_histogram(OTLP_METRICS_PROCESSING_DURATION_SECONDS),
+        }
+    }
+
+    /// Creates a no-op instance for use in tests where real metric recording is not needed.
+    pub fn for_tests() -> Self {
+        Self {
+            errors_translate: Counter::noop(),
+            dropped_unsupported_temporality: Counter::noop(),
+            dropped_histogram_conversion: Counter::noop(),
+            dropped_invalid_value: Counter::noop(),
+            processing_duration: Histogram::noop(),
+        }
+    }
+
+    /// Increments the batch-level translation error counter.
+    ///
+    /// Call this when an entire resource batch fails to translate and `translate_metrics` returns an error.
+    pub fn increment_translate_error(&self) {
+        self.errors_translate.increment(1);
+    }
+
+    /// Increments the dropped-point counter for an unsupported aggregation temporality.
+    ///
+    /// Call this when a metric point is dropped because its aggregation temporality is not supported (for example,
+    /// an unknown temporality value on a `Sum`, `Histogram`, or `ExponentialHistogram`).
+    pub fn increment_dropped_unsupported_temporality(&self) {
+        self.dropped_unsupported_temporality.increment(1);
+    }
+
+    /// Increments the dropped-point counter for a histogram conversion failure.
+    ///
+    /// Call this when a histogram or exponential histogram data point could not be converted (for example, a
+    /// cumulative exponential histogram, a malformed bucket/bound count mismatch, or a DDSketch remapping failure).
+    pub fn increment_dropped_histogram_conversion(&self) {
+        self.dropped_histogram_conversion.increment(1);
+    }
+
+    /// Increments the dropped-point counter for an invalid metric value.
+    ///
+    /// Call this when a metric point is dropped because its value is `NaN` or `Infinity`.
+    pub fn increment_dropped_invalid_value(&self) {
+        self.dropped_invalid_value.increment(1);
+    }
+
+    /// Records a processing-latency sample, in seconds.
+    ///
+    /// Call this for every translated batch, whether the translation succeeded or failed, so the histogram captures
+    /// the full distribution of processing times.
+    pub fn record_processing_duration(&self, duration: Duration) {
+        self.processing_duration.record(duration.as_secs_f64());
+    }
+}

--- a/lib/saluki-components/src/sources/otlp/metrics/telemetry.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/telemetry.rs
@@ -1,49 +1,18 @@
 //! Self-telemetry for the OTLP metrics translator.
 //!
-//! Holds counters and histograms that measure translation errors, dropped metric points, and processing latency for
-//! OTLP metrics batches. These metrics are distinct from the server-level volume counters in
-//! [`crate::common::otlp::Metrics`], which track bytes and events received.
+//! These metrics are distinct from the server-level volume counters in [`crate::common::otlp::Metrics`], which
+//! track bytes and events received. All counters use a bounded `reason` tag:
 //!
-//! All counters use a bounded `reason` tag so that the cardinality of emitted series stays fixed regardless of input.
-//! The supported reasons are:
-//!
-//! - `translate`: a batch-level translation failure (the translator returned an error for the entire resource).
+//! - `translate`: the translator returned an error for an entire resource batch.
 //! - `unsupported_temporality`: a metric point was dropped because its aggregation temporality is not supported.
 //! - `histogram_conversion`: a histogram or exponential histogram data point could not be converted.
 //! - `invalid_value`: a metric point was dropped because its value was `NaN` or `Infinity`.
-
-use std::time::Duration;
 
 use ::metrics::{Counter, Histogram};
 use saluki_core::components::ComponentContext;
 use saluki_core::observability::ComponentMetricsExt;
 use saluki_metrics::MetricsBuilder;
 
-/// The counter name for OTLP metrics translation errors.
-const OTLP_METRICS_ERRORS_TOTAL: &str = "otlp_metrics_errors_total";
-
-/// The counter name for OTLP metric points dropped during translation.
-const OTLP_METRICS_DROPPED_POINTS_TOTAL: &str = "otlp_metrics_dropped_points_total";
-
-/// The histogram name for OTLP metrics processing latency, in seconds.
-const OTLP_METRICS_PROCESSING_DURATION_SECONDS: &str = "otlp_metrics_processing_duration_seconds";
-
-/// Reason tag value for a batch-level translation error.
-const REASON_TRANSLATE: &str = "translate";
-
-/// Reason tag value for an unsupported aggregation temporality drop.
-const REASON_UNSUPPORTED_TEMPORALITY: &str = "unsupported_temporality";
-
-/// Reason tag value for a histogram or exponential histogram conversion failure.
-const REASON_HISTOGRAM_CONVERSION: &str = "histogram_conversion";
-
-/// Reason tag value for a metric point with an invalid value (`NaN` or `Infinity`).
-const REASON_INVALID_VALUE: &str = "invalid_value";
-
-/// Self-telemetry for the OTLP metrics translator.
-///
-/// Holds translation-specific error and dropped-point counters, plus a processing-latency histogram. The counters
-/// use a bounded `reason` tag so the cardinality of emitted series is fixed.
 #[derive(Clone)]
 pub struct OtlpMetricsTranslatorMetrics {
     errors_translate: Counter,
@@ -54,31 +23,26 @@ pub struct OtlpMetricsTranslatorMetrics {
 }
 
 impl OtlpMetricsTranslatorMetrics {
-    /// Builds the translator telemetry from the given component context.
-    ///
-    /// Each counter is pre-registered with its fixed `reason` tag so that the emitted series cardinality is bounded
-    /// and does not grow with input.
     pub fn from_component_context(component_context: &ComponentContext) -> Self {
         let builder = MetricsBuilder::from_component_context(component_context);
 
         Self {
             errors_translate: builder
-                .register_counter_with_tags(OTLP_METRICS_ERRORS_TOTAL, [("reason", REASON_TRANSLATE)]),
+                .register_counter_with_tags("otlp_metrics_errors_total", [("reason", "translate")]),
             dropped_unsupported_temporality: builder.register_counter_with_tags(
-                OTLP_METRICS_DROPPED_POINTS_TOTAL,
-                [("reason", REASON_UNSUPPORTED_TEMPORALITY)],
+                "otlp_metrics_dropped_points_total",
+                [("reason", "unsupported_temporality")],
             ),
             dropped_histogram_conversion: builder.register_counter_with_tags(
-                OTLP_METRICS_DROPPED_POINTS_TOTAL,
-                [("reason", REASON_HISTOGRAM_CONVERSION)],
+                "otlp_metrics_dropped_points_total",
+                [("reason", "histogram_conversion")],
             ),
             dropped_invalid_value: builder
-                .register_counter_with_tags(OTLP_METRICS_DROPPED_POINTS_TOTAL, [("reason", REASON_INVALID_VALUE)]),
-            processing_duration: builder.register_histogram(OTLP_METRICS_PROCESSING_DURATION_SECONDS),
+                .register_counter_with_tags("otlp_metrics_dropped_points_total", [("reason", "invalid_value")]),
+            processing_duration: builder.register_histogram("otlp_metrics_processing_duration_seconds"),
         }
     }
 
-    /// Creates a no-op instance for use in tests where real metric recording is not needed.
     pub fn for_tests() -> Self {
         Self {
             errors_translate: Counter::noop(),
@@ -89,41 +53,23 @@ impl OtlpMetricsTranslatorMetrics {
         }
     }
 
-    /// Increments the batch-level translation error counter.
-    ///
-    /// Call this when an entire resource batch fails to translate and `translate_metrics` returns an error.
-    pub fn increment_translate_error(&self) {
-        self.errors_translate.increment(1);
+    pub fn errors_translate(&self) -> &Counter {
+        &self.errors_translate
     }
 
-    /// Increments the dropped-point counter for an unsupported aggregation temporality.
-    ///
-    /// Call this when a metric point is dropped because its aggregation temporality is not supported (for example,
-    /// an unknown temporality value on a `Sum`, `Histogram`, or `ExponentialHistogram`).
-    pub fn increment_dropped_unsupported_temporality(&self) {
-        self.dropped_unsupported_temporality.increment(1);
+    pub fn dropped_unsupported_temporality(&self) -> &Counter {
+        &self.dropped_unsupported_temporality
     }
 
-    /// Increments the dropped-point counter for a histogram conversion failure.
-    ///
-    /// Call this when a histogram or exponential histogram data point could not be converted (for example, a
-    /// cumulative exponential histogram, a malformed bucket/bound count mismatch, or a DDSketch remapping failure).
-    pub fn increment_dropped_histogram_conversion(&self) {
-        self.dropped_histogram_conversion.increment(1);
+    pub fn dropped_histogram_conversion(&self) -> &Counter {
+        &self.dropped_histogram_conversion
     }
 
-    /// Increments the dropped-point counter for an invalid metric value.
-    ///
-    /// Call this when a metric point is dropped because its value is `NaN` or `Infinity`.
-    pub fn increment_dropped_invalid_value(&self) {
-        self.dropped_invalid_value.increment(1);
+    pub fn dropped_invalid_value(&self) -> &Counter {
+        &self.dropped_invalid_value
     }
 
-    /// Records a processing-latency sample, in seconds.
-    ///
-    /// Call this for every translated batch, whether the translation succeeded or failed, so the histogram captures
-    /// the full distribution of processing times.
-    pub fn record_processing_duration(&self, duration: Duration) {
-        self.processing_duration.record(duration.as_secs_f64());
+    pub fn processing_duration(&self) -> &Histogram {
+        &self.processing_duration
     }
 }

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::LazyLock;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use std::vec::IntoIter;
 
 use ::ddsketch::canonical::mapping::IndexMapping;
@@ -37,6 +37,7 @@ use super::dimensions::Dimensions;
 use super::internal::{instrumentationlibrary, instrumentationscope};
 use super::remap;
 use super::runtime_metrics::{RuntimeMetricMapping, RUNTIME_METRICS_MAPPINGS, RUNTIME_METRIC_PREFIX_LANGUAGE_MAP};
+use super::telemetry::OtlpMetricsTranslatorMetrics;
 use crate::common::otlp::attributes::translator::AttributeTranslator;
 use crate::common::otlp::attributes::ResourceAttributeTagMode;
 use crate::common::otlp::origin::OtlpOriginTagResolver;
@@ -104,6 +105,8 @@ pub struct OtlpMetricsTranslator {
     metric_type_override_warnings: FastHashSet<(String, MetricTypeOverrideWarningKind)>,
     // Configured tags (`otlp_config.metrics.tags`) added to every emitted metric.
     metric_tags: SharedTagSet,
+    // Self-telemetry for translation errors, dropped points, and processing latency.
+    translator_metrics: OtlpMetricsTranslatorMetrics,
 }
 
 #[derive(Debug, Default)]
@@ -445,6 +448,7 @@ impl OtlpMetricsTranslator {
     pub fn new(
         config: OtlpMetricsTranslatorConfig, default_hostname: MetaString, context_resolver: ContextResolver,
         origin_tag_resolver: OtlpOriginTagResolver, metric_tags: SharedTagSet,
+        translator_metrics: OtlpMetricsTranslatorMetrics,
     ) -> Result<Self, GenericError> {
         config
             .validate()
@@ -463,6 +467,7 @@ impl OtlpMetricsTranslator {
             attribute_translator: AttributeTranslator::new(),
             metric_type_override_warnings: FastHashSet::default(),
             metric_tags,
+            translator_metrics,
         })
     }
 
@@ -471,7 +476,22 @@ impl OtlpMetricsTranslator {
     ///
     /// Returns the translated events and the set of runtime languages detected from metric names
     /// in this `ResourceMetrics`.
+    ///
+    /// The processing duration is recorded on the translator's latency histogram regardless of whether the
+    /// translation succeeds or fails, so the histogram captures the full distribution of processing times.
     pub fn translate_metrics(
+        &mut self, resource_metrics: OtlpResourceMetrics, metrics: &Metrics,
+    ) -> Result<(IntoIter<Event>, FastHashSet<&'static str>), GenericError> {
+        let start = Instant::now();
+        let result = self.translate_metrics_inner(resource_metrics, metrics);
+        self.translator_metrics.record_processing_duration(start.elapsed());
+        if let Err(ref _e) = &result {
+            self.translator_metrics.increment_translate_error();
+        }
+        result
+    }
+
+    fn translate_metrics_inner(
         &mut self, resource_metrics: OtlpResourceMetrics, metrics: &Metrics,
     ) -> Result<(IntoIter<Event>, FastHashSet<&'static str>), GenericError> {
         let mut events = Vec::new();
@@ -656,6 +676,13 @@ impl OtlpMetricsTranslator {
 
     /// Creates a new `OtlpMetricsTranslator` for tests.
     pub fn for_tests() -> OtlpMetricsTranslator {
+        Self::for_tests_with_translator_metrics(OtlpMetricsTranslatorMetrics::for_tests())
+    }
+
+    /// Creates a new `OtlpMetricsTranslator` for tests with the given translator telemetry.
+    pub fn for_tests_with_translator_metrics(
+        translator_metrics: OtlpMetricsTranslatorMetrics,
+    ) -> OtlpMetricsTranslator {
         let process_start_time_ns = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("System time is before the UNIX epoch, this should not happen.")
@@ -674,6 +701,7 @@ impl OtlpMetricsTranslator {
             attribute_translator: AttributeTranslator::new(),
             metric_type_override_warnings: FastHashSet::default(),
             metric_tags: SharedTagSet::default(),
+            translator_metrics,
         }
     }
 
@@ -725,6 +753,7 @@ impl OtlpMetricsTranslator {
                             temporality = sum.aggregation_temporality,
                             "Unsupported or unknown aggregation temporality for Sum metric."
                         );
+                        self.translator_metrics.increment_dropped_unsupported_temporality();
                         Vec::new()
                     }
                 },
@@ -742,6 +771,7 @@ impl OtlpMetricsTranslator {
                                 temporality = histogram.aggregation_temporality,
                                 "Unsupported or unknown aggregation temporality for Histogram metric."
                             );
+                            self.translator_metrics.increment_dropped_unsupported_temporality();
                             Vec::new()
                         }
                     }
@@ -761,6 +791,7 @@ impl OtlpMetricsTranslator {
                                 temporality = exponential_histogram.aggregation_temporality,
                                 "Unknown or unsupported aggregation temporality"
                             );
+                            self.translator_metrics.increment_dropped_unsupported_temporality();
                             Vec::new()
                         }
                     }
@@ -842,6 +873,8 @@ impl OtlpMetricsTranslator {
                     if ok {
                         self.record_metric_event(&sum_dims, sum_delta, ts, DataType::Count, &mut events, context);
                     }
+                } else {
+                    self.translator_metrics.increment_dropped_invalid_value();
                 }
             }
 
@@ -850,6 +883,7 @@ impl OtlpMetricsTranslator {
                 let quantiles = &dp.quantile_values;
                 for quantile in quantiles {
                     if is_skippable(quantile.value) {
+                        self.translator_metrics.increment_dropped_invalid_value();
                         continue;
                     }
                     let quantile_dims = base_quantile_dims.add_tags([format_quantile_tag(quantile.quantile)]);
@@ -889,6 +923,7 @@ impl OtlpMetricsTranslator {
                     metric_name = point_dims.name,
                     value, "Skipping metric with unsupported value (NaN or Infinity)."
                 );
+                self.translator_metrics.increment_dropped_invalid_value();
                 continue;
             }
 
@@ -951,6 +986,7 @@ impl OtlpMetricsTranslator {
                     metric_name = point_dims.name,
                     value, "Skipping metric with unsupported value (NaN or Infinity)."
                 );
+                self.translator_metrics.increment_dropped_invalid_value();
                 continue;
             }
 
@@ -1209,6 +1245,7 @@ impl OtlpMetricsTranslator {
             // Validate before updating cumulative state.
             if let Err(e) = validate_histogram_buckets(&point_dims, &dp) {
                 warn!(error = %e, "Failed to validate histogram buckets, dropping data point.");
+                self.translator_metrics.increment_dropped_histogram_conversion();
                 continue;
             }
 
@@ -1258,6 +1295,7 @@ impl OtlpMetricsTranslator {
                 }
             } else {
                 hist_info.ok = false;
+                self.translator_metrics.increment_dropped_histogram_conversion();
             }
 
             if let Some(min) = dp.min {
@@ -1305,11 +1343,13 @@ impl OtlpMetricsTranslator {
                 HistogramMode::Counters => {
                     if let Err(e) = self.get_legacy_buckets(context, point_dims, dp, delta, &mut events) {
                         warn!(error = %e, "Failed to convert histogram buckets to counters, dropping data point.");
+                        self.translator_metrics.increment_dropped_histogram_conversion();
                     }
                 }
                 HistogramMode::Distributions => {
                     if let Err(e) = self.get_sketch_buckets(context, point_dims, &dp, delta, &mut events, hist_info) {
                         warn!(error = %e, "Failed to convert histogram buckets to sketch, dropping data point.");
+                        self.translator_metrics.increment_dropped_histogram_conversion();
                     }
                 }
             }
@@ -1372,6 +1412,7 @@ impl OtlpMetricsTranslator {
                 }
             } else {
                 hist_info.ok = false;
+                self.translator_metrics.increment_dropped_histogram_conversion();
             }
 
             let min_dims = point_dims.with_suffix("min");
@@ -1412,6 +1453,7 @@ impl OtlpMetricsTranslator {
                         error = %e,
                         "Failed to convert ExponentialHistogram into DDSketch"
                     );
+                    self.translator_metrics.increment_dropped_histogram_conversion();
                     continue;
                 }
             };
@@ -1424,6 +1466,7 @@ impl OtlpMetricsTranslator {
                         error = %e,
                         "Failed to convert DDSketch into agent sketch"
                     );
+                    self.translator_metrics.increment_dropped_histogram_conversion();
                     continue;
                 }
             };
@@ -5033,5 +5076,179 @@ mod tests {
 
         let runtime_beacon = metric_by_name(&events, "datadog.agent.otlp.runtime_metrics");
         assert_eq!(runtime_beacon.context().host(), Some("default-host"));
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Self-telemetry: error, dropped-point, and latency metrics.
+    // -----------------------------------------------------------------------------------------------
+
+    use saluki_core::components::ComponentContext;
+    use saluki_metrics::test::TestRecorder;
+
+    fn test_translator_metrics(recorder: &TestRecorder) -> OtlpMetricsTranslatorMetrics {
+        let _ = recorder; // recorder is already set as the default local recorder by the caller
+        OtlpMetricsTranslatorMetrics::from_component_context(&ComponentContext::test_source("otlp_test"))
+    }
+
+    /// Default tags attached to every metric registered via `ComponentContext::test_source("otlp_test")`.
+    const TELEMETRY_DEFAULT_TAGS: &[(&str, &str)] = &[("component_id", "otlp_test"), ("component_type", "source")];
+
+    #[test]
+    fn translate_metrics_records_processing_duration_on_success() {
+        let recorder = TestRecorder::default();
+        let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+
+        let translator_metrics = test_translator_metrics(&recorder);
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests_with_translator_metrics(translator_metrics);
+
+        let _ = translator.translate_metrics(single_gauge_resource_metrics(None), &metrics);
+
+        let samples = recorder
+            .histogram(("otlp_metrics_processing_duration_seconds", TELEMETRY_DEFAULT_TAGS))
+            .expect("processing duration histogram should have a sample");
+        assert_eq!(samples.len(), 1, "exactly one latency sample should be recorded");
+        assert!(samples[0] >= 0.0, "duration should be non-negative");
+    }
+
+    #[test]
+    fn translate_metrics_increments_dropped_points_for_unsupported_temporality() {
+        let recorder = TestRecorder::default();
+        let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+
+        let translator_metrics = test_translator_metrics(&recorder);
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests_with_translator_metrics(translator_metrics);
+
+        // A Sum with an invalid aggregation temporality (99) triggers the unsupported-temporality drop path.
+        let metric = OtlpMetric {
+            name: "unsupported.temporality".to_string(),
+            data: Some(OtlpMetricData::Sum(Sum {
+                aggregation_temporality: 99,
+                is_monotonic: false,
+                data_points: vec![OtlpNumberDataPoint {
+                    value: Some(OtlpNumberDataPointValue::AsDouble(1.0)),
+                    time_unix_nano: nanos_from_seconds(1),
+                    ..Default::default()
+                }],
+            })),
+            ..Default::default()
+        };
+
+        let _ = translator.translate_metrics(resource_metrics_with_metric(metric), &metrics);
+
+        let tags: &[(&str, &str)] = &[
+            ("component_id", "otlp_test"),
+            ("component_type", "source"),
+            ("reason", "unsupported_temporality"),
+        ];
+        assert_eq!(recorder.counter(("otlp_metrics_dropped_points_total", tags)), Some(1));
+    }
+
+    #[test]
+    fn translate_metrics_increments_dropped_points_for_invalid_value() {
+        let recorder = TestRecorder::default();
+        let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+
+        let translator_metrics = test_translator_metrics(&recorder);
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests_with_translator_metrics(translator_metrics);
+
+        // A gauge with a NaN value triggers the invalid-value drop path.
+        let metric = OtlpMetric {
+            name: "nan.gauge".to_string(),
+            data: Some(OtlpMetricData::Gauge(Gauge {
+                data_points: vec![OtlpNumberDataPoint {
+                    value: Some(OtlpNumberDataPointValue::AsDouble(f64::NAN)),
+                    time_unix_nano: nanos_from_seconds(1),
+                    ..Default::default()
+                }],
+            })),
+            ..Default::default()
+        };
+
+        let _ = translator.translate_metrics(resource_metrics_with_metric(metric), &metrics);
+
+        let tags: &[(&str, &str)] = &[
+            ("component_id", "otlp_test"),
+            ("component_type", "source"),
+            ("reason", "invalid_value"),
+        ];
+        assert_eq!(recorder.counter(("otlp_metrics_dropped_points_total", tags)), Some(1));
+    }
+
+    #[test]
+    fn translate_metrics_increments_dropped_points_for_histogram_conversion_failure() {
+        let recorder = TestRecorder::default();
+        let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+
+        let translator_metrics = test_translator_metrics(&recorder);
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests_with_translator_metrics(translator_metrics);
+        translator.config.hist_mode = HistogramMode::Distributions;
+
+        // Mismatched bucket/bound counts trigger the histogram conversion failure path.
+        let metric = OtlpMetric {
+            name: "bad.histogram".to_string(),
+            data: Some(OtlpMetricData::Histogram(
+                otlp_protos::opentelemetry::proto::metrics::v1::Histogram {
+                    aggregation_temporality: AggregationTemporality::Delta as i32,
+                    data_points: vec![OtlpHistogramDataPoint {
+                        count: 1,
+                        sum: Some(0.5),
+                        bucket_counts: vec![1],
+                        explicit_bounds: vec![1.0, 2.0],
+                        time_unix_nano: nanos_from_seconds(1),
+                        ..Default::default()
+                    }],
+                },
+            )),
+            ..Default::default()
+        };
+
+        let _ = translator.translate_metrics(resource_metrics_with_metric(metric), &metrics);
+
+        let tags: &[(&str, &str)] = &[
+            ("component_id", "otlp_test"),
+            ("component_type", "source"),
+            ("reason", "histogram_conversion"),
+        ];
+        assert_eq!(recorder.counter(("otlp_metrics_dropped_points_total", tags)), Some(1));
+    }
+
+    #[test]
+    fn translate_metrics_does_not_increment_drop_counters_on_success() {
+        let recorder = TestRecorder::default();
+        let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+
+        let translator_metrics = test_translator_metrics(&recorder);
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests_with_translator_metrics(translator_metrics);
+
+        // A valid gauge should not increment any drop counter.
+        let _ = translator.translate_metrics(single_gauge_resource_metrics(None), &metrics);
+
+        for reason in [
+            "unsupported_temporality",
+            "histogram_conversion",
+            "invalid_value",
+            "translate",
+        ] {
+            let tags: &[(&str, &str)] = &[
+                ("component_id", "otlp_test"),
+                ("component_type", "source"),
+                ("reason", reason),
+            ];
+            let counter_name = if reason == "translate" {
+                "otlp_metrics_errors_total"
+            } else {
+                "otlp_metrics_dropped_points_total"
+            };
+            assert_eq!(
+                recorder.counter((counter_name, tags)),
+                Some(0),
+                "counter {counter_name} with reason={reason} should be zero after a successful translation"
+            );
+        }
     }
 }

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -755,7 +755,9 @@ impl OtlpMetricsTranslator {
                             temporality = sum.aggregation_temporality,
                             "Unsupported or unknown aggregation temporality for Sum metric."
                         );
-                        self.translator_metrics.dropped_unsupported_temporality().increment(1);
+                        self.translator_metrics
+                            .dropped_unsupported_temporality()
+                            .increment(sum.data_points.len() as u64);
                         Vec::new()
                     }
                 },
@@ -773,7 +775,9 @@ impl OtlpMetricsTranslator {
                                 temporality = histogram.aggregation_temporality,
                                 "Unsupported or unknown aggregation temporality for Histogram metric."
                             );
-                            self.translator_metrics.dropped_unsupported_temporality().increment(1);
+                            self.translator_metrics
+                                .dropped_unsupported_temporality()
+                                .increment(histogram.data_points.len() as u64);
                             Vec::new()
                         }
                     }
@@ -793,7 +797,9 @@ impl OtlpMetricsTranslator {
                                 temporality = exponential_histogram.aggregation_temporality,
                                 "Unknown or unsupported aggregation temporality"
                             );
-                            self.translator_metrics.dropped_unsupported_temporality().increment(1);
+                            self.translator_metrics
+                                .dropped_unsupported_temporality()
+                                .increment(exponential_histogram.data_points.len() as u64);
                             Vec::new()
                         }
                     }
@@ -1297,7 +1303,7 @@ impl OtlpMetricsTranslator {
                 }
             } else {
                 hist_info.ok = false;
-                self.translator_metrics.dropped_histogram_conversion().increment(1);
+                self.translator_metrics.dropped_invalid_value().increment(1);
             }
 
             if let Some(min) = dp.min {
@@ -1414,7 +1420,7 @@ impl OtlpMetricsTranslator {
                 }
             } else {
                 hist_info.ok = false;
-                self.translator_metrics.dropped_histogram_conversion().increment(1);
+                self.translator_metrics.dropped_invalid_value().increment(1);
             }
 
             let min_dims = point_dims.with_suffix("min");
@@ -5123,16 +5129,24 @@ mod tests {
         let mut translator = OtlpMetricsTranslator::for_tests_with_translator_metrics(translator_metrics);
 
         // A Sum with an invalid aggregation temporality (99) triggers the unsupported-temporality drop path.
+        // Two data points are dropped, so the counter should increment by 2.
         let metric = OtlpMetric {
             name: "unsupported.temporality".to_string(),
             data: Some(OtlpMetricData::Sum(Sum {
                 aggregation_temporality: 99,
                 is_monotonic: false,
-                data_points: vec![OtlpNumberDataPoint {
-                    value: Some(OtlpNumberDataPointValue::AsDouble(1.0)),
-                    time_unix_nano: nanos_from_seconds(1),
-                    ..Default::default()
-                }],
+                data_points: vec![
+                    OtlpNumberDataPoint {
+                        value: Some(OtlpNumberDataPointValue::AsDouble(1.0)),
+                        time_unix_nano: nanos_from_seconds(1),
+                        ..Default::default()
+                    },
+                    OtlpNumberDataPoint {
+                        value: Some(OtlpNumberDataPointValue::AsDouble(2.0)),
+                        time_unix_nano: nanos_from_seconds(2),
+                        ..Default::default()
+                    },
+                ],
             })),
             ..Default::default()
         };
@@ -5144,7 +5158,7 @@ mod tests {
             ("component_type", "source"),
             ("reason", "unsupported_temporality"),
         ];
-        assert_eq!(recorder.counter(("otlp_metrics_dropped_points_total", tags)), Some(1));
+        assert_eq!(recorder.counter(("otlp_metrics_dropped_points_total", tags)), Some(2));
     }
 
     #[test]

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -487,7 +487,7 @@ impl OtlpMetricsTranslator {
         self.translator_metrics
             .processing_duration()
             .record(start.elapsed().as_secs_f64());
-        if let Err(ref _e) = &result {
+        if result.is_err() {
             self.translator_metrics.errors_translate().increment(1);
         }
         result
@@ -5113,7 +5113,7 @@ mod tests {
         let _ = translator.translate_metrics(single_gauge_resource_metrics(None), &metrics);
 
         let samples = recorder
-            .histogram(("otlp_metrics_processing_duration_seconds", TELEMETRY_DEFAULT_TAGS))
+            .histogram(("component_processing_duration_seconds", TELEMETRY_DEFAULT_TAGS))
             .expect("processing duration histogram should have a sample");
         assert_eq!(samples.len(), 1, "exactly one latency sample should be recorded");
         assert!(samples[0] >= 0.0, "duration should be non-negative");
@@ -5158,7 +5158,7 @@ mod tests {
             ("component_type", "source"),
             ("reason", "unsupported_temporality"),
         ];
-        assert_eq!(recorder.counter(("otlp_metrics_dropped_points_total", tags)), Some(2));
+        assert_eq!(recorder.counter(("component_events_dropped_total", tags)), Some(2));
     }
 
     #[test]
@@ -5190,7 +5190,7 @@ mod tests {
             ("component_type", "source"),
             ("reason", "invalid_value"),
         ];
-        assert_eq!(recorder.counter(("otlp_metrics_dropped_points_total", tags)), Some(1));
+        assert_eq!(recorder.counter(("component_events_dropped_total", tags)), Some(1));
     }
 
     #[test]
@@ -5229,7 +5229,7 @@ mod tests {
             ("component_type", "source"),
             ("reason", "histogram_conversion"),
         ];
-        assert_eq!(recorder.counter(("otlp_metrics_dropped_points_total", tags)), Some(1));
+        assert_eq!(recorder.counter(("component_events_dropped_total", tags)), Some(1));
     }
 
     #[test]
@@ -5256,9 +5256,9 @@ mod tests {
                 ("reason", reason),
             ];
             let counter_name = if reason == "translate" {
-                "otlp_metrics_errors_total"
+                "component_errors_total"
             } else {
-                "otlp_metrics_dropped_points_total"
+                "component_events_dropped_total"
             };
             assert_eq!(
                 recorder.counter((counter_name, tags)),

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -484,9 +484,11 @@ impl OtlpMetricsTranslator {
     ) -> Result<(IntoIter<Event>, FastHashSet<&'static str>), GenericError> {
         let start = Instant::now();
         let result = self.translate_metrics_inner(resource_metrics, metrics);
-        self.translator_metrics.record_processing_duration(start.elapsed());
+        self.translator_metrics
+            .processing_duration()
+            .record(start.elapsed().as_secs_f64());
         if let Err(ref _e) = &result {
-            self.translator_metrics.increment_translate_error();
+            self.translator_metrics.errors_translate().increment(1);
         }
         result
     }
@@ -753,7 +755,7 @@ impl OtlpMetricsTranslator {
                             temporality = sum.aggregation_temporality,
                             "Unsupported or unknown aggregation temporality for Sum metric."
                         );
-                        self.translator_metrics.increment_dropped_unsupported_temporality();
+                        self.translator_metrics.dropped_unsupported_temporality().increment(1);
                         Vec::new()
                     }
                 },
@@ -771,7 +773,7 @@ impl OtlpMetricsTranslator {
                                 temporality = histogram.aggregation_temporality,
                                 "Unsupported or unknown aggregation temporality for Histogram metric."
                             );
-                            self.translator_metrics.increment_dropped_unsupported_temporality();
+                            self.translator_metrics.dropped_unsupported_temporality().increment(1);
                             Vec::new()
                         }
                     }
@@ -791,7 +793,7 @@ impl OtlpMetricsTranslator {
                                 temporality = exponential_histogram.aggregation_temporality,
                                 "Unknown or unsupported aggregation temporality"
                             );
-                            self.translator_metrics.increment_dropped_unsupported_temporality();
+                            self.translator_metrics.dropped_unsupported_temporality().increment(1);
                             Vec::new()
                         }
                     }
@@ -874,7 +876,7 @@ impl OtlpMetricsTranslator {
                         self.record_metric_event(&sum_dims, sum_delta, ts, DataType::Count, &mut events, context);
                     }
                 } else {
-                    self.translator_metrics.increment_dropped_invalid_value();
+                    self.translator_metrics.dropped_invalid_value().increment(1);
                 }
             }
 
@@ -883,7 +885,7 @@ impl OtlpMetricsTranslator {
                 let quantiles = &dp.quantile_values;
                 for quantile in quantiles {
                     if is_skippable(quantile.value) {
-                        self.translator_metrics.increment_dropped_invalid_value();
+                        self.translator_metrics.dropped_invalid_value().increment(1);
                         continue;
                     }
                     let quantile_dims = base_quantile_dims.add_tags([format_quantile_tag(quantile.quantile)]);
@@ -923,7 +925,7 @@ impl OtlpMetricsTranslator {
                     metric_name = point_dims.name,
                     value, "Skipping metric with unsupported value (NaN or Infinity)."
                 );
-                self.translator_metrics.increment_dropped_invalid_value();
+                self.translator_metrics.dropped_invalid_value().increment(1);
                 continue;
             }
 
@@ -986,7 +988,7 @@ impl OtlpMetricsTranslator {
                     metric_name = point_dims.name,
                     value, "Skipping metric with unsupported value (NaN or Infinity)."
                 );
-                self.translator_metrics.increment_dropped_invalid_value();
+                self.translator_metrics.dropped_invalid_value().increment(1);
                 continue;
             }
 
@@ -1245,7 +1247,7 @@ impl OtlpMetricsTranslator {
             // Validate before updating cumulative state.
             if let Err(e) = validate_histogram_buckets(&point_dims, &dp) {
                 warn!(error = %e, "Failed to validate histogram buckets, dropping data point.");
-                self.translator_metrics.increment_dropped_histogram_conversion();
+                self.translator_metrics.dropped_histogram_conversion().increment(1);
                 continue;
             }
 
@@ -1295,7 +1297,7 @@ impl OtlpMetricsTranslator {
                 }
             } else {
                 hist_info.ok = false;
-                self.translator_metrics.increment_dropped_histogram_conversion();
+                self.translator_metrics.dropped_histogram_conversion().increment(1);
             }
 
             if let Some(min) = dp.min {
@@ -1343,13 +1345,13 @@ impl OtlpMetricsTranslator {
                 HistogramMode::Counters => {
                     if let Err(e) = self.get_legacy_buckets(context, point_dims, dp, delta, &mut events) {
                         warn!(error = %e, "Failed to convert histogram buckets to counters, dropping data point.");
-                        self.translator_metrics.increment_dropped_histogram_conversion();
+                        self.translator_metrics.dropped_histogram_conversion().increment(1);
                     }
                 }
                 HistogramMode::Distributions => {
                     if let Err(e) = self.get_sketch_buckets(context, point_dims, &dp, delta, &mut events, hist_info) {
                         warn!(error = %e, "Failed to convert histogram buckets to sketch, dropping data point.");
-                        self.translator_metrics.increment_dropped_histogram_conversion();
+                        self.translator_metrics.dropped_histogram_conversion().increment(1);
                     }
                 }
             }
@@ -1412,7 +1414,7 @@ impl OtlpMetricsTranslator {
                 }
             } else {
                 hist_info.ok = false;
-                self.translator_metrics.increment_dropped_histogram_conversion();
+                self.translator_metrics.dropped_histogram_conversion().increment(1);
             }
 
             let min_dims = point_dims.with_suffix("min");
@@ -1453,7 +1455,7 @@ impl OtlpMetricsTranslator {
                         error = %e,
                         "Failed to convert ExponentialHistogram into DDSketch"
                     );
-                    self.translator_metrics.increment_dropped_histogram_conversion();
+                    self.translator_metrics.dropped_histogram_conversion().increment(1);
                     continue;
                 }
             };
@@ -1466,7 +1468,7 @@ impl OtlpMetricsTranslator {
                         error = %e,
                         "Failed to convert DDSketch into agent sketch"
                     );
-                    self.translator_metrics.increment_dropped_histogram_conversion();
+                    self.translator_metrics.dropped_histogram_conversion().increment(1);
                     continue;
                 }
             };

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -847,7 +847,7 @@ mod tests {
             ("component_type", "source"),
             ("reason", "decode"),
         ];
-        assert_eq!(recorder.counter(("otlp_metrics_errors_total", tags)), Some(1));
+        assert_eq!(recorder.counter(("component_errors_total", tags)), Some(1));
     }
 
     #[tokio::test]
@@ -872,7 +872,7 @@ mod tests {
             ("component_type", "source"),
             ("reason", "channel"),
         ];
-        assert_eq!(recorder.counter(("otlp_metrics_errors_total", tags)), Some(1));
+        assert_eq!(recorder.counter(("component_errors_total", tags)), Some(1));
 
         // The decode counter should not have been incremented.
         let decode_tags: &[(&str, &str)] = &[
@@ -880,6 +880,6 @@ mod tests {
             ("component_type", "source"),
             ("reason", "decode"),
         ];
-        assert_eq!(recorder.counter(("otlp_metrics_errors_total", decode_tags)), Some(0));
+        assert_eq!(recorder.counter(("component_errors_total", decode_tags)), Some(0));
     }
 }

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -224,6 +224,8 @@ impl SourceBuilder for OtlpConfiguration {
         let http_tls_config = build_tls_config(&self.otlp.receiver.http.tls)?;
         let grpc_tls_config = build_tls_config(&self.otlp.receiver.grpc.tls)?;
         let metrics = build_metrics(context.component_context());
+        let translator_metrics =
+            metrics::telemetry::OtlpMetricsTranslatorMetrics::from_component_context(context.component_context());
 
         Ok(Box::new(Otlp {
             context_resolver,
@@ -240,6 +242,7 @@ impl SourceBuilder for OtlpConfiguration {
             http_tls_config,
             grpc_tls_config,
             metrics,
+            translator_metrics,
         }))
     }
 }
@@ -268,6 +271,7 @@ pub struct Otlp {
     http_tls_config: Option<OtlpTlsConfiguration>,
     grpc_tls_config: Option<OtlpTlsConfiguration>,
     metrics: Metrics, // Telemetry metrics, not DD native metrics.
+    translator_metrics: metrics::telemetry::OtlpMetricsTranslatorMetrics,
 }
 
 #[async_trait]
@@ -288,6 +292,7 @@ impl Source for Otlp {
             http_tls_config,
             grpc_tls_config,
             metrics,
+            translator_metrics,
         } = *self;
 
         let global_shutdown = context.take_shutdown_handle();
@@ -305,6 +310,7 @@ impl Source for Otlp {
             context_resolver,
             origin_tag_resolver.clone(),
             metric_tags,
+            translator_metrics,
         )?;
 
         // Build our gRPC and HTTP servers and spawn them.
@@ -472,6 +478,7 @@ async fn run_converter(
                                         });
                                         if let Err(e) = dispatcher.push(event).await {
                                             error!(error = %e, "Failed to dispatch metric event.");
+                                            metrics.metrics_errors_dispatch().increment(1);
                                         }
                                     }
                                 }
@@ -529,6 +536,7 @@ async fn run_converter(
                 if let Some(dispatcher) = metrics_dispatcher.take() {
                     if let Err(e) = dispatcher.flush().await {
                         error!(error = %e, "Failed to flush metric events.");
+                        metrics.metrics_errors_flush().increment(1);
                     }
                 }
                 if let Some(dispatcher) = logs_dispatcher.take() {
@@ -552,6 +560,7 @@ async fn run_converter(
     if let Some(dispatcher) = metrics_dispatcher.take() {
         if let Err(e) = dispatcher.flush().await {
             error!(error = %e, "Failed to flush metric events.");
+            metrics.metrics_errors_flush().increment(1);
         }
     }
     if let Some(dispatcher) = logs_dispatcher.take() {

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -314,7 +314,7 @@ impl Source for Otlp {
         )?;
 
         // Build our gRPC and HTTP servers and spawn them.
-        let handler = SourceHandler::new(tx);
+        let handler = SourceHandler::new(tx, metrics.clone());
         let mut server_config =
             OtlpServerConfiguration::new(http_endpoint, grpc_endpoint, grpc_max_recv_msg_size_bytes)
                 .with_cors(cors)
@@ -390,27 +390,30 @@ enum OtlpSignal {
 /// Handler that decodes OTLP bytes and sends resources to the converter.
 struct SourceHandler {
     tx: mpsc::Sender<OtlpSignal>,
+    metrics: Metrics,
 }
 
 impl SourceHandler {
-    fn new(tx: mpsc::Sender<OtlpSignal>) -> Self {
-        Self { tx }
+    fn new(tx: mpsc::Sender<OtlpSignal>, metrics: Metrics) -> Self {
+        Self { tx, metrics }
     }
 }
 
 #[async_trait]
 impl OtlpHandler for SourceHandler {
     async fn handle_metrics(&self, body: Bytes) -> Result<(), GenericError> {
-        let request =
-            ExportMetricsServiceRequest::decode(body).error_context("Failed to decode metrics export request")?;
+        let request = ExportMetricsServiceRequest::decode(body).map_err(|e| {
+            self.metrics.metrics_errors_decode().increment(1);
+            generic_error!("Failed to decode metrics export request: {}", e)
+        })?;
 
         // Send the entire request as a single channel message so the converter processes it
         // atomically. This preserves the request boundary for usage beacon emission without
         // needing control markers or shared state across concurrent requests.
-        self.tx
-            .send(OtlpSignal::Metrics(request))
-            .await
-            .error_context("Failed to send metrics request to converter: channel is closed.")?;
+        self.tx.send(OtlpSignal::Metrics(request)).await.map_err(|e| {
+            self.metrics.metrics_errors_channel().increment(1);
+            generic_error!("Failed to send metrics request to converter: channel is closed: {}", e)
+        })?;
         Ok(())
     }
 
@@ -585,8 +588,12 @@ mod tests {
     use agent_data_plane_config::domains::otlp::{
         CumulativeMonotonicMode, HistogramMode, InitialCumulativeMonotonicValue, SummaryMode,
     };
+    use prost::Message;
+    use saluki_core::components::ComponentContext;
+    use saluki_metrics::test::TestRecorder;
 
     use super::{apply_static_metric_tags, parse_configured_metric_tags, OtlpConfiguration};
+    use crate::common::otlp::{build_metrics, OtlpHandler};
 
     fn tags(raw: &str) -> Vec<String> {
         parse_configured_metric_tags(raw)
@@ -816,5 +823,63 @@ mod tests {
             tags("env:prod,,team:core"),
             vec!["env:prod".to_string(), "team:core".to_string()]
         );
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Self-telemetry: server-level decode and channel error counters.
+    // -----------------------------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn source_handler_increments_decode_error_on_malformed_body() {
+        let recorder = TestRecorder::default();
+        let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+
+        let metrics = build_metrics(&ComponentContext::test_source("otlp_test"));
+        let (tx, _rx) = tokio::sync::mpsc::channel::<super::OtlpSignal>(1);
+        let handler = super::SourceHandler::new(tx, metrics);
+
+        // Invalid protobuf bytes cause decode to fail.
+        let result = handler.handle_metrics(bytes::Bytes::from_static(b"not protobuf")).await;
+        assert!(result.is_err());
+
+        let tags: &[(&str, &str)] = &[
+            ("component_id", "otlp_test"),
+            ("component_type", "source"),
+            ("reason", "decode"),
+        ];
+        assert_eq!(recorder.counter(("otlp_metrics_errors_total", tags)), Some(1));
+    }
+
+    #[tokio::test]
+    async fn source_handler_increments_channel_error_on_closed_channel() {
+        let recorder = TestRecorder::default();
+        let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+
+        let metrics = build_metrics(&ComponentContext::test_source("otlp_test"));
+        // Create a channel with no receiver, then drop the receiver so the send fails.
+        let (tx, rx) = tokio::sync::mpsc::channel::<super::OtlpSignal>(1);
+        drop(rx);
+        let handler = super::SourceHandler::new(tx, metrics);
+
+        // A valid (empty) request that decodes fine but can't be sent because the channel is closed.
+        let request = otlp_protos::opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest::default();
+        let body = bytes::Bytes::from(request.encode_to_vec());
+        let result = handler.handle_metrics(body).await;
+        assert!(result.is_err());
+
+        let tags: &[(&str, &str)] = &[
+            ("component_id", "otlp_test"),
+            ("component_type", "source"),
+            ("reason", "channel"),
+        ];
+        assert_eq!(recorder.counter(("otlp_metrics_errors_total", tags)), Some(1));
+
+        // The decode counter should not have been incremented.
+        let decode_tags: &[(&str, &str)] = &[
+            ("component_id", "otlp_test"),
+            ("component_type", "source"),
+            ("reason", "decode"),
+        ];
+        assert_eq!(recorder.counter(("otlp_metrics_errors_total", decode_tags)), Some(0));
     }
 }

--- a/releasenotes/notes/otlp-metrics-telemetry-170b14c09313df2d.yaml
+++ b/releasenotes/notes/otlp-metrics-telemetry-170b14c09313df2d.yaml
@@ -1,0 +1,6 @@
+enhancements:
+  - |
+    Added self-telemetry for OTLP metrics ingest: error counters for decode, channel,
+    dispatch, flush, and translation failures; dropped-point counters for unsupported
+    aggregation temporalities, histogram conversion failures, and invalid values; and a
+    processing-latency histogram for OTLP metrics batches.


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Adds new telemetry for metric drops, errors, and we now have latency reporting. New `Counters` `otlp_metrics_errors_total`  `otlp_metrics_dropped_points_total` and `Histogram` `otlp_metrics_processing_duration_seconds` - each with varying tag giving more granular report on the reason (e.g. `translate`, `unsupported_temporality`, etc.) 

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
Unit tests

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->
- Closes: #2091

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
