### PR TITLE
chore(env): add `Into<GenericError>` bound to associated type for host provider errors

### DIFF
--- a/lib/saluki-components/src/transforms/host_enrichment/mod.rs
+++ b/lib/saluki-components/src/transforms/host_enrichment/mod.rs
@@ -5,7 +5,7 @@ use saluki_core::{
     components::BuildContext,
     data_model::event::{eventd::EventD, service_check::ServiceCheck},
 };
-use saluki_env::{EnvironmentProvider, HostProvider};
+use saluki_env::{EnvironmentProvider, HostProvider as _};
 use saluki_error::GenericError;
 use stringtheory::MetaString;
 
@@ -28,7 +28,6 @@ impl<E> HostEnrichmentConfiguration<E> {
 impl<E> SynchronousTransformBuilder for HostEnrichmentConfiguration<E>
 where
     E: EnvironmentProvider + Send + Sync + 'static,
-    <E::Host as HostProvider>::Error: Into<GenericError>,
 {
     async fn build(&self, _context: BuildContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
         Ok(Box::new(
@@ -60,7 +59,6 @@ impl HostEnrichment {
     pub async fn from_environment_provider<E>(env_provider: &E) -> Result<Self, GenericError>
     where
         E: EnvironmentProvider + Send + Sync + 'static,
-        <E::Host as HostProvider>::Error: Into<GenericError>,
     {
         Ok(Self {
             hostname: env_provider

--- a/lib/saluki-env/src/host/mod.rs
+++ b/lib/saluki-env/src/host/mod.rs
@@ -7,12 +7,13 @@
 pub mod providers;
 
 use async_trait::async_trait;
+use saluki_error::GenericError;
 
 /// Provides information about the process host itself.
 #[async_trait]
 pub trait HostProvider {
     /// Errors produced by the provider.
-    type Error;
+    type Error: Into<GenericError>;
 
     /// Gets the hostname of the process host.
     ///


### PR DESCRIPTION
## Summary
Add the `Into<GenericError>` bound to the `HostProvider::Error` associated type, to avoid repetition at call sites.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
`make test`

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
