### PR TITLE
chore(releasenotes): add a create-release-note skill and tighten note validation

### DIFF
--- a/.agents/skills/create-release-note/SKILL.md
+++ b/.agents/skills/create-release-note/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: create-release-note
+description: >
+  Write a Reno release-note fragment under `releasenotes/notes/` for a change, or determine that a
+  change needs the `changelog/no-changelog` label instead. TRIGGER when: user asks for a release
+  note, a changelog entry, or a changelog fragment; the release-note check has failed on a pull
+  request; or user invokes `/create-release-note`. DO NOT TRIGGER when: user asks to publish or
+  repair the release notes of an already-tagged release — that is the `Release notes` workflow's
+  job, not a fragment.
+argument-hint: <topic>   e.g. `fix-listener-shutdown-race`
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
+---
+
+# /create-release-note
+
+Every pull request records whether it has customer-visible release information. When it does, it
+carries a Reno note under `releasenotes/notes/`; when it does not, a maintainer applies the
+`changelog/no-changelog` label. The `Release note check` workflow requires one of the two before a
+pull request can merge.
+
+Notes are the source for the curated section of each tagged GitHub release: `reno report` renders
+them as reStructuredText, and `ci/tooling/release_notes.py render` converts that to
+GitHub-flavored Markdown. **The prose you write is reStructuredText, not Markdown** — see step 4.
+
+## Step 1: Decide whether the change needs a note
+
+Read the change before asking the user anything:
+
+```bash
+git diff $(git merge-base HEAD origin/main)...HEAD --stat
+```
+
+A note is needed when the change alters behavior someone operating Agent Data Plane could observe:
+new or changed configuration, metrics, telemetry, defaults, performance characteristics, error
+handling, or a fixed bug.
+
+A note is not needed for changes with no observable effect on the shipped binary: tests,
+documentation, CI configuration, developer tooling, dependency bumps that change no behavior, and
+pure refactors. In that case, don't invent one — tell the user the change looks like a
+`changelog/no-changelog` candidate and that a maintainer applies that label on the pull request.
+
+When it's genuinely ambiguous, ask the user with `AskUserQuestion` rather than guessing.
+
+## Step 2: Choose the section and draft the content
+
+Propose a section and a draft entry from the diff, then confirm both with the user. Sections come
+from `releasenotes/config.yaml`:
+
+| Section | When to use |
+|---|---|
+| `upgrade` | A required operator action or a major behavior change on upgrade |
+| `features` | A wholly new customer-visible capability |
+| `enhancements` | A customer-visible improvement too small to be a feature |
+| `issues` | A known customer-visible limitation |
+| `deprecations` | A planned customer-visible removal |
+| `security` | A customer-relevant security change |
+| `fixes` | A customer-visible correction |
+| `other` | Customer-visible release information that fits no other section |
+
+The entry is read by people operating Agent Data Plane, not by reviewers of this pull request.
+Describe the observable effect, not the implementation, and make it self-contained: no references
+to pull requests, commits, internal type names, or other release notes.
+
+## Step 3: Create the file with Reno
+
+```bash
+make ensure-python-venv          # only if .venv/bin/reno is missing
+.venv/bin/reno new <topic> --no-edit
+```
+
+`<topic>` is a short kebab-case slug describing the change, for example
+`fix-listener-shutdown-race`. Reno writes `releasenotes/notes/<topic>-<16 hex characters>.yaml`.
+
+**Never hand-write the file or its filename.** The hex suffix is Reno's unique identifier for the
+note. `make check-release-notes` rejects a filename that doesn't match
+`<topic>-<16 lowercase hex characters>.yaml`, and it rejects two notes that share an identifier —
+a collision that a guessed or copied suffix produces and that breaks `reno report` at release time.
+
+If `reno` can't be installed at all, generate a real suffix with `openssl rand -hex 8` rather than
+typing one.
+
+## Step 4: Write the entry
+
+Keep only the section chosen in step 2 and delete every other section of the template, including
+its comments. The result is small:
+
+```yaml
+fixes:
+  - |
+    Fix a listener shutdown race that could drop telemetry during process exit.
+```
+
+Prose is reStructuredText. `make check-release-notes` rejects the Markdown spellings:
+
+| Instead of Markdown | Write reStructuredText |
+|---|---|
+| `` `dogstatsd_port` `` | ``` ``dogstatsd_port`` ``` |
+| `[the docs](https://example.test)` | ``` `the docs <https://example.test>`_ ``` |
+| `__important__` | `**important**` |
+| `# Heading` | A title underlined with `===` |
+| A ` ``` `-fenced code block | A `.. code-block:: yaml` directive |
+| `> quoted text` | Indentation, or a `.. note::` directive |
+
+`**bold**` is the same in both, so it needs no change.
+
+Use a separate list item per distinct change, in the same section:
+
+```yaml
+fixes:
+  - |
+    Fix a listener shutdown race that could drop telemetry during process exit.
+  - |
+    Fix a panic when a DogStatsD payload ends mid-tag.
+```
+
+## Step 5: Validate
+
+```bash
+make check-release-notes
+.venv/bin/reno lint
+```
+
+Fix anything either reports and re-run. Report to the user which file you created, its section, and
+its content.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ test/build/
 test/ddprof
 test/lading
 test/one-off/__pycache__
+ci/tooling/__pycache__
 dhat-heap.json
 .DS_Store
 dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ of software projects, in addition to making them harder to maintain and debug ov
   not for production use and supporting it need not be a blocker during feature development.
 - We have customized our use of `cargo fmt` and `clippy`. The `Makefile` is authoritative.
 - Our Rust code wraps at 120 characters.
+- Customer-visible changes need a Reno release note under `releasenotes/notes/`, created with `reno new` and written in
+  reStructuredText; read `.claude/skills/create-release-note/SKILL.md`.
 - For configuration work, read `.claude/skills/config-system/SKILL.md`.
   - Keys in `lib/datadog-agent/config/schema/core/` are Datadog; absent keys are Saluki-only.
   - Edit `schema_overlay.yaml` for Datadog inventory; generated code files are output.

--- a/ci/tooling/release_notes.py
+++ b/ci/tooling/release_notes.py
@@ -23,11 +23,16 @@ MARKDOWN_PATTERNS = (
     (re.compile(r"!\[[^\]]*\]\(([^)]+)\)"), "image syntax; use a '.. image:: {0}' directive"),
     (re.compile(r"(?<!!)\[([^\]]+)\]\(([^)]+)\)"), "link syntax; use '`{0} <{1}>`_'"),
     (re.compile(r"__([^_]+)__"), "bold syntax; use '**{0}**'"),
-    (re.compile(r"(?<!`)`([^`<>]+)`(?![_`])"), "single-backtick inline code; use '``{0}``'"),
+    # A single-backtick span is Markdown inline code, unless it is a reStructuredText hyperlink or
+    # reference (both end in an underscore) or the payload of an explicit role such as :code:`x`.
+    (re.compile(r"(?<![:`])`([^`]+)`(?![_`])"), "single-backtick inline code; use '``{0}``'"),
     (re.compile(r"^#{1,6}\s+\S"), "heading syntax; use a reStructuredText title underline"),
     (re.compile(r"^```"), "fenced code block; use a '.. code-block::' directive"),
     (re.compile(r"^>\s+\S"), "block quote syntax; use indentation or a '.. note::' directive"),
 )
+# Prose inside a reStructuredText inline literal renders verbatim, so Markdown spelled there is
+# intentional rather than a mistake.
+RST_INLINE_LITERAL_RE = re.compile(r"``[^`]+``")
 RELEASE_NOTE_CONFIG_PATH = "releasenotes/config.yaml"
 
 
@@ -66,7 +71,7 @@ def find_markdown_syntax(text: str) -> list[str]:
     """Return descriptions of the Markdown constructs used in one release-note entry."""
     return [
         description.format(*match.groups())
-        for line in text.splitlines()
+        for line in (RST_INLINE_LITERAL_RE.sub(" ", line) for line in text.splitlines())
         for pattern, description in MARKDOWN_PATTERNS
         for match in pattern.finditer(line)
     ]

--- a/ci/tooling/release_notes.py
+++ b/ci/tooling/release_notes.py
@@ -16,7 +16,18 @@ RELEASE_TAG_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 START_MARKER = "<!-- saluki-curated-notes:start -->"
 END_MARKER = "<!-- saluki-curated-notes:end -->"
 CATEGORY_ORDER = ("upgrade", "features", "enhancements", "issues", "deprecations", "security", "fixes", "other")
-RENO_FILENAME_RE = re.compile(r"^.+-[0-9a-f]{16}\.yaml$")
+RENO_FILENAME_RE = re.compile(r"^.+-([0-9a-f]{16})\.yaml$")
+# Reno renders note prose as reStructuredText, so Markdown markup survives into the release body
+# verbatim. Each pattern pairs with a description of the reStructuredText spelling to use instead.
+MARKDOWN_PATTERNS = (
+    (re.compile(r"!\[[^\]]*\]\(([^)]+)\)"), "image syntax; use a '.. image:: {0}' directive"),
+    (re.compile(r"(?<!!)\[([^\]]+)\]\(([^)]+)\)"), "link syntax; use '`{0} <{1}>`_'"),
+    (re.compile(r"__([^_]+)__"), "bold syntax; use '**{0}**'"),
+    (re.compile(r"(?<!`)`([^`<>]+)`(?![_`])"), "single-backtick inline code; use '``{0}``'"),
+    (re.compile(r"^#{1,6}\s+\S"), "heading syntax; use a reStructuredText title underline"),
+    (re.compile(r"^```"), "fenced code block; use a '.. code-block::' directive"),
+    (re.compile(r"^>\s+\S"), "block quote syntax; use indentation or a '.. note::' directive"),
+)
 RELEASE_NOTE_CONFIG_PATH = "releasenotes/config.yaml"
 
 
@@ -51,6 +62,31 @@ def merge_release_body(existing: str, markdown: str) -> str:
     return block + "\n\n" + existing if existing else block
 
 
+def find_markdown_syntax(text: str) -> list[str]:
+    """Return descriptions of the Markdown constructs used in one release-note entry."""
+    return [
+        description.format(*match.groups())
+        for line in text.splitlines()
+        for pattern, description in MARKDOWN_PATTERNS
+        for match in pattern.finditer(line)
+    ]
+
+
+def find_duplicate_note_ids(paths: list[Path]) -> list[str]:
+    """Return errors for release notes sharing a Reno unique identifier."""
+    notes_by_id: dict[str, list[Path]] = {}
+    for path in sorted(paths):
+        match = RENO_FILENAME_RE.fullmatch(path.name)
+        if match:
+            notes_by_id.setdefault(match.group(1), []).append(path)
+    return [
+        f"{', '.join(str(path) for path in notes)}: release notes share the Reno unique identifier "
+        f"{identifier!r}; create notes with `reno new` so each one gets a fresh identifier"
+        for identifier, notes in sorted(notes_by_id.items())
+        if len(notes) > 1
+    ]
+
+
 def validate_note_file(path: Path) -> list[str]:
     """Return validation errors for one opt-in Reno release note."""
     errors = []
@@ -67,12 +103,19 @@ def validate_note_file(path: Path) -> list[str]:
             errors.append(f"{path}: unsupported release-note category {category!r}")
         elif not isinstance(entries, list) or not entries or any(not isinstance(entry, str) or not entry.strip() for entry in entries):
             errors.append(f"{path}: {category!r} must be a non-empty list of non-empty strings")
+        else:
+            errors.extend(
+                f"{path}: {category!r} uses Markdown {problem}"
+                for entry in entries
+                for problem in find_markdown_syntax(entry)
+            )
     return errors
 
 
 def check_command(arguments: argparse.Namespace) -> int:
     """Validate every supplied release-note file."""
     errors = [error for path in arguments.note_files for error in validate_note_file(path)]
+    errors.extend(find_duplicate_note_ids(arguments.note_files))
     if errors:
         print("\n".join(errors), file=sys.stderr)
         return 1

--- a/ci/tooling/test_release_notes.py
+++ b/ci/tooling/test_release_notes.py
@@ -102,6 +102,56 @@ class ReleaseNoteValidationTest(unittest.TestCase):
 
         self.assertTrue(subject.validate_note_file(path))
 
+    def test_rejects_markdown_where_reno_renders_restructuredtext(self):
+        markdown_entries = (
+            "See [the docs](https://example.test) for details.",
+            "Set `dogstatsd_port` to 8125.",
+            "This is __important__ to note.",
+            "# Heading",
+            "```yaml",
+            "> Quoted text.",
+            "![diagram](https://example.test/diagram.png)",
+        )
+        for entry in markdown_entries:
+            with self.subTest(entry=entry):
+                path = self.write_note("fix-listener-0123456789abcdef.yaml", f"fixes:\n  - |\n    {entry}\n")
+
+                self.assertTrue(any("uses Markdown" in error for error in subject.validate_note_file(path)))
+
+    def test_accepts_restructuredtext_markup(self):
+        entries = (
+            "Set ``dogstatsd_port`` to 8125.",
+            "See `the docs <https://example.test>`_ for details.",
+            "This is **important** to note.",
+            "Rename metric_name_prefix to metric_prefix.",
+        )
+        for entry in entries:
+            with self.subTest(entry=entry):
+                path = self.write_note("fix-listener-0123456789abcdef.yaml", f"fixes:\n  - |\n    {entry}\n")
+
+                self.assertEqual(subject.validate_note_file(path), [])
+
+    def test_rejects_notes_sharing_a_reno_unique_identifier(self):
+        notes = [
+            self.write_note("fix-listener-0123456789abcdef.yaml", "fixes:\n  - First.\n"),
+            self.write_note("fix-forwarder-0123456789abcdef.yaml", "fixes:\n  - Second.\n"),
+        ]
+
+        errors = subject.find_duplicate_note_ids(notes)
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("0123456789abcdef", errors[0])
+        self.assertIn("fix-forwarder-0123456789abcdef.yaml", errors[0])
+        self.assertIn("fix-listener-0123456789abcdef.yaml", errors[0])
+
+    def test_accepts_notes_with_distinct_reno_unique_identifiers(self):
+        notes = [
+            self.write_note("fix-listener-0123456789abcdef.yaml", "fixes:\n  - First.\n"),
+            self.write_note("fix-forwarder-fedcba9876543210.yaml", "fixes:\n  - Second.\n"),
+        ]
+
+        self.assertEqual(subject.find_duplicate_note_ids(notes), [])
+
 
 class ReleaseNoteRenderingTest(unittest.TestCase):
     def setUp(self):

--- a/ci/tooling/test_release_notes.py
+++ b/ci/tooling/test_release_notes.py
@@ -111,6 +111,8 @@ class ReleaseNoteValidationTest(unittest.TestCase):
             "```yaml",
             "> Quoted text.",
             "![diagram](https://example.test/diagram.png)",
+            "Point it at `<host>:8125` to send metrics.",
+            "Set `value > 0` to enable the check.",
         )
         for entry in markdown_entries:
             with self.subTest(entry=entry):
@@ -124,6 +126,10 @@ class ReleaseNoteValidationTest(unittest.TestCase):
             "See `the docs <https://example.test>`_ for details.",
             "This is **important** to note.",
             "Rename metric_name_prefix to metric_prefix.",
+            "Set :code:`dogstatsd_port` to 8125.",
+            "The ``foo__bar__baz`` identifier is unchanged.",
+            "Use ``[a](b)`` to spell a Markdown link.",
+            "See `the docs <https://example.test>`__ for details.",
         )
         for entry in entries:
             with self.subTest(entry=entry):

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -55,6 +55,9 @@ make ensure-python-venv
 .venv/bin/reno new describe-the-change --edit
 ```
 
+Always create the file with `reno new`: the hexadecimal suffix it appends is the note's unique identifier, and two notes
+that share one break release-note rendering at release time.
+
 Keep the applicable section and remove unused template sections. For example:
 
 ```yaml
@@ -62,6 +65,9 @@ fixes:
   - |
     Fix a listener shutdown race that could drop telemetry during process exit.
 ```
+
+Reno renders note prose as reStructuredText, so write ``double backticks`` for inline code and
+`` `link text <https://example.test>`_ `` for links. Markdown spellings appear verbatim in the published release notes.
 
 Validate notes locally with `make check-release-notes`.
 


### PR DESCRIPTION
## Summary

Add some AI helpers for generating release note fragments and CI checks for checking them, cribbing from the datadog-agent repo.

## Changes

- `.agents/skills/create-release-note/SKILL.md` — new skill, reachable as `/create-release-note`.
- `ci/tooling/release_notes.py` — reject Markdown syntax in note prose, and reject two notes sharing a Reno unique identifier.
- `docs/development/contributing.md`, `AGENTS.md` — document the `reno new` requirement and the reStructuredText rule.
- `.gitignore` — ignore `ci/tooling/__pycache__`, which `make test-release-notes` creates.

## Test plan

- [x] `make test-release-notes` — four new tests cover Markdown rejection (links, images, single-backtick code, `__bold__`, headings, fences, block quotes), acceptance of the reStructuredText spellings and of `snake_case` identifiers, and duplicate/distinct unique-identifier detection.
- [x] `make check-release-notes` passes against the committed corpus.
- [x] `vale` clean on the changed documentation.

This PR is tooling and documentation only, so it wants the `changelog/no-changelog` label.
