### PR TITLE
chore(config): app memory settings from typed config

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use agent_data_plane_config::{
+    control::MemoryMode,
     domains::{dogstatsd, multi_region_failover},
     shared::SharedConfiguration,
     SalukiConfiguration,
@@ -16,7 +17,7 @@ use bytesize::ByteSize;
 use datadog_agent_commons::{ipc::config::RemoteAgentClientConfiguration, platform::PlatformSettings};
 use datadog_agent_config::classifier::{ConfigClassifier, Pipeline, PipelineAffinity, Severity, SupportLevel};
 use saluki_app::{
-    accounting::{initialize_memory_bounds, MemoryBoundsConfiguration},
+    accounting::{initialize_memory_bounds, MemoryBoundsConfiguration, MemoryMode as AppMemoryMode},
     bootstrap::BootstrapGuard,
     metrics::emit_startup_metrics,
     util::wait_for_shutdown_signal,
@@ -212,7 +213,19 @@ pub async fn handle_run_command(
     .error_context("Failed to create internal supervisor.")?;
 
     // Run memory bounds validation to ensure that we can launch the topology with our configured memory limit, if any.
-    let bounds_config = MemoryBoundsConfiguration::try_from_config(&config_sys.raw_map())?;
+    let bounds_config = {
+        let control = &config_sys.config().control;
+        MemoryBoundsConfiguration {
+            memory_limit: control.memory_limit.map(ByteSize::b),
+            memory_slop_factor: control.memory_slop_factor,
+            enable_global_limiter: control.enable_global_limiter,
+            memory_mode: match control.memory_mode {
+                MemoryMode::Disabled => AppMemoryMode::Disabled,
+                MemoryMode::Permissive => AppMemoryMode::Permissive,
+                MemoryMode::Strict => AppMemoryMode::Strict,
+            },
+        }
+    };
     let memory_limiter = initialize_memory_bounds(bounds_config, component_registry.root())?;
 
     if let Ok(val) = std::env::var("DD_ADP_WRITE_SIZING_GUIDE") {

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -89,8 +89,7 @@ async fn main() -> Result<(), GenericError> {
     //
     // This initializes logging, metrics, allocator telemetry, TLS, and more. We get handled a guard that we need to
     // hold until the application is about to exit, which ensures things like flushing any buffered logs, and so on.
-    let bootstrapper = AppBootstrapper::from_configuration(&local_config.raw_config())
-        .error_context("Failed to parse bootstrap configuration during bootstrap phase.")?
+    let bootstrapper = AppBootstrapper::new()
         .with_metrics_prefix("adp")
         .with_metrics_default_level(metrics_default_level)
         .with_logging_configuration(bootstrap_logging_config);

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -646,8 +646,10 @@ The following settings are specific to ADP and have no equivalent in the core ag
 | `dogstatsd_permissive_decoding`                                 | Relaxes decoder strictness                 | true           |
 | `dogstatsd_string_interner_size_bytes`                          | Explicit byte budget for context interner  |                |
 | `dogstatsd_tcp_port`                                            | DogStatsD TCP listen port; 0 disables TCP  | 0              |
+| `enable_global_limiter`                                         | Global memory limiter toggle               | true           |
 | `flush_timeout_secs`                                            | Encoder flush timeout (secs)               |                |
 | `memory_limit`                                                  | Process memory limit                       |                |
+| `memory_mode`                                                   | Memory bounds validation mode              | disabled       |
 | `memory_slop_factor`                                            | Memory accounting slop fraction            | 0.25           |
 | `metric_tag_value_allowlist`                                    | Per-metric tag value allow-list            | []             |
 | `otlp_allow_context_heap_allocs`                                | Allow heap allocations for OTLP contexts   |                |
@@ -718,6 +720,14 @@ ADP uses an explicit process memory limit (`memory_limit`) rather than relying o
 ### `memory_slop_factor`
 
 See `memory_limit` above.
+
+### `enable_global_limiter`
+
+Controls whether the global memory limiter exerts backpressure as memory usage approaches `memory_limit`. The default is `true`. When set to `false`, the limiter becomes a no-op and only the memory bounds of the running components influence memory usage.
+
+### `memory_mode`
+
+Controls how the calculated memory bounds are reconciled against `memory_limit`. The default is `disabled`. Accepted values: `disabled` skips bounds validation and applies no memory limiting; `permissive` logs a warning when the bounds do not fit within the limit and starts anyway; `strict` refuses to start. Under `permissive` and `strict`, the global memory limiter is active only when a limit is in effect (configured or detected from cgroups) and `enable_global_limiter` is `true`.
 
 
 ## Transparent Settings

--- a/lib/agent-data-plane-config-system/src/lib.rs
+++ b/lib/agent-data-plane-config-system/src/lib.rs
@@ -18,6 +18,8 @@
 //! configuration without shadowing it, and what lets translation resolve a setting whose meaning
 //! depends on whether it was set explicitly.
 
+#![recursion_limit = "256"]
+
 mod env_provider;
 mod loaded;
 mod saluki_env_overlay;

--- a/lib/agent-data-plane-config-system/src/lib.rs
+++ b/lib/agent-data-plane-config-system/src/lib.rs
@@ -18,7 +18,9 @@
 //! configuration without shadowing it, and what lets translation resolve a setting whose meaning
 //! depends on whether it was set explicitly.
 
-#![recursion_limit = "256"]
+// The `json!` fixture in `saluki_only`'s tests nests deeply enough to exhaust the default macro
+// expansion limit. Only test builds need the higher limit.
+#![cfg_attr(test, recursion_limit = "256")]
 
 mod env_provider;
 mod loaded;

--- a/lib/agent-data-plane-config-system/src/saluki_only.rs
+++ b/lib/agent-data-plane-config-system/src/saluki_only.rs
@@ -73,8 +73,10 @@ use std::{
     time::Duration,
 };
 
+use agent_data_plane_config::control::MemoryMode;
 use agent_data_plane_config::defaults::{
-    DEFAULT_METRICS_LEVEL, DEFAULT_STRING_INTERNER_SIZE_BYTES, MAX_STRING_INTERNER_SIZE_BYTES,
+    DEFAULT_ENABLE_GLOBAL_LIMITER, DEFAULT_MEMORY_SLOP_FACTOR, DEFAULT_METRICS_LEVEL,
+    DEFAULT_STRING_INTERNER_SIZE_BYTES, MAX_STRING_INTERNER_SIZE_BYTES,
 };
 use agent_data_plane_config::domains::dogstatsd::{validate_metric_tag_value_allowlists, MetricTagValueAllowlistEntry};
 use agent_data_plane_config::domains::traces::{OttlErrorMode, OttlFilter, OttlTransform};
@@ -157,6 +159,10 @@ pub struct SalukiOnly {
     pub memory_limit: Option<ByteSize>,
     /// Memory-accounting slop fraction (`memory_slop_factor`).
     pub memory_slop_factor: Option<f64>,
+    /// Whether the global memory limiter is enabled (`enable_global_limiter`).
+    pub enable_global_limiter: Option<bool>,
+    /// Memory bounds validation and global limiter behavior (`memory_mode`).
+    pub memory_mode: MemoryModeSource,
     /// Encoder flush timeout, in seconds (`flush_timeout_secs`).
     pub flush_timeout_secs: Option<u64>,
     /// Maximum metrics per payload (`serializer_max_metrics_per_payload`).
@@ -472,6 +478,29 @@ pub enum OttlErrorModeSource {
     Propagate,
 }
 
+/// Memory bounds behavior as written at `memory_mode`.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum MemoryModeSource {
+    /// Skip bounds validation and apply no memory limiting.
+    #[default]
+    Disabled,
+    /// Log bounds validation failures and continue.
+    Permissive,
+    /// Treat bounds validation failures as fatal.
+    Strict,
+}
+
+impl From<MemoryModeSource> for MemoryMode {
+    fn from(mode: MemoryModeSource) -> Self {
+        match mode {
+            MemoryModeSource::Disabled => MemoryMode::Disabled,
+            MemoryModeSource::Permissive => MemoryMode::Permissive,
+            MemoryModeSource::Strict => MemoryMode::Strict,
+        }
+    }
+}
+
 impl From<OttlErrorModeSource> for OttlErrorMode {
     fn from(mode: OttlErrorModeSource) -> Self {
         match mode {
@@ -496,12 +525,10 @@ impl SalukiOnly {
         if let Some(v) = self.data_plane.checks.enabled {
             config.control.checks = v;
         }
-        if let Some(v) = self.memory_limit {
-            config.control.memory_limit = v.as_u64();
-        }
-        if let Some(v) = self.memory_slop_factor {
-            config.control.memory_slop_factor = v;
-        }
+        config.control.memory_limit = self.memory_limit.map(|v| v.as_u64());
+        config.control.memory_slop_factor = self.memory_slop_factor.unwrap_or(DEFAULT_MEMORY_SLOP_FACTOR);
+        config.control.enable_global_limiter = self.enable_global_limiter.unwrap_or(DEFAULT_ENABLE_GLOBAL_LIMITER);
+        config.control.memory_mode = self.memory_mode.into();
         if let Some(v) = self.remote_agent_string_interner_size_bytes {
             config.control.ipc.remote_agent_string_interner_size_bytes = v;
         }
@@ -692,6 +719,8 @@ mod tests {
             "checks_ipc_endpoint": "localhost:5006",
             "memory_limit": "512MB",
             "memory_slop_factor": 0.3,
+            "enable_global_limiter": false,
+            "memory_mode": "strict",
             "flush_timeout_secs": 7,
             "serializer_max_metrics_per_payload": 999,
             // dogstatsd listener/context/mapper
@@ -773,8 +802,10 @@ mod tests {
         assert_eq!(config.control.stop_timeout, Some(Duration::from_secs(45)));
         assert!(config.control.standalone_mode);
         assert!(config.control.checks);
-        assert_eq!(config.control.memory_limit, ByteSize::mb(512).as_u64());
+        assert_eq!(config.control.memory_limit, Some(ByteSize::mb(512).as_u64()));
         assert_eq!(config.control.memory_slop_factor, 0.3);
+        assert!(!config.control.enable_global_limiter);
+        assert_eq!(config.control.memory_mode, MemoryMode::Strict);
         assert_eq!(config.control.ipc.remote_agent_string_interner_size_bytes, 4096);
 
         // shared
@@ -860,8 +891,56 @@ mod tests {
             let saluki_only: SalukiOnly = serde_json::from_value(value).expect("memory_limit deserializes");
             let mut config = SalukiConfiguration::default();
             saluki_only.seed(&mut config);
+            assert_eq!(config.control.memory_limit, Some(expected));
+        }
+    }
+
+    #[test]
+    fn memory_limit_distinguishes_absence_from_an_explicit_zero() {
+        for (value, expected) in [(json!({}), None), (json!({ "memory_limit": 0 }), Some(0))] {
+            let saluki_only: SalukiOnly = serde_json::from_value(value).expect("memory_limit deserializes");
+            let mut config = SalukiConfiguration::default();
+            saluki_only.seed(&mut config);
             assert_eq!(config.control.memory_limit, expected);
         }
+    }
+
+    #[test]
+    fn memory_accounting_defaults_resolve_and_explicit_values_seed() {
+        let saluki_only: SalukiOnly = serde_json::from_value(json!({})).expect("empty source deserializes");
+        let mut config = SalukiConfiguration::default();
+        saluki_only.seed(&mut config);
+        assert_eq!(config.control.memory_slop_factor, DEFAULT_MEMORY_SLOP_FACTOR);
+        assert_eq!(config.control.enable_global_limiter, DEFAULT_ENABLE_GLOBAL_LIMITER);
+        assert_eq!(config.control.memory_mode, MemoryMode::Disabled);
+
+        let saluki_only: SalukiOnly =
+            serde_json::from_value(json!({ "memory_slop_factor": 0.0, "enable_global_limiter": false }))
+                .expect("explicit memory accounting values deserialize");
+        let mut config = SalukiConfiguration::default();
+        saluki_only.seed(&mut config);
+        assert_eq!(config.control.memory_slop_factor, 0.0);
+        assert!(!config.control.enable_global_limiter);
+    }
+
+    #[test]
+    fn memory_mode_values_round_trip_and_reject_unknown_spellings() {
+        for (source, expected) in [
+            ("disabled", MemoryMode::Disabled),
+            ("permissive", MemoryMode::Permissive),
+            ("strict", MemoryMode::Strict),
+        ] {
+            let saluki_only: SalukiOnly =
+                serde_json::from_value(json!({ "memory_mode": source })).expect("valid memory_mode deserializes");
+            let mut config = SalukiConfiguration::default();
+            saluki_only.seed(&mut config);
+            assert_eq!(config.control.memory_mode, expected, "memory_mode={source}");
+        }
+
+        assert!(
+            serde_json::from_value::<SalukiOnly>(json!({ "memory_mode": "disabeld" })).is_err(),
+            "an unrecognized memory_mode should fail the load"
+        );
     }
 
     /// An unrecognized `error_mode` must fail deserialization rather than silently resolving to

--- a/lib/agent-data-plane-config/src/control.rs
+++ b/lib/agent-data-plane-config/src/control.rs
@@ -58,12 +58,32 @@ pub struct ControlConfiguration {
     /// `aggregator_stop_timeout` and `forwarder_stop_timeout`.
     pub stop_timeout: Option<Duration>,
 
-    /// Process memory ceiling, in bytes. (not in Datadog Agent config schema)
-    pub memory_limit: u64,
+    /// Process memory ceiling in bytes. `None` defers to cgroup detection.
+    pub memory_limit: Option<u64>,
 
-    /// Fraction of the memory limit held back as headroom during memory accounting. (not in Datadog
-    /// Agent config schema)
+    /// Fraction of the memory limit held back as headroom. Defaults to `DEFAULT_MEMORY_SLOP_FACTOR`.
     pub memory_slop_factor: f64,
+
+    /// Whether the global memory limiter exerts backpressure. Defaults to `DEFAULT_ENABLE_GLOBAL_LIMITER`.
+    pub enable_global_limiter: bool,
+
+    /// Memory bounds validation and limiter behavior.
+    pub memory_mode: MemoryMode,
+}
+
+/// Memory bounds validation and limiter behavior.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MemoryMode {
+    /// Bounds validation is skipped and no memory limiting is applied.
+    #[default]
+    Disabled,
+
+    /// Bounds validation failures are logged and startup continues.
+    Permissive,
+
+    /// Bounds validation failures are fatal.
+    Strict,
 }
 
 impl ControlConfiguration {

--- a/lib/agent-data-plane-config/src/control.rs
+++ b/lib/agent-data-plane-config/src/control.rs
@@ -11,6 +11,9 @@ use serde::Serialize;
 use crate::ConfigValue;
 
 /// Topology gates and orchestration decisions. Most are static; `logging.level` is live.
+///
+/// The derived `Default` is all zeroes, empty, and `false`, and serves only as the starting point for translation. The
+/// effective default of each field is the one translation resolves, noted per field below.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct ControlConfiguration {
     /// Master switch for the whole data plane; when false, no pipelines are built.
@@ -58,16 +61,48 @@ pub struct ControlConfiguration {
     /// `aggregator_stop_timeout` and `forwarder_stop_timeout`.
     pub stop_timeout: Option<Duration>,
 
-    /// Process memory ceiling in bytes. `None` defers to cgroup detection.
+    /// Process memory ceiling, in bytes, that bounds validation and the global limiter work against.
+    ///
+    /// Defaults to `None`. When absent, ADP reads the ceiling from the process cgroup, but only when `DOCKER_DD_AGENT`
+    /// is set to a non-empty value. When neither source supplies a value, bounds validation is skipped and the global
+    /// limiter never exerts backpressure, whatever `memory_mode` and `enable_global_limiter` say.
+    ///
+    /// `Some(0)` is a ceiling of zero bytes rather than "no ceiling": every component bound then exceeds it, which is
+    /// fatal under [`MemoryMode::Strict`]. A ceiling above 2^53 bytes is rejected during startup.
+    ///
+    /// Set this to the memory the process is allowed to use, and leave it unset only where cgroup detection supplies
+    /// that number.
     pub memory_limit: Option<u64>,
 
-    /// Fraction of the memory limit held back as headroom. Defaults to `DEFAULT_MEMORY_SLOP_FACTOR`.
+    /// Fraction of `memory_limit` held back as headroom for memory the component bounds do not account for.
+    ///
+    /// Defaults to [`DEFAULT_MEMORY_SLOP_FACTOR`](crate::defaults::DEFAULT_MEMORY_SLOP_FACTOR) (`0.25`), which
+    /// validates bounds against 75% of `memory_limit`. Valid values run from `0.0` up to but excluding `1.0`, where
+    /// `0.0` holds nothing back. A value outside that range, including `NaN`, fails startup once a memory ceiling
+    /// resolves, and goes unused when none does.
+    ///
+    /// Raise this for a workload whose real usage overshoots its validated bounds; lower it to hand more of a tight
+    /// ceiling to the components that do account for their usage.
     pub memory_slop_factor: f64,
 
-    /// Whether the global memory limiter exerts backpressure. Defaults to `DEFAULT_ENABLE_GLOBAL_LIMITER`.
+    /// Whether the global memory limiter exerts backpressure as usage approaches the effective ceiling.
+    ///
+    /// Defaults to [`DEFAULT_ENABLE_GLOBAL_LIMITER`](crate::defaults::DEFAULT_ENABLE_GLOBAL_LIMITER) (`true`). When
+    /// `false`, the limiter is a no-op: it throttles nothing, and only the components' own bounds hold memory usage
+    /// down. Either way it does nothing unless a memory ceiling resolves and `memory_mode` is
+    /// [`MemoryMode::Permissive`] or [`MemoryMode::Strict`], because no other case installs a limiter.
+    ///
+    /// Turn this off to attribute a throughput drop to memory backpressure, accepting that the process can then run
+    /// past `memory_limit`.
     pub enable_global_limiter: bool,
 
-    /// Memory bounds validation and limiter behavior.
+    /// How the component memory bounds are reconciled with the effective memory ceiling during startup.
+    ///
+    /// Defaults to [`MemoryMode::Disabled`]. Validation runs only when a memory ceiling resolves; without one,
+    /// `Permissive` and `Strict` log that validation was skipped and startup continues.
+    ///
+    /// Run `Permissive` first to learn whether a ceiling fits the topology, then move to `Strict` where the platform
+    /// kills a process that exceeds its ceiling and refusing to start is the better failure.
     pub memory_mode: MemoryMode,
 }
 
@@ -75,14 +110,19 @@ pub struct ControlConfiguration {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum MemoryMode {
-    /// Bounds validation is skipped and no memory limiting is applied.
+    /// Bounds validation is skipped and no limiter is installed, whatever `enable_global_limiter` says.
     #[default]
     Disabled,
 
-    /// Bounds validation failures are logged and startup continues.
+    /// Bounds that do not fit the ceiling are logged as a warning and startup continues.
+    ///
+    /// Memory limiting is best effort: the limiter is installed when a ceiling resolves and
+    /// `enable_global_limiter` is `true`.
     Permissive,
 
-    /// Bounds validation failures are fatal.
+    /// Bounds that do not fit the ceiling fail startup.
+    ///
+    /// The limiter is installed on the same terms as [`MemoryMode::Permissive`].
     Strict,
 }
 

--- a/lib/agent-data-plane-config/src/defaults.rs
+++ b/lib/agent-data-plane-config/src/defaults.rs
@@ -13,6 +13,12 @@ use std::{
 /// Default internal telemetry verbosity.
 pub const DEFAULT_METRICS_LEVEL: &str = "info";
 
+/// Default memory-accounting slop factor.
+pub const DEFAULT_MEMORY_SLOP_FACTOR: f64 = 0.25;
+
+/// Default global memory limiter state.
+pub const DEFAULT_ENABLE_GLOBAL_LIMITER: bool = true;
+
 /// Default Checks IPC endpoint.
 pub const DEFAULT_CHECKS_IPC_ENDPOINT: &str = "tcp://0.0.0.0:5105";
 

--- a/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
+++ b/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
@@ -643,7 +643,7 @@ pub static SALUKI_KEYS: &[SalukiKey] = &[
         env_vars: &[],
         env_var_override: None,
         additional_yaml_paths: &[],
-        used_by: &[],
+        used_by: &["TYPED_CONFIG_SYSTEM"],
         test_json: None,
         pipeline_affinity: "PipelineAffinity::CrossCutting",
         filename: "accounting.rs",
@@ -658,7 +658,49 @@ pub static SALUKI_KEYS: &[SalukiKey] = &[
         env_vars: &[],
         env_var_override: None,
         additional_yaml_paths: &[],
-        used_by: &[],
+        used_by: &["TYPED_CONFIG_SYSTEM"],
+        test_json: None,
+        pipeline_affinity: "PipelineAffinity::CrossCutting",
+        filename: "accounting.rs",
+    },
+    SalukiKey {
+        yaml_path: "enable_global_limiter",
+        description: "Global memory limiter toggle",
+        default: "true",
+        documentation: Some(
+            "Controls whether the global memory limiter exerts backpressure as memory usage \
+             approaches `memory_limit`. The default is `true`. When set to `false`, the limiter \
+             becomes a no-op and only the memory bounds of the running components influence \
+             memory usage.",
+        ),
+        value_type: "ValueType::Bool",
+        schema_default: Some("true"),
+        env_vars: &[],
+        env_var_override: None,
+        additional_yaml_paths: &[],
+        used_by: &["TYPED_CONFIG_SYSTEM"],
+        test_json: None,
+        pipeline_affinity: "PipelineAffinity::CrossCutting",
+        filename: "accounting.rs",
+    },
+    SalukiKey {
+        yaml_path: "memory_mode",
+        description: "Memory bounds validation mode",
+        default: "disabled",
+        documentation: Some(
+            "Controls how the calculated memory bounds are reconciled against `memory_limit`. The \
+             default is `disabled`. Accepted values: `disabled` skips bounds validation and applies \
+             no memory limiting; `permissive` logs a warning when the bounds do not fit within the \
+             limit and starts anyway; `strict` refuses to start. Under `permissive` and `strict`, \
+             the global memory limiter is active only when a limit is in effect (configured or \
+             detected from cgroups) and `enable_global_limiter` is `true`.",
+        ),
+        value_type: "ValueType::String",
+        schema_default: Some("disabled"),
+        env_vars: &[],
+        env_var_override: None,
+        additional_yaml_paths: &[],
+        used_by: &["TYPED_CONFIG_SYSTEM"],
         test_json: None,
         pipeline_affinity: "PipelineAffinity::CrossCutting",
         filename: "accounting.rs",

--- a/lib/datadog-agent/config-testing/src/config_registry/accounting.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/accounting.rs
@@ -4,12 +4,28 @@ use super::schema;
 #[allow(unused_imports)]
 use super::*;
 
+static ENABLE_GLOBAL_LIMITER_SCHEMA: SchemaEntry = SchemaEntry {
+    schema: Schema::Saluki,
+    yaml_path: "enable_global_limiter",
+    env_vars: &[],
+    value_type: ValueType::Bool,
+    default: Some("true"),
+};
+
 static MEMORY_LIMIT_SCHEMA: SchemaEntry = SchemaEntry {
     schema: Schema::Saluki,
     yaml_path: "memory_limit",
     env_vars: &[],
     value_type: ValueType::String,
     default: None,
+};
+
+static MEMORY_MODE_SCHEMA: SchemaEntry = SchemaEntry {
+    schema: Schema::Saluki,
+    yaml_path: "memory_mode",
+    env_vars: &[],
+    value_type: ValueType::String,
+    default: Some("disabled"),
 };
 
 static MEMORY_SLOP_FACTOR_SCHEMA: SchemaEntry = SchemaEntry {
@@ -21,13 +37,35 @@ static MEMORY_SLOP_FACTOR_SCHEMA: SchemaEntry = SchemaEntry {
 };
 
 crate::declare_annotations! {
+    /// `enable_global_limiter`
+    ENABLE_GLOBAL_LIMITER = SalukiAnnotation {
+        schema: &ENABLE_GLOBAL_LIMITER_SCHEMA,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
     /// `memory_limit`
     MEMORY_LIMIT = SalukiAnnotation {
         schema: &MEMORY_LIMIT_SCHEMA,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
-        used_by: &[],
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
+    /// `memory_mode`
+    MEMORY_MODE = SalukiAnnotation {
+        schema: &MEMORY_MODE_SCHEMA,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
         value_type_override: None,
         test_json: None,
         pipeline_affinity: PipelineAffinity::CrossCutting,
@@ -38,7 +76,7 @@ crate::declare_annotations! {
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
-        used_by: &[],
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
         value_type_override: None,
         test_json: None,
         pipeline_affinity: PipelineAffinity::CrossCutting,

--- a/lib/saluki-app/src/accounting.rs
+++ b/lib/saluki-app/src/accounting.rs
@@ -7,7 +7,6 @@ use metrics::{counter, gauge, Counter, Gauge, Level};
 use saluki_api::{DynamicRoute, EndpointType};
 use saluki_common::resource_tracking::{ResourceGroupRegistry, ResourceStats, ResourceStatsSnapshot};
 use saluki_common::{collections::FastHashMap, sync::shutdown::ShutdownHandle};
-use saluki_config::GenericConfiguration;
 use saluki_core::accounting::{
     ComponentBounds, ComponentRegistry, ComponentRegistryHandle, MemoryGrant, MemoryLimiter,
 };
@@ -17,22 +16,12 @@ use saluki_core::{
     support::SubsystemIdentifier,
 };
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
-use serde::Deserialize;
 use tokio::{select, time::sleep};
 use tonic::async_trait;
 use tracing::{error, info, warn};
 
-const fn default_memory_slop_factor() -> f64 {
-    0.25
-}
-
-const fn default_enable_global_limiter() -> bool {
-    true
-}
-
 /// Bounds validation and global memory limiter behavior.
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
-#[serde(rename_all = "lowercase")]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum MemoryMode {
     /// Bounds validation is skipped, and no memory limiting is applied.
     #[default]
@@ -50,16 +39,9 @@ pub enum MemoryMode {
 }
 
 /// Configuration for memory bounds.
-#[derive(Deserialize)]
 pub struct MemoryBoundsConfiguration {
-    /// The memory limit to adhere to.
-    ///
-    /// This should be the overall memory limit for the entire process. The value can either be an integer for
-    /// specifying the limit in bytes, or a string that uses SI byte prefixes (case-insensitive) such as `1mb` or `1GB`.
-    ///
-    /// If not specified, no memory bounds verification will be performed.
-    #[serde(default)]
-    memory_limit: Option<ByteSize>,
+    /// Process memory limit. `None` enables cgroup detection.
+    pub memory_limit: Option<ByteSize>,
 
     /// The slop factor to apply to the given memory limit.
     ///
@@ -71,73 +53,24 @@ pub struct MemoryBoundsConfiguration {
     /// Values between 0 to 1 are allowed, and represent the percentage of `memory_limit` that is held back. This means
     /// that a slop factor of 0.25, for example, will cause 25% of `memory_limit` to be withheld. If `memory_limit` was
     /// 100 MB, we would then verify that the memory bounds can fit within 75 MB (100 MB * (1 - 0.25) => 75 MB).
-    #[serde(default = "default_memory_slop_factor")]
-    memory_slop_factor: f64,
+    pub memory_slop_factor: f64,
 
     /// Whether or not to enable the global memory limiter.
     ///
     /// When set to `false`, the global memory limiter will operate in a no-op mode. All calls to use it will never
     /// exert backpressure, and only the inherent memory bounds of the running components will influence memory usage.
-    ///
-    /// Defaults to `true`.
-    #[serde(default = "default_enable_global_limiter")]
-    enable_global_limiter: bool,
+    pub enable_global_limiter: bool,
 
     /// The memory mode to use when reconciling the calculated memory bounds against the configured memory limit.
     ///
     /// See [`MemoryMode`] for the available modes and their behavior.
-    ///
-    /// Defaults to [`MemoryMode::Disabled`].
-    #[serde(default)]
-    memory_mode: MemoryMode,
-}
-
-impl MemoryBoundsConfiguration {
-    /// Attempts to read memory bounds configuration from the provided configuration.
-    ///
-    /// # Errors
-    ///
-    /// If an error occurs during deserialization, an error will be returned.
-    pub fn try_from_config(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let mut config = config
-            .as_typed::<Self>()
-            .error_context("Failed to parse memory bounds configuration.")?;
-
-        if config.memory_limit.is_none() {
-            // Try to pull configured memory limit from Cgroup if running in a containerized environment.
-            if let Ok(value) = env::var("DOCKER_DD_AGENT") {
-                if !value.is_empty() {
-                    let cgroup_memory_reader = CgroupMemoryParser;
-                    if let Some(memory) = cgroup_memory_reader.parse() {
-                        info!(
-                            "Setting memory limit to {} based on detected cgroups limit.",
-                            memory.display().si()
-                        );
-                        config.memory_limit = Some(memory);
-                    }
-                }
-            }
-        }
-
-        // Try constructing the initial grant based on the configuration as a smoke test to validate the values.
-        if let Some(limit) = config.memory_limit {
-            let _ = MemoryGrant::with_slop_factor(limit.as_u64() as usize, config.memory_slop_factor)
-                .error_context("Given memory limit and/or slop factor invalid.")?;
-        }
-
-        Ok(config)
-    }
-
-    /// Gets the initial memory grant based on the configuration.
-    pub fn get_initial_grant(&self) -> Option<MemoryGrant> {
-        self.memory_limit.map(|limit| {
-            MemoryGrant::with_slop_factor(limit.as_u64() as usize, self.memory_slop_factor)
-                .expect("memory limit should be valid")
-        })
-    }
+    pub memory_mode: MemoryMode,
 }
 
 /// Initializes the memory bounds system and verifies any configured bounds based on the configured memory mode.
+///
+/// When no memory limit is configured and `DOCKER_DD_AGENT` is set to a non-empty value, the limit is read from the
+/// process cgroup instead.
 ///
 /// See [`MemoryMode`] for details on the behavior of each mode.
 ///
@@ -148,10 +81,12 @@ impl MemoryBoundsConfiguration {
 pub fn initialize_memory_bounds(
     configuration: MemoryBoundsConfiguration, component_registry: ComponentRegistryHandle,
 ) -> Result<MemoryLimiter, GenericError> {
-    let configured_grant = configuration
-        .memory_limit
+    let memory_limit = configuration.memory_limit.or_else(detect_cgroup_memory_limit);
+
+    let configured_grant = memory_limit
         .map(|limit| MemoryGrant::with_slop_factor(limit.as_u64() as usize, configuration.memory_slop_factor))
-        .transpose()?;
+        .transpose()
+        .error_context("Given memory limit and/or slop factor invalid.")?;
 
     let limiter_grant = match configuration.memory_mode {
         MemoryMode::Disabled => {
@@ -377,6 +312,20 @@ async fn run_resource_group_metrics_loop() {
     }
 }
 
+fn detect_cgroup_memory_limit() -> Option<ByteSize> {
+    if !env::var("DOCKER_DD_AGENT").is_ok_and(|value| !value.is_empty()) {
+        return None;
+    }
+
+    let memory = CgroupMemoryParser.parse()?;
+    info!(
+        "Setting memory limit to {} based on detected cgroups limit.",
+        memory.display().si()
+    );
+
+    Some(memory)
+}
+
 struct CgroupMemoryParser;
 
 impl CgroupMemoryParser {
@@ -427,9 +376,28 @@ fn bytes_to_si_string(bytes: usize) -> bytesize::Display {
 
 #[cfg(test)]
 mod tests {
-    use saluki_config::{config_from, test_env_lock};
+    use saluki_config::test_env_lock;
+    use saluki_core::support::SubsystemIdentifier;
 
     use super::*;
+
+    fn config_with_limit(limit: ByteSize, memory_mode: MemoryMode) -> MemoryBoundsConfiguration {
+        MemoryBoundsConfiguration {
+            memory_limit: Some(limit),
+            memory_slop_factor: 0.25,
+            enable_global_limiter: false,
+            memory_mode,
+        }
+    }
+
+    fn registry_with_firm_bound(bytes: usize) -> ComponentRegistry {
+        let registry = ComponentRegistry::default();
+        registry
+            .bounds_builder(&SubsystemIdentifier::from_dotted("test"))
+            .firm()
+            .with_fixed_amount("buffer", bytes);
+        registry
+    }
 
     #[test]
     fn cgroup_memory_parser_converts_raw_limits_to_bytes() {
@@ -448,48 +416,80 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn memory_bounds_configuration_parses_limit_and_slop_factor() {
-        let cfg = config_from(serde_json::json!({
-            "memory_limit": 1_048_576,
-            "memory_slop_factor": 0.25,
-        }))
-        .await;
+    #[test]
+    fn out_of_range_slop_factor_is_rejected() {
+        let mut config = config_with_limit(ByteSize::mib(1), MemoryMode::Strict);
+        config.memory_slop_factor = 1.5;
 
-        let bounds = MemoryBoundsConfiguration::try_from_config(&cfg).expect("valid config should parse");
-        let grant = bounds
-            .get_initial_grant()
-            .expect("a configured memory limit should yield an initial grant");
-
-        assert_eq!(grant.initial_limit_bytes(), 1_048_576);
-        assert_eq!(grant.slop_factor(), 0.25);
+        let error = initialize_memory_bounds(config, ComponentRegistry::default().root())
+            .err()
+            .expect("a slop factor of 1.5 should be rejected");
+        assert!(error
+            .to_string()
+            .contains("Given memory limit and/or slop factor invalid."));
     }
 
-    #[tokio::test]
-    async fn memory_bounds_configuration_rejects_out_of_range_slop_factor() {
-        // `try_from_config` builds a grant as a smoke test, and a slop factor outside `[0.0, 1.0)` makes that fail.
-        let cfg = config_from(serde_json::json!({
-            "memory_limit": 1_048_576,
-            "memory_slop_factor": 1.5,
-        }))
-        .await;
+    #[test]
+    fn disabled_memory_mode_skips_bounds_verification() {
+        let registry = registry_with_firm_bound(64 * 1024 * 1024);
 
-        assert!(
-            MemoryBoundsConfiguration::try_from_config(&cfg).is_err(),
-            "a slop factor of 1.5 should be rejected"
-        );
+        initialize_memory_bounds(
+            config_with_limit(ByteSize::b(1024), MemoryMode::Disabled),
+            registry.root(),
+        )
+        .expect("disabled mode should not verify bounds");
     }
 
-    #[tokio::test]
-    async fn memory_bounds_configuration_without_limit_has_no_grant() {
-        let cfg = config_from(serde_json::json!({})).await;
+    #[test]
+    fn strict_memory_mode_rejects_bounds_exceeding_the_limit() {
+        let registry = registry_with_firm_bound(64 * 1024 * 1024);
 
-        // With no explicit limit, `try_from_config` consults the `DOCKER_DD_AGENT` environment variable, so serialize
-        // against the shared env lock and ensure it's unset for a deterministic "no limit" result.
+        let error = initialize_memory_bounds(
+            config_with_limit(ByteSize::b(1024), MemoryMode::Strict),
+            registry.root(),
+        )
+        .err()
+        .expect("bounds larger than the limit should be fatal in strict mode");
+        assert!(error
+            .to_string()
+            .contains("Configured memory limit is insufficient for the current configuration."));
+    }
+
+    #[test]
+    fn permissive_memory_mode_tolerates_bounds_exceeding_the_limit() {
+        let registry = registry_with_firm_bound(64 * 1024 * 1024);
+
+        initialize_memory_bounds(
+            config_with_limit(ByteSize::b(1024), MemoryMode::Permissive),
+            registry.root(),
+        )
+        .expect("bounds larger than the limit should be non-fatal in permissive mode");
+    }
+
+    #[test]
+    fn absent_memory_limit_skips_bounds_verification() {
+        let registry = registry_with_firm_bound(64 * 1024 * 1024);
+        let config = MemoryBoundsConfiguration {
+            memory_limit: None,
+            memory_slop_factor: 0.25,
+            enable_global_limiter: false,
+            memory_mode: MemoryMode::Strict,
+        };
+
         let _env_guard = test_env_lock();
         std::env::remove_var("DOCKER_DD_AGENT");
 
-        let bounds = MemoryBoundsConfiguration::try_from_config(&cfg).expect("empty config should parse");
-        assert!(bounds.get_initial_grant().is_none());
+        initialize_memory_bounds(config, registry.root()).expect("no limit means no bounds verification");
+    }
+
+    #[test]
+    fn cgroup_memory_limit_is_not_detected_outside_a_container() {
+        let _env_guard = test_env_lock();
+        std::env::remove_var("DOCKER_DD_AGENT");
+        assert_eq!(detect_cgroup_memory_limit(), None);
+
+        std::env::set_var("DOCKER_DD_AGENT", "");
+        assert_eq!(detect_cgroup_memory_limit(), None);
+        std::env::remove_var("DOCKER_DD_AGENT");
     }
 }

--- a/lib/saluki-app/src/bootstrap.rs
+++ b/lib/saluki-app/src/bootstrap.rs
@@ -1,7 +1,6 @@
 //! Bootstrap utilities.
 
 use metrics::Level;
-use saluki_config::GenericConfiguration;
 use saluki_core::runtime::Supervisor;
 use saluki_error::{ErrorContext as _, GenericError};
 
@@ -63,16 +62,12 @@ impl AppBootstrapper {
     /// The bootstrapper is initialized with a [`simple`][LoggingConfiguration::simple] logging configuration. Callers
     /// that have application-specific logging requirements should follow up with
     /// [`with_logging_configuration`][Self::with_logging_configuration] to override this default.
-    ///
-    /// # Errors
-    ///
-    /// This currently doesn't fail, but the signature returns `Result` to leave room for future failures.
-    pub fn from_configuration(_config: &GenericConfiguration) -> Result<Self, GenericError> {
-        Ok(Self {
+    pub fn new() -> Self {
+        Self {
             logging_config: LoggingConfiguration::simple(),
             metrics_prefix: "saluki".to_string(),
             metrics_default_level: Level::INFO,
-        })
+        }
     }
 
     /// Sets the prefix to use for internal metrics.
@@ -96,8 +91,7 @@ impl AppBootstrapper {
 
     /// Sets the logging configuration to use during bootstrap.
     ///
-    /// Replaces the [`simple`][LoggingConfiguration::simple] default that
-    /// [`from_configuration`][Self::from_configuration] installs.
+    /// Replaces the [`simple`][LoggingConfiguration::simple] default that [`new`][Self::new] installs.
     pub fn with_logging_configuration(mut self, logging_config: LoggingConfiguration) -> Self {
         self.logging_config = logging_config;
         self


### PR DESCRIPTION
## Human Summary

Found a couple of untracked saluki only configuration keys and added them to the inventory and documentation. Uneventful. LGTM.

## AI Summary

- Build memory bounds from typed control settings.
- Preserve cgroup limit detection, slop validation, limiter defaults, and validation modes.
- Add typed Saluki-only settings for memory mode and the global limiter.
- Remove the unused raw configuration input from app bootstrap.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make fmt`
- `make check-docs`
- `make check-clippy`
- `cargo check --workspace --tests`
- Targeted `cargo nextest` runs for affected packages

## References

- Progresses: #2169
