### PR TITLE
chore(config): type environment detection inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5328,7 +5328,6 @@ dependencies = [
  "prost",
  "regex",
  "saluki-common",
- "saluki-config",
  "saluki-context",
  "saluki-core",
  "saluki-error",

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -184,6 +184,7 @@ pub async fn handle_run_command(
     let (env_provider, maybe_env_supervisor) = ADPEnvironmentProvider::from_configuration(
         standalone,
         &config_sys.raw_map(),
+        &config_sys.config().shared.environment,
         remote_agent_client_config.as_ref(),
         &component_registry,
         &health_registry,

--- a/bin/agent-data-plane/src/internal/env/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/mod.rs
@@ -64,13 +64,12 @@ impl ADPEnvironmentProvider {
         if standalone {
             warn!("Running in standalone mode. Origin detection/enrichment and other features dependent upon the Datadog Agent will not be available.");
 
-            let hostname = environment
-                .hostname
-                .is_explicit()
-                .then(|| environment.hostname.value.clone())
-                .ok_or_else(|| {
-                    generic_error!("A hostname must be configured (`hostname`) when using the fixed host provider.")
-                })?;
+            let hostname = environment.hostname.value.clone();
+            if !environment.hostname.is_explicit() || hostname.is_empty() {
+                return Err(generic_error!(
+                    "A non-empty hostname must be configured (`hostname`) when running in standalone mode."
+                ));
+            }
 
             let env = Self {
                 host_provider: BoxedHostProvider::from_provider(FixedHostProvider::new(hostname)),

--- a/bin/agent-data-plane/src/internal/env/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/mod.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 
+use agent_data_plane_config::shared::Environment;
 use datadog_agent_commons::ipc::config::RemoteAgentClientConfiguration;
 use saluki_config::GenericConfiguration;
 use saluki_core::accounting::ComponentRegistry;
@@ -55,15 +56,24 @@ impl ADPEnvironmentProvider {
     /// In standalone mode, no supervisor is returned as all behavior/functionality is either provided via
     /// fixed configuration or operates in a no-op fashion.
     pub async fn from_configuration(
-        standalone: bool, raw_map: &GenericConfiguration, client_config: Option<&RemoteAgentClientConfiguration>,
-        component_registry: &ComponentRegistry, health_registry: &HealthRegistry,
+        standalone: bool, raw_map: &GenericConfiguration, environment: &Environment,
+        client_config: Option<&RemoteAgentClientConfiguration>, component_registry: &ComponentRegistry,
+        health_registry: &HealthRegistry,
     ) -> Result<(Self, Option<Supervisor>), GenericError> {
         // When we're in standalone mode, all of our functionality is either fixed or a no-op.
         if standalone {
             warn!("Running in standalone mode. Origin detection/enrichment and other features dependent upon the Datadog Agent will not be available.");
 
+            let hostname = environment
+                .hostname
+                .is_explicit()
+                .then(|| environment.hostname.value.clone())
+                .ok_or_else(|| {
+                    generic_error!("A hostname must be configured (`hostname`) when using the fixed host provider.")
+                })?;
+
             let env = Self {
-                host_provider: BoxedHostProvider::from_provider(FixedHostProvider::from_configuration(raw_map)?),
+                host_provider: BoxedHostProvider::from_provider(FixedHostProvider::new(hostname)),
                 workload_provider: None,
                 autodiscovery_provider: None,
                 health_registry: health_registry.clone(),
@@ -80,6 +90,7 @@ impl ADPEnvironmentProvider {
 
         let (workload_provider, workload_supervisor) = RemoteAgentWorkloadProvider::from_configuration(
             raw_map,
+            environment,
             client_config,
             component_registry,
             health_registry,

--- a/bin/agent-data-plane/src/internal/env/workload/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/workload/mod.rs
@@ -129,14 +129,15 @@ impl RemoteAgentWorkloadProvider {
             .is_explicit()
             .then(|| environment.container_roots.cgroup_root.value.clone());
 
-        // Add the containerd collector if the feature is available.
         let feature_detector = FeatureDetector::automatic(containerd_socket_path.clone());
+
+        // Add the containerd collector if the feature is available.
         #[cfg(unix)]
         if feature_detector.is_feature_available(Feature::Containerd) {
-            let containerd_config = ContainerdConfiguration::new(
-                environment.containerd.connection_timeout,
-                environment.containerd.query_timeout,
-            );
+            let containerd_config = ContainerdConfiguration {
+                connection_timeout: environment.containerd.connection_timeout,
+                query_timeout: environment.containerd.query_timeout,
+            };
             let cri_collector = build_collector(
                 &collectors_root,
                 "containerd",

--- a/bin/agent-data-plane/src/internal/env/workload/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/workload/mod.rs
@@ -2,6 +2,7 @@
 
 use std::{future::Future, num::NonZeroUsize, time::Duration};
 
+use agent_data_plane_config::shared::Environment;
 use datadog_agent_commons::ipc::config::RemoteAgentClientConfiguration;
 use saluki_config::GenericConfiguration;
 use saluki_context::{
@@ -17,9 +18,9 @@ use saluki_core::{
 #[cfg(unix)]
 use saluki_env::features::Feature;
 #[cfg(target_os = "linux")]
-use saluki_env::workload::collectors::CgroupsMetadataCollector;
+use saluki_env::workload::{collectors::CgroupsMetadataCollector, CgroupsConfiguration};
 #[cfg(unix)]
-use saluki_env::workload::collectors::ContainerdMetadataCollector;
+use saluki_env::workload::{collectors::ContainerdMetadataCollector, ContainerdConfiguration};
 use saluki_env::{
     features::FeatureDetector,
     workload::{
@@ -83,7 +84,7 @@ impl RemoteAgentWorkloadProvider {
     /// If there is an issue with any of the provider configuration, or creating the underlying metadata collectors, an
     /// error is returned.
     pub async fn from_configuration(
-        config: &GenericConfiguration, client_config: &RemoteAgentClientConfiguration,
+        config: &GenericConfiguration, environment: &Environment, client_config: &RemoteAgentClientConfiguration,
         component_registry: &ComponentRegistry, health_registry: &HealthRegistry,
     ) -> Result<(Self, Supervisor), GenericError> {
         let workload_provider_id = root_provider_id().child("workload").child("remote_agent");
@@ -112,16 +113,43 @@ impl RemoteAgentWorkloadProvider {
         let mut collector_bounds = provider_bounds.subcomponent("collectors");
         let mut collector_workers: Vec<MetadataCollectorWorker> = Vec::new();
 
+        let containerd_socket_path = environment
+            .containerd
+            .socket_path
+            .is_explicit()
+            .then(|| environment.containerd.socket_path.value.clone());
+        let container_proc_root = environment
+            .container_roots
+            .proc_root
+            .is_explicit()
+            .then(|| environment.container_roots.proc_root.value.clone());
+        let container_cgroup_root = environment
+            .container_roots
+            .cgroup_root
+            .is_explicit()
+            .then(|| environment.container_roots.cgroup_root.value.clone());
+
         // Add the containerd collector if the feature is available.
-        let feature_detector = FeatureDetector::automatic(config);
+        let feature_detector = FeatureDetector::automatic(containerd_socket_path.clone());
         #[cfg(unix)]
         if feature_detector.is_feature_available(Feature::Containerd) {
+            let containerd_config = ContainerdConfiguration::new(
+                environment.containerd.connection_timeout,
+                environment.containerd.query_timeout,
+            );
             let cri_collector = build_collector(
                 &collectors_root,
                 "containerd",
                 health_registry,
                 &mut collector_bounds,
-                |health| ContainerdMetadataCollector::from_configuration(config, health, string_interner.clone()),
+                |health| {
+                    ContainerdMetadataCollector::new(
+                        containerd_socket_path.clone(),
+                        &containerd_config,
+                        health,
+                        string_interner.clone(),
+                    )
+                },
             )
             .await?;
 
@@ -131,19 +159,17 @@ impl RemoteAgentWorkloadProvider {
         // Add the cgroups collector if the feature if we're on Linux.
         #[cfg(target_os = "linux")]
         {
+            let cgroups_config = CgroupsConfiguration::new(
+                container_proc_root.clone(),
+                container_cgroup_root.clone(),
+                &feature_detector,
+            );
             let cgroups_collector = build_collector(
                 &collectors_root,
                 "cgroups",
                 health_registry,
                 &mut collector_bounds,
-                |health| {
-                    CgroupsMetadataCollector::from_configuration(
-                        config,
-                        feature_detector.clone(),
-                        health,
-                        string_interner.clone(),
-                    )
-                },
+                |health| CgroupsMetadataCollector::new(&cgroups_config, health, string_interner.clone()),
             )
             .await?;
 
@@ -184,8 +210,12 @@ impl RemoteAgentWorkloadProvider {
 
         aggregator.add_store(external_data_store);
 
-        let on_demand_pid_resolver =
-            OnDemandPIDResolver::from_configuration(config, feature_detector, string_interner)?;
+        let on_demand_pid_resolver = OnDemandPIDResolver::new(
+            container_proc_root,
+            container_cgroup_root,
+            &feature_detector,
+            string_interner,
+        )?;
         let origin_resolver = OriginResolver::new(eds_resolver.clone());
 
         // With the aggregator configured, update the memory bounds before handing it off to the supervisor.

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -1026,10 +1026,12 @@ The following settings work in ADP with the same behavior as the core agent.
 
 ADP reads the cgroups hierarchy from this root. When the key is not set explicitly, ADP
 selects the root from detected features: the host-mapped `/host/sys/fs/cgroup` when a
-host-mapped cgroupfs is detected, the legacy `/cgroup` root when the cgroups v1 `memory`
-controller is found there, and `/sys/fs/cgroup` otherwise. That detection is independent of
-the procfs mount. The core Agent reports its own detected root as a default value, which ADP
-can't tell apart from a schema default, so ADP repeats the detection instead of consuming it.
+host-mapped cgroupfs is detected, the legacy `/cgroup` root when ADP runs directly on a host
+whose cgroups v1 `memory` controller is found there, and `/sys/fs/cgroup` otherwise. Like the
+core Agent, ADP considers the legacy root only when it is not containerized. That detection is
+independent of the procfs mount. The core Agent reports its own detected root as a default
+value, which ADP can't tell apart from a schema default, so ADP repeats the detection instead
+of consuming it.
 
 ### `container_proc_root`
 

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -1026,8 +1026,10 @@ The following settings work in ADP with the same behavior as the core agent.
 
 ADP reads the cgroups hierarchy from this root. When the key is not set explicitly, ADP
 selects the root from detected features: the host-mapped `/host/sys/fs/cgroup` when a
-host-mapped cgroupfs is detected, and `/sys/fs/cgroup` otherwise. That detection is
-independent of the procfs mount.
+host-mapped cgroupfs is detected, the legacy `/cgroup` root when the cgroups v1 `memory`
+controller is found there, and `/sys/fs/cgroup` otherwise. That detection is independent of
+the procfs mount. The core Agent reports its own detected root as a default value, which ADP
+can't tell apart from a schema default, so ADP repeats the detection instead of consuming it.
 
 ### `container_proc_root`
 

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -831,8 +831,11 @@ The following settings work in ADP with the same behavior as the core agent.
 | `cluster_agent.url`                                                                        | Cluster Agent HTTPS endpoint                       |
 | `cluster_name`                                                                             | EKS Fargate cluster name static tag                |
 | `cmd_port`                                                                                 | Core Agent CMD API port for ADP gRPC IPC           |
+| `container_cgroup_root`                                                                    | cgroupfs root for container metadata               |
+| `container_proc_root`                                                                      | procfs root for container metadata                 |
 | `cri_connection_timeout`                                                                   | CRI container runtime connection timeout (s)       |
 | `cri_query_timeout`                                                                        | CRI container runtime query timeout (s)            |
+| `cri_socket_path`                                                                          | containerd/CRI socket path                         |
 | `data_plane.api_listen_address`                                                            | Unprivileged API listen address                    |
 | `data_plane.dogstatsd.aggregator_tag_filter_cache_capacity`                                | Tag-filter deduplication cache size                |
 | `data_plane.dogstatsd.enabled`                                                             | Enable the DogStatsD pipeline                      |
@@ -908,6 +911,7 @@ The following settings work in ADP with the same behavior as the core agent.
 | `histogram_copy_to_distribution`                                                           | Copy histograms to distributions                   |
 | `histogram_copy_to_distribution_prefix`                                                    | Prefix for hist-to-dist copies                     |
 | `histogram_percentiles`                                                                    | Histogram percentile aggregates                    |
+| `hostname`                                                                                 | Forced hostname for emitted data                   |
 | `ipc_cert_file_path`                                                                       | Agent IPC certificate file path                    |
 | `kubernetes_kubelet_nodename`                                                              | Kubernetes node name for EKS Fargate static tags   |
 | `log_file_max_rolls`                                                                       | Max rolled log files to retain                     |

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -421,6 +421,7 @@ default values.
 | Config Key                                   | Description                                  |
 | -------------------------------------------- | -------------------------------------------- |
 | `aggregator_stop_timeout`                    | Timeout (s) for aggregator flush on stop     |
+| `cri_socket_path`                            | containerd/CRI socket path                   |
 | `dogstatsd_mapper_cache_size`                | Mapper result LRU cache size                 |
 | `dogstatsd_metrics_stats_enable`             | Enable per-metric debug stats                |
 | `dogstatsd_workers_count`                    | Number of DSD processing workers             |
@@ -454,6 +455,22 @@ Support is partial because ADP does not apply this timeout only to an aggregator
 Shutdown is coordinated by the Saluki topology: sources stop first, downstream inputs close,
 and the aggregate transform performs its final flush when its input stream ends. Whether open
 aggregation windows are included is controlled by `dogstatsd_flush_incomplete_buckets`.
+
+### `cri_socket_path`
+
+The core Agent uses this key to enable both its CRI and containerd integrations, classifying
+the socket by path: a path containing `containerd` selects containerd, a path containing
+`crio` selects CRI-O, and any other reachable CRI socket is treated as a nonstandard CRI
+runtime. When the key is unset, the core Agent probes well-known containerd and CRI-O paths.
+
+ADP implements the containerd runtime only. Setting this path enables the containerd
+integration against that socket, but only when the path contains `containerd`. A CRI-O or
+otherwise nonstandard CRI socket path leaves containerd undetected, and ADP starts no
+container runtime metadata collector for it. When the key is not set explicitly, ADP probes
+the well-known containerd socket paths only. An explicitly empty path leaves containerd
+undetected.
+
+Container ID resolution through cgroups is independent of this key and is unaffected.
 
 ### `dogstatsd_mapper_cache_size`
 
@@ -835,7 +852,6 @@ The following settings work in ADP with the same behavior as the core agent.
 | `container_proc_root`                                                                      | procfs root for container metadata                 |
 | `cri_connection_timeout`                                                                   | CRI container runtime connection timeout (s)       |
 | `cri_query_timeout`                                                                        | CRI container runtime query timeout (s)            |
-| `cri_socket_path`                                                                          | containerd/CRI socket path                         |
 | `data_plane.api_listen_address`                                                            | Unprivileged API listen address                    |
 | `data_plane.dogstatsd.aggregator_tag_filter_cache_capacity`                                | Tag-filter deduplication cache size                |
 | `data_plane.dogstatsd.enabled`                                                             | Enable the DogStatsD pipeline                      |
@@ -1006,6 +1022,19 @@ The following settings work in ADP with the same behavior as the core agent.
 
 ## Additional Notes
 
+### `container_cgroup_root`
+
+ADP reads the cgroups hierarchy from this root. When the key is not set explicitly, ADP
+selects the root from detected features: the host-mapped `/host/sys/fs/cgroup` when a
+host-mapped cgroupfs is detected, and `/sys/fs/cgroup` otherwise. That detection is
+independent of the procfs mount.
+
+### `container_proc_root`
+
+ADP inspects container processes under this root. When the key is not set explicitly, ADP
+selects the root from detected features: the host-mapped `/host/proc` when a host-mapped
+procfs is detected, and `/proc` otherwise.
+
 ### `data_plane.api_listen_address`
 
 This is the unprivileged (internal) API endpoint. Addresses must include a URL scheme
@@ -1114,6 +1143,11 @@ The on-demand PID resolver is also Linux-only because it reads procfs and cgroup
 metadata can still populate `ContainerPid` aliases in the tag store on Unix platforms, which
 covers steady-state tagging when another source provides a PID, but macOS UDS origin detection
 cannot obtain that PID from the socket.
+
+### `hostname`
+
+ADP uses this only in standalone mode, where the fixed host provider requires a configured
+hostname. In connected mode the hostname comes from the Datadog Agent.
 
 ### Payload debug logging (`log_payloads`)
 

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -94,6 +94,16 @@ impl<'a> DatadogTranslator<'a> {
             }
         }
     }
+
+    fn parse_timeout_secs(&mut self, key: &'static str, value: i64) -> Option<Duration> {
+        match u64::try_from(value) {
+            Ok(secs) => Some(Duration::from_secs(secs)),
+            Err(_) => {
+                self.record_error(TranslateError::new_with_message(key, "timeout must not be negative"));
+                None
+            }
+        }
+    }
 }
 
 /// Resolves the keepalive ping interval, applying the default for unset values.
@@ -440,12 +450,31 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
         }
     }
 
+    fn consume_container_cgroup_root(&mut self, value: String) {
+        let provenance = self.sources.provenance("container_cgroup_root");
+        self.config.shared.environment.container_roots.cgroup_root = ConfigValue::new(PathBuf::from(value), provenance);
+    }
+
+    fn consume_container_proc_root(&mut self, value: String) {
+        let provenance = self.sources.provenance("container_proc_root");
+        self.config.shared.environment.container_roots.proc_root = ConfigValue::new(PathBuf::from(value), provenance);
+    }
+
     fn consume_cri_connection_timeout(&mut self, value: i64) {
-        self.config.control.ipc.cri_connection_timeout = value;
+        if let Some(timeout) = self.parse_timeout_secs("cri_connection_timeout", value) {
+            self.config.shared.environment.containerd.connection_timeout = timeout;
+        }
     }
 
     fn consume_cri_query_timeout(&mut self, value: i64) {
-        self.config.control.ipc.cri_query_timeout = value;
+        if let Some(timeout) = self.parse_timeout_secs("cri_query_timeout", value) {
+            self.config.shared.environment.containerd.query_timeout = timeout;
+        }
+    }
+
+    fn consume_cri_socket_path(&mut self, value: String) {
+        let provenance = self.sources.provenance("cri_socket_path");
+        self.config.shared.environment.containerd.socket_path = ConfigValue::new(PathBuf::from(value), provenance);
     }
 
     fn consume_data_plane_api_listen_address(&mut self, value: String) {
@@ -931,6 +960,11 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
 
     fn consume_histogram_percentiles(&mut self, value: Vec<String>) {
         self.config.shared.metrics_encoding.histogram.percentiles = value;
+    }
+
+    fn consume_hostname(&mut self, value: String) {
+        let provenance = self.sources.provenance("hostname");
+        self.config.shared.environment.hostname = ConfigValue::new(value, provenance);
     }
 
     fn consume_ipc_cert_file_path(&mut self, value: String) {
@@ -1918,6 +1952,66 @@ mod tests {
                 .get("https://app.datadoghq.com"),
             Some(&V3SeriesMode::Disabled)
         );
+    }
+
+    #[test]
+    fn defaulted_environment_settings_stay_distinguishable_from_configured_ones() {
+        let (config, errors) = translate_stream(&[
+            ("hostname", json!(""), StreamProvenance::Default),
+            ("cri_socket_path", json!(""), StreamProvenance::Default),
+            ("container_proc_root", json!("/host/proc"), StreamProvenance::Default),
+            (
+                "container_cgroup_root",
+                json!("/host/sys/fs/cgroup/"),
+                StreamProvenance::Default,
+            ),
+        ]);
+
+        assert!(errors.is_none());
+        let environment = &config.shared.environment;
+        assert_defaulted(&environment.hostname, "");
+        assert_defaulted(&environment.containerd.socket_path, PathBuf::from(""));
+        assert_defaulted(&environment.container_roots.proc_root, PathBuf::from("/host/proc"));
+        assert_defaulted(
+            &environment.container_roots.cgroup_root,
+            PathBuf::from("/host/sys/fs/cgroup/"),
+        );
+    }
+
+    #[test]
+    fn explicit_environment_settings_are_carried_verbatim() {
+        let (config, errors) = translate_stream(&[
+            ("hostname", json!("my-host"), StreamProvenance::Explicit),
+            ("cri_socket_path", json!(""), StreamProvenance::Explicit),
+            ("container_proc_root", json!("/proc"), StreamProvenance::Explicit),
+        ]);
+
+        assert!(errors.is_none());
+        let environment = &config.shared.environment;
+        assert_explicit(&environment.hostname, "my-host");
+        assert_explicit(&environment.containerd.socket_path, PathBuf::from(""));
+        assert_explicit(&environment.container_roots.proc_root, PathBuf::from("/proc"));
+    }
+
+    #[test]
+    fn cri_timeouts_become_durations_and_reject_negative_values() {
+        let (config, errors) = translate_explicit(json!({ "cri_connection_timeout": 2, "cri_query_timeout": 7 }));
+
+        assert!(errors.is_none());
+        assert_eq!(
+            config.shared.environment.containerd.connection_timeout,
+            Duration::from_secs(2)
+        );
+        assert_eq!(
+            config.shared.environment.containerd.query_timeout,
+            Duration::from_secs(7)
+        );
+
+        let (config, errors) = translate_explicit(json!({ "cri_query_timeout": -1 }));
+
+        let errors = errors.expect("a negative timeout should record a translation error");
+        assert!(errors.to_string().contains("cri_query_timeout"));
+        assert_eq!(config.shared.environment.containerd.query_timeout, Duration::ZERO);
     }
 
     // Issue #1965: the Core Agent streams `dd_url` at its schema default even when the operator

--- a/lib/agent-data-plane-config/src/control.rs
+++ b/lib/agent-data-plane-config/src/control.rs
@@ -217,12 +217,6 @@ pub struct ControlIpc {
     /// Defaults to `134217728` (128 MiB).
     pub grpc_max_message_size: usize,
 
-    /// Timeout for establishing a connection to the container runtime interface.
-    pub cri_connection_timeout: i64,
-
-    /// Timeout for a single container runtime interface query.
-    pub cri_query_timeout: i64,
-
     /// Byte budget for the remote-agent IPC string interner. (not in Datadog Agent config schema)
     pub remote_agent_string_interner_size_bytes: usize,
 }

--- a/lib/agent-data-plane-config/src/shared.rs
+++ b/lib/agent-data-plane-config/src/shared.rs
@@ -55,7 +55,13 @@ pub struct SharedConfiguration {
 /// Host identity and container runtime discovery inputs.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct Environment {
-    /// Hostname override. A defaulted empty value is treated as absent.
+    /// Hostname reported for all emitted data.
+    ///
+    /// Only read in standalone mode, where it is reported verbatim. In connected mode the hostname comes from the
+    /// Datadog Agent and this value is ignored.
+    ///
+    /// Defaults to empty, and a defaulted or empty value is treated as absent. Operators running standalone must set
+    /// it explicitly; startup fails otherwise.
     pub hostname: ConfigValue<String>,
 
     /// containerd runtime discovery and client timeouts.

--- a/lib/agent-data-plane-config/src/shared.rs
+++ b/lib/agent-data-plane-config/src/shared.rs
@@ -55,7 +55,7 @@ pub struct SharedConfiguration {
 /// Host identity and container runtime discovery inputs.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct Environment {
-    /// Hostname override, with provenance to distinguish the schema default.
+    /// Hostname override. A defaulted empty value is treated as absent.
     pub hostname: ConfigValue<String>,
 
     /// containerd runtime discovery and client timeouts.
@@ -68,23 +68,23 @@ pub struct Environment {
 /// containerd runtime discovery and client timeouts.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct Containerd {
-    /// containerd gRPC socket, with provenance to control path detection.
+    /// containerd gRPC socket. A defaulted empty value enables path probing.
     pub socket_path: ConfigValue<PathBuf>,
 
-    /// Timeout for establishing a containerd gRPC connection.
+    /// Timeout for establishing a containerd gRPC connection. Defaults to 1 second; `0` never connects.
     pub connection_timeout: Duration,
 
-    /// Per-RPC timeout for containerd API calls.
+    /// Per-RPC timeout for containerd API calls. Defaults to 5 seconds; `0` fails every call.
     pub query_timeout: Duration,
 }
 
 /// Filesystem roots describing container workloads.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct ContainerRoots {
-    /// procfs root, with provenance for host-mount detection.
+    /// procfs root. Defaults to `/host/proc`, which is only used when set explicitly.
     pub proc_root: ConfigValue<PathBuf>,
 
-    /// cgroupfs root, with provenance for host-mount detection.
+    /// cgroupfs root. Defaults to `/host/sys/fs/cgroup/`, which is only used when set explicitly.
     pub cgroup_root: ConfigValue<PathBuf>,
 }
 

--- a/lib/agent-data-plane-config/src/shared.rs
+++ b/lib/agent-data-plane-config/src/shared.rs
@@ -37,6 +37,9 @@ pub struct SharedConfiguration {
     /// Secrets management, read by the Datadog intake forwarders.
     pub secrets: Secrets,
 
+    /// Host and container runtime discovery, read by the environment providers.
+    pub environment: Environment,
+
     /// Verbosity of the internal telemetry emitted about the runtime itself. (not in Datadog Agent
     /// config schema)
     pub metrics_level: String,
@@ -47,6 +50,42 @@ pub struct SharedConfiguration {
     /// DogStatsD context dumps. Defaults to unset when configuration does not provide a concrete
     /// `run_path`.
     pub run_path: Option<PathBuf>,
+}
+
+/// Host identity and container runtime discovery inputs.
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct Environment {
+    /// Hostname override, with provenance to distinguish the schema default.
+    pub hostname: ConfigValue<String>,
+
+    /// containerd runtime discovery and client timeouts.
+    pub containerd: Containerd,
+
+    /// Filesystem roots describing container workloads.
+    pub container_roots: ContainerRoots,
+}
+
+/// containerd runtime discovery and client timeouts.
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct Containerd {
+    /// containerd gRPC socket, with provenance to control path detection.
+    pub socket_path: ConfigValue<PathBuf>,
+
+    /// Timeout for establishing a containerd gRPC connection.
+    pub connection_timeout: Duration,
+
+    /// Per-RPC timeout for containerd API calls.
+    pub query_timeout: Duration,
+}
+
+/// Filesystem roots describing container workloads.
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct ContainerRoots {
+    /// procfs root, with provenance for host-mount detection.
+    pub proc_root: ConfigValue<PathBuf>,
+
+    /// cgroupfs root, with provenance for host-mount detection.
+    pub cgroup_root: ConfigValue<PathBuf>,
 }
 
 /// Inputs used to derive deployment-wide static tags.

--- a/lib/datadog-agent/config-overlay-model/src/smoke_test_support.rs
+++ b/lib/datadog-agent/config-overlay-model/src/smoke_test_support.rs
@@ -10,7 +10,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
 pub enum ConfigurationStruct {
     AggregateConfiguration,
-    ContainerdConfiguration,
     DatadogEventsConfiguration,
     DatadogLogsConfiguration,
     DatadogServiceChecksConfiguration,
@@ -40,7 +39,6 @@ impl ConfigurationStruct {
     pub fn as_smoke_test_const(&self) -> &'static str {
         match self {
             ConfigurationStruct::AggregateConfiguration => "AGGREGATE_CONFIGURATION",
-            ConfigurationStruct::ContainerdConfiguration => "CONTAINERD_CONFIGURATION",
             ConfigurationStruct::DatadogEventsConfiguration => "DATADOG_EVENTS_CONFIGURATION",
             ConfigurationStruct::DatadogLogsConfiguration => "DATADOG_LOGS_CONFIGURATION",
             ConfigurationStruct::DatadogServiceChecksConfiguration => "DATADOG_SERVICE_CHECKS_CONFIGURATION",

--- a/lib/datadog-agent/config-testing/src/config_registry/containerd.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/containerd.rs
@@ -52,7 +52,7 @@ crate::declare_annotations! {
     /// `cri_socket_path`-containerd/CRI socket path
     CRI_SOCKET_PATH = SalukiAnnotation {
         schema: &schema::CRI_SOCKET_PATH,
-        support_level: SupportLevel::Full,
+        support_level: SupportLevel::Partial,
         additional_yaml_paths: &[],
         env_var_override: None,
         used_by: &[structs::TYPED_CONFIG_SYSTEM],

--- a/lib/datadog-agent/config-testing/src/config_registry/containerd.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/containerd.rs
@@ -11,7 +11,7 @@ crate::declare_annotations! {
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
-        used_by: &[structs::CONTAINERD_CONFIGURATION],
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
         value_type_override: None,
         test_json: None,
         pipeline_affinity: PipelineAffinity::CrossCutting,
@@ -22,7 +22,40 @@ crate::declare_annotations! {
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
-        used_by: &[structs::CONTAINERD_CONFIGURATION],
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
+    /// `container_cgroup_root`-cgroupfs root for container metadata
+    CONTAINER_CGROUP_ROOT = SalukiAnnotation {
+        schema: &schema::CONTAINER_CGROUP_ROOT,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
+    /// `container_proc_root`-procfs root for container metadata
+    CONTAINER_PROC_ROOT = SalukiAnnotation {
+        schema: &schema::CONTAINER_PROC_ROOT,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
+    /// `cri_socket_path`-containerd/CRI socket path
+    CRI_SOCKET_PATH = SalukiAnnotation {
+        schema: &schema::CRI_SOCKET_PATH,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
         value_type_override: None,
         test_json: None,
         pipeline_affinity: PipelineAffinity::CrossCutting,

--- a/lib/datadog-agent/config-testing/src/config_registry/shared.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/shared.rs
@@ -104,6 +104,17 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::CrossCutting,
     };
+    /// `hostname`-Forced hostname for emitted data
+    HOSTNAME = SalukiAnnotation {
+        schema: &schema::HOSTNAME,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
     /// `kubernetes_kubelet_nodename`-Kubernetes node name for EKS Fargate static tags
     KUBERNETES_KUBELET_NODENAME = SalukiAnnotation {
         schema: &schema::KUBERNETES_KUBELET_NODENAME,

--- a/lib/datadog-agent/config-testing/src/smoke_test.rs
+++ b/lib/datadog-agent/config-testing/src/smoke_test.rs
@@ -313,12 +313,12 @@ mod tests {
 
     #[tokio::test]
     async fn flags_a_supported_key_that_never_changes_the_struct() {
-        // `CONTAINERD_CONFIGURATION` has registered (supported) keys. A factory that ignores the config
+        // `TYPED_CONFIG_SYSTEM` has registered (supported) keys. A factory that ignores the config
         // entirely means each supported key "produces the default struct", violating the supported-key
         // guarantee, which the harness must flag.
         let outcome = tokio::spawn(async {
             run_config_smoke_tests(
-                structs::CONTAINERD_CONFIGURATION,
+                structs::TYPED_CONFIG_SYSTEM,
                 &[],
                 json!({}),
                 |_cfg: GenericConfiguration| json!({}),

--- a/lib/datadog-agent/config-testing/src/smoke_test.rs
+++ b/lib/datadog-agent/config-testing/src/smoke_test.rs
@@ -313,9 +313,10 @@ mod tests {
 
     #[tokio::test]
     async fn flags_a_supported_key_that_never_changes_the_struct() {
-        // `TYPED_CONFIG_SYSTEM` has registered (supported) keys. A factory that ignores the config
-        // entirely means each supported key "produces the default struct", violating the supported-key
-        // guarantee, which the harness must flag.
+        // This case needs a consumer with registered (supported) keys. No struct-deserializing consumer has
+        // any left, so it uses the `TYPED_CONFIG_SYSTEM` sentinel. A factory that ignores the config entirely
+        // means each supported key "produces the default struct", violating the supported-key guarantee, which
+        // the harness must flag.
         let outcome = tokio::spawn(async {
             run_config_smoke_tests(
                 structs::TYPED_CONFIG_SYSTEM,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -568,10 +568,12 @@ inventory:
     documentation: |-
       ADP reads the cgroups hierarchy from this root. When the key is not set explicitly, ADP
       selects the root from detected features: the host-mapped `/host/sys/fs/cgroup` when a
-      host-mapped cgroupfs is detected, the legacy `/cgroup` root when the cgroups v1 `memory`
-      controller is found there, and `/sys/fs/cgroup` otherwise. That detection is independent of
-      the procfs mount. The core Agent reports its own detected root as a default value, which ADP
-      can't tell apart from a schema default, so ADP repeats the detection instead of consuming it.
+      host-mapped cgroupfs is detected, the legacy `/cgroup` root when ADP runs directly on a host
+      whose cgroups v1 `memory` controller is found there, and `/sys/fs/cgroup` otherwise. Like the
+      core Agent, ADP considers the legacy root only when it is not containerized. That detection is
+      independent of the procfs mount. The core Agent reports its own detected root as a default
+      value, which ADP can't tell apart from a schema default, so ADP repeats the detection instead
+      of consuming it.
     test_support:
       used_by: [TypedConfigSystem]
       additional_attributes:

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -561,12 +561,38 @@ inventory:
     description: "Fleet Automation config ID tag"
     documentation: "Core Agent uses this only on Agent HA telemetry metrics."
 
+  container_cgroup_root:
+    support: full
+    pipelines: [cross_cutting]
+    description: "cgroupfs root for container metadata"
+    documentation: |-
+      ADP reads the cgroups hierarchy from this root. When the key is not set explicitly, ADP
+      selects the root from detected features: the host-mapped `/host/sys/fs/cgroup` when a
+      host-mapped filesystem is detected, and `/sys/fs/cgroup` otherwise.
+    test_support:
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: containerd.rs
+
+  container_proc_root:
+    support: full
+    pipelines: [cross_cutting]
+    description: "procfs root for container metadata"
+    documentation: |-
+      ADP inspects container processes under this root. When the key is not set explicitly, ADP
+      selects the root from detected features: the host-mapped `/host/proc` when a host-mapped
+      procfs is detected, and `/proc` otherwise.
+    test_support:
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: containerd.rs
+
   cri_connection_timeout:
     support: full
     pipelines: [cross_cutting]
     description: "CRI container runtime connection timeout (s)"
     test_support:
-      used_by: [ContainerdConfiguration]
+      used_by: [TypedConfigSystem]
       additional_attributes:
         config_registry_filename: containerd.rs
 
@@ -575,7 +601,20 @@ inventory:
     pipelines: [cross_cutting]
     description: "CRI container runtime query timeout (s)"
     test_support:
-      used_by: [ContainerdConfiguration]
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: containerd.rs
+
+  cri_socket_path:
+    support: full
+    pipelines: [cross_cutting]
+    description: "containerd/CRI socket path"
+    documentation: |-
+      Setting this path enables the containerd integration against that socket. When the key is not
+      set explicitly, ADP probes the well-known containerd socket paths instead. An explicitly empty
+      path leaves containerd undetected.
+    test_support:
+      used_by: [TypedConfigSystem]
       additional_attributes:
         config_registry_filename: containerd.rs
 
@@ -1882,6 +1921,18 @@ inventory:
       test_json: '["0.95"]'
       additional_attributes:
         config_registry_filename: aggregate.rs
+
+  hostname:
+    support: full
+    pipelines: [cross_cutting]
+    description: "Forced hostname for emitted data"
+    documentation: |-
+      ADP uses this only in standalone mode, where the fixed host provider requires a configured
+      hostname. In connected mode the hostname comes from the Datadog Agent.
+    test_support:
+      used_by: [TypedConfigSystem]
+      additional_attributes:
+        config_registry_filename: shared.rs
 
   ipc_cert_file_path:
     support: full
@@ -4175,7 +4226,6 @@ excluded:
   config_files_discovery.heartbeat_jitter: "2026-09-08 ADP does not currently discover or report application configuration files."
   config_files_discovery.startup_jitter: "2026-09-08 ADP does not currently discover or report application configuration files."
   config_providers: "ignored in initial audit 2026-04-23"
-  container_cgroup_root: "ignored in second bulk edit 2026-05-06"
   container_env_as_tags: "ignored in initial audit 2026-04-23"
   container_exclude: "ignored in initial audit 2026-04-23"
   container_exclude_logs: "ignored in initial audit 2026-04-23"
@@ -4231,13 +4281,11 @@ excluded:
   container_lifecycle.use_v2_api: "ignored in initial audit 2026-04-23"
   container_lifecycle.zstd_compression_level: "ignored in initial audit 2026-04-23"
   container_pid_mapper: "ignored in initial audit 2026-04-23"
-  container_proc_root: "ignored in second bulk edit 2026-05-06"
   containerd_exclude_namespaces: "ignored in initial audit 2026-04-23"
   containerd_namespace: "ignored in initial audit 2026-04-23"
   containerd_namespaces: "ignored in initial audit 2026-04-23"
   convert_dd_site_fqdn.enabled: "ignored in initial audit 2026-04-23"
   core_agent.enabled: "ignored in initial audit 2026-04-23"
-  cri_socket_path: "ignored in second bulk edit 2026-05-06"
   csi.driver: "ignored in initial audit 2026-04-23"
   csi.enabled: "ignored in initial audit 2026-04-23"
   data_observability.forwarder.additional_endpoints: "ignored in initial audit 2026-04-23"
@@ -4530,7 +4578,6 @@ excluded:
   health_platform.persist_on_kubernetes: "ignored in initial audit 2026-04-23"
   health_port: "ignored in initial audit 2026-04-23"
   host_aliases: "ignored in initial audit 2026-04-23"
-  hostname: "ignored in second bulk edit 2026-05-06"
   hostname_drift_initial_delay: "ignored in initial audit 2026-04-23"
   hostname_drift_recurring_interval: "ignored in initial audit 2026-04-23"
   hostname_file: "ignored in initial audit 2026-04-23"

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -568,7 +568,8 @@ inventory:
     documentation: |-
       ADP reads the cgroups hierarchy from this root. When the key is not set explicitly, ADP
       selects the root from detected features: the host-mapped `/host/sys/fs/cgroup` when a
-      host-mapped filesystem is detected, and `/sys/fs/cgroup` otherwise.
+      host-mapped cgroupfs is detected, and `/sys/fs/cgroup` otherwise. That detection is
+      independent of the procfs mount.
     test_support:
       used_by: [TypedConfigSystem]
       additional_attributes:
@@ -606,13 +607,23 @@ inventory:
         config_registry_filename: containerd.rs
 
   cri_socket_path:
-    support: full
+    support: partial
     pipelines: [cross_cutting]
     description: "containerd/CRI socket path"
     documentation: |-
-      Setting this path enables the containerd integration against that socket. When the key is not
-      set explicitly, ADP probes the well-known containerd socket paths instead. An explicitly empty
-      path leaves containerd undetected.
+      The core Agent uses this key to enable both its CRI and containerd integrations, classifying
+      the socket by path: a path containing `containerd` selects containerd, a path containing
+      `crio` selects CRI-O, and any other reachable CRI socket is treated as a nonstandard CRI
+      runtime. When the key is unset, the core Agent probes well-known containerd and CRI-O paths.
+
+      ADP implements the containerd runtime only. Setting this path enables the containerd
+      integration against that socket, but only when the path contains `containerd`. A CRI-O or
+      otherwise nonstandard CRI socket path leaves containerd undetected, and ADP starts no
+      container runtime metadata collector for it. When the key is not set explicitly, ADP probes
+      the well-known containerd socket paths only. An explicitly empty path leaves containerd
+      undetected.
+
+      Container ID resolution through cgroups is independent of this key and is unaffected.
     test_support:
       used_by: [TypedConfigSystem]
       additional_attributes:

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -568,8 +568,10 @@ inventory:
     documentation: |-
       ADP reads the cgroups hierarchy from this root. When the key is not set explicitly, ADP
       selects the root from detected features: the host-mapped `/host/sys/fs/cgroup` when a
-      host-mapped cgroupfs is detected, and `/sys/fs/cgroup` otherwise. That detection is
-      independent of the procfs mount.
+      host-mapped cgroupfs is detected, the legacy `/cgroup` root when the cgroups v1 `memory`
+      controller is found there, and `/sys/fs/cgroup` otherwise. That detection is independent of
+      the procfs mount. The core Agent reports its own detected root as a default value, which ADP
+      can't tell apart from a schema default, so ADP repeats the detection instead of consuming it.
     test_support:
       used_by: [TypedConfigSystem]
       additional_attributes:

--- a/lib/datadog-agent/config/src/classifier/mod.rs
+++ b/lib/datadog-agent/config/src/classifier/mod.rs
@@ -36,8 +36,6 @@ pub use classifier::{Classification, ConfigClassifier};
 ///
 /// Used as values in annotation `used_by` fields to declare which consumers incorporate a key.
 pub mod structs {
-    /// Identifier for `ContainerdConfiguration`.
-    pub const CONTAINERD_CONFIGURATION: &str = "ContainerdConfiguration";
     /// Identifier for `AggregateConfiguration`.
     pub const AGGREGATE_CONFIGURATION: &str = "AggregateConfiguration";
     /// Identifier for `DogStatsDMapperConfiguration`.

--- a/lib/datadog-agent/config/src/generated/datadog_configuration.rs
+++ b/lib/datadog-agent/config/src/generated/datadog_configuration.rs
@@ -89,6 +89,14 @@ pub struct DatadogConfiguration {
     #[serde(deserialize_with = "crate::cast_de::deserialize_i64")]
     pub cmd_port: i64,
 
+    #[serde(default = "defaults::datadog_configuration_container_cgroup_root")]
+    #[serde(deserialize_with = "crate::cast_de::deserialize_string")]
+    pub container_cgroup_root: String,
+
+    #[serde(default = "defaults::datadog_configuration_container_proc_root")]
+    #[serde(deserialize_with = "crate::cast_de::deserialize_string")]
+    pub container_proc_root: String,
+
     #[serde(default = "defaults::default_u64::<i64, 1>")]
     #[serde(deserialize_with = "crate::cast_de::deserialize_i64")]
     pub cri_connection_timeout: i64,
@@ -96,6 +104,10 @@ pub struct DatadogConfiguration {
     #[serde(default = "defaults::default_u64::<i64, 5>")]
     #[serde(deserialize_with = "crate::cast_de::deserialize_i64")]
     pub cri_query_timeout: i64,
+
+    #[serde(default)]
+    #[serde(deserialize_with = "crate::cast_de::deserialize_string")]
+    pub cri_socket_path: String,
 
     #[serde(default)]
     pub data_plane: DataPlane,
@@ -366,6 +378,10 @@ pub struct DatadogConfiguration {
 
     #[serde(default)]
     #[serde(deserialize_with = "crate::cast_de::deserialize_string")]
+    pub hostname: String,
+
+    #[serde(default)]
+    #[serde(deserialize_with = "crate::cast_de::deserialize_string")]
     pub ipc_cert_file_path: String,
 
     #[serde(default)]
@@ -583,8 +599,11 @@ impl Default for DatadogConfiguration {
             cluster_agent: Default::default(),
             cluster_name: Default::default(),
             cmd_port: defaults::default_u64::<i64, 5001>(),
+            container_cgroup_root: defaults::datadog_configuration_container_cgroup_root(),
+            container_proc_root: defaults::datadog_configuration_container_proc_root(),
             cri_connection_timeout: defaults::default_u64::<i64, 1>(),
             cri_query_timeout: defaults::default_u64::<i64, 5>(),
+            cri_socket_path: Default::default(),
             data_plane: Default::default(),
             dd_url: defaults::datadog_configuration_dd_url(),
             disable_file_logging: Default::default(),
@@ -656,6 +675,7 @@ impl Default for DatadogConfiguration {
             histogram_copy_to_distribution: Default::default(),
             histogram_copy_to_distribution_prefix: Default::default(),
             histogram_percentiles: defaults::datadog_configuration_histogram_percentiles(),
+            hostname: Default::default(),
             ipc_cert_file_path: Default::default(),
             kubernetes_kubelet_nodename: Default::default(),
             log_file_max_rolls: defaults::default_u64::<i64, 1>(),
@@ -2082,6 +2102,12 @@ pub mod defaults {
         <T as ::std::convert::TryFrom<u64>>::Error: ::std::fmt::Debug,
     {
         T::try_from(V).unwrap()
+    }
+    pub(super) fn datadog_configuration_container_cgroup_root() -> String {
+        "/host/sys/fs/cgroup/".to_string()
+    }
+    pub(super) fn datadog_configuration_container_proc_root() -> String {
+        "/host/proc".to_string()
     }
     pub(super) fn datadog_configuration_dd_url() -> String {
         "https://app.datadoghq.com".to_string()

--- a/lib/datadog-agent/config/src/generated/env_keys.rs
+++ b/lib/datadog-agent/config/src/generated/env_keys.rs
@@ -233,6 +233,16 @@ pub static DATADOG_ENV_KEYS: &[EnvKey] = &[
         decode: EnvDecode::Integer,
     },
     EnvKey {
+        env_vars: &["DD_CONTAINER_CGROUP_ROOT"],
+        path: &["container_cgroup_root"],
+        decode: EnvDecode::RawString,
+    },
+    EnvKey {
+        env_vars: &["DD_CONTAINER_PROC_ROOT"],
+        path: &["container_proc_root"],
+        decode: EnvDecode::RawString,
+    },
+    EnvKey {
         env_vars: &["DD_CRI_CONNECTION_TIMEOUT"],
         path: &["cri_connection_timeout"],
         decode: EnvDecode::Integer,
@@ -241,6 +251,11 @@ pub static DATADOG_ENV_KEYS: &[EnvKey] = &[
         env_vars: &["DD_CRI_QUERY_TIMEOUT"],
         path: &["cri_query_timeout"],
         decode: EnvDecode::Integer,
+    },
+    EnvKey {
+        env_vars: &["DD_CRI_SOCKET_PATH"],
+        path: &["cri_socket_path"],
+        decode: EnvDecode::RawString,
     },
     EnvKey {
         env_vars: &["DD_DATA_PLANE_API_LISTEN_ADDRESS"],
@@ -664,6 +679,11 @@ pub static DATADOG_ENV_KEYS: &[EnvKey] = &[
         env_vars: &["DD_HISTOGRAM_PERCENTILES"],
         path: &["histogram_percentiles"],
         decode: EnvDecode::StringList,
+    },
+    EnvKey {
+        env_vars: &["DD_HOSTNAME"],
+        path: &["hostname"],
+        decode: EnvDecode::RawString,
     },
     EnvKey {
         env_vars: &["DD_IPC_CERT_FILE_PATH"],

--- a/lib/datadog-agent/config/src/generated/witness.rs
+++ b/lib/datadog-agent/config/src/generated/witness.rs
@@ -58,8 +58,11 @@ pub trait DatadogConfigWitness {
     fn consume_cluster_agent_url(&mut self, value: String);
     fn consume_cluster_name(&mut self, value: String);
     fn consume_cmd_port(&mut self, value: i64);
+    fn consume_container_cgroup_root(&mut self, value: String);
+    fn consume_container_proc_root(&mut self, value: String);
     fn consume_cri_connection_timeout(&mut self, value: i64);
     fn consume_cri_query_timeout(&mut self, value: i64);
+    fn consume_cri_socket_path(&mut self, value: String);
     fn consume_data_plane_api_listen_address(&mut self, value: String);
     fn consume_data_plane_dogstatsd_aggregator_tag_filter_cache_capacity(&mut self, value: i64);
     fn consume_data_plane_dogstatsd_enabled(&mut self, value: bool);
@@ -143,6 +146,7 @@ pub trait DatadogConfigWitness {
     fn consume_histogram_copy_to_distribution(&mut self, value: bool);
     fn consume_histogram_copy_to_distribution_prefix(&mut self, value: String);
     fn consume_histogram_percentiles(&mut self, value: Vec<String>);
+    fn consume_hostname(&mut self, value: String);
     fn consume_ipc_cert_file_path(&mut self, value: String);
     fn consume_kubernetes_kubelet_nodename(&mut self, value: String);
     fn consume_log_file_max_rolls(&mut self, value: i64);
@@ -340,8 +344,11 @@ pub fn drive(config: &DatadogConfiguration, consumer: &mut impl DatadogConfigWit
     consumer.consume_cluster_agent_url(config.cluster_agent.url.clone());
     consumer.consume_cluster_name(config.cluster_name.clone());
     consumer.consume_cmd_port(config.cmd_port.clone());
+    consumer.consume_container_cgroup_root(config.container_cgroup_root.clone());
+    consumer.consume_container_proc_root(config.container_proc_root.clone());
     consumer.consume_cri_connection_timeout(config.cri_connection_timeout.clone());
     consumer.consume_cri_query_timeout(config.cri_query_timeout.clone());
+    consumer.consume_cri_socket_path(config.cri_socket_path.clone());
     consumer.consume_data_plane_api_listen_address(config.data_plane.api_listen_address.clone());
     consumer.consume_data_plane_dogstatsd_aggregator_tag_filter_cache_capacity(
         config.data_plane.dogstatsd.aggregator_tag_filter_cache_capacity.clone(),
@@ -435,6 +442,7 @@ pub fn drive(config: &DatadogConfiguration, consumer: &mut impl DatadogConfigWit
     consumer.consume_histogram_copy_to_distribution(config.histogram_copy_to_distribution.clone());
     consumer.consume_histogram_copy_to_distribution_prefix(config.histogram_copy_to_distribution_prefix.clone());
     consumer.consume_histogram_percentiles(config.histogram_percentiles.clone());
+    consumer.consume_hostname(config.hostname.clone());
     consumer.consume_ipc_cert_file_path(config.ipc_cert_file_path.clone());
     consumer.consume_kubernetes_kubelet_nodename(config.kubernetes_kubelet_nodename.clone());
     consumer.consume_log_file_max_rolls(config.log_file_max_rolls.clone());

--- a/lib/saluki-env/Cargo.toml
+++ b/lib/saluki-env/Cargo.toml
@@ -25,7 +25,6 @@ hyper-util = { workspace = true }
 prost = { workspace = true }
 regex = { workspace = true, features = ["std", "perf"] }
 saluki-common = { workspace = true }
-saluki-config = { workspace = true }
 saluki-context = { workspace = true }
 saluki-core = { workspace = true }
 saluki-error = { workspace = true }
@@ -43,5 +42,4 @@ twox-hash = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
-saluki-config = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }

--- a/lib/saluki-env/src/features/containerd.rs
+++ b/lib/saluki-env/src/features/containerd.rs
@@ -15,10 +15,13 @@ const DEFAULT_CONTAINERD_SOCKET_PATH_LINUX: &str = "/var/run/containerd/containe
 pub struct ContainerdDetector;
 
 impl ContainerdDetector {
-    /// Returns a non-empty containerd socket override or probes well-known Unix sockets.
+    /// Tries to detect the containerd gRPC socket path.
+    ///
+    /// If `socket_path` is given, that path is used. Otherwise, well-known paths are probed for a Unix domain socket.
+    /// Either way, `None` is returned unless the resulting path refers to containerd.
     #[cfg(unix)]
-    pub fn detect_grpc_socket_path(configured_socket_path: Option<PathBuf>) -> Option<PathBuf> {
-        let detected_socket_path = match configured_socket_path {
+    pub fn detect_grpc_socket_path(socket_path: Option<PathBuf>) -> Option<PathBuf> {
+        let detected_socket_path = match socket_path {
             Some(socket_path) => Some(socket_path),
             None => {
                 if is_running_inside_docker() {

--- a/lib/saluki-env/src/features/containerd.rs
+++ b/lib/saluki-env/src/features/containerd.rs
@@ -1,8 +1,7 @@
 use std::path::PathBuf;
 
-use saluki_config::GenericConfiguration;
 #[cfg(unix)]
-use tracing::{debug, error};
+use tracing::debug;
 
 #[cfg(unix)]
 use super::{
@@ -18,30 +17,24 @@ pub struct ContainerdDetector;
 impl ContainerdDetector {
     /// Tries to detect the containerd gRPC socket path.
     ///
-    /// The socket path can be specified in the configuration, or if it's not present, default paths will be checked for
-    /// the presence of the socket path.
+    /// When a socket path is configured, it is used as-is. Otherwise, default paths are checked for the presence of the
+    /// socket path.
     ///
     /// If the socket path is configured or detected, and is a valid Unix domain socket, `Some` is returned with the
     /// socket path. Otherwise, `None` is returned.
     #[cfg(unix)]
-    pub fn detect_grpc_socket_path(config: &GenericConfiguration) -> Option<PathBuf> {
-        // Try and read the socket path from either the configuration, or if it's not present there, from the possible
-        // default paths we would expect it to be listening at.
-        let detected_socket_path = match config.try_get_typed::<PathBuf>("cri_socket_path") {
-            Ok(Some(cri_socket_path)) => Some(cri_socket_path),
-            Ok(None) => {
+    pub fn detect_grpc_socket_path(configured_socket_path: Option<PathBuf>) -> Option<PathBuf> {
+        let detected_socket_path = match configured_socket_path {
+            Some(socket_path) => Some(socket_path),
+            None => {
                 if is_running_inside_docker() {
                     None
                 } else {
-                    debug!("Containerd socket path (`cri_socket_path`) not present in configuration. Trying to detect at default paths...");
+                    debug!("No containerd socket path configured. Trying to detect at default paths...");
 
                     let default_socket_paths = with_host_mount_prefixes([DEFAULT_CONTAINERD_SOCKET_PATH_LINUX]);
                     find_first_available_unix_socket(default_socket_paths)
                 }
-            }
-            Err(e) => {
-                error!(error = %e, "Value for `cri_socket_path` could not be parsed as a valid path.");
-                None
             }
         }?;
 
@@ -56,7 +49,7 @@ impl ContainerdDetector {
 
     /// Returns `None` because containerd Unix socket detection isn't supported on this platform.
     #[cfg(not(unix))]
-    pub fn detect_grpc_socket_path(_: &GenericConfiguration) -> Option<PathBuf> {
+    pub fn detect_grpc_socket_path(_: Option<PathBuf>) -> Option<PathBuf> {
         None
     }
 }

--- a/lib/saluki-env/src/features/containerd.rs
+++ b/lib/saluki-env/src/features/containerd.rs
@@ -15,13 +15,7 @@ const DEFAULT_CONTAINERD_SOCKET_PATH_LINUX: &str = "/var/run/containerd/containe
 pub struct ContainerdDetector;
 
 impl ContainerdDetector {
-    /// Tries to detect the containerd gRPC socket path.
-    ///
-    /// When a socket path is configured, it is used as-is. Otherwise, default paths are checked for the presence of the
-    /// socket path.
-    ///
-    /// If the socket path is configured or detected, and is a valid Unix domain socket, `Some` is returned with the
-    /// socket path. Otherwise, `None` is returned.
+    /// Returns a non-empty containerd socket override or probes well-known Unix sockets.
     #[cfg(unix)]
     pub fn detect_grpc_socket_path(configured_socket_path: Option<PathBuf>) -> Option<PathBuf> {
         let detected_socket_path = match configured_socket_path {
@@ -51,5 +45,34 @@ impl ContainerdDetector {
     #[cfg(not(unix))]
     pub fn detect_grpc_socket_path(_: Option<PathBuf>) -> Option<PathBuf> {
         None
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::ContainerdDetector;
+
+    #[test]
+    fn a_configured_socket_path_is_used_without_probing() {
+        let configured = PathBuf::from("/custom/run/containerd/containerd.sock");
+
+        assert_eq!(
+            ContainerdDetector::detect_grpc_socket_path(Some(configured.clone())),
+            Some(configured)
+        );
+    }
+
+    #[test]
+    fn a_configured_empty_socket_path_leaves_containerd_undetected() {
+        assert_eq!(ContainerdDetector::detect_grpc_socket_path(Some(PathBuf::new())), None);
+    }
+
+    #[test]
+    fn a_configured_socket_path_for_another_runtime_leaves_containerd_undetected() {
+        let configured = PathBuf::from("/var/run/crio/crio.sock");
+
+        assert_eq!(ContainerdDetector::detect_grpc_socket_path(Some(configured)), None);
     }
 }

--- a/lib/saluki-env/src/features/detector.rs
+++ b/lib/saluki-env/src/features/detector.rs
@@ -1,4 +1,5 @@
-use saluki_config::GenericConfiguration;
+use std::path::PathBuf;
+
 use tracing::info;
 
 use super::{has_host_mapped_cgroupfs, has_host_mapped_procfs, ContainerdDetector, Feature};
@@ -18,16 +19,16 @@ pub struct FeatureDetector {
 }
 
 impl FeatureDetector {
-    /// Creates a new `FeatureDetector` that checks for all possible features.
-    pub fn automatic(config: &GenericConfiguration) -> Self {
-        Self::for_feature(config, Feature::all_bits())
+    /// Creates a detector for all features and an optional containerd socket override.
+    pub fn automatic(configured_containerd_socket_path: Option<PathBuf>) -> Self {
+        Self::for_feature(configured_containerd_socket_path, Feature::all_bits())
     }
 
     /// Creates a new `FeatureDetector` that checks for the given features.
     ///
     /// Multiple features can be checked for by combining the feature variants in a bitwise OR fashion.
-    pub fn for_feature(config: &GenericConfiguration, feature_mask: Feature) -> Self {
-        let detected_features = Self::detect_features(config, feature_mask);
+    pub fn for_feature(configured_containerd_socket_path: Option<PathBuf>, feature_mask: Feature) -> Self {
+        let detected_features = Self::detect_features(configured_containerd_socket_path, feature_mask);
 
         Self { detected_features }
     }
@@ -37,7 +38,7 @@ impl FeatureDetector {
         self.detected_features.contains(feature)
     }
 
-    fn detect_features(config: &GenericConfiguration, feature_mask: Feature) -> Feature {
+    fn detect_features(configured_containerd_socket_path: Option<PathBuf>, feature_mask: Feature) -> Feature {
         let mut detected_features = Feature::none();
 
         if feature_mask.contains(Feature::HostMappedProcfs) && has_host_mapped_procfs() {
@@ -50,7 +51,9 @@ impl FeatureDetector {
             detected_features |= Feature::HostMappedCgroupfs;
         }
 
-        if feature_mask.contains(Feature::Containerd) && ContainerdDetector::detect_grpc_socket_path(config).is_some() {
+        if feature_mask.contains(Feature::Containerd)
+            && ContainerdDetector::detect_grpc_socket_path(configured_containerd_socket_path).is_some()
+        {
             info!("Detected presence of containerd.");
             detected_features |= Feature::Containerd;
         }

--- a/lib/saluki-env/src/features/detector.rs
+++ b/lib/saluki-env/src/features/detector.rs
@@ -19,16 +19,22 @@ pub struct FeatureDetector {
 }
 
 impl FeatureDetector {
-    /// Detects all features, probing containerd when no socket is configured.
-    pub fn automatic(configured_containerd_socket_path: Option<PathBuf>) -> Self {
-        Self::for_feature(configured_containerd_socket_path, Feature::all_bits())
+    /// Creates a new `FeatureDetector` that checks for all possible features.
+    ///
+    /// If `containerd_socket_path` is given, that path is used for containerd detection. Otherwise, well-known paths
+    /// are probed.
+    pub fn automatic(containerd_socket_path: Option<PathBuf>) -> Self {
+        Self::for_feature(containerd_socket_path, Feature::all_bits())
     }
 
     /// Creates a new `FeatureDetector` that checks for the given features.
     ///
     /// Multiple features can be checked for by combining the feature variants in a bitwise OR fashion.
-    pub fn for_feature(configured_containerd_socket_path: Option<PathBuf>, feature_mask: Feature) -> Self {
-        let detected_features = Self::detect_features(configured_containerd_socket_path, feature_mask);
+    ///
+    /// If `containerd_socket_path` is given, that path is used for containerd detection. Otherwise, well-known paths
+    /// are probed.
+    pub fn for_feature(containerd_socket_path: Option<PathBuf>, feature_mask: Feature) -> Self {
+        let detected_features = Self::detect_features(containerd_socket_path, feature_mask);
 
         Self { detected_features }
     }
@@ -38,7 +44,7 @@ impl FeatureDetector {
         self.detected_features.contains(feature)
     }
 
-    fn detect_features(configured_containerd_socket_path: Option<PathBuf>, feature_mask: Feature) -> Feature {
+    fn detect_features(containerd_socket_path: Option<PathBuf>, feature_mask: Feature) -> Feature {
         let mut detected_features = Feature::none();
 
         if feature_mask.contains(Feature::HostMappedProcfs) && has_host_mapped_procfs() {
@@ -52,7 +58,7 @@ impl FeatureDetector {
         }
 
         if feature_mask.contains(Feature::Containerd)
-            && ContainerdDetector::detect_grpc_socket_path(configured_containerd_socket_path).is_some()
+            && ContainerdDetector::detect_grpc_socket_path(containerd_socket_path).is_some()
         {
             info!("Detected presence of containerd.");
             detected_features |= Feature::Containerd;

--- a/lib/saluki-env/src/features/detector.rs
+++ b/lib/saluki-env/src/features/detector.rs
@@ -19,7 +19,7 @@ pub struct FeatureDetector {
 }
 
 impl FeatureDetector {
-    /// Creates a detector for all features and an optional containerd socket override.
+    /// Detects all features, probing containerd when no socket is configured.
     pub fn automatic(configured_containerd_socket_path: Option<PathBuf>) -> Self {
         Self::for_feature(configured_containerd_socket_path, Feature::all_bits())
     }

--- a/lib/saluki-env/src/features/detector.rs
+++ b/lib/saluki-env/src/features/detector.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use tracing::info;
 
-use super::{has_host_mapped_cgroupfs, has_host_mapped_procfs, ContainerdDetector, Feature};
+use super::{has_host_mapped_cgroupfs, has_host_mapped_procfs, has_legacy_cgroupfs_root, ContainerdDetector, Feature};
 
 /// Detects workload features.
 ///
@@ -55,6 +55,11 @@ impl FeatureDetector {
         if feature_mask.contains(Feature::HostMappedCgroupfs) && has_host_mapped_cgroupfs() {
             info!("Detected presence of host-mapped cgroupfs.");
             detected_features |= Feature::HostMappedCgroupfs;
+        }
+
+        if feature_mask.contains(Feature::LegacyCgroupfsRoot) && has_legacy_cgroupfs_root() {
+            info!("Detected presence of legacy cgroupfs root.");
+            detected_features |= Feature::LegacyCgroupfsRoot;
         }
 
         if feature_mask.contains(Feature::Containerd)

--- a/lib/saluki-env/src/features/mod.rs
+++ b/lib/saluki-env/src/features/mod.rs
@@ -44,8 +44,9 @@ pub enum Feature {
 
     /// Legacy cgroupfs root.
     ///
-    /// This implies that the cgroups v1 hierarchy sits at `/cgroup` rather than `/sys/fs/cgroup`, which is the layout
-    /// used by older Amazon Linux hosts.
+    /// This implies that we're running directly on a host whose cgroups v1 hierarchy sits at `/cgroup` rather than
+    /// `/sys/fs/cgroup`, which is the layout used by older Amazon Linux hosts. This is never detected in a
+    /// containerized environment, where the host's hierarchy is reached through a host-mapped path instead.
     LegacyCgroupfsRoot,
 
     /// Containerd.
@@ -231,6 +232,14 @@ fn has_host_mapped_cgroupfs() -> bool {
 }
 
 fn has_legacy_cgroupfs_root() -> bool {
+    // This layout only describes a host we're running on directly. The Datadog Agent probes for it only when it isn't
+    // containerized, and otherwise picks between the host-mapped and local cgroupfs roots without considering
+    // `/cgroup` at all. A `/cgroup` path inside our own container is not the host's hierarchy, so treating it as one
+    // would point the reader at a root with no cgroups under it.
+    if is_running_inside_container() {
+        return false;
+    }
+
     // The Datadog Agent looks for the `memory` controller's `memory.stat` rather than the `/cgroup` directory itself,
     // since the directory can exist while empty. Like the Agent, we count a stat that fails for any reason other than
     // the file being absent: the layout is there, we just can't read the marker.

--- a/lib/saluki-env/src/features/mod.rs
+++ b/lib/saluki-env/src/features/mod.rs
@@ -19,6 +19,7 @@ mod detector;
 pub use self::detector::FeatureDetector;
 
 const CONTAINER_HOST_MOUNT_PATH: &str = "/host";
+const LEGACY_CGROUPFS_ROOT_MARKER: &str = "/cgroup/memory/memory.stat";
 #[cfg(unix)]
 const SOCKET_CHECK_CONNECT_TIMEOUT: Duration = Duration::from_millis(500);
 
@@ -40,6 +41,12 @@ pub enum Feature {
     /// This implies that we're in a containerized environment and the host's cgroupfs (`/sys/fs/cgroup`) has been
     /// mapped into the container using a `/host` prefix, resulting in a `/host/sys/fs/cgroup` path.
     HostMappedCgroupfs,
+
+    /// Legacy cgroupfs root.
+    ///
+    /// This implies that the cgroups v1 hierarchy sits at `/cgroup` rather than `/sys/fs/cgroup`, which is the layout
+    /// used by older Amazon Linux hosts.
+    LegacyCgroupfsRoot,
 
     /// Containerd.
     Containerd,
@@ -221,4 +228,14 @@ fn has_host_mapped_procfs() -> bool {
 fn has_host_mapped_cgroupfs() -> bool {
     let path = PathBuf::from(CONTAINER_HOST_MOUNT_PATH).join("sys/fs/cgroup");
     is_running_inside_container() && file_exists(&path)
+}
+
+fn has_legacy_cgroupfs_root() -> bool {
+    // The Datadog Agent looks for the `memory` controller's `memory.stat` rather than the `/cgroup` directory itself,
+    // since the directory can exist while empty. Like the Agent, we count a stat that fails for any reason other than
+    // the file being absent: the layout is there, we just can't read the marker.
+    match std::fs::metadata(LEGACY_CGROUPFS_ROOT_MARKER) {
+        Ok(_) => true,
+        Err(e) => e.kind() != std::io::ErrorKind::NotFound,
+    }
 }

--- a/lib/saluki-env/src/host/providers/fixed.rs
+++ b/lib/saluki-env/src/host/providers/fixed.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use saluki_config::GenericConfiguration;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_error::GenericError;
 
@@ -12,17 +11,9 @@ pub struct FixedHostProvider {
 }
 
 impl FixedHostProvider {
-    /// Creates a new `FixedHostProvider` from the given configuration.
-    ///
-    /// Depends on the hostname existing in the given configuration under the `hostname` key.
-    ///
-    /// # Errors
-    ///
-    /// If the hostname isn't specified in the configuration, an error is returned.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let hostname = config.get_typed::<String>("hostname")?;
-
-        Ok(Self { hostname })
+    /// Creates a new `FixedHostProvider` that reports the given hostname.
+    pub fn new(hostname: String) -> Self {
+        Self { hostname }
     }
 }
 

--- a/lib/saluki-env/src/workload/collectors/cgroups.rs
+++ b/lib/saluki-env/src/workload/collectors/cgroups.rs
@@ -5,7 +5,6 @@ use saluki_common::{
     collections::{FastHashMap, FastHashSet},
     sync::shutdown::ShutdownHandle,
 };
-use saluki_config::GenericConfiguration;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::health::Health;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
@@ -15,13 +14,10 @@ use tokio::{pin, select, sync::mpsc};
 use tracing::{debug, warn};
 
 use super::MetadataCollector;
-use crate::{
-    features::FeatureDetector,
-    workload::{
-        entity::EntityId,
-        helpers::cgroups::{CgroupsConfiguration, CgroupsReader},
-        metadata::MetadataOperation,
-    },
+use crate::workload::{
+    entity::EntityId,
+    helpers::cgroups::{CgroupsConfiguration, CgroupsReader},
+    metadata::MetadataOperation,
 };
 
 #[static_metrics(prefix = cgroups_metadata_collector)]
@@ -55,16 +51,15 @@ pub struct CgroupsMetadataCollector {
 }
 
 impl CgroupsMetadataCollector {
-    /// Creates a new `CgroupsMetadataCollector` from the given configuration.
+    /// Creates a new `CgroupsMetadataCollector` from the given cgroups configuration.
     ///
     /// # Errors
     ///
     /// If a valid cgroups hierarchy can not be located at the configured path, an error will be returned.
-    pub async fn from_configuration(
-        config: &GenericConfiguration, feature_detector: FeatureDetector, health: Health, interner: GenericMapInterner,
+    pub async fn new(
+        cgroups_config: &CgroupsConfiguration, health: Health, interner: GenericMapInterner,
     ) -> Result<Self, GenericError> {
-        let cgroups_config = CgroupsConfiguration::from_configuration(config, feature_detector)?;
-        let reader = match CgroupsReader::try_from_config(&cgroups_config, interner)? {
+        let reader = match CgroupsReader::try_from_config(cgroups_config, interner)? {
             Some(reader) => reader,
             None => {
                 return Err(generic_error!("Failed to detect any cgroups v1/v2 hierarchy. "));

--- a/lib/saluki-env/src/workload/collectors/containerd.rs
+++ b/lib/saluki-env/src/workload/collectors/containerd.rs
@@ -1,10 +1,9 @@
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
 
 use async_stream::stream;
 use async_trait::async_trait;
 use containerd_protos::services::namespaces::v1::Namespace;
 use futures::{stream::select_all, Stream, StreamExt as _};
-use saluki_config::GenericConfiguration;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::health::Health;
 use saluki_error::GenericError;
@@ -18,7 +17,7 @@ use crate::workload::{
     entity::EntityId,
     helpers::containerd::{
         events::{ContainerdEvent, ContainerdTopic},
-        ContainerdClient,
+        ContainerdClient, ContainerdConfiguration,
     },
     metadata::MetadataOperation,
 };
@@ -43,16 +42,17 @@ pub struct ContainerdMetadataCollector {
 }
 
 impl ContainerdMetadataCollector {
-    /// Creates a new `ContainerdMetadataCollector` from the given configuration.
+    /// Creates a new `ContainerdMetadataCollector` from the given containerd configuration.
     ///
     /// # Errors
     ///
     /// If the containerd gRPC client can't be created, or listing the namespaces in the containerd runtime fails, an
     /// error will be returned.
-    pub async fn from_configuration(
-        config: &GenericConfiguration, health: Health, tag_interner: GenericMapInterner,
+    pub async fn new(
+        configured_socket_path: Option<PathBuf>, containerd_config: &ContainerdConfiguration, health: Health,
+        tag_interner: GenericMapInterner,
     ) -> Result<Self, GenericError> {
-        let client = ContainerdClient::from_configuration(config).await?;
+        let client = ContainerdClient::new(configured_socket_path, containerd_config).await?;
         let watched_namespaces = client.list_namespaces().await?;
 
         Ok(Self {

--- a/lib/saluki-env/src/workload/collectors/containerd.rs
+++ b/lib/saluki-env/src/workload/collectors/containerd.rs
@@ -44,15 +44,17 @@ pub struct ContainerdMetadataCollector {
 impl ContainerdMetadataCollector {
     /// Creates a new `ContainerdMetadataCollector` from the given containerd configuration.
     ///
+    /// If `socket_path` is given, that path is used. Otherwise, well-known paths are probed.
+    ///
     /// # Errors
     ///
     /// If the containerd gRPC client can't be created, or listing the namespaces in the containerd runtime fails, an
     /// error will be returned.
     pub async fn new(
-        configured_socket_path: Option<PathBuf>, containerd_config: &ContainerdConfiguration, health: Health,
+        socket_path: Option<PathBuf>, containerd_config: &ContainerdConfiguration, health: Health,
         tag_interner: GenericMapInterner,
     ) -> Result<Self, GenericError> {
-        let client = ContainerdClient::new(configured_socket_path, containerd_config).await?;
+        let client = ContainerdClient::new(socket_path, containerd_config).await?;
         let watched_namespaces = client.list_namespaces().await?;
 
         Ok(Self {

--- a/lib/saluki-env/src/workload/helpers/cgroups.rs
+++ b/lib/saluki-env/src/workload/helpers/cgroups.rs
@@ -21,6 +21,7 @@ use crate::features::{Feature, FeatureDetector};
 
 const DEFAULT_PROCFS_ROOT: &str = "/proc";
 const DEFAULT_CGROUPFS_ROOT: &str = "/sys/fs/cgroup";
+const DEFAULT_LEGACY_CGROUPFS_ROOT: &str = "/cgroup";
 const DEFAULT_HOST_MAPPED_PROCFS_ROOT: &str = "/host/proc";
 const DEFAULT_HOST_MAPPED_CGROUPFS_ROOT: &str = "/host/sys/fs/cgroup";
 const CGROUPS_V1_BASE_CONTROLLER_NAME: &str = "memory";
@@ -45,7 +46,8 @@ impl CgroupsConfiguration {
     /// Creates a new `CgroupsConfiguration` from the given filesystem roots.
     ///
     /// If a root is given, that path is used. Otherwise, each root falls back to its host-mapped default when its own
-    /// filesystem is detected as host-mapped, and to its local default when it isn't.
+    /// filesystem is detected as host-mapped, and to its local default when it isn't. The cgroupfs root has one more
+    /// fallback: the legacy `/cgroup` root, when that layout is detected.
     pub fn new(
         procfs_root: Option<PathBuf>, cgroupfs_root: Option<PathBuf>, feature_detector: &FeatureDetector,
     ) -> Self {
@@ -63,6 +65,11 @@ impl CgroupsConfiguration {
             // there, or make us miss the host's hierarchy in favor of our own container's.
             if feature_detector.is_feature_available(Feature::HostMappedCgroupfs) {
                 PathBuf::from(DEFAULT_HOST_MAPPED_CGROUPFS_ROOT)
+            } else if feature_detector.is_feature_available(Feature::LegacyCgroupfsRoot) {
+                // Older Amazon Linux hosts put the cgroups v1 hierarchy at `/cgroup`. The Datadog Agent detects that
+                // layout and defaults `container_cgroup_root` to it, but it sends us the result as a default value,
+                // which we can't tell apart from a schema default, so we detect the layout ourselves.
+                PathBuf::from(DEFAULT_LEGACY_CGROUPFS_ROOT)
             } else {
                 PathBuf::from(DEFAULT_CGROUPFS_ROOT)
             }
@@ -764,7 +771,8 @@ mod tests {
         extract_container_id, extract_container_id_from_path, get_container_id_from_cgroup_lines,
         is_usable_controller_inode, visit_subdirectories, CgroupControllerEntry, CgroupsConfiguration, CgroupsReader,
         Feature, FeatureDetector, HierarchyReader, TraversalResult, DEFAULT_CGROUPFS_ROOT,
-        DEFAULT_HOST_MAPPED_CGROUPFS_ROOT, DEFAULT_HOST_MAPPED_PROCFS_ROOT, DEFAULT_PROCFS_ROOT,
+        DEFAULT_HOST_MAPPED_CGROUPFS_ROOT, DEFAULT_HOST_MAPPED_PROCFS_ROOT, DEFAULT_LEGACY_CGROUPFS_ROOT,
+        DEFAULT_PROCFS_ROOT,
     };
 
     #[test]
@@ -1343,6 +1351,23 @@ mod tests {
 
         assert_eq!(config.procfs_path(), Path::new(DEFAULT_HOST_MAPPED_PROCFS_ROOT));
         assert_eq!(config.cgroupfs_path(), Path::new(DEFAULT_CGROUPFS_ROOT));
+    }
+
+    #[test]
+    fn cgroupfs_root_follows_legacy_root() {
+        let config = cgroups_config_with(Feature::LegacyCgroupfsRoot);
+
+        assert_eq!(config.cgroupfs_path(), Path::new(DEFAULT_LEGACY_CGROUPFS_ROOT));
+        assert_eq!(config.procfs_path(), Path::new(DEFAULT_PROCFS_ROOT));
+    }
+
+    #[test]
+    fn host_mapped_cgroupfs_takes_precedence_over_legacy_root() {
+        // The legacy root is a host layout, so a container that has the host cgroupfs mapped in reads the host
+        // hierarchy through that mount rather than through a `/cgroup` path in its own filesystem.
+        let config = cgroups_config_with(Feature::HostMappedCgroupfs | Feature::LegacyCgroupfsRoot);
+
+        assert_eq!(config.cgroupfs_path(), Path::new(DEFAULT_HOST_MAPPED_CGROUPFS_ROOT));
     }
 
     #[test]

--- a/lib/saluki-env/src/workload/helpers/cgroups.rs
+++ b/lib/saluki-env/src/workload/helpers/cgroups.rs
@@ -10,7 +10,6 @@ use std::{
 };
 
 use regex::Regex;
-use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use stringtheory::{
     interning::{GenericMapInterner, Interner as _},
@@ -43,44 +42,33 @@ pub struct CgroupsConfiguration {
 }
 
 impl CgroupsConfiguration {
-    /// Creates a new `CgroupsConfiguration` from the given configuration.
-    ///
-    /// # Errors
-    ///
-    /// If any of the paths in the configuration aren't valid, an error will be returned. This doesn't include,
-    /// however, if any of the configured paths don't _exist_.
-    pub fn from_configuration(
-        config: &GenericConfiguration, feature_detector: FeatureDetector,
-    ) -> Result<Self, GenericError> {
-        let procfs_root = match config.try_get_typed::<PathBuf>("container_proc_root")? {
-            Some(path) => path,
-            None => {
-                if feature_detector.is_feature_available(Feature::HostMappedProcfs) {
-                    PathBuf::from(DEFAULT_HOST_MAPPED_PROCFS_ROOT)
-                } else {
-                    PathBuf::from(DEFAULT_PROCFS_ROOT)
-                }
+    /// Resolves optional roots from the detected host-mount features.
+    pub fn new(
+        procfs_root: Option<PathBuf>, cgroupfs_root: Option<PathBuf>, feature_detector: &FeatureDetector,
+    ) -> Self {
+        let procfs_root = procfs_root.unwrap_or_else(|| {
+            if feature_detector.is_feature_available(Feature::HostMappedProcfs) {
+                PathBuf::from(DEFAULT_HOST_MAPPED_PROCFS_ROOT)
+            } else {
+                PathBuf::from(DEFAULT_PROCFS_ROOT)
             }
-        };
+        });
 
-        let cgroupfs_root = match config.try_get_typed::<PathBuf>("container_cgroup_root")? {
-            Some(path) => path,
-            None => {
-                // Detected separately from procfs: the two are independent mounts, and a deployment can map one
-                // without the other. Keying this off the procfs feature would point us at a cgroupfs path that isn't
-                // there, or make us miss the host's hierarchy in favor of our own container's.
-                if feature_detector.is_feature_available(Feature::HostMappedCgroupfs) {
-                    PathBuf::from(DEFAULT_HOST_MAPPED_CGROUPFS_ROOT)
-                } else {
-                    PathBuf::from(DEFAULT_CGROUPFS_ROOT)
-                }
+        let cgroupfs_root = cgroupfs_root.unwrap_or_else(|| {
+            // Detected separately from procfs: the two are independent mounts, and a deployment can map one
+            // without the other. Keying this off the procfs feature would point us at a cgroupfs path that isn't
+            // there, or make us miss the host's hierarchy in favor of our own container's.
+            if feature_detector.is_feature_available(Feature::HostMappedCgroupfs) {
+                PathBuf::from(DEFAULT_HOST_MAPPED_CGROUPFS_ROOT)
+            } else {
+                PathBuf::from(DEFAULT_CGROUPFS_ROOT)
             }
-        };
+        });
 
-        Ok(Self {
+        Self {
             procfs_root,
             cgroupfs_root,
-        })
+        }
     }
 
     /// Returns the path to the "procfs" filesystem.
@@ -763,7 +751,6 @@ mod tests {
         path::{Path, PathBuf},
     };
 
-    use saluki_config::ConfigurationLoader;
     use stringtheory::{
         interning::{GenericMapInterner, InternedString, Interner as _},
         MetaString,
@@ -1326,41 +1313,38 @@ mod tests {
         assert!(traversal.cgroups.is_empty());
     }
 
-    async fn cgroups_config_with(detected: Feature) -> CgroupsConfiguration {
-        let (config, _updates_tx) = ConfigurationLoader::for_tests(None, None, false).await;
-
-        CgroupsConfiguration::from_configuration(&config, FeatureDetector::from_detected_features(detected))
-            .expect("configuration should load")
+    fn cgroups_config_with(detected: Feature) -> CgroupsConfiguration {
+        CgroupsConfiguration::new(None, None, &FeatureDetector::from_detected_features(detected))
     }
 
-    #[tokio::test]
-    async fn cgroupfs_root_defaults_to_local_when_nothing_is_host_mapped() {
-        let config = cgroups_config_with(Feature::none()).await;
+    #[test]
+    fn cgroupfs_root_defaults_to_local_when_nothing_is_host_mapped() {
+        let config = cgroups_config_with(Feature::none());
 
         assert_eq!(config.procfs_path(), Path::new(DEFAULT_PROCFS_ROOT));
         assert_eq!(config.cgroupfs_path(), Path::new(DEFAULT_CGROUPFS_ROOT));
     }
 
-    #[tokio::test]
-    async fn cgroupfs_root_follows_host_mapped_cgroupfs() {
-        let config = cgroups_config_with(Feature::HostMappedCgroupfs).await;
+    #[test]
+    fn cgroupfs_root_follows_host_mapped_cgroupfs() {
+        let config = cgroups_config_with(Feature::HostMappedCgroupfs);
 
         assert_eq!(config.cgroupfs_path(), Path::new(DEFAULT_HOST_MAPPED_CGROUPFS_ROOT));
     }
 
-    #[tokio::test]
-    async fn cgroupfs_root_ignores_host_mapped_procfs() {
+    #[test]
+    fn cgroupfs_root_ignores_host_mapped_procfs() {
         // procfs and cgroupfs are independent mounts. A deployment that maps one without the other used to get the
         // host cgroupfs path off the back of the procfs mount, pointing the reader at a path that isn't there.
-        let config = cgroups_config_with(Feature::HostMappedProcfs).await;
+        let config = cgroups_config_with(Feature::HostMappedProcfs);
 
         assert_eq!(config.procfs_path(), Path::new(DEFAULT_HOST_MAPPED_PROCFS_ROOT));
         assert_eq!(config.cgroupfs_path(), Path::new(DEFAULT_CGROUPFS_ROOT));
     }
 
-    #[tokio::test]
-    async fn procfs_root_ignores_host_mapped_cgroupfs() {
-        let config = cgroups_config_with(Feature::HostMappedCgroupfs).await;
+    #[test]
+    fn procfs_root_ignores_host_mapped_cgroupfs() {
+        let config = cgroups_config_with(Feature::HostMappedCgroupfs);
 
         assert_eq!(config.procfs_path(), Path::new(DEFAULT_PROCFS_ROOT));
     }

--- a/lib/saluki-env/src/workload/helpers/cgroups.rs
+++ b/lib/saluki-env/src/workload/helpers/cgroups.rs
@@ -42,7 +42,10 @@ pub struct CgroupsConfiguration {
 }
 
 impl CgroupsConfiguration {
-    /// Resolves unset roots from host-mapped filesystem detection.
+    /// Creates a new `CgroupsConfiguration` from the given filesystem roots.
+    ///
+    /// If a root is given, that path is used. Otherwise, each root falls back to its host-mapped default when its own
+    /// filesystem is detected as host-mapped, and to its local default when it isn't.
     pub fn new(
         procfs_root: Option<PathBuf>, cgroupfs_root: Option<PathBuf>, feature_detector: &FeatureDetector,
     ) -> Self {

--- a/lib/saluki-env/src/workload/helpers/cgroups.rs
+++ b/lib/saluki-env/src/workload/helpers/cgroups.rs
@@ -42,7 +42,7 @@ pub struct CgroupsConfiguration {
 }
 
 impl CgroupsConfiguration {
-    /// Resolves optional roots from the detected host-mount features.
+    /// Resolves unset roots from host-mapped filesystem detection.
     pub fn new(
         procfs_root: Option<PathBuf>, cgroupfs_root: Option<PathBuf>, feature_detector: &FeatureDetector,
     ) -> Self {

--- a/lib/saluki-env/src/workload/helpers/cgroups.rs
+++ b/lib/saluki-env/src/workload/helpers/cgroups.rs
@@ -1364,7 +1364,9 @@ mod tests {
     #[test]
     fn host_mapped_cgroupfs_takes_precedence_over_legacy_root() {
         // The legacy root is a host layout, so a container that has the host cgroupfs mapped in reads the host
-        // hierarchy through that mount rather than through a `/cgroup` path in its own filesystem.
+        // hierarchy through that mount rather than through a `/cgroup` path in its own filesystem. Feature detection
+        // never reports both at once, since it only looks for the legacy root when it isn't containerized, but the
+        // ordering here is what makes that safe.
         let config = cgroups_config_with(Feature::HostMappedCgroupfs | Feature::LegacyCgroupfsRoot);
 
         assert_eq!(config.cgroupfs_path(), Path::new(DEFAULT_HOST_MAPPED_CGROUPFS_ROOT));

--- a/lib/saluki-env/src/workload/helpers/containerd/mod.rs
+++ b/lib/saluki-env/src/workload/helpers/containerd/mod.rs
@@ -28,20 +28,12 @@ use self::events::{decode_envelope_to_event, ContainerdEvent, ContainerdTopic};
 const MAX_LIST_CONTAINERS_RESPONSE_SIZE: usize = 16 * 1024 * 1024;
 
 /// Containerd gRPC client configuration.
-#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct ContainerdConfiguration {
-    connection_timeout: Duration,
-    query_timeout: Duration,
-}
+    /// Timeout for establishing the gRPC connection to the containerd socket.
+    pub connection_timeout: Duration,
 
-impl ContainerdConfiguration {
-    /// Creates a client configuration with connection and query timeouts.
-    pub const fn new(connection_timeout: Duration, query_timeout: Duration) -> Self {
-        Self {
-            connection_timeout,
-            query_timeout,
-        }
-    }
+    /// Per-RPC timeout for containerd API calls.
+    pub query_timeout: Duration,
 }
 
 /// A [`ContainerdClient`] error.

--- a/lib/saluki-env/src/workload/helpers/containerd/mod.rs
+++ b/lib/saluki-env/src/workload/helpers/containerd/mod.rs
@@ -1,4 +1,7 @@
-use std::{path::Path, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use containerd_protos::services::{
     containers::v1::{containers_client::ContainersClient, Container, ListContainersRequest},
@@ -8,9 +11,7 @@ use containerd_protos::services::{
 };
 use futures::{Stream, StreamExt as _, TryStreamExt as _};
 use hyper_util::rt::TokioIo;
-use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, GenericError};
-use serde::Deserialize;
 use snafu::{ResultExt as _, Snafu};
 use tokio::net::UnixStream;
 use tonic::{
@@ -26,45 +27,20 @@ use self::events::{decode_envelope_to_event, ContainerdEvent, ContainerdTopic};
 
 const MAX_LIST_CONTAINERS_RESPONSE_SIZE: usize = 16 * 1024 * 1024;
 
-const fn default_connection_timeout_secs() -> u64 {
-    1
-}
-
-const fn default_query_timeout_secs() -> u64 {
-    5
-}
-
 /// Containerd gRPC client configuration.
-#[derive(Deserialize)]
-#[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct ContainerdConfiguration {
-    /// Timeout for establishing the gRPC connection to the containerd socket.
-    ///
-    /// Defaults to 1 second. Increase this for hosts where containerd may accept socket connections slowly.
-    #[serde(default = "default_connection_timeout_secs", rename = "cri_connection_timeout")]
-    connection_timeout_secs: u64,
-
-    /// Per-RPC timeout for containerd API calls.
-    ///
-    /// Defaults to 5 seconds. Each containerd RPC receives this deadline independently.
-    #[serde(default = "default_query_timeout_secs", rename = "cri_query_timeout")]
-    query_timeout_secs: u64,
+    connection_timeout: Duration,
+    query_timeout: Duration,
 }
 
 impl ContainerdConfiguration {
-    /// Creates a new `ContainerdConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        Ok(config.as_typed::<Self>()?)
-    }
-
-    /// Returns the timeout for establishing the gRPC connection to the containerd socket.
-    pub const fn connection_timeout(&self) -> Duration {
-        Duration::from_secs(self.connection_timeout_secs)
-    }
-
-    /// Returns the per-RPC timeout for containerd API calls.
-    pub const fn query_timeout(&self) -> Duration {
-        Duration::from_secs(self.query_timeout_secs)
+    /// Creates a client configuration with connection and query timeouts.
+    pub const fn new(connection_timeout: Duration, query_timeout: Duration) -> Self {
+        Self {
+            connection_timeout,
+            query_timeout,
+        }
     }
 }
 
@@ -99,14 +75,16 @@ pub struct ContainerdClient {
 }
 
 impl ContainerdClient {
-    /// Creates a new `ContainerdClient` from the given configuration.
+    /// Creates a client using an optional socket override and client configuration.
     ///
     /// ## Errors
     ///
-    /// If the containerd socket path wasn't present in the configuration or couldn't be detected, or if the gRPC
-    /// transport to containerd couldn't be created, an error will be returned.
-    pub async fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let socket_path = ContainerdDetector::detect_grpc_socket_path(config)
+    /// If the containerd socket path wasn't configured or couldn't be detected, or if the gRPC transport to containerd
+    /// couldn't be created, an error will be returned.
+    pub async fn new(
+        configured_socket_path: Option<PathBuf>, containerd_config: &ContainerdConfiguration,
+    ) -> Result<Self, GenericError> {
+        let socket_path = ContainerdDetector::detect_grpc_socket_path(configured_socket_path)
             .ok_or(generic_error!(
                 "failed to detect containerd socket path; not available at default path and not specified in configuration (`cri_socket_path`)"
             ))?;
@@ -118,10 +96,9 @@ impl ContainerdClient {
             ));
         }
 
-        let containerd_config = ContainerdConfiguration::from_configuration(config)?;
         let channel = Endpoint::try_from("https://[::]")
             .unwrap()
-            .connect_timeout(containerd_config.connection_timeout())
+            .connect_timeout(containerd_config.connection_timeout)
             .connect_with_connector(service_fn(move |_| {
                 let socket_path = socket_path.clone();
                 async move { UnixStream::connect(socket_path).await.map(TokioIo::new) }
@@ -130,7 +107,7 @@ impl ContainerdClient {
 
         Ok(Self {
             channel,
-            query_timeout: containerd_config.query_timeout(),
+            query_timeout: containerd_config.query_timeout,
         })
     }
 
@@ -259,36 +236,7 @@ async fn path_exists(path: &Path) -> bool {
 mod tests {
     use std::time::Duration;
 
-    use saluki_config::ConfigurationLoader;
-
     use super::*;
-
-    #[tokio::test]
-    async fn configuration_uses_core_agent_cri_timeout_defaults() {
-        let (config, _updates_tx) = ConfigurationLoader::for_tests(None, None, false).await;
-        let containerd_config =
-            ContainerdConfiguration::from_configuration(&config).expect("configuration should load");
-
-        assert_eq!(Duration::from_secs(1), containerd_config.connection_timeout());
-        assert_eq!(Duration::from_secs(5), containerd_config.query_timeout());
-    }
-
-    #[tokio::test]
-    async fn configuration_reads_cri_timeout_overrides() {
-        let raw_config = serde_yaml::from_str(
-            r#"
-            cri_connection_timeout: 2
-            cri_query_timeout: 7
-            "#,
-        )
-        .expect("config should parse");
-        let (config, _updates_tx) = ConfigurationLoader::for_tests(Some(raw_config), None, false).await;
-        let containerd_config =
-            ContainerdConfiguration::from_configuration(&config).expect("configuration should load");
-
-        assert_eq!(Duration::from_secs(2), containerd_config.connection_timeout());
-        assert_eq!(Duration::from_secs(7), containerd_config.query_timeout());
-    }
 
     #[test]
     fn create_timed_request_sets_grpc_timeout() {

--- a/lib/saluki-env/src/workload/helpers/containerd/mod.rs
+++ b/lib/saluki-env/src/workload/helpers/containerd/mod.rs
@@ -67,24 +67,26 @@ pub struct ContainerdClient {
 }
 
 impl ContainerdClient {
-    /// Creates a client using an optional socket override and client configuration.
+    /// Creates a new `ContainerdClient` from the given socket path and client configuration.
+    ///
+    /// If `socket_path` is given, that path is used. Otherwise, well-known paths are probed.
     ///
     /// ## Errors
     ///
-    /// If the containerd socket path wasn't configured or couldn't be detected, or if the gRPC transport to containerd
+    /// If the containerd socket path wasn't given and couldn't be detected, or if the gRPC transport to containerd
     /// couldn't be created, an error will be returned.
     pub async fn new(
-        configured_socket_path: Option<PathBuf>, containerd_config: &ContainerdConfiguration,
+        socket_path: Option<PathBuf>, containerd_config: &ContainerdConfiguration,
     ) -> Result<Self, GenericError> {
-        let socket_path = ContainerdDetector::detect_grpc_socket_path(configured_socket_path)
+        let detected_socket_path = ContainerdDetector::detect_grpc_socket_path(socket_path)
             .ok_or(generic_error!(
                 "failed to detect containerd socket path; not available at default path and not specified in configuration (`cri_socket_path`)"
             ))?;
 
-        if !path_exists(&socket_path).await {
+        if !path_exists(&detected_socket_path).await {
             return Err(generic_error!(
                 "Detected containerd socket path ({}) but path does not exist, or process lacks permissions.",
-                socket_path.to_string_lossy()
+                detected_socket_path.to_string_lossy()
             ));
         }
 
@@ -92,7 +94,7 @@ impl ContainerdClient {
             .unwrap()
             .connect_timeout(containerd_config.connection_timeout)
             .connect_with_connector(service_fn(move |_| {
-                let socket_path = socket_path.clone();
+                let socket_path = detected_socket_path.clone();
                 async move { UnixStream::connect(socket_path).await.map(TokioIo::new) }
             }))
             .await?;

--- a/lib/saluki-env/src/workload/mod.rs
+++ b/lib/saluki-env/src/workload/mod.rs
@@ -18,6 +18,11 @@ pub mod entity;
 pub use self::entity::EntityId;
 
 mod helpers;
+#[cfg(target_os = "linux")]
+pub use self::helpers::cgroups::CgroupsConfiguration;
+#[cfg(unix)]
+pub use self::helpers::containerd::ContainerdConfiguration;
+
 mod metadata;
 pub use self::metadata::{MetadataAction, MetadataOperation};
 

--- a/lib/saluki-env/src/workload/on_demand_pid/linux.rs
+++ b/lib/saluki-env/src/workload/on_demand_pid/linux.rs
@@ -1,7 +1,6 @@
 use std::{num::NonZeroUsize, time::Duration};
 
 use saluki_common::cache::{Cache, CacheBuilder};
-use saluki_config::GenericConfiguration;
 use saluki_error::GenericError;
 use saluki_metrics::{static_metrics, Gauge};
 use stringtheory::interning::{GenericMapInterner, Interner as _};
@@ -9,7 +8,7 @@ use tokio::time::sleep;
 use tracing::{debug, trace};
 
 use crate::workload::helpers::cgroups::{get_self_container_id, CgroupsConfiguration, CgroupsReader};
-use crate::{features::FeatureDetector, workload::EntityId};
+use crate::workload::EntityId;
 
 #[static_metrics(prefix = pid_resolver)]
 #[derive(Clone)]
@@ -30,21 +29,18 @@ pub struct ResolverImpl {
 }
 
 impl ResolverImpl {
-    /// Creates a new `ResolverImpl` from the given configuration.
+    /// Creates a new `ResolverImpl` from the given cgroups configuration.
     ///
     /// # Errors
     ///
     /// If a cgroups hierarchy can't be found, or the internal cache can't be created, an error is returned.
-    pub fn from_configuration(
-        config: &GenericConfiguration, feature_detector: FeatureDetector, interner: GenericMapInterner,
-    ) -> Result<Self, GenericError> {
+    pub fn new(cgroups_config: &CgroupsConfiguration, interner: GenericMapInterner) -> Result<Self, GenericError> {
         let telemetry = Telemetry::new();
         telemetry
             .interner_capacity_bytes()
             .set(interner.capacity_bytes() as f64);
 
-        let cgroups_config = CgroupsConfiguration::from_configuration(config, feature_detector)?;
-        let cgroups_reader = match CgroupsReader::try_from_config(&cgroups_config, interner.clone())? {
+        let cgroups_reader = match CgroupsReader::try_from_config(cgroups_config, interner.clone())? {
             Some(reader) => reader,
             None => {
                 return Err(GenericError::msg("Failed to detect any cgroups v1/v2 hierarchy."));

--- a/lib/saluki-env/src/workload/on_demand_pid/mod.rs
+++ b/lib/saluki-env/src/workload/on_demand_pid/mod.rs
@@ -1,7 +1,7 @@
+use std::path::PathBuf;
 #[cfg(target_os = "linux")]
 use std::sync::Arc;
 
-use saluki_config::GenericConfiguration;
 use saluki_error::GenericError;
 use stringtheory::interning::GenericMapInterner;
 
@@ -27,17 +27,25 @@ pub struct OnDemandPIDResolver {
 }
 
 impl OnDemandPIDResolver {
-    /// Creates a new `OnDemandPIDResolver` from the given configuration.
+    /// Creates a new `OnDemandPIDResolver` for the given container filesystem roots.
+    ///
+    /// A root given as `None` isn't configured, and is resolved from the detected features.
     ///
     /// # Errors
     ///
     /// If a cgroups hierarchy can't be found, or the internal cache can't be created, an error is returned.
-    pub fn from_configuration(
-        config: &GenericConfiguration, feature_detector: FeatureDetector, interner: GenericMapInterner,
+    pub fn new(
+        procfs_root: Option<PathBuf>, cgroupfs_root: Option<PathBuf>, feature_detector: &FeatureDetector,
+        interner: GenericMapInterner,
     ) -> Result<Self, GenericError> {
         #[cfg(target_os = "linux")]
         {
-            let resolver_inner = linux::ResolverImpl::from_configuration(config, feature_detector, interner)?;
+            let cgroups_config = crate::workload::helpers::cgroups::CgroupsConfiguration::new(
+                procfs_root,
+                cgroupfs_root,
+                feature_detector,
+            );
+            let resolver_inner = linux::ResolverImpl::new(&cgroups_config, interner)?;
             Ok(Self {
                 inner: Arc::new(resolver_inner),
             })
@@ -46,7 +54,8 @@ impl OnDemandPIDResolver {
         #[cfg(not(target_os = "linux"))]
         {
             // Rebind to make compiler happy.
-            let _config = config;
+            let _procfs_root = procfs_root;
+            let _cgroupfs_root = cgroupfs_root;
             let _feature_detector = feature_detector;
             let _interner = interner;
 

--- a/lib/saluki-env/src/workload/on_demand_pid/mod.rs
+++ b/lib/saluki-env/src/workload/on_demand_pid/mod.rs
@@ -29,7 +29,7 @@ pub struct OnDemandPIDResolver {
 impl OnDemandPIDResolver {
     /// Creates a new `OnDemandPIDResolver` for the given container filesystem roots.
     ///
-    /// A root given as `None` isn't configured, and is resolved from the detected features.
+    /// If a root is given, that path is used. Otherwise, it is resolved from the detected features.
     ///
     /// # Errors
     ///

--- a/lib/saluki-env/src/workload/on_demand_pid/mod.rs
+++ b/lib/saluki-env/src/workload/on_demand_pid/mod.rs
@@ -33,7 +33,8 @@ impl OnDemandPIDResolver {
     ///
     /// # Errors
     ///
-    /// If a cgroups hierarchy can't be found, or the internal cache can't be created, an error is returned.
+    /// On Linux, if a cgroups hierarchy can't be found, or the internal cache can't be created, an error is returned.
+    /// On all other platforms, no error is possible.
     pub fn new(
         procfs_root: Option<PathBuf>, cgroupfs_root: Option<PathBuf>, feature_detector: &FeatureDetector,
         interner: GenericMapInterner,


### PR DESCRIPTION
## Human Summary

Larger diff but ultimately there is no real need for saluki-env to read what it needs from the configuration map. It can take the few, scalar parameters it needs as arguments when constructing types.

## AI Summary

- Model host identity, container roots, and containerd settings in typed configuration.
- Preserve source awareness so schema defaults do not suppress runtime discovery.
- Pass concrete paths and timeouts into environment providers.
- Reject negative CRI timeouts and remove migrated raw config reads from saluki-env.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make fmt`
- `make check-docs`
- `cargo check --workspace --tests`
- Targeted `cargo nextest` and clippy runs for affected packages

## References

- Progresses: #2169
