### PR TITLE
chore(config): isolate raw configuration views

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -183,7 +183,7 @@ pub async fn handle_run_command(
     let resource_registry = ResourceRegistry::new();
     let (env_provider, maybe_env_supervisor) = ADPEnvironmentProvider::from_configuration(
         standalone,
-        &config_sys.raw_map(),
+        config_sys.config().control.ipc.remote_agent_string_interner_size_bytes,
         &config_sys.config().shared.environment,
         remote_agent_client_config.as_ref(),
         &component_registry,

--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -52,7 +52,10 @@ pub async fn create_control_plane_supervisor(
         config_system.live(|config| &config.control.logging.level),
         logging_controller,
     ));
-    supervisor.add_worker(ConfigWorker::new(raw_map));
+    // Re-read the compatibility map on every request/dump so the endpoint reflects live updates.
+    supervisor.add_worker(ConfigWorker::new(Arc::new(move || {
+        raw_map.as_typed::<serde_json::Value>().map_err(Into::into)
+    })));
     supervisor.add_worker(ConfigRuntimeWorker::new(current_config));
 
     let api_listen_address = dp.api_listen_address()?;

--- a/bin/agent-data-plane/src/internal/env/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/mod.rs
@@ -1,8 +1,7 @@
-use std::future::Future;
+use std::{future::Future, num::NonZeroUsize};
 
 use agent_data_plane_config::shared::Environment;
 use datadog_agent_commons::ipc::config::RemoteAgentClientConfiguration;
-use saluki_config::GenericConfiguration;
 use saluki_core::accounting::ComponentRegistry;
 use saluki_core::health::HealthRegistry;
 use saluki_core::runtime::Supervisor;
@@ -56,7 +55,7 @@ impl ADPEnvironmentProvider {
     /// In standalone mode, no supervisor is returned as all behavior/functionality is either provided via
     /// fixed configuration or operates in a no-op fashion.
     pub async fn from_configuration(
-        standalone: bool, raw_map: &GenericConfiguration, environment: &Environment,
+        standalone: bool, string_interner_size_bytes: NonZeroUsize, environment: &Environment,
         client_config: Option<&RemoteAgentClientConfiguration>, component_registry: &ComponentRegistry,
         health_registry: &HealthRegistry,
     ) -> Result<(Self, Option<Supervisor>), GenericError> {
@@ -87,8 +86,8 @@ impl ADPEnvironmentProvider {
 
         let host_provider = RemoteAgentHostProvider::new(client_config, component_registry).await?;
 
-        let (workload_provider, workload_supervisor) = RemoteAgentWorkloadProvider::from_configuration(
-            raw_map,
+        let (workload_provider, workload_supervisor) = RemoteAgentWorkloadProvider::new(
+            string_interner_size_bytes,
             environment,
             client_config,
             component_registry,

--- a/bin/agent-data-plane/src/internal/env/workload/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/workload/mod.rs
@@ -4,7 +4,6 @@ use std::{future::Future, num::NonZeroUsize, time::Duration};
 
 use agent_data_plane_config::shared::Environment;
 use datadog_agent_commons::ipc::config::RemoteAgentClientConfiguration;
-use saluki_config::GenericConfiguration;
 use saluki_context::{
     origin::{OriginTagCardinality, RawOrigin},
     tags::SharedTagSet,
@@ -51,9 +50,6 @@ const DEFAULT_TAG_STORE_ENTITY_LIMIT: NonZeroUsize = NonZeroUsize::new(2000).unw
 // SAFETY: The value is demonstrably not zero.
 const DEFAULT_EXTERNAL_DATA_STORE_ENTITY_LIMIT: NonZeroUsize = NonZeroUsize::new(2000).unwrap();
 
-// SAFETY: We know the value is not zero.
-const DEFAULT_STRING_INTERNER_SIZE_BYTES: NonZeroUsize = NonZeroUsize::new(512 * 1024).unwrap(); // 512KB.
-
 /// Datadog Agent-based workload provider.
 ///
 /// This provider is based primarily on the remote tagger API exposed by the Datadog Agent, which handles the bulk of
@@ -76,24 +72,19 @@ pub struct RemoteAgentWorkloadProvider {
 }
 
 impl RemoteAgentWorkloadProvider {
-    /// Create a new `RemoteAgentWorkloadProvider` based on the given configuration, along with a [`Supervisor`] that
-    /// drives the aggregator and all collector workers.
+    /// Creates a provider and the [`Supervisor`] that drives its collectors.
     ///
     /// # Errors
     ///
-    /// If there is an issue with any of the provider configuration, or creating the underlying metadata collectors, an
-    /// error is returned.
-    pub async fn from_configuration(
-        config: &GenericConfiguration, environment: &Environment, client_config: &RemoteAgentClientConfiguration,
-        component_registry: &ComponentRegistry, health_registry: &HealthRegistry,
+    /// If there is an issue creating the underlying metadata collectors, an error is returned.
+    pub async fn new(
+        string_interner_size_bytes: NonZeroUsize, environment: &Environment,
+        client_config: &RemoteAgentClientConfiguration, component_registry: &ComponentRegistry,
+        health_registry: &HealthRegistry,
     ) -> Result<(Self, Supervisor), GenericError> {
         let workload_provider_id = root_provider_id().child("workload").child("remote_agent");
         let mut provider_bounds = component_registry.bounds_builder(&workload_provider_id);
 
-        // Create our string interner which will get used primarily for tags, but also for any other long-ish lived strings.
-        let string_interner_size_bytes = config
-            .try_get_typed::<NonZeroUsize>("remote_agent_string_interner_size_bytes")?
-            .unwrap_or(DEFAULT_STRING_INTERNER_SIZE_BYTES);
         let string_interner = GenericMapInterner::new(string_interner_size_bytes);
 
         provider_bounds

--- a/lib/agent-data-plane-config-system/src/saluki_only.rs
+++ b/lib/agent-data-plane-config-system/src/saluki_only.rs
@@ -150,7 +150,8 @@ pub struct SalukiOnly {
     /// Internal-telemetry verbosity (`metrics_level`).
     pub metrics_level: Option<String>,
     /// Remote-agent IPC string interner byte budget (`remote_agent_string_interner_size_bytes`).
-    pub remote_agent_string_interner_size_bytes: Option<usize>,
+    /// An explicit `0` fails the load: the interner cannot be built with no capacity.
+    pub remote_agent_string_interner_size_bytes: Option<NonZeroUsize>,
     /// Checks IPC endpoint (`checks_ipc_endpoint`).
     pub checks_ipc_endpoint: Option<String>,
     /// Process memory limit (`memory_limit`), given as a bare integer number of bytes or a
@@ -684,8 +685,8 @@ mod tests {
     use agent_data_plane_config::defaults::{
         DEFAULT_AGGREGATE_WINDOW_DURATION_SECONDS, DEFAULT_DOGSTATSD_MAPPER_STRING_INTERNER_SIZE_BYTES,
         DEFAULT_ENCODER_FLUSH_TIMEOUT, DEFAULT_ERROR_SAMPLING_ENABLED, DEFAULT_RARE_SAMPLER_CARDINALITY,
-        DEFAULT_RARE_SAMPLER_COOLDOWN_SECS, DEFAULT_RARE_SAMPLER_TPS, DEFAULT_TRACE_ENV,
-        MAX_STRING_INTERNER_SIZE_BYTES,
+        DEFAULT_RARE_SAMPLER_COOLDOWN_SECS, DEFAULT_RARE_SAMPLER_TPS, DEFAULT_REMOTE_AGENT_STRING_INTERNER_SIZE_BYTES,
+        DEFAULT_TRACE_ENV, MAX_STRING_INTERNER_SIZE_BYTES,
     };
     use agent_data_plane_config::domains::dogstatsd::TagValueMismatchAction;
     use serde_json::json;
@@ -789,7 +790,7 @@ mod tests {
         assert_eq!(config.control.memory_slop_factor, 0.3);
         assert!(!config.control.enable_global_limiter);
         assert_eq!(config.control.memory_mode, MemoryMode::Strict);
-        assert_eq!(config.control.ipc.remote_agent_string_interner_size_bytes, 4096);
+        assert_eq!(config.control.ipc.remote_agent_string_interner_size_bytes.get(), 4096);
 
         // shared
         assert_eq!(config.shared.metrics_level, "debug");
@@ -965,6 +966,29 @@ mod tests {
                 expected
             );
         }
+    }
+
+    #[test]
+    fn remote_agent_string_interner_size_resolves_the_default_and_rejects_zero() {
+        let saluki_only: SalukiOnly = serde_json::from_value(json!({})).expect("empty source deserializes");
+        let mut config = SalukiConfiguration::default();
+        saluki_only.seed(&mut config);
+        assert_eq!(
+            config.control.ipc.remote_agent_string_interner_size_bytes,
+            DEFAULT_REMOTE_AGENT_STRING_INTERNER_SIZE_BYTES
+        );
+
+        let saluki_only: SalukiOnly =
+            serde_json::from_value(json!({ "remote_agent_string_interner_size_bytes": 8192 }))
+                .expect("explicit interner budget deserializes");
+        let mut config = SalukiConfiguration::default();
+        saluki_only.seed(&mut config);
+        assert_eq!(config.control.ipc.remote_agent_string_interner_size_bytes.get(), 8192);
+
+        assert!(
+            serde_json::from_value::<SalukiOnly>(json!({ "remote_agent_string_interner_size_bytes": 0 })).is_err(),
+            "a zero remote-agent string interner budget must fail the load"
+        );
     }
 
     #[test]

--- a/lib/agent-data-plane-config/src/control.rs
+++ b/lib/agent-data-plane-config/src/control.rs
@@ -217,9 +217,15 @@ pub struct ControlIpc {
     /// Defaults to `134217728` (128 MiB).
     pub grpc_max_message_size: usize,
 
-    /// Byte budget for the remote-agent IPC string interner. (not in Datadog Agent config schema)
+    /// Byte budget for the remote-agent workload metadata string interner. (not in Datadog Agent config schema)
     ///
-    /// Defaults to `524288` (512 KiB). An explicit `0` fails the configuration load.
+    /// The workload provider interns entity IDs and tags into a single allocation of this size, taken at startup and
+    /// charged in full against the memory bounds ceiling. A workload whose tag cardinality outgrows the budget starts
+    /// failing to intern, which drops the affected tags and entity updates and increments the collectors'
+    /// `intern_failed_total` counters.
+    ///
+    /// Defaults to `524288` (512 KiB). An explicit `0` fails the configuration load. Change it when tuning ADP itself;
+    /// operators are not expected to.
     pub remote_agent_string_interner_size_bytes: NonZeroUsize,
 }
 

--- a/lib/agent-data-plane-config/src/control.rs
+++ b/lib/agent-data-plane-config/src/control.rs
@@ -4,11 +4,11 @@
 //! components. It carries pipeline activation gates, topology-shaping decisions, listen addresses,
 //! logging (read before topology exists), bootstrap IPC parameters, and process-lifecycle knobs.
 
-use std::{path::PathBuf, time::Duration};
+use std::{num::NonZeroUsize, path::PathBuf, time::Duration};
 
 use serde::Serialize;
 
-use crate::ConfigValue;
+use crate::{defaults::DEFAULT_REMOTE_AGENT_STRING_INTERNER_SIZE_BYTES, ConfigValue};
 
 /// Topology gates and orchestration decisions. Most are static; `logging.level` is live.
 ///
@@ -181,9 +181,9 @@ pub struct Logging {
 /// IPC and remote-agent connection parameters, read once at bootstrap before runtime authority
 /// exists and again from the authoritative configuration once it does.
 ///
-/// The derived `Default` is all zeroes and serves only as the starting point for translation. The
-/// effective default of each field is the one the Datadog schema declares, noted per field below.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+/// Witnessed fields get their effective defaults during translation. The Saluki-only interner
+/// budget uses its Rust `Default`.
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct ControlIpc {
     /// Path to the Agent authentication token file.
     ///
@@ -218,5 +218,21 @@ pub struct ControlIpc {
     pub grpc_max_message_size: usize,
 
     /// Byte budget for the remote-agent IPC string interner. (not in Datadog Agent config schema)
-    pub remote_agent_string_interner_size_bytes: usize,
+    ///
+    /// Defaults to `524288` (512 KiB). An explicit `0` fails the configuration load.
+    pub remote_agent_string_interner_size_bytes: NonZeroUsize,
+}
+
+impl Default for ControlIpc {
+    fn default() -> Self {
+        Self {
+            // Written by the Datadog witness driver.
+            auth_token_file_path: PathBuf::new(),
+            ipc_cert_file_path: PathBuf::new(),
+            cmd_port: 0,
+            vsock_addr: String::new(),
+            grpc_max_message_size: 0,
+            remote_agent_string_interner_size_bytes: DEFAULT_REMOTE_AGENT_STRING_INTERNER_SIZE_BYTES,
+        }
+    }
 }

--- a/lib/agent-data-plane-config/src/defaults.rs
+++ b/lib/agent-data-plane-config/src/defaults.rs
@@ -37,6 +37,9 @@ pub const DEFAULT_AGGREGATE_PASSTHROUGH_IDLE_FLUSH_TIMEOUT: Duration = Duration:
 /// Default byte capacity of the DogStatsD mapper's string interner.
 pub const DEFAULT_DOGSTATSD_MAPPER_STRING_INTERNER_SIZE_BYTES: NonZeroUsize = NonZeroUsize::new(64 * 1024).unwrap();
 
+/// Default remote-agent IPC string interner budget.
+pub const DEFAULT_REMOTE_AGENT_STRING_INTERNER_SIZE_BYTES: NonZeroUsize = NonZeroUsize::new(512 * 1024).unwrap();
+
 /// Default DogStatsD TCP listen port.
 ///
 /// A value of `0` disables the TCP listener.

--- a/lib/saluki-app/Cargo.toml
+++ b/lib/saluki-app/Cargo.toml
@@ -29,7 +29,6 @@ rustls-pki-types = { workspace = true }
 ryu = { workspace = true }
 saluki-api = { workspace = true }
 saluki-common = { workspace = true }
-saluki-config = { workspace = true }
 saluki-core = { workspace = true }
 saluki-error = { workspace = true }
 saluki-io = { workspace = true }

--- a/lib/saluki-app/src/config.rs
+++ b/lib/saluki-app/src/config.rs
@@ -1,5 +1,7 @@
 //! Configuration API handler.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use http::StatusCode;
 use saluki_api::{
@@ -9,19 +11,21 @@ use saluki_api::{
     APIHandler, DynamicRoute, EndpointType,
 };
 use saluki_common::sync::shutdown::ShutdownHandle;
-use saluki_config::GenericConfiguration;
 use saluki_core::{
     diagnostic::DiagnosticsEmitter,
     runtime::{state::DataspaceRegistry, InitializationError, Supervisable, SupervisorFuture},
     support::SubsystemIdentifier,
 };
-use saluki_error::generic_error;
+use saluki_error::{generic_error, GenericError};
 use serde_json::Value;
+
+/// Produces a fresh serialized configuration snapshot per call.
+pub type ConfigSnapshotFn = Arc<dyn Fn() -> Result<Value, GenericError> + Send + Sync>;
 
 /// State used for the config API handler.
 #[derive(Clone)]
 pub struct ConfigState {
-    config: GenericConfiguration,
+    snapshot: ConfigSnapshotFn,
 }
 
 /// An API handler for returning the current configuration.
@@ -34,14 +38,14 @@ pub struct ConfigAPIHandler {
 }
 
 impl ConfigAPIHandler {
-    fn new(config: GenericConfiguration) -> Self {
+    fn new(snapshot: ConfigSnapshotFn) -> Self {
         Self {
-            state: ConfigState { config },
+            state: ConfigState { snapshot },
         }
     }
 
     async fn config_handler(State(state): State<ConfigState>) -> impl IntoResponse {
-        match state.config.as_typed::<Value>() {
+        match (state.snapshot)() {
             Ok(config) => (StatusCode::OK, serde_json::to_string(&config).unwrap()).into_response(),
             Err(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -74,10 +78,10 @@ pub struct ConfigWorker {
 }
 
 impl ConfigWorker {
-    /// Creates a new [`ConfigWorker`] with the given configuration.
-    pub fn new(config: GenericConfiguration) -> Self {
+    /// Creates a new [`ConfigWorker`] that serves the snapshots produced by the given closure.
+    pub fn new(snapshot: ConfigSnapshotFn) -> Self {
         Self {
-            handler: ConfigAPIHandler::new(config),
+            handler: ConfigAPIHandler::new(snapshot),
         }
     }
 }
@@ -91,7 +95,7 @@ impl Supervisable for ConfigWorker {
     async fn initialize(&self, process_shutdown: ShutdownHandle) -> Result<SupervisorFuture, InitializationError> {
         let config_route = DynamicRoute::http(EndpointType::Privileged, &self.handler);
 
-        let config = self.handler.state.config.clone();
+        let snapshot = self.handler.state.snapshot.clone();
 
         Ok(Box::pin(async move {
             let dataspace =
@@ -102,8 +106,7 @@ impl Supervisable for ConfigWorker {
             let diagnostics =
                 DiagnosticsEmitter::from_dataspace(SubsystemIdentifier::from_segments(["config-api"]), dataspace);
             diagnostics.register_collector("runtime_config_dump.yaml", move || {
-                config
-                    .as_typed::<serde_json::Value>()
+                snapshot()
                     .map(|v| serde_json::to_vec_pretty(&v).unwrap_or_default())
                     .unwrap_or_default()
             });
@@ -111,5 +114,53 @@ impl Supervisable for ConfigWorker {
             process_shutdown.await;
             Ok(())
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use http_body_util::BodyExt as _;
+    use saluki_error::generic_error;
+    use serde_json::json;
+
+    use super::*;
+
+    async fn response_parts(handler: &ConfigAPIHandler) -> (StatusCode, String) {
+        let response = ConfigAPIHandler::config_handler(State(handler.state.clone()))
+            .await
+            .into_response();
+        let status = response.status();
+        let body = response.into_body().collect().await.expect("body collects").to_bytes();
+
+        (status, String::from_utf8(body.to_vec()).expect("body is UTF-8"))
+    }
+
+    #[tokio::test]
+    async fn config_endpoint_serves_a_fresh_snapshot_per_request() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let snapshot_calls = Arc::clone(&calls);
+        let handler = ConfigAPIHandler::new(Arc::new(move || {
+            Ok(json!({ "revision": snapshot_calls.fetch_add(1, Ordering::Relaxed) }))
+        }));
+
+        let (status, body) = response_parts(&handler).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, r#"{"revision":0}"#);
+
+        let (status, body) = response_parts(&handler).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, r#"{"revision":1}"#);
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn config_endpoint_reports_a_failed_snapshot() {
+        let handler = ConfigAPIHandler::new(Arc::new(|| Err(generic_error!("cannot serialize"))));
+
+        let (status, body) = response_parts(&handler).await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(body.contains("cannot serialize"), "unexpected body: {body}");
     }
 }


### PR DESCRIPTION
## Human Summary

Cleans up a few more raw map sites, including `saluki-app`, whose types can be easily constructed from normal constructor arguments.

## AI Summary

- Pass the typed remote-agent interner budget into the environment provider.
- Reject a zero interner budget during configuration loading.
- Replace saluki-app's raw map dependency with a live snapshot callback.
- Preserve current `/config` and runtime configuration dump output.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make fmt`
- `make check-clippy`
- `make check-unused-deps`
- `cargo check --workspace --tests`
- Targeted `cargo nextest` runs for affected packages

## References

- Progresses: #2169
