### PR TITLE
chore(deps): bump `mio` to latest to fix AIX/Windows bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1554,7 +1554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2833,9 +2833,9 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "log",
@@ -2932,7 +2932,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4040,7 +4040,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4111,7 +4111,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4643,7 +4643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5185,7 +5185,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6136,7 +6136,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2834,7 +2834,8 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 [[package]]
 name = "mio"
 version = "1.2.2"
-source = "git+https://github.com/tokio-rs/mio?rev=1e79434244eed630a1ee7f227117960c6296e7f3#1e79434244eed630a1ee7f227117960c6296e7f3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,7 @@ ndarray = { version = "0.17", default-features = false }
 ndarray-stats = { version = "0.7", default-features = false }
 noisy_float = { version = "0.2", default-features = false }
 libc = { version = "0.2.186", default-features = false }
+mio = { version = "1.2.3", default-features = false }
 socket2 = { version = "0.6", default-features = false }
 tonic-prost-build = { version = "0.14", default-features = false }
 tonic-prost = { version = "0.14", default-features = false }
@@ -296,7 +297,3 @@ mutable_key_type = "allow"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(system_allocator)'] }
-
-[patch.crates-io]
-# Backport the Unix listener poll readiness re-arm fix from tokio-rs/mio#1998.
-mio = { git = "https://github.com/tokio-rs/mio", rev = "1e79434244eed630a1ee7f227117960c6296e7f3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,6 @@ ndarray = { version = "0.17", default-features = false }
 ndarray-stats = { version = "0.7", default-features = false }
 noisy_float = { version = "0.2", default-features = false }
 libc = { version = "0.2.186", default-features = false }
-mio = { version = "1.2.3", default-features = false }
 socket2 = { version = "0.6", default-features = false }
 tonic-prost-build = { version = "0.14", default-features = false }
 tonic-prost = { version = "0.14", default-features = false }

--- a/releasenotes/notes/bump-mio-1-2-3-390d1afd2a178179.yaml
+++ b/releasenotes/notes/bump-mio-1-2-3-390d1afd2a178179.yaml
@@ -1,4 +1,4 @@
 fixes:
   - |
-    Updated `mio` to 1.2.3, which fixes an issue with listening for new connections on Unix Domain Socket-based API
+    Updated ``mio`` to 1.2.3, which fixes an issue with listening for new connections on Unix Domain Socket-based API
     endpoints on AIX, as well as spurious crashes due to a race condition when using named pipes on Windows.

--- a/releasenotes/notes/bump-mio-1-2-3-390d1afd2a178179.yaml
+++ b/releasenotes/notes/bump-mio-1-2-3-390d1afd2a178179.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    Updated `mio` to 1.2.3, which fixes an issue with listening for new connections on Unix Domain Socket-based API
+    endpoints on AIX, as well as spurious crashes due to a race condition when using named pipes on Windows.


### PR DESCRIPTION
## Summary

This PR updates `mio` from a patched Git dependency to a regular versioned release in order to pull in the following two fixes:

- [Fix UDS listener re-arming with poll](https://github.com/tokio-rs/mio/pull/1998/s)
- [Fix race condition in NamedPipe::connect](https://github.com/tokio-rs/mio/pull/1954/s)

The first was fixed by @thieman after it was discovered that UDS sockets would get wedged on AIX after accepting the first connection. The second was discovered in automated testing due to ADP crashing on Windows. 

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing tests.

## References

DADP-2
