### PR TITLE
chore(config): encapsulate raw config snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,7 @@ dependencies = [
  "datadog-agent-config-overlay-model",
  "figment",
  "saluki-config",
+ "saluki-error",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -40,7 +40,6 @@ pub async fn create_control_plane_supervisor(
 ) -> Result<Supervisor, GenericError> {
     let config = config_system.config();
     let dp = DataPlaneConfiguration::from_configuration(&config);
-    let raw_map = config_system.raw_map();
     let mut supervisor = Supervisor::new("ctrl-pln")?
         .with_dedicated_runtime(RuntimeConfiguration::single_threaded())
         .with_restart_strategy(RestartStrategy::one_to_one());
@@ -52,10 +51,7 @@ pub async fn create_control_plane_supervisor(
         config_system.live(|config| &config.control.logging.level),
         logging_controller,
     ));
-    // Re-read the compatibility map on every request/dump so the endpoint reflects live updates.
-    supervisor.add_worker(ConfigWorker::new(Arc::new(move || {
-        raw_map.as_typed::<serde_json::Value>().map_err(Into::into)
-    })));
+    supervisor.add_worker(ConfigWorker::new(config_system.raw_snapshot()));
     supervisor.add_worker(ConfigRuntimeWorker::new(current_config));
 
     let api_listen_address = dp.api_listen_address()?;

--- a/lib/agent-data-plane-config-system/Cargo.toml
+++ b/lib/agent-data-plane-config-system/Cargo.toml
@@ -12,6 +12,7 @@ bytesize = { workspace = true }
 datadog-agent-config = { workspace = true }
 figment = { workspace = true }
 saluki-config = { workspace = true }
+saluki-error = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/lib/agent-data-plane-config-system/src/system.rs
+++ b/lib/agent-data-plane-config-system/src/system.rs
@@ -8,6 +8,7 @@ use arc_swap::ArcSwap;
 use datadog_agent_config::{DatadogConfiguration, TranslateErrors};
 use saluki_config::dynamic::ConfigUpdate;
 use saluki_config::{ConfigurationError, GenericConfiguration};
+use saluki_error::GenericError;
 use serde::Deserialize;
 use serde_json::Value;
 use snafu::Snafu;
@@ -176,6 +177,12 @@ impl ConfigurationSystem {
     pub fn raw_map(&self) -> GenericConfiguration {
         self.raw_map.clone()
     }
+
+    /// Returns a callback that reads the current raw configuration as JSON.
+    pub fn raw_snapshot(&self) -> Arc<dyn Fn() -> std::result::Result<Value, GenericError> + Send + Sync> {
+        let raw_map = self.raw_map.clone();
+        Arc::new(move || raw_map.as_typed::<Value>().map_err(Into::into))
+    }
 }
 
 /// Owns the Datadog Agent config stream for the life of the process: validates each update against
@@ -337,6 +344,7 @@ fn translate(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
     use std::time::Duration;
 
     use agent_data_plane_config::domains::dogstatsd::OriginTagCardinality;
@@ -552,6 +560,31 @@ mod tests {
         assert!(opw.enabled);
         assert_eq!(opw.url, "https://opw.example.com");
         assert!(opw.use_v3_series);
+    }
+
+    #[tokio::test]
+    async fn raw_snapshot_reflects_streamed_updates() {
+        let (system, agent_tx) = connected_system(json!({})).await;
+        let snapshot = system.raw_snapshot();
+        let cloned = Arc::clone(&snapshot);
+
+        assert_eq!(snapshot().expect("serializes").pointer("/dogstatsd_port"), None);
+
+        agent_tx
+            .send(ConfigUpdate::Partial(ConfigSetting::explicit(
+                "dogstatsd_port",
+                json!(9125),
+            )))
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while cloned().expect("serializes").pointer("/dogstatsd_port") != Some(&json!(9125)) {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for the raw snapshot to reflect the update");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Human Summary

Hides the raw map access behind a serde `Value` to keep the `/config` api unchanged for now. Soon we need to decide what to do with that, but the change here is unobservable and removes another use of the `raw_map` backdoor.

## AI Summary

- Move live raw JSON snapshot construction into the configuration system.
- Keep `/config` and runtime diagnostics backed by the current compatibility map.
- Remove direct raw-map access from control-plane setup.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make fmt`
- `make check-docs`
- `make check-clippy`
- `make check-unused-deps`
- `cargo check --workspace --tests`
- `cargo nextest run -p agent-data-plane-config-system`

## References

- Progresses: #2169
