### PR TITLE
chore(config): move compatibility checks to the config system

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashSet,
     path::{Path, PathBuf},
     sync::Arc,
     time::{Duration, Instant},
@@ -15,7 +14,6 @@ use agent_data_plane_config_system::{ConfigurationSystem, LoadedConfiguration};
 use argh::FromArgs;
 use bytesize::ByteSize;
 use datadog_agent_commons::{ipc::config::RemoteAgentClientConfiguration, platform::PlatformSettings};
-use datadog_agent_config::classifier::{ConfigClassifier, Pipeline, PipelineAffinity, Severity, SupportLevel};
 use saluki_app::{
     accounting::{initialize_memory_bounds, MemoryBoundsConfiguration, MemoryMode as AppMemoryMode},
     bootstrap::BootstrapGuard,
@@ -56,7 +54,7 @@ use saluki_env::{features, EnvironmentProvider as _, HostProvider as _};
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use saluki_io::net::ListenAddress;
 use stringtheory::MetaString;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, info, warn};
 
 use crate::{
     components::{
@@ -169,7 +167,9 @@ pub async fn handle_run_command(
         return Ok(());
     }
 
-    check_and_warn_config(&config_sys, &active_pipelines).error_context("Incompatible configuration detected.")?;
+    config_sys
+        .check_compatibility(&active_pipelines)
+        .error_context("Incompatible configuration detected.")?;
 
     let remote_agent_client_config = if standalone {
         None
@@ -299,98 +299,6 @@ pub async fn handle_run_command(
             Ok(())
         }
         Err(e) => Err(e.into()),
-    }
-}
-
-/// Check the resolved configuration against the config registry for incompatibilities.
-///
-/// Classifies each flattened key in `config` with the config registry `Classifier`. Returns an
-/// `Error` if one or more high severity incompatibility is discovered. Emits warnings for less
-/// severe incompatibilities. Keys are only considered incompatible when they have non-default
-/// values and the pipelines they affect are active.
-///
-/// # Input
-///
-/// - `config`: the state of our configuration which we will flatten and consider all keys from.
-/// - `active_pipelines`: the list of pipelines that are enabled based on the configuration.
-///
-/// # Error
-///
-/// To provide a better debugging experience in the presence of multiple high-severity incompatible
-/// keys, all keys are checked before returning. The error reports the count of incompatible keys;
-/// individual keys are logged at error level during iteration.
-///
-fn check_and_warn_config(
-    config: &ConfigurationSystem, active_pipelines: &HashSet<Pipeline>,
-) -> Result<(), GenericError> {
-    let classifier = ConfigClassifier::new();
-    let mut high_severity_incompatibilities = 0u32;
-    debug!("Analyzing configuration.");
-    // TODO: transfer this functionality to the config system
-    let config = config.raw_map();
-    for (key, val) in config
-        .flattened_keys()
-        .error_context("Unable to flatten configuration into a list of dot-separated keys.")?
-    {
-        // Get the classification. The classifier returns None if the config key is invalid or not-applicable to ADP.
-        let Some(classification) = classifier.classify(&key, &val) else {
-            continue;
-        };
-
-        // Ignore it if none of the affected pipelines are active.
-        if !is_a_pipeline_affected(active_pipelines, &classification.pipeline_affinity) {
-            continue;
-        }
-
-        // The Agent populates default values into the config, so we do not consider keys with default values.
-        if classification.is_default {
-            trace!(key = %key, "Configuration key has a default value.");
-            continue;
-        }
-
-        match classification.support_level {
-            SupportLevel::Incompatible(Severity::Low) => debug!("Low-severity incompatible key detected. Proceeding."),
-            SupportLevel::Partial => {
-                warn!(key = %key, "Partially supported configuration key. See documentation for details. Proceeding.")
-            }
-            SupportLevel::Incompatible(Severity::Medium) => {
-                warn!(key = %key, "Unsupported configuration key. Proceeding.")
-            }
-            SupportLevel::Incompatible(Severity::High) => {
-                error!(key = %key, "Unsupported configuration key with non-default value. ADP cannot run safely with \
-                this setting.");
-                high_severity_incompatibilities += 1;
-            }
-            SupportLevel::Ignored | SupportLevel::Unrecognized => {
-                trace!(key = %key, "Configuration key not-applicable. Silently ignoring.")
-            }
-        }
-    }
-
-    if high_severity_incompatibilities > 0 {
-        return Err(generic_error!(
-            "{high_severity_incompatibilities} incompatible configuration detected. ADP cannot start. Review error \
-            logs for details."
-        ));
-    }
-
-    Ok(())
-}
-
-/// Returns `true` if at least one of the `active_pipelines` is affected based on `pipeline_affinity`.
-fn is_a_pipeline_affected(active_pipelines: &HashSet<Pipeline>, pipeline_affinity: &PipelineAffinity) -> bool {
-    match pipeline_affinity {
-        PipelineAffinity::Pipelines(affected_pipelines) => {
-            for affected_pipeline in *affected_pipelines {
-                if active_pipelines.contains(affected_pipeline) {
-                    // We found an active pipeline that is in the affected list. Early return true.
-                    return true;
-                }
-            }
-            // We checked all affected pipelines against those that are active and none matched.
-            false
-        }
-        PipelineAffinity::CrossCutting => true,
     }
 }
 

--- a/lib/agent-data-plane-config-system/src/compatibility.rs
+++ b/lib/agent-data-plane-config-system/src/compatibility.rs
@@ -1,0 +1,165 @@
+//! Compatibility checks against the raw Datadog configuration.
+//!
+//! The typed model excludes unsupported keys, so classification uses the by-key view.
+
+use std::collections::HashSet;
+
+use datadog_agent_config::classifier::{ConfigClassifier, Pipeline, PipelineAffinity, Severity, SupportLevel};
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use tracing::{debug, error, trace, warn};
+
+use crate::ConfigurationSystem;
+
+impl ConfigurationSystem {
+    /// Checks non-default settings that affect active pipelines and logs their severity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if flattening fails or high-severity incompatibilities exist. All keys are
+    /// checked before returning, so the error includes the total count.
+    pub fn check_compatibility(&self, active_pipelines: &HashSet<Pipeline>) -> Result<(), GenericError> {
+        let classifier = ConfigClassifier::new();
+        let mut high_severity_incompatibilities = 0u32;
+        debug!("Analyzing configuration.");
+        for (key, val) in self
+            .raw_map()
+            .flattened_keys()
+            .error_context("Unable to flatten configuration into a list of dot-separated keys.")?
+        {
+            let Some(classification) = classifier.classify(&key, &val) else {
+                continue;
+            };
+
+            let pipeline_is_active = match &classification.pipeline_affinity {
+                PipelineAffinity::Pipelines(affected) => affected.iter().any(|p| active_pipelines.contains(p)),
+                PipelineAffinity::CrossCutting => true,
+            };
+            if !pipeline_is_active {
+                continue;
+            }
+
+            // The Agent includes schema defaults even when the operator did not set them.
+            if classification.is_default {
+                trace!(key = %key, "Configuration key has a default value.");
+                continue;
+            }
+
+            match classification.support_level {
+                SupportLevel::Incompatible(Severity::Low) => {
+                    debug!("Low-severity incompatible key detected. Proceeding.")
+                }
+                SupportLevel::Partial => {
+                    warn!(key = %key, "Partially supported configuration key. See documentation for details. Proceeding.")
+                }
+                SupportLevel::Incompatible(Severity::Medium) => {
+                    warn!(key = %key, "Unsupported configuration key. Proceeding.")
+                }
+                SupportLevel::Incompatible(Severity::High) => {
+                    error!(key = %key, "Unsupported configuration key with non-default value. ADP cannot run safely with \
+                    this setting.");
+                    high_severity_incompatibilities += 1;
+                }
+                SupportLevel::Ignored | SupportLevel::Unrecognized => {
+                    trace!(key = %key, "Configuration key not-applicable. Silently ignoring.")
+                }
+            }
+        }
+
+        if high_severity_incompatibilities > 0 {
+            return Err(generic_error!(
+                "{high_severity_incompatibilities} incompatible configuration detected. ADP cannot start. Review error \
+                logs for details."
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use datadog_agent_config::classifier::Pipeline;
+    use saluki_config::ConfigurationLoader;
+    use serde_json::{json, Value};
+
+    use crate::system::translate_strict;
+    use crate::{source::SourceTree, ConfigurationSystem};
+
+    async fn system_with(file: Value) -> ConfigurationSystem {
+        let (raw_map, _) = ConfigurationLoader::for_tests(Some(file), None, false).await;
+        let base = SourceTree::all_explicit(raw_map.as_typed::<Value>().expect("base extracts"));
+        let config = translate_strict(&base).expect("sources translate");
+        ConfigurationSystem::standalone(raw_map, config)
+    }
+
+    fn pipelines(active: &[Pipeline]) -> HashSet<Pipeline> {
+        active.iter().copied().collect()
+    }
+
+    fn otlp_tls_settings(cert_pem: &str, key_pem: &str) -> Value {
+        json!({
+            "otlp_config": {
+                "receiver": {
+                    "protocols": {
+                        "http": {
+                            "tls": { "cert_pem": cert_pem, "key_pem": key_pem }
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn high_severity_keys_fail_the_check_and_are_all_counted() {
+        let system = system_with(otlp_tls_settings("/etc/adp/cert.pem", "/etc/adp/key.pem")).await;
+
+        let error = system
+            .check_compatibility(&pipelines(&[Pipeline::Otlp]))
+            .expect_err("a high-severity incompatible key should fail the check");
+
+        assert!(error.to_string().contains("2 incompatible configuration detected"));
+    }
+
+    #[tokio::test]
+    async fn a_high_severity_key_holding_its_default_is_skipped() {
+        let system = system_with(otlp_tls_settings("", "")).await;
+
+        system
+            .check_compatibility(&pipelines(&[Pipeline::Otlp]))
+            .expect("default-valued keys are not incompatibilities");
+    }
+
+    #[tokio::test]
+    async fn a_high_severity_key_affecting_no_active_pipeline_is_skipped() {
+        let system = system_with(otlp_tls_settings("/etc/adp/cert.pem", "/etc/adp/key.pem")).await;
+
+        system
+            .check_compatibility(&pipelines(&[Pipeline::DogStatsD]))
+            .expect("an inactive pipeline's keys are not incompatibilities");
+    }
+
+    #[tokio::test]
+    async fn lower_severity_keys_pass_and_cross_cutting_keys_ignore_active_pipelines() {
+        let system = system_with(json!({ "dogstatsd_queue_size": 2048, "min_tls_version": "tlsv1.3" })).await;
+        system
+            .check_compatibility(&pipelines(&[Pipeline::DogStatsD]))
+            .expect("only high-severity incompatibilities fail the check");
+
+        let cross_cutting = system_with(json!({ "heroku_dyno": true })).await;
+        cross_cutting
+            .check_compatibility(&pipelines(&[]))
+            .expect_err("a cross-cutting high-severity key fails the check with no pipeline active");
+    }
+
+    #[tokio::test]
+    async fn keys_the_registry_does_not_know_are_ignored() {
+        let system = system_with(json!({ "not_a_real_agent_setting": true, "dogstatsd_port": 9125 })).await;
+
+        system
+            .check_compatibility(&pipelines(&[Pipeline::DogStatsD]))
+            .expect("unclassified keys are not incompatibilities");
+    }
+}

--- a/lib/agent-data-plane-config-system/src/lib.rs
+++ b/lib/agent-data-plane-config-system/src/lib.rs
@@ -22,6 +22,7 @@
 // expansion limit. Only test builds need the higher limit.
 #![cfg_attr(test, recursion_limit = "256")]
 
+mod compatibility;
 mod env_provider;
 mod loaded;
 mod saluki_env_overlay;


### PR DESCRIPTION
## Human Summary

Moves the pipeline-aware config compatibility checks and warnings to the config system (to keep map access there).

## AI Summary

- Move startup config compatibility checks into the configuration system.
- Keep default filtering, pipeline affinity, severity logging, and fatal aggregation unchanged.
- Remove classifier-specific raw config access from the run command.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make fmt`
- `make check-docs`
- `make check-clippy`
- `cargo check --workspace --tests`
- Targeted `cargo nextest` runs for config-system and agent-data-plane

## References

- Progresses: #2169
- Progresses: #2197
