### PR TITLE
chore(telemetry): add client and transport tags to DogStatsD COAT metrics

### DIFF
--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -582,7 +582,12 @@ mod tests {
             Event::Metric(Metric::counter(
                 Context::from_static_parts(
                     internal_name,
-                    &["component_id:dsd_client_telemetry_out", "component_type:destination"],
+                    &[
+                        "component_id:dsd_client_telemetry_out",
+                        "component_type:destination",
+                        "client:go",
+                        "client_transport:uds",
+                    ],
                 ),
                 7.0,
             ))
@@ -598,7 +603,10 @@ mod tests {
             "dogstatsd_client__bytes_dropped_writer",
         ] {
             assert!(output.contains(&format!("# TYPE {exported_name} counter")), "{output}");
-            assert!(output.contains(&format!("{exported_name} 7")), "{output}");
+            assert!(
+                output.contains(&format!("{exported_name}{{client=\"go\",client_transport=\"uds\"}} 7")),
+                "{output}"
+            );
         }
     }
 

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -140,28 +140,31 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
         .with_original_tags(["message_type", "origin"])
         .with_additional_tags(["state:error"])
         .with_help_text("Count of service checks/events/metrics processed by dogstatsd"),
-        // DogStatsD client byte telemetry. These counters mirror the post-aggregation metric stream without
-        // client-provided dimensions, so COAT receives the same byte totals that ADP sends to customer intake while
-        // retaining bounded cardinality.
+        // DogStatsD client byte telemetry. These counters mirror the post-aggregation metric stream and retain the
+        // client library and transport dimensions supplied by the DogStatsD client.
         RemapperRule::by_name(
             "adp.dogstatsd_client_telemetry_bytes_sent",
             "dogstatsd_client.bytes_sent",
         )
+        .with_original_tags(["client", "client_transport"])
         .with_help_text("Total bytes sent by DogStatsD clients"),
         RemapperRule::by_name(
             "adp.dogstatsd_client_telemetry_bytes_dropped",
             "dogstatsd_client.bytes_dropped",
         )
+        .with_original_tags(["client", "client_transport"])
         .with_help_text("Total bytes dropped by DogStatsD clients"),
         RemapperRule::by_name(
             "adp.dogstatsd_client_telemetry_bytes_dropped_queue",
             "dogstatsd_client.bytes_dropped_queue",
         )
+        .with_original_tags(["client", "client_transport"])
         .with_help_text("Total bytes dropped because the DogStatsD client sender queue is full"),
         RemapperRule::by_name(
             "adp.dogstatsd_client_telemetry_bytes_dropped_writer",
             "dogstatsd_client.bytes_dropped_writer",
         )
+        .with_original_tags(["client", "client_transport"])
         .with_help_text("Total bytes dropped because the DogStatsD client writer cannot send"),
     ]
 }

--- a/lib/saluki-components/src/destinations/dogstatsd_client_telemetry.rs
+++ b/lib/saluki-components/src/destinations/dogstatsd_client_telemetry.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use metrics::Counter;
+use saluki_common::collections::FastHashMap;
 use saluki_core::{
     accounting::{MemoryBounds, MemoryBoundsBuilder},
     components::{destinations::*, BuildContext},
@@ -13,6 +14,95 @@ use saluki_error::GenericError;
 use saluki_metrics::MetricsBuilder;
 use tokio::select;
 use tracing::debug;
+
+const BYTES_SENT_METRIC: &str = "dogstatsd_client_telemetry_bytes_sent";
+const BYTES_DROPPED_METRIC: &str = "dogstatsd_client_telemetry_bytes_dropped";
+const BYTES_DROPPED_QUEUE_METRIC: &str = "dogstatsd_client_telemetry_bytes_dropped_queue";
+const BYTES_DROPPED_WRITER_METRIC: &str = "dogstatsd_client_telemetry_bytes_dropped_writer";
+
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+struct ClientTelemetryTags {
+    client: &'static str,
+    client_transport: &'static str,
+}
+
+impl ClientTelemetryTags {
+    fn from_metric(metric: &Metric) -> Self {
+        let mut tags = Self {
+            client: "unknown",
+            client_transport: "unknown",
+        };
+        for tag in metric.context().tags() {
+            match tag.name() {
+                "client" => tags.client = normalize_client_library(tag.value()),
+                "client_transport" => tags.client_transport = normalize_client_transport(tag.value()),
+                _ => {}
+            }
+            if tags.client != "unknown" && tags.client_transport != "unknown" {
+                break;
+            }
+        }
+        tags
+    }
+
+    fn as_metric_tags(&self) -> [(&'static str, &'static str); 2] {
+        [("client", self.client), ("client_transport", self.client_transport)]
+    }
+}
+
+pub(super) fn normalize_client_library(client: Option<&str>) -> &'static str {
+    match client {
+        Some("go") => "go",
+        Some("py") => "py",
+        Some("java") => "java",
+        Some("ruby") => "ruby",
+        Some("csharp") => "csharp",
+        Some("php") => "php",
+        Some("rust") => "rust",
+        _ => "unknown",
+    }
+}
+
+pub(super) fn normalize_client_transport(transport: Option<&str>) -> &'static str {
+    match transport {
+        Some("udp") => "udp",
+        Some("uds") => "uds",
+        Some("uds-stream") => "uds-stream",
+        Some("uds-datagram") => "uds-datagram",
+        Some("pipe") => "pipe",
+        Some("namedpipe") => "namedpipe",
+        Some("named_pipe") => "named_pipe",
+        Some("custom") => "custom",
+        Some("http") => "http",
+        _ => "unknown",
+    }
+}
+
+struct ClientTelemetryCounters {
+    bytes_sent: Counter,
+    bytes_dropped: Counter,
+    bytes_dropped_queue: Counter,
+    bytes_dropped_writer: Counter,
+}
+
+impl ClientTelemetryCounters {
+    fn new(metrics_builder: &MetricsBuilder, tags: &ClientTelemetryTags) -> Self {
+        let metric_tags = tags.as_metric_tags();
+        Self {
+            bytes_sent: metrics_builder.register_counter_with_tags(BYTES_SENT_METRIC, metric_tags),
+            bytes_dropped: metrics_builder.register_counter_with_tags(BYTES_DROPPED_METRIC, metric_tags),
+            bytes_dropped_queue: metrics_builder.register_counter_with_tags(BYTES_DROPPED_QUEUE_METRIC, metric_tags),
+            bytes_dropped_writer: metrics_builder.register_counter_with_tags(BYTES_DROPPED_WRITER_METRIC, metric_tags),
+        }
+    }
+}
+
+enum ClientTelemetryMetric {
+    Sent,
+    Dropped,
+    DroppedQueue,
+    DroppedWriter,
+}
 
 /// Configuration for the DogStatsD client telemetry destination.
 #[derive(Default)]
@@ -41,34 +131,42 @@ impl MemoryBounds for DogStatsDClientTelemetryConfiguration {
 
 /// Mirrors supported DogStatsD client telemetry metrics into ADP internal telemetry.
 pub struct DogStatsDClientTelemetry {
-    bytes_sent: Counter,
-    bytes_dropped: Counter,
-    bytes_dropped_queue: Counter,
-    bytes_dropped_writer: Counter,
+    metrics_builder: MetricsBuilder,
+    counters_by_tags: FastHashMap<ClientTelemetryTags, ClientTelemetryCounters>,
 }
 
 impl DogStatsDClientTelemetry {
     pub(super) fn new(metrics_builder: MetricsBuilder) -> Self {
         Self {
-            bytes_sent: metrics_builder.register_counter("dogstatsd_client_telemetry_bytes_sent"),
-            bytes_dropped: metrics_builder.register_counter("dogstatsd_client_telemetry_bytes_dropped"),
-            bytes_dropped_queue: metrics_builder.register_counter("dogstatsd_client_telemetry_bytes_dropped_queue"),
-            bytes_dropped_writer: metrics_builder.register_counter("dogstatsd_client_telemetry_bytes_dropped_writer"),
+            metrics_builder,
+            counters_by_tags: FastHashMap::default(),
         }
     }
 
-    pub(super) fn record_metric(&self, metric: &Metric) {
-        let counter = match metric.context().name().as_ref() {
-            "datadog.dogstatsd.client.bytes_sent" => &self.bytes_sent,
-            "datadog.dogstatsd.client.bytes_dropped" => &self.bytes_dropped,
-            "datadog.dogstatsd.client.bytes_dropped_queue" => &self.bytes_dropped_queue,
-            "datadog.dogstatsd.client.bytes_dropped_writer" => &self.bytes_dropped_writer,
+    pub(super) fn record_metric(&mut self, metric: &Metric) {
+        let metric_kind = match metric.context().name().as_ref() {
+            "datadog.dogstatsd.client.bytes_sent" => ClientTelemetryMetric::Sent,
+            "datadog.dogstatsd.client.bytes_dropped" => ClientTelemetryMetric::Dropped,
+            "datadog.dogstatsd.client.bytes_dropped_queue" => ClientTelemetryMetric::DroppedQueue,
+            "datadog.dogstatsd.client.bytes_dropped_writer" => ClientTelemetryMetric::DroppedWriter,
             _ => return,
         };
 
         if let MetricValues::Rate(values, _) = metric.values() {
             // A delayed aggregate flush can contain several closed time buckets in one metric. Separate tag contexts
-            // arrive as separate metrics and intentionally accumulate into this dimensionless COAT counter.
+            // arrive as separate metrics and accumulate into counters with their client dimensions preserved.
+            let tags = ClientTelemetryTags::from_metric(metric);
+            let metrics_builder = &self.metrics_builder;
+            let counters = self
+                .counters_by_tags
+                .entry(tags)
+                .or_insert_with_key(|tags| ClientTelemetryCounters::new(metrics_builder, tags));
+            let counter = match metric_kind {
+                ClientTelemetryMetric::Sent => &counters.bytes_sent,
+                ClientTelemetryMetric::Dropped => &counters.bytes_dropped,
+                ClientTelemetryMetric::DroppedQueue => &counters.bytes_dropped_queue,
+                ClientTelemetryMetric::DroppedWriter => &counters.bytes_dropped_writer,
+            };
             for (_, value) in values {
                 if value.is_finite() && value >= 0.0 && value.fract() == 0.0 && value <= u64::MAX as f64 {
                     counter.increment(value as u64);
@@ -80,7 +178,7 @@ impl DogStatsDClientTelemetry {
 
 #[async_trait]
 impl Destination for DogStatsDClientTelemetry {
-    async fn run(self: Box<Self>, mut context: DestinationContext) -> Result<(), GenericError> {
+    async fn run(mut self: Box<Self>, mut context: DestinationContext) -> Result<(), GenericError> {
         let mut health = context.take_health_handle();
         health.mark_ready();
         debug!("DogStatsD client telemetry destination started.");

--- a/lib/saluki-components/src/destinations/dogstatsd_client_telemetry.rs
+++ b/lib/saluki-components/src/destinations/dogstatsd_client_telemetry.rs
@@ -1,26 +1,18 @@
 use async_trait::async_trait;
-use metrics::Counter;
-use saluki_common::collections::FastHashMap;
 use saluki_core::{
     accounting::{MemoryBounds, MemoryBoundsBuilder},
-    components::{destinations::*, BuildContext},
+    components::{destinations::*, BuildContext, ComponentContext},
     data_model::event::{
         metric::{Metric, MetricValues},
         Event, EventType,
     },
-    observability::ComponentMetricsExt as _,
 };
 use saluki_error::GenericError;
-use saluki_metrics::MetricsBuilder;
+use saluki_metrics::{static_metrics, Counter};
 use tokio::select;
 use tracing::debug;
 
-const BYTES_SENT_METRIC: &str = "dogstatsd_client_telemetry_bytes_sent";
-const BYTES_DROPPED_METRIC: &str = "dogstatsd_client_telemetry_bytes_dropped";
-const BYTES_DROPPED_QUEUE_METRIC: &str = "dogstatsd_client_telemetry_bytes_dropped_queue";
-const BYTES_DROPPED_WRITER_METRIC: &str = "dogstatsd_client_telemetry_bytes_dropped_writer";
-
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy)]
 struct ClientTelemetryTags {
     client: &'static str,
     client_transport: &'static str,
@@ -43,10 +35,6 @@ impl ClientTelemetryTags {
             }
         }
         tags
-    }
-
-    fn as_metric_tags(&self) -> [(&'static str, &'static str); 2] {
-        [("client", self.client), ("client_transport", self.client_transport)]
     }
 }
 
@@ -78,23 +66,17 @@ pub(super) fn normalize_client_transport(transport: Option<&str>) -> &'static st
     }
 }
 
+#[static_metrics(prefix = dogstatsd_client_telemetry, labels(component_id, component_type))]
+#[derive(Clone)]
 struct ClientTelemetryCounters {
+    #[metric(mapped(client, client_transport))]
     bytes_sent: Counter,
+    #[metric(mapped(client, client_transport))]
     bytes_dropped: Counter,
+    #[metric(mapped(client, client_transport))]
     bytes_dropped_queue: Counter,
+    #[metric(mapped(client, client_transport))]
     bytes_dropped_writer: Counter,
-}
-
-impl ClientTelemetryCounters {
-    fn new(metrics_builder: &MetricsBuilder, tags: &ClientTelemetryTags) -> Self {
-        let metric_tags = tags.as_metric_tags();
-        Self {
-            bytes_sent: metrics_builder.register_counter_with_tags(BYTES_SENT_METRIC, metric_tags),
-            bytes_dropped: metrics_builder.register_counter_with_tags(BYTES_DROPPED_METRIC, metric_tags),
-            bytes_dropped_queue: metrics_builder.register_counter_with_tags(BYTES_DROPPED_QUEUE_METRIC, metric_tags),
-            bytes_dropped_writer: metrics_builder.register_counter_with_tags(BYTES_DROPPED_WRITER_METRIC, metric_tags),
-        }
-    }
 }
 
 enum ClientTelemetryMetric {
@@ -115,9 +97,7 @@ impl DestinationBuilder for DogStatsDClientTelemetryConfiguration {
     }
 
     async fn build(&self, context: BuildContext) -> Result<Box<dyn Destination + Send>, GenericError> {
-        Ok(Box::new(DogStatsDClientTelemetry::new(
-            MetricsBuilder::from_component_context(context.component_context()),
-        )))
+        Ok(Box::new(DogStatsDClientTelemetry::new(context.component_context())))
     }
 }
 
@@ -131,19 +111,20 @@ impl MemoryBounds for DogStatsDClientTelemetryConfiguration {
 
 /// Mirrors supported DogStatsD client telemetry metrics into ADP internal telemetry.
 pub struct DogStatsDClientTelemetry {
-    metrics_builder: MetricsBuilder,
-    counters_by_tags: FastHashMap<ClientTelemetryTags, ClientTelemetryCounters>,
+    counters: ClientTelemetryCounters,
 }
 
 impl DogStatsDClientTelemetry {
-    pub(super) fn new(metrics_builder: MetricsBuilder) -> Self {
+    pub(super) fn new(component_context: &ComponentContext) -> Self {
         Self {
-            metrics_builder,
-            counters_by_tags: FastHashMap::default(),
+            counters: ClientTelemetryCounters::new(
+                component_context.component_id(),
+                component_context.component_type().as_str(),
+            ),
         }
     }
 
-    pub(super) fn record_metric(&mut self, metric: &Metric) {
+    pub(super) fn record_metric(&self, metric: &Metric) {
         let metric_kind = match metric.context().name().as_ref() {
             "datadog.dogstatsd.client.bytes_sent" => ClientTelemetryMetric::Sent,
             "datadog.dogstatsd.client.bytes_dropped" => ClientTelemetryMetric::Dropped,
@@ -156,16 +137,15 @@ impl DogStatsDClientTelemetry {
             // A delayed aggregate flush can contain several closed time buckets in one metric. Separate tag contexts
             // arrive as separate metrics and accumulate into counters with their client dimensions preserved.
             let tags = ClientTelemetryTags::from_metric(metric);
-            let metrics_builder = &self.metrics_builder;
-            let counters = self
-                .counters_by_tags
-                .entry(tags)
-                .or_insert_with_key(|tags| ClientTelemetryCounters::new(metrics_builder, tags));
             let counter = match metric_kind {
-                ClientTelemetryMetric::Sent => &counters.bytes_sent,
-                ClientTelemetryMetric::Dropped => &counters.bytes_dropped,
-                ClientTelemetryMetric::DroppedQueue => &counters.bytes_dropped_queue,
-                ClientTelemetryMetric::DroppedWriter => &counters.bytes_dropped_writer,
+                ClientTelemetryMetric::Sent => self.counters.bytes_sent(tags.client, tags.client_transport),
+                ClientTelemetryMetric::Dropped => self.counters.bytes_dropped(tags.client, tags.client_transport),
+                ClientTelemetryMetric::DroppedQueue => {
+                    self.counters.bytes_dropped_queue(tags.client, tags.client_transport)
+                }
+                ClientTelemetryMetric::DroppedWriter => {
+                    self.counters.bytes_dropped_writer(tags.client, tags.client_transport)
+                }
             };
             for (_, value) in values {
                 if value.is_finite() && value >= 0.0 && value.fract() == 0.0 && value <= u64::MAX as f64 {
@@ -178,7 +158,7 @@ impl DogStatsDClientTelemetry {
 
 #[async_trait]
 impl Destination for DogStatsDClientTelemetry {
-    async fn run(mut self: Box<Self>, mut context: DestinationContext) -> Result<(), GenericError> {
+    async fn run(self: Box<Self>, mut context: DestinationContext) -> Result<(), GenericError> {
         let mut health = context.take_health_handle();
         health.mark_ready();
         debug!("DogStatsD client telemetry destination started.");

--- a/lib/saluki-components/src/destinations/dogstatsd_client_telemetry_tests.rs
+++ b/lib/saluki-components/src/destinations/dogstatsd_client_telemetry_tests.rs
@@ -2,15 +2,23 @@ use std::time::Duration;
 
 use metrics::{set_default_local_recorder, Key, Label};
 use saluki_context::Context;
-use saluki_core::data_model::event::metric::Metric;
-use saluki_metrics::{test::TestRecorder, MetricsBuilder};
+use saluki_core::{components::ComponentContext, data_model::event::metric::Metric};
+use saluki_metrics::test::TestRecorder;
 
 use super::dogstatsd_client_telemetry::{normalize_client_transport, DogStatsDClientTelemetry};
+
+const COMPONENT_ID: &str = "dogstatsd_client_telemetry_test";
+
+fn test_telemetry() -> DogStatsDClientTelemetry {
+    DogStatsDClientTelemetry::new(&ComponentContext::test_destination(COMPONENT_ID))
+}
 
 fn client_counter_key(metric_name: &'static str, client: &str, client_transport: &str) -> Key {
     Key::from_parts(
         metric_name,
         vec![
+            Label::new("component_id", COMPONENT_ID),
+            Label::new("component_type", "destination"),
             Label::new("client", client.to_string()),
             Label::new("client_transport", client_transport.to_string()),
         ],
@@ -21,7 +29,7 @@ fn client_counter_key(metric_name: &'static str, client: &str, client_transport:
 fn records_all_supported_client_telemetry_rates_with_client_dimensions() {
     let recorder = TestRecorder::default();
     let _recorder_guard = set_default_local_recorder(&recorder);
-    let mut telemetry = DogStatsDClientTelemetry::new(MetricsBuilder::default());
+    let telemetry = test_telemetry();
 
     for (metric_name, telemetry_name) in [
         (
@@ -60,7 +68,7 @@ fn records_all_supported_client_telemetry_rates_with_client_dimensions() {
 fn ignores_unknown_client_telemetry_names_and_non_rate_values() {
     let recorder = TestRecorder::default();
     let _recorder_guard = set_default_local_recorder(&recorder);
-    let mut telemetry = DogStatsDClientTelemetry::new(MetricsBuilder::default());
+    let telemetry = test_telemetry();
 
     telemetry.record_metric(&Metric::rate(
         "datadog.dogstatsd.client.unrecognized",
@@ -95,7 +103,7 @@ fn ignores_unknown_client_telemetry_names_and_non_rate_values() {
 fn accumulates_client_telemetry_rate_buckets_as_counter_deltas() {
     let recorder = TestRecorder::default();
     let _recorder_guard = set_default_local_recorder(&recorder);
-    let mut telemetry = DogStatsDClientTelemetry::new(MetricsBuilder::default());
+    let telemetry = test_telemetry();
 
     telemetry.record_metric(&Metric::rate(
         "datadog.dogstatsd.client.bytes_sent",
@@ -117,7 +125,7 @@ fn accumulates_client_telemetry_rate_buckets_as_counter_deltas() {
 fn keeps_client_telemetry_tag_contexts_separate() {
     let recorder = TestRecorder::default();
     let _recorder_guard = set_default_local_recorder(&recorder);
-    let mut telemetry = DogStatsDClientTelemetry::new(MetricsBuilder::default());
+    let telemetry = test_telemetry();
 
     telemetry.record_metric(&Metric::rate(
         Context::from_static_parts(

--- a/lib/saluki-components/src/destinations/dogstatsd_client_telemetry_tests.rs
+++ b/lib/saluki-components/src/destinations/dogstatsd_client_telemetry_tests.rs
@@ -1,16 +1,27 @@
 use std::time::Duration;
 
-use metrics::set_default_local_recorder;
+use metrics::{set_default_local_recorder, Key, Label};
+use saluki_context::Context;
 use saluki_core::data_model::event::metric::Metric;
 use saluki_metrics::{test::TestRecorder, MetricsBuilder};
 
-use super::dogstatsd_client_telemetry::DogStatsDClientTelemetry;
+use super::dogstatsd_client_telemetry::{normalize_client_transport, DogStatsDClientTelemetry};
+
+fn client_counter_key(metric_name: &'static str, client: &str, client_transport: &str) -> Key {
+    Key::from_parts(
+        metric_name,
+        vec![
+            Label::new("client", client.to_string()),
+            Label::new("client_transport", client_transport.to_string()),
+        ],
+    )
+}
 
 #[test]
-fn records_all_supported_client_telemetry_rates_without_client_dimensions() {
+fn records_all_supported_client_telemetry_rates_with_client_dimensions() {
     let recorder = TestRecorder::default();
     let _recorder_guard = set_default_local_recorder(&recorder);
-    let telemetry = DogStatsDClientTelemetry::new(MetricsBuilder::default());
+    let mut telemetry = DogStatsDClientTelemetry::new(MetricsBuilder::default());
 
     for (metric_name, telemetry_name) in [
         (
@@ -30,10 +41,18 @@ fn records_all_supported_client_telemetry_rates_without_client_dimensions() {
             "dogstatsd_client_telemetry_bytes_dropped_writer",
         ),
     ] {
-        let metric = Metric::rate(metric_name, [(100, 7.0)], Duration::from_secs(10));
+        let metric = Metric::rate(
+            Context::from_static_parts(metric_name, &["client:go", "client_transport:uds"]),
+            [(100, 7.0)],
+            Duration::from_secs(10),
+        );
         telemetry.record_metric(&metric);
 
-        assert_eq!(recorder.counter(telemetry_name), Some(7), "{metric_name}");
+        assert_eq!(
+            recorder.counter(client_counter_key(telemetry_name, "go", "uds")),
+            Some(7),
+            "{metric_name}"
+        );
     }
 }
 
@@ -41,7 +60,7 @@ fn records_all_supported_client_telemetry_rates_without_client_dimensions() {
 fn ignores_unknown_client_telemetry_names_and_non_rate_values() {
     let recorder = TestRecorder::default();
     let _recorder_guard = set_default_local_recorder(&recorder);
-    let telemetry = DogStatsDClientTelemetry::new(MetricsBuilder::default());
+    let mut telemetry = DogStatsDClientTelemetry::new(MetricsBuilder::default());
 
     telemetry.record_metric(&Metric::rate(
         "datadog.dogstatsd.client.unrecognized",
@@ -60,7 +79,15 @@ fn ignores_unknown_client_telemetry_names_and_non_rate_values() {
         Duration::from_secs(10),
     ));
 
-    assert_eq!(recorder.counter("dogstatsd_client_telemetry_bytes_sent"), Some(0));
+    assert_eq!(
+        recorder.counter(client_counter_key(
+            "dogstatsd_client_telemetry_bytes_sent",
+            "unknown",
+            "unknown"
+        )),
+        Some(0)
+    );
+    assert_eq!(recorder.counter("dogstatsd_client_telemetry_bytes_sent"), None);
     assert_eq!(recorder.counter("dogstatsd_client_telemetry_metrics"), None);
 }
 
@@ -68,7 +95,7 @@ fn ignores_unknown_client_telemetry_names_and_non_rate_values() {
 fn accumulates_client_telemetry_rate_buckets_as_counter_deltas() {
     let recorder = TestRecorder::default();
     let _recorder_guard = set_default_local_recorder(&recorder);
-    let telemetry = DogStatsDClientTelemetry::new(MetricsBuilder::default());
+    let mut telemetry = DogStatsDClientTelemetry::new(MetricsBuilder::default());
 
     telemetry.record_metric(&Metric::rate(
         "datadog.dogstatsd.client.bytes_sent",
@@ -76,5 +103,56 @@ fn accumulates_client_telemetry_rate_buckets_as_counter_deltas() {
         Duration::from_secs(10),
     ));
 
-    assert_eq!(recorder.counter("dogstatsd_client_telemetry_bytes_sent"), Some(10));
+    assert_eq!(
+        recorder.counter(client_counter_key(
+            "dogstatsd_client_telemetry_bytes_sent",
+            "unknown",
+            "unknown"
+        )),
+        Some(10)
+    );
+}
+
+#[test]
+fn keeps_client_telemetry_tag_contexts_separate() {
+    let recorder = TestRecorder::default();
+    let _recorder_guard = set_default_local_recorder(&recorder);
+    let mut telemetry = DogStatsDClientTelemetry::new(MetricsBuilder::default());
+
+    telemetry.record_metric(&Metric::rate(
+        Context::from_static_parts(
+            "datadog.dogstatsd.client.bytes_sent",
+            &["client:go", "client_transport:uds"],
+        ),
+        [(100, 7.0)],
+        Duration::from_secs(10),
+    ));
+    telemetry.record_metric(&Metric::rate(
+        Context::from_static_parts(
+            "datadog.dogstatsd.client.bytes_sent",
+            &["client:java", "client_transport:udp"],
+        ),
+        [(100, 3.0)],
+        Duration::from_secs(10),
+    ));
+
+    assert_eq!(
+        recorder.counter(client_counter_key("dogstatsd_client_telemetry_bytes_sent", "go", "uds")),
+        Some(7)
+    );
+    assert_eq!(
+        recorder.counter(client_counter_key(
+            "dogstatsd_client_telemetry_bytes_sent",
+            "java",
+            "udp"
+        )),
+        Some(3)
+    );
+}
+
+#[test]
+fn preserves_supported_named_pipe_transport_values() {
+    for transport in ["pipe", "namedpipe", "named_pipe"] {
+        assert_eq!(normalize_client_transport(Some(transport)), transport);
+    }
 }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Preserves the `client` and `client_transport` dimensions on DogStatsD client byte telemetry exported to COAT.

Client and transport values are restricted to known values, with unsupported or missing values reported as `unknown`. This keeps cardinality bounded while allowing DogStatsD payload drops to be analyzed by client library and transport.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
New + Updated unit tests

## References

<!-- Please list any issues closed by this PR. -->

Datadog-agent PR: https://github.com/DataDog/datadog-agent/pull/55768

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
