### PR TITLE
chore(ci): exclude automated bump PRs from changelog requirement

### DIFF
--- a/.github/workflows/bump-adp-version.yml
+++ b/.github/workflows/bump-adp-version.yml
@@ -167,7 +167,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: updatePR.data.number,
-              labels: [prLabel, 'automated']
+              labels: [prLabel, 'automated', 'changelog/no-changelog']
             });
 
             // Look for other open PRs bumping the ADP version on the same target branch, and close them out so this

--- a/.github/workflows/update-agent-tagger-prefixes.yml
+++ b/.github/workflows/update-agent-tagger-prefixes.yml
@@ -243,7 +243,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: updatePR.data.number,
-              labels: [prLabel, 'automated']
+              labels: [prLabel, 'automated', 'changelog/no-changelog']
             });
 
             // Close out any older PRs from this workflow: the newest fixture is a superset of what they reported.

--- a/.github/workflows/update-agent-version.yml
+++ b/.github/workflows/update-agent-version.yml
@@ -180,7 +180,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: updatePR.data.number,
-              labels: [prLabel, 'automated']
+              labels: [prLabel, 'automated', 'changelog/no-changelog']
             });
 
             // Look for other open PRs for updating the Agent version, and close them out so this one takes precedence.


### PR DESCRIPTION
## Summary

As stated in the PR title.

For most bump PRs (ADP version, Datadog Agent version, etc), it's not a changelog-worthy thing... so we just want to mark the PRs as not needing a changelog entry so that the CI check passes.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Can't test it until it's merged.

## References

DADP-2
