### PR TITLE
chore(ci): polish the auto-generated release notes

### DIFF
--- a/ci/tooling/release_notes.py
+++ b/ci/tooling/release_notes.py
@@ -46,7 +46,7 @@ def build_curated_block(markdown: str) -> str:
     if not markdown.strip():
         return ""
 
-    return "\n".join((START_MARKER, "# Release notes", "", markdown.strip(), END_MARKER))
+    return "\n".join((START_MARKER, markdown.strip(), END_MARKER))
 
 
 def merge_release_body(existing: str, markdown: str) -> str:

--- a/ci/tooling/test_release_notes.py
+++ b/ci/tooling/test_release_notes.py
@@ -29,7 +29,7 @@ class ReleaseBodyTest(unittest.TestCase):
 
         merged = subject.merge_release_body(existing, "## Bug Fixes\n- Fix parser behavior")
 
-        self.assertTrue(merged.startswith(subject.START_MARKER + "\n# Release Notes"))
+        self.assertTrue(merged.startswith(subject.START_MARKER + "\n## Bug Fixes"))
         self.assertTrue(merged.endswith(existing))
 
     def test_replaces_only_the_existing_generated_block(self):

--- a/ci/tooling/test_release_notes.py
+++ b/ci/tooling/test_release_notes.py
@@ -29,7 +29,7 @@ class ReleaseBodyTest(unittest.TestCase):
 
         merged = subject.merge_release_body(existing, "## Bug Fixes\n- Fix parser behavior")
 
-        self.assertTrue(merged.startswith(subject.START_MARKER + "\n# Release notes"))
+        self.assertTrue(merged.startswith(subject.START_MARKER + "\n# Release Notes"))
         self.assertTrue(merged.endswith(existing))
 
     def test_replaces_only_the_existing_generated_block(self):

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -31,9 +31,9 @@ template: |
 sections:
   - [upgrade, Upgrade Notes]
   - [features, New Features]
-  - [enhancements, Enhancement Notes]
+  - [enhancements, Enhancements]
   - [issues, Known Issues]
-  - [deprecations, Deprecation Notes]
+  - [deprecations, Deprecations]
   - [security, Security Notes]
   - [fixes, Bug Fixes]
   - [other, Other Notes]

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -31,9 +31,9 @@ template: |
 sections:
   - [upgrade, Upgrade Notes]
   - [features, New Features]
-  - [enhancements, Enhancements]
+  - [enhancements, Enhancement Notes]
   - [issues, Known Issues]
-  - [deprecations, Deprecations]
+  - [deprecations, Deprecation Notes]
   - [security, Security Notes]
   - [fixes, Bug Fixes]
   - [other, Other Notes]


### PR DESCRIPTION
## Summary

Just a little bit of polish on the auto-generated release notes.

Notably, Reno already adds it's own `# Release Notes` to its output, so we don't need to also do it.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

Can't test without it running.

## References

DADP-2
