### PR TITLE
fix(docs): resolve vale lint failures in doc comments

### DIFF
--- a/bin/correctness/panoramic/src/dynamic_vars.rs
+++ b/bin/correctness/panoramic/src/dynamic_vars.rs
@@ -11,6 +11,7 @@
 //! In a test's `config.yaml`, add a `PANORAMIC_DYNAMIC_<KEY>` env var whose value is a shell
 //! command. Reference the resolved value anywhere in the config with `{{PANORAMIC_DYNAMIC_<KEY>}}`:
 //!
+//! <!-- vale off -->
 //! ```yaml
 //! container:
 //!   env:
@@ -22,6 +23,7 @@
 //!     pattern: "listen_addr:{{PANORAMIC_DYNAMIC_CONTAINER_IP}}:8125"
 //!     timeout: 15s
 //! ```
+//! <!-- vale on -->
 //!
 //! ## How resolution works
 //!

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -279,7 +279,7 @@ pub struct Receiver {
 /// Default gRPC maximum inbound message size, in MiB.
 ///
 /// The Datadog schema default for `max_recv_msg_size_mib` is `0`, which grpc-go treats as "apply the
-/// built-in 4 MiB limit". Translation substitutes this constant for a configured `0` so the model
+/// built-in 4 MiB limit." Translation substitutes this constant for a configured `0` so the model
 /// always carries an effective limit.
 pub const DEFAULT_GRPC_MAX_RECV_MSG_SIZE_MIB: u64 = 4;
 

--- a/lib/agent-data-plane-config/src/provenance.rs
+++ b/lib/agent-data-plane-config/src/provenance.rs
@@ -51,7 +51,7 @@ pub enum Provenance {
 ///
 /// Prefer `ConfigValue<T>` over `ConfigValue<Option<T>>`. Reaching for the inner `Option` usually
 /// means it is duplicating the provenance: a `T` with [`Provenance::Default`] already expresses "no
-/// one configured this", and the nested form leaves two different ways to say so.
+/// one configured this," and the nested form leaves two different ways to say so.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ConfigValue<T> {
     /// The effective value.

--- a/lib/ottl/src/editors.rs
+++ b/lib/ottl/src/editors.rs
@@ -9,6 +9,7 @@
 //!
 //! # Example
 //!
+//! <!-- vale off -->
 //! ```ignore
 //! // Start with the standard editors…
 //! let mut editors = ottl::editors::standard();
@@ -18,6 +19,7 @@
 //!     todo!()
 //! }));
 //! ```
+//! <!-- vale on -->
 
 use std::sync::Arc;
 

--- a/lib/ottl/src/mod.rs
+++ b/lib/ottl/src/mod.rs
@@ -5,6 +5,7 @@
 ///
 /// # Example
 ///
+/// <!-- vale off -->
 /// ```ignore
 /// use ottl::{Parser, OttlParser, CallbackMap, EnumMap, PathResolverMap, EvalContextFamily};
 ///
@@ -22,6 +23,7 @@
 /// let mut ctx = MyContext { /* ... */ };
 /// let result = parser.execute(&mut ctx);
 /// ```
+/// <!-- vale on -->
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
@@ -69,6 +71,7 @@ pub type Result<T> = std::result::Result<T, BoxError>;
 ///
 /// # Example
 ///
+/// <!-- vale off -->
 /// ```ignore
 /// struct SpanFamily;
 ///
@@ -81,6 +84,7 @@ pub type Result<T> = std::result::Result<T, BoxError>;
 ///     resource: &'a Resource,
 /// }
 /// ```
+/// <!-- vale on -->
 pub trait EvalContextFamily: 'static {
     /// The concrete context type for a given borrow lifetime.
     type Context<'a>;
@@ -241,6 +245,7 @@ pub type EnumMap = HashMap<String, i64>;
 ///
 /// # Example
 ///
+/// <!-- vale off -->
 /// ```ignore
 /// use ottl::{OttlParser, Parser, EvalContextFamily};
 ///
@@ -253,6 +258,7 @@ pub type EnumMap = HashMap<String, i64>;
 /// let mut ctx = MyContext { /* ... */ };
 /// let result = parser.execute(&mut ctx)?;
 /// ```
+/// <!-- vale on -->
 pub trait OttlParser<F: EvalContextFamily> {
     /// Checks if the parser encountered any errors during creation.
     ///

--- a/lib/saluki-common/src/resource_tracking/groups.rs
+++ b/lib/saluki-common/src/resource_tracking/groups.rs
@@ -163,6 +163,7 @@ pub trait Track: Sized {
     ///
     /// # Examples
     ///
+    /// <!-- vale off -->
     /// ```rust
     /// use saluki_common::resource_tracking::{ResourceGroupRegistry, ResourceGroupToken, Track as _};
     ///
@@ -177,6 +178,8 @@ pub trait Track: Sized {
     ///     .track_resources(token)
     ///     .await
     /// # }
+    /// ```
+    /// <!-- vale on -->
     fn track_resources(self, token: ResourceGroupToken) -> Tracked<Self> {
         Tracked { token, inner: self }
     }
@@ -189,6 +192,7 @@ pub trait Track: Sized {
     ///
     /// # Examples
     ///
+    /// <!-- vale off -->
     /// ```rust
     /// use saluki_common::resource_tracking::{ResourceGroupRegistry, ResourceGroupToken, Track as _};
     ///
@@ -208,6 +212,7 @@ pub trait Track: Sized {
     /// tokio::spawn(future.in_current_resource_group());
     /// # }
     /// ```
+    /// <!-- vale on -->
     fn in_current_resource_group(self) -> Tracked<Self> {
         Tracked {
             token: ResourceGroupToken::current(),

--- a/lib/saluki-components/src/common/datadog/config.rs
+++ b/lib/saluki-components/src/common/datadog/config.rs
@@ -181,7 +181,7 @@ impl OpwMetricsConfiguration {
 /// Forwarder configuration based on the Datadog Agent's forwarder configuration.
 ///
 /// This adapter provides a simple way to utilize the existing configuration values that are passed to the Datadog
-/// Agent, which are used to control the behavior of its forwarder, such as retries and concurrency, in conjunction with
+/// Agent, which are used to control the behavior of its forwarder, such as retries and concurrency, in conjunction
 /// with existing primitives, as such retry policies in [`saluki_io::util::retry`].
 #[derive(Clone)]
 #[cfg_attr(test, derive(Debug, PartialEq))]

--- a/lib/saluki-core/src/diagnostic/emitter.rs
+++ b/lib/saluki-core/src/diagnostic/emitter.rs
@@ -43,6 +43,7 @@ pub enum DiagnosticsEmitterError {
 ///
 /// # Example
 ///
+/// <!-- vale off -->
 /// ```
 /// use saluki_core::diagnostic::{DiagnosticDetails, DiagnosticEvent, DiagnosticsEmitter};
 /// use saluki_core::runtime::state::DataspaceRegistry;
@@ -60,6 +61,7 @@ pub enum DiagnosticsEmitterError {
 /// // Emit a point-in-time event:
 /// emitter.emit(DiagnosticEvent::new("credentials rejected", DiagnosticDetails::InvalidApiKey));
 /// ```
+/// <!-- vale on -->
 #[derive(Clone)]
 pub struct DiagnosticsEmitter {
     base_id: MetaString,

--- a/lib/saluki-core/src/observability/metrics/reflector.rs
+++ b/lib/saluki-core/src/observability/metrics/reflector.rs
@@ -91,7 +91,7 @@ pub struct Reflector<P: Processor> {
 impl<P: Processor> Reflector<P> {
     /// Creates a new reflector with the given data source and processor.
     ///
-    /// A reflector composes a source of data with a processor that's used to transform the data, and then stores the
+    /// A reflector composes a source of data with a processor that's used to transform the data, and then stores
     /// the processed results. It can be listened to for updates, and cheaply shared. This allows multiple interested
     /// components to subscribe to the same data source without having to duplicate the processing or storage of the
     /// data.

--- a/lib/saluki-core/src/pooling/helpers.rs
+++ b/lib/saluki-core/src/pooling/helpers.rs
@@ -34,6 +34,7 @@ use super::{Poolable, ReclaimStrategy};
 ///
 /// ## Usage
 ///
+/// <!-- vale off -->
 /// ```rust
 /// use saluki_core::pooling::helpers::pooled;
 ///
@@ -69,6 +70,7 @@ use super::{Poolable, ReclaimStrategy};
 ///     assert_eq!(doubled_value, original_value * 2);
 /// }
 /// ```
+/// <!-- vale on -->
 #[macro_export]
 macro_rules! pooled {
     ($(#[$outer:meta])* struct $name:ident {
@@ -148,6 +150,7 @@ macro_rules! pooled {
 ///
 /// ## Usage
 ///
+/// <!-- vale off -->
 /// ```rust
 /// use saluki_core::{pooled_newtype, pooling::Clearable};
 ///
@@ -193,6 +196,7 @@ macro_rules! pooled {
 ///     assert_eq!(buf.len(), 13);
 /// }
 /// ```
+/// <!-- vale on -->
 #[macro_export]
 macro_rules! pooled_newtype {
     (outer => $name:ident, inner => $inner_ty:ty $(,)?) => {

--- a/lib/saluki-core/src/runtime/state/dataspace.rs
+++ b/lib/saluki-core/src/runtime/state/dataspace.rs
@@ -18,6 +18,7 @@
 //!
 //! # Example
 //!
+//! <!-- vale off -->
 //! ```
 //! use saluki_core::runtime::state::{DataspaceUpdate, Identifier, IdentifierFilter, DataspaceRegistry};
 //!
@@ -37,6 +38,7 @@
 //! assert_eq!(value, Some(DataspaceUpdate::Asserted(id, 42)));
 //! # }
 //! ```
+//! <!-- vale on -->
 
 use std::{
     any::{Any, TypeId},

--- a/lib/saluki-metadata/src/lib.rs
+++ b/lib/saluki-metadata/src/lib.rs
@@ -47,6 +47,7 @@ pub fn set_app_details(details: AppDetails) {
 ///
 /// # Examples
 ///
+/// <!-- vale off -->
 /// ```
 /// # use saluki_metadata::{declare_app_details, AppDetails};
 /// pub const APP_DETAILS: AppDetails = declare_app_details!(
@@ -55,6 +56,7 @@ pub fn set_app_details(details: AppDetails) {
 ///     identifier = "ex",
 /// );
 /// ```
+/// <!-- vale on -->
 #[macro_export]
 macro_rules! declare_app_details {
     (full_name = $full_name:expr, short_name = $short_name:expr, identifier = $identifier:expr $(,)?) => {

--- a/lib/saluki-metrics-macros/src/lib.rs
+++ b/lib/saluki-metrics-macros/src/lib.rs
@@ -48,6 +48,7 @@ use syn::{
 /// A field can be *mapped* by one or more labels whose values are supplied at emission time rather than at
 /// construction:
 ///
+/// <!-- vale off -->
 /// ```ignore
 /// #[static_metrics(prefix = component, labels(component_id))]
 /// #[derive(Clone)]
@@ -61,6 +62,7 @@ use syn::{
 ///     other_total: Counter,
 /// }
 /// ```
+/// <!-- vale on -->
 ///
 /// A mapped field's storage is rewritten to hold a concurrent map of the dynamic label values to lazily registered
 /// handles (the source keeps writing `Counter`/`Gauge`/`Histogram`). Its accessor accepts each label value either by


### PR DESCRIPTION
## Summary

`make check-docs` was failing because Vale's doc-comment extraction doesn't exclude fenced code blocks from prose rules, so Rust keywords, identifiers, and code punctuation inside rustdoc examples were being flagged as spelling and quoting errors; this suppresses those rules around the affected examples and fixes a few genuine prose typos and a doc example with a missing closing code fence found along the way.

## Test plan

- [x] `make check-all` passes
- [x] `cargo test --doc` passes for all crates with edited doc examples, including a previously-broken example in `saluki-common::resource_tracking::groups` that was missing a closing code fence