### PR TITLE
chore(ci): apply `automated` label to Renovate PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -28,6 +28,12 @@
     "schedule:weekly"
   ],
 
+  // Renovate PRs are dependency bumps, not customer-facing changes, so they don't need a
+  // release-note fragment. Applying this label satisfies the release-note-check CI job by
+  // default; a reviewer who spots a bump that does warrant a changelog entry (e.g. one that
+  // fixes a user-visible bug) can remove the label and add a release note instead.
+  "labels": ["changelog/no-changelog"],
+
   // Maximum number of Renovate-authored PRs that may be open at once.
   "prConcurrentLimit": 5,
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -29,9 +29,7 @@
   ],
 
   // Renovate PRs are dependency bumps, not customer-facing changes, so they don't need a
-  // release-note fragment. Applying this label satisfies the release-note-check CI job by
-  // default; a reviewer who spots a bump that does warrant a changelog entry (e.g. one that
-  // fixes a user-visible bug) can remove the label and add a release note instead.
+  // release-note fragment.
   "labels": ["changelog/no-changelog"],
 
   // Maximum number of Renovate-authored PRs that may be open at once.

--- a/renovate.json5
+++ b/renovate.json5
@@ -28,9 +28,9 @@
     "schedule:weekly"
   ],
 
-  // Renovate PRs are dependency bumps, not customer-facing changes, so they don't need a
-  // release-note fragment.
-  "labels": ["changelog/no-changelog"],
+  // Mark Renovate PRs as automated so various checks that only apply to
+  // non-automated changes will skip running for dependency update PRs.
+  "labels": ["automated"],
 
   // Maximum number of Renovate-authored PRs that may be open at once.
   "prConcurrentLimit": 5,


### PR DESCRIPTION
## Summary

Automated dependency bumps from Renovate were failing the release-note-check gate until a human manually added the `changelog/no-changelog` label after the fact. #2538 updated the release note check to exclude PRs with the `automated` label, but missed changing the Renovate configuration to generate dependency update PRs with that tag.

## Test plan

- [ ] Confirm the next Renovate-opened PR carries the `automated` label