### PR TITLE
chore(ci): exclude automated PRs from release notes check via labels

### DIFF
--- a/.github/workflows/bump-adp-version.yml
+++ b/.github/workflows/bump-adp-version.yml
@@ -167,7 +167,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: updatePR.data.number,
-              labels: [prLabel, 'automated', 'changelog/no-changelog']
+              labels: [prLabel, 'automated']
             });
 
             // Look for other open PRs bumping the ADP version on the same target branch, and close them out so this

--- a/.github/workflows/release-note-check.yml
+++ b/.github/workflows/release-note-check.yml
@@ -27,7 +27,9 @@ jobs:
               (file) => file.filename.startsWith('releasenotes/notes/') && file.status !== 'removed',
             );
 
-            if (hasReleaseNote || labels.includes('changelog/no-changelog')) {
+            const explicitlyExcluded = labels.includes('changelog/no-changelog')
+            const isAutomatedPR = labels.includes('automated') || labels.includes('campaigner-automated-change')
+            if (hasReleaseNote || explicitlyExcluded || isAutomatedPR) {
               return;
             }
 

--- a/.github/workflows/update-agent-tagger-prefixes.yml
+++ b/.github/workflows/update-agent-tagger-prefixes.yml
@@ -243,7 +243,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: updatePR.data.number,
-              labels: [prLabel, 'automated', 'changelog/no-changelog']
+              labels: [prLabel, 'automated']
             });
 
             // Close out any older PRs from this workflow: the newest fixture is a superset of what they reported.

--- a/.github/workflows/update-agent-version.yml
+++ b/.github/workflows/update-agent-version.yml
@@ -180,7 +180,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: updatePR.data.number,
-              labels: [prLabel, 'automated', 'changelog/no-changelog']
+              labels: [prLabel, 'automated']
             });
 
             // Look for other open PRs for updating the Agent version, and close them out so this one takes precedence.


### PR DESCRIPTION
## Summary

In #2531, we excluded some automated PRs from our release note check by updating them to add the necessary sentinel label that the release note check pays attention to. However, we missed a spot (campaigner automated update PRs) and thinking on it more... it's silly to add the exclusion label everywhere instead of just having the release note check figure this out itself: after all, these automated PRs all already carry a label that defines them as being automated PRs.

So.. I went and did that. :)

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

Can't test until this is merged.

## References

DADP-2
