### PR TITLE
feat(panoramic): persist failed test traffic

### DIFF
--- a/.agents/skills/panoramic/SKILL.md
+++ b/.agents/skills/panoramic/SKILL.md
@@ -47,8 +47,10 @@ before selecting them.
 
 ## Run non-interactively
 
-Build with the current Make recipe, then use `--no-tui -o json` for an agent-readable run. Set
-`-l DIR` when the artifacts need a predictable base directory.
+The Panoramic test targets write artifacts beneath `{{saluki}}/target/test-output/panoramic/` by
+default. This in-tree path is visible to Docker on macOS. Set `SALUKI_TEST_OUTPUT_DIR` to relocate the
+shared test-output root or `PANORAMIC_LOG_DIR` to override Panoramic only. Use the same base for direct
+runs.
 
 ```bash
 make build-panoramic
@@ -56,11 +58,13 @@ target/release/panoramic run \
   -d "$(pwd)/test/integration/cases" \
   --runtime linux \
   -t <case-name> \
-  --no-tui -o json -l /tmp/panoramic-logs
+  --no-tui -o json -l "$(pwd)/target/test-output/panoramic"
 ```
 
 Use comma-separated names with `-t` and `-p 1` when one case needs attributable output. Each run
-creates a timestamped directory beneath `-l`; stdout and `run.json` identify that directory.
+creates a timestamped `panoramic-*` directory beneath the base. `make clean-test-logs` deletes the
+Panoramic directory under the shared test-output root; `make clean` includes that target. Stdout and
+`run.json` identify the directory for a run.
 
 ## Interpret the result
 

--- a/.agents/skills/panoramic/SKILL.md
+++ b/.agents/skills/panoramic/SKILL.md
@@ -92,3 +92,21 @@ context. Correctness assertion details may point to uncapped files under `detail
 
 `run.json` includes `build_revision`: the source revision used to build Panoramic, with `-dirty` for
 a modified checkout and `unknown` when it cannot be determined.
+
+## Read the traffic artifacts
+
+A correctness test records what it sent and what each side decoded under `<log_dir>/traffic/`. Start
+with `traffic/manifest.json`: it names each capture, reports its compressed size, and says whether
+the file is still on disk (`file.present`). A passing test keeps only the manifest; every other
+outcome keeps the captures. When `input` is `null`, read `input_unavailable_reason` - the
+`kubernetes_in_docker` runtime never produces an input capture.
+
+The captures are zstd-compressed JSON Lines, one record per line, so decompress before reading:
+
+```bash
+zstd -dc traffic/input.jsonl.zst | head -5
+zstd -dc traffic/baseline-decoded.jsonl.zst | jq -c 'select(.kind == "metric") | .value.context'
+```
+
+Input records are in send order, which is not packet order. Decoded records are grouped by kind and
+indexed within each kind, so `index` is a position within a kind, not a global receive order.

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 .vscode/
 test/k8s/charts/
 test/build/
+test/output/
 test/ddprof
 test/lading
 test/one-off/__pycache__

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,11 +3697,15 @@ dependencies = [
  "rand 0.10.2",
  "saluki-error",
  "serde",
+ "serde_json",
  "serde_yaml",
+ "simdutf8",
+ "tempfile",
  "tokio",
  "tonic",
  "tracing",
  "tracing-subscriber",
+ "zstd",
 ]
 
 [[package]]
@@ -4060,6 +4064,7 @@ dependencies = [
  "tracing-subscriber",
  "treediff",
  "vergen-gix",
+ "zstd",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ MACOS_TEST_AGENT_INSTALL_DIR ?= /tmp/saluki-dda/datadog-agent
 # General build settings used for tooling, etc.
 export GO_BUILD_IMAGE ?= golang:1.23-bullseye
 export GO_APP_IMAGE ?= ubuntu:24.04
+# TODO: move this to test/output when everyone has it in their gitignore
+SALUKI_TEST_OUTPUT_DIR ?= $(CURDIR)/target/test-output
+export PANORAMIC_LOG_DIR ?= $(SALUKI_TEST_OUTPUT_DIR)/panoramic
 
 # Pinned nightly toolchain shared by the Miri tests and API-doc generation, both of which rely on
 # nightly-only features. Keeping it in one variable ensures the two stay in lockstep; bump here to
@@ -952,10 +955,15 @@ update-protos: ## Updates all vendored Protocol Buffers definitions from their s
 	./ci/tooling/update-protos.sh
 
 .PHONY: clean
-clean: check-rust-build-tools
+clean: check-rust-build-tools clean-test-logs
 clean: ## Clean all build artifacts (debug/release)
 	@echo "[*] Cleaning Rust build artifacts..."
 	@cargo clean
+
+.PHONY: clean-test-logs
+clean-test-logs: ## Deletes Panoramic test logs
+	@echo "[*] Cleaning Panoramic test logs..."
+	@rm -rf "$(SALUKI_TEST_OUTPUT_DIR)/panoramic"
 
 .PHONY: clean-docker
 clean-docker: ## Cleans up Docker build cache

--- a/bin/correctness/millstone/Cargo.toml
+++ b/bin/correctness/millstone/Cargo.toml
@@ -18,7 +18,9 @@ prost = { workspace = true }
 rand = { workspace = true, features = ["std_rng"] }
 saluki-error = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+simdutf8 = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tonic = { workspace = true }
 tracing = { workspace = true }
@@ -31,3 +33,7 @@ tracing-subscriber = { workspace = true, features = [
   "std",
   "tracing-log",
 ] }
+zstd = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/bin/correctness/millstone/src/capture.rs
+++ b/bin/correctness/millstone/src/capture.rs
@@ -1,0 +1,453 @@
+//! Capture of the payload stream a run sent to its target.
+//!
+//! Diagnosing a failed correctness test starts with knowing what the target was fed, so the capture records the
+//! payloads instead of leaving them to be re-derived from the seed.
+//!
+//! Two files are written into the capture directory:
+//!
+//! - `input.jsonl.zst`: one JSON object per payload, zstd-compressed, in the order the payloads were handed to the
+//!   transport. That is not packet order: a datagram transport may reorder or drop what it was given, and a
+//!   partially written payload still appears at its full length.
+//! - `input-manifest.json`: the facts a reader needs to interpret the records.
+
+use std::{
+    borrow::Cow,
+    fs::File,
+    io::{BufWriter, Write},
+    path::Path,
+};
+
+use base64::Engine as _;
+use bytes::Bytes;
+use saluki_error::{ErrorContext as _, GenericError};
+use serde::Serialize;
+use tracing::info;
+
+const INPUT_RECORDS_FILE_NAME: &str = "input.jsonl.zst";
+const INPUT_MANIFEST_FILE_NAME: &str = "input-manifest.json";
+
+/// Format identifier written into the manifest, so a reader can tell what it is holding.
+const INPUT_FORMAT: &str = "millstone-input-capture";
+
+/// Bump whenever a record or manifest field changes meaning.
+const INPUT_FORMAT_VERSION: u32 = 1;
+
+const ZSTD_LEVEL: i32 = 3;
+
+/// How records are ordered, as reported to a reader.
+const ORDERING: &str = "logical_send_order";
+
+const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+/// A single captured payload.
+#[derive(Serialize)]
+struct InputRecord<'a> {
+    /// Position in the send order, starting at zero.
+    seq: usize,
+
+    /// Index into the generated corpus, which repeats when the volume exceeds the corpus size.
+    corpus_index: usize,
+
+    /// Length of the payload as handed to the transport. Any framing the corpus generated, such as the length
+    /// prefix DogStatsD uses over a stream socket, is part of it.
+    byte_len: usize,
+
+    /// How `payload` is encoded: `utf8` or `base64`.
+    encoding: &'static str,
+
+    payload: Cow<'a, str>,
+}
+
+impl<'a> InputRecord<'a> {
+    /// Builds a record for `payload`, preferring text and falling back to base64 for anything that isn't UTF-8.
+    fn new(seq: usize, corpus_index: usize, payload: &'a [u8]) -> Self {
+        let (encoding, encoded) = match simdutf8::basic::from_utf8(payload) {
+            Ok(text) => ("utf8", Cow::Borrowed(text)),
+            Err(_) => (
+                "base64",
+                Cow::Owned(base64::engine::general_purpose::STANDARD.encode(payload)),
+            ),
+        };
+
+        Self {
+            seq,
+            corpus_index,
+            byte_len: payload.len(),
+            encoding,
+            payload: encoded,
+        }
+    }
+}
+
+/// Facts a reader needs in order to interpret the records.
+#[derive(Serialize)]
+struct InputManifest {
+    format: &'static str,
+    version: u32,
+    records_file: &'static str,
+    compression: &'static str,
+    ordering: &'static str,
+
+    /// Hex-encoded RNG seed the corpus was generated from.
+    seed: String,
+    payload_kind: &'static str,
+    target_kind: &'static str,
+    send_delay_us: u64,
+
+    /// Number of distinct payloads the corpus generated. Fewer than `records` means the corpus was cycled; more
+    /// means its tail was never sent.
+    corpus_payloads: usize,
+
+    /// How many payloads the run was configured to send.
+    volume: usize,
+
+    /// Number of records in the capture.
+    records: usize,
+
+    /// Total payload bytes across every record.
+    logical_bytes: u64,
+
+    /// Bytes the transport reported as written, which differs from `logical_bytes` only when a send was partial.
+    wire_bytes: u64,
+
+    /// Number of sends the transport only partially wrote. When nonzero, the wire stream is not byte-identical to
+    /// the payloads captured here.
+    partial_sends: usize,
+
+    digest: Digest,
+}
+
+/// A named, non-cryptographic digest of the record stream. It identifies a stream cheaply, so two runs can be
+/// compared without shipping both captures.
+#[derive(Serialize)]
+struct Digest {
+    algorithm: &'static str,
+    value: String,
+}
+
+/// Everything about a finished run that isn't derivable from the payloads themselves.
+pub(crate) struct RunFacts {
+    /// Hex-encoded RNG seed the corpus was generated from.
+    pub seed: String,
+    pub payload_kind: &'static str,
+    pub target_kind: &'static str,
+    pub send_delay_us: u64,
+
+    /// How many payloads the run was configured to send.
+    pub volume: usize,
+    pub payloads_sent: usize,
+
+    /// Bytes the transport reported as written.
+    pub wire_bytes: u64,
+    pub partial_sends: usize,
+}
+
+/// Writes the capture for a finished run into `dir`, creating it if necessary.
+///
+/// `payloads` is the generated corpus and `facts.payloads_sent` is how many payloads the run took from it, cycling
+/// when the volume exceeded the corpus size. Only that many records are written.
+///
+/// # Errors
+///
+/// If the directory can't be created, or either file can't be written, an error is returned. Callers treat this as
+/// non-fatal: a missing capture is a lost diagnostic, not a failed run.
+pub(crate) fn write_input_capture(dir: &Path, payloads: &[Bytes], facts: RunFacts) -> Result<(), GenericError> {
+    std::fs::create_dir_all(dir)
+        .with_error_context(|| format!("Failed to create traffic capture directory '{}'.", dir.display()))?;
+
+    let records_path = dir.join(INPUT_RECORDS_FILE_NAME);
+    let summary = match write_records_file(&records_path, payloads, facts.payloads_sent) {
+        Ok(summary) => summary,
+        Err(e) => {
+            // A half-written file can't be read back, and leaving it would look like a complete capture.
+            let _ = std::fs::remove_file(&records_path);
+            return Err(e);
+        }
+    };
+
+    let manifest = InputManifest {
+        format: INPUT_FORMAT,
+        version: INPUT_FORMAT_VERSION,
+        records_file: INPUT_RECORDS_FILE_NAME,
+        compression: "zstd",
+        ordering: ORDERING,
+        seed: facts.seed,
+        payload_kind: facts.payload_kind,
+        target_kind: facts.target_kind,
+        send_delay_us: facts.send_delay_us,
+        corpus_payloads: payloads.len(),
+        volume: facts.volume,
+        records: summary.records,
+        logical_bytes: summary.logical_bytes,
+        wire_bytes: facts.wire_bytes,
+        partial_sends: facts.partial_sends,
+        digest: Digest {
+            algorithm: "fnv1a64",
+            value: format!("{:016x}", summary.digest),
+        },
+    };
+
+    let manifest_path = dir.join(INPUT_MANIFEST_FILE_NAME);
+    let manifest_json =
+        serde_json::to_string_pretty(&manifest).error_context("Failed to serialize traffic capture manifest.")?;
+    std::fs::write(&manifest_path, format!("{}\n", manifest_json)).with_error_context(|| {
+        format!(
+            "Failed to write traffic capture manifest '{}'.",
+            manifest_path.display()
+        )
+    })?;
+
+    info!(
+        records = summary.records,
+        logical_bytes = summary.logical_bytes,
+        path = %records_path.display(),
+        "Wrote input traffic capture."
+    );
+
+    Ok(())
+}
+
+/// Totals describing what [`write_records`] wrote.
+struct RecordSummary {
+    records: usize,
+    logical_bytes: u64,
+    digest: u64,
+}
+
+fn write_records_file(path: &Path, payloads: &[Bytes], payloads_sent: usize) -> Result<RecordSummary, GenericError> {
+    let file = File::create(path)
+        .with_error_context(|| format!("Failed to create traffic capture file '{}'.", path.display()))?;
+
+    let mut encoder = zstd::stream::write::Encoder::new(BufWriter::new(file), ZSTD_LEVEL)
+        .error_context("Failed to initialize zstd encoder for traffic capture.")?;
+    let summary = write_records(&mut encoder, payloads, payloads_sent)?;
+    encoder
+        .finish()
+        .error_context("Failed to finalize zstd stream for traffic capture.")?
+        .into_inner()
+        .map_err(|e| saluki_error::generic_error!("Failed to flush traffic capture file: {}", e))?
+        .sync_all()
+        .error_context("Failed to sync traffic capture file.")?;
+
+    Ok(summary)
+}
+
+/// Writes `payloads_sent` records to `writer` in send order, cycling the corpus as the send loop did.
+fn write_records<W: Write>(
+    writer: &mut W, payloads: &[Bytes], payloads_sent: usize,
+) -> Result<RecordSummary, GenericError> {
+    let mut summary = RecordSummary {
+        records: 0,
+        logical_bytes: 0,
+        digest: FNV_OFFSET_BASIS,
+    };
+
+    if payloads.is_empty() {
+        return Ok(summary);
+    }
+
+    for seq in 0..payloads_sent {
+        let corpus_index = seq % payloads.len();
+        let payload = &payloads[corpus_index];
+
+        serde_json::to_writer(&mut *writer, &InputRecord::new(seq, corpus_index, payload))
+            .error_context("Failed to serialize captured payload.")?;
+        writer
+            .write_all(b"\n")
+            .error_context("Failed to write captured payload separator.")?;
+
+        summary.records += 1;
+        summary.logical_bytes += payload.len() as u64;
+        // Each payload's length goes into the digest ahead of its bytes, so a stream can't collide with a
+        // differently split stream of the same bytes.
+        summary.digest = fnv1a64_update(summary.digest, &(payload.len() as u64).to_le_bytes());
+        summary.digest = fnv1a64_update(summary.digest, payload);
+    }
+
+    Ok(summary)
+}
+
+fn fnv1a64_update(mut digest: u64, bytes: &[u8]) -> u64 {
+    for byte in bytes {
+        digest ^= u64::from(*byte);
+        digest = digest.wrapping_mul(FNV_PRIME);
+    }
+    digest
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn corpus(payloads: &[&[u8]]) -> Vec<Bytes> {
+        payloads.iter().map(|p| Bytes::copy_from_slice(p)).collect()
+    }
+
+    fn records_from(payloads: &[Bytes], payloads_sent: usize) -> (Vec<serde_json::Value>, RecordSummary) {
+        let mut buffer = Vec::new();
+        let summary = write_records(&mut buffer, payloads, payloads_sent).expect("records should be written");
+        let text = String::from_utf8(buffer).expect("records should be valid UTF-8");
+        let records = text
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("record should be valid JSON"))
+            .collect();
+
+        (records, summary)
+    }
+
+    #[test]
+    fn records_follow_send_order() {
+        let payloads = corpus(&[b"first", b"second"]);
+        let (records, summary) = records_from(&payloads, 2);
+
+        assert_eq!(summary.records, 2);
+        assert_eq!(summary.logical_bytes, 11);
+        assert_eq!(records[0]["seq"], 0);
+        assert_eq!(records[0]["corpus_index"], 0);
+        assert_eq!(records[0]["payload"], "first");
+        assert_eq!(records[1]["seq"], 1);
+        assert_eq!(records[1]["corpus_index"], 1);
+        assert_eq!(records[1]["payload"], "second");
+    }
+
+    #[test]
+    fn volume_larger_than_corpus_cycles_the_corpus() {
+        let payloads = corpus(&[b"a", b"bb"]);
+        let (records, summary) = records_from(&payloads, 5);
+
+        assert_eq!(summary.records, 5);
+        // Three sends of "a" and two of "bb".
+        assert_eq!(summary.logical_bytes, 7);
+        let corpus_indexes = records
+            .iter()
+            .map(|record| record["corpus_index"].as_u64().expect("index should be a number"))
+            .collect::<Vec<_>>();
+        assert_eq!(corpus_indexes, vec![0, 1, 0, 1, 0]);
+        let seqs = records
+            .iter()
+            .map(|record| record["seq"].as_u64().expect("seq should be a number"))
+            .collect::<Vec<_>>();
+        assert_eq!(seqs, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn volume_smaller_than_corpus_stops_at_the_volume() {
+        let payloads = corpus(&[b"a", b"bb", b"ccc"]);
+        let (records, summary) = records_from(&payloads, 2);
+
+        assert_eq!(summary.records, 2);
+        assert_eq!(summary.logical_bytes, 3);
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[1]["corpus_index"], 1);
+    }
+
+    #[test]
+    fn non_utf8_payloads_are_captured_as_base64() {
+        let payloads = corpus(&[&[0x00, 0xff, 0x10]]);
+        let (records, summary) = records_from(&payloads, 1);
+
+        assert_eq!(summary.logical_bytes, 3);
+        assert_eq!(records[0]["encoding"], "base64");
+        assert_eq!(records[0]["byte_len"], 3);
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(records[0]["payload"].as_str().expect("payload should be a string"))
+            .expect("payload should decode");
+        assert_eq!(decoded, vec![0x00, 0xff, 0x10]);
+    }
+
+    #[test]
+    fn digest_covers_record_boundaries() {
+        let (_, split) = records_from(&corpus(&[b"a", b"b"]), 2);
+        let (_, joined) = records_from(&corpus(&[b"ab"]), 1);
+        let (_, different_content) = records_from(&corpus(&[b"a", b"c"]), 2);
+        let (_, same) = records_from(&corpus(&[b"a", b"b"]), 2);
+
+        assert_ne!(split.digest, joined.digest);
+        assert_ne!(split.digest, different_content.digest);
+        assert_eq!(split.digest, same.digest);
+    }
+
+    #[test]
+    fn an_empty_corpus_writes_no_records() {
+        let (records, summary) = records_from(&[], 3);
+
+        assert!(records.is_empty());
+        assert_eq!(summary.records, 0);
+        assert_eq!(summary.logical_bytes, 0);
+    }
+
+    #[test]
+    fn the_manifest_describes_the_records_it_was_written_with() {
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        let payloads = corpus(&[b"one", b"two"]);
+
+        write_input_capture(
+            dir.path(),
+            &payloads,
+            RunFacts {
+                seed: "00".repeat(32),
+                payload_kind: "DogStatsD",
+                target_kind: "unixgram",
+                send_delay_us: 500,
+                volume: 5,
+                payloads_sent: 5,
+                wire_bytes: 14,
+                partial_sends: 1,
+            },
+        )
+        .expect("capture should be written");
+
+        let manifest: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join(INPUT_MANIFEST_FILE_NAME)).expect("manifest should be readable"),
+        )
+        .expect("manifest should be valid JSON");
+
+        assert_eq!(manifest["format"], INPUT_FORMAT);
+        assert_eq!(manifest["version"], INPUT_FORMAT_VERSION);
+        assert_eq!(manifest["ordering"], ORDERING);
+        assert_eq!(manifest["records_file"], INPUT_RECORDS_FILE_NAME);
+        assert_eq!(manifest["compression"], "zstd");
+        assert_eq!(manifest["corpus_payloads"], 2);
+        assert_eq!(manifest["volume"], 5);
+        assert_eq!(manifest["records"], 5);
+        assert_eq!(manifest["logical_bytes"], 15);
+        assert_eq!(manifest["wire_bytes"], 14);
+        assert_eq!(manifest["partial_sends"], 1);
+        assert_eq!(manifest["digest"]["algorithm"], "fnv1a64");
+        assert_eq!(manifest["target_kind"], "unixgram");
+        assert_eq!(manifest["send_delay_us"], 500);
+
+        // The record file is a real zstd stream holding one line per payload.
+        let compressed = std::fs::read(dir.path().join(INPUT_RECORDS_FILE_NAME)).expect("records should be readable");
+        let decompressed = zstd::stream::decode_all(&compressed[..]).expect("records should decompress");
+        let text = String::from_utf8(decompressed).expect("records should be valid UTF-8");
+        assert_eq!(text.lines().count(), 5);
+    }
+
+    #[test]
+    fn a_failed_record_write_leaves_no_capture_behind() {
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        // A directory where the records file belongs makes `File::create` fail.
+        std::fs::create_dir(dir.path().join(INPUT_RECORDS_FILE_NAME)).expect("blocker should be created");
+
+        let error = write_input_capture(
+            dir.path(),
+            &corpus(&[b"one"]),
+            RunFacts {
+                seed: "00".to_string(),
+                payload_kind: "DogStatsD",
+                target_kind: "unixgram",
+                send_delay_us: 0,
+                volume: 1,
+                payloads_sent: 1,
+                wire_bytes: 3,
+                partial_sends: 0,
+            },
+        );
+
+        assert!(error.is_err());
+        // No manifest, so a reader treats the capture as absent rather than partial.
+        assert!(!dir.path().join(INPUT_MANIFEST_FILE_NAME).exists());
+    }
+}

--- a/bin/correctness/millstone/src/capture.rs
+++ b/bin/correctness/millstone/src/capture.rs
@@ -9,6 +9,9 @@
 //!   transport. That is not packet order: a datagram transport may reorder or drop what it was given, and a
 //!   partially written payload still appears at its full length.
 //! - `input-manifest.json`: the facts a reader needs to interpret the records.
+//!
+//! A capture is also written when the send loop fails partway through: it holds exactly the payloads that made it
+//! onto the wire before the error, and the manifest's `complete` field is `false`.
 
 use std::{
     borrow::Cow,
@@ -115,6 +118,10 @@ struct InputManifest {
     /// the payloads captured here.
     partial_sends: usize,
 
+    /// `false` when the run stopped on a send error rather than reaching its configured volume. The records still
+    /// present are exactly the payloads that made it onto the wire before the failure.
+    complete: bool,
+
     digest: Digest,
 }
 
@@ -141,6 +148,9 @@ pub(crate) struct RunFacts {
     /// Bytes the transport reported as written.
     pub wire_bytes: u64,
     pub partial_sends: usize,
+
+    /// `false` when the run stopped on a send error rather than reaching its configured volume.
+    pub complete: bool,
 }
 
 /// Writes the capture for a finished run into `dir`, creating it if necessary.
@@ -182,6 +192,7 @@ pub(crate) fn write_input_capture(dir: &Path, payloads: &[Bytes], facts: RunFact
         logical_bytes: summary.logical_bytes,
         wire_bytes: facts.wire_bytes,
         partial_sends: facts.partial_sends,
+        complete: facts.complete,
         digest: Digest {
             algorithm: "fnv1a64",
             value: format!("{:016x}", summary.digest),
@@ -394,6 +405,7 @@ mod tests {
                 payloads_sent: 5,
                 wire_bytes: 14,
                 partial_sends: 1,
+                complete: true,
             },
         )
         .expect("capture should be written");
@@ -414,6 +426,7 @@ mod tests {
         assert_eq!(manifest["logical_bytes"], 15);
         assert_eq!(manifest["wire_bytes"], 14);
         assert_eq!(manifest["partial_sends"], 1);
+        assert_eq!(manifest["complete"], true);
         assert_eq!(manifest["digest"]["algorithm"], "fnv1a64");
         assert_eq!(manifest["target_kind"], "unixgram");
         assert_eq!(manifest["send_delay_us"], 500);
@@ -423,6 +436,40 @@ mod tests {
         let decompressed = zstd::stream::decode_all(&compressed[..]).expect("records should decompress");
         let text = String::from_utf8(decompressed).expect("records should be valid UTF-8");
         assert_eq!(text.lines().count(), 5);
+    }
+
+    #[test]
+    fn a_send_error_writes_the_sent_prefix_as_incomplete() {
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        let payloads = corpus(&[b"one", b"two", b"three"]);
+
+        // Volume was 5, but the send loop only got through 2 before the transport failed.
+        write_input_capture(
+            dir.path(),
+            &payloads,
+            RunFacts {
+                seed: "00".repeat(32),
+                payload_kind: "DogStatsD",
+                target_kind: "unixgram",
+                send_delay_us: 0,
+                volume: 5,
+                payloads_sent: 2,
+                wire_bytes: 6,
+                partial_sends: 0,
+                complete: false,
+            },
+        )
+        .expect("capture should be written");
+
+        let manifest: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join(INPUT_MANIFEST_FILE_NAME)).expect("manifest should be readable"),
+        )
+        .expect("manifest should be valid JSON");
+
+        assert_eq!(manifest["complete"], false);
+        assert_eq!(manifest["volume"], 5);
+        // Only the prefix that was actually sent is recorded.
+        assert_eq!(manifest["records"], 2);
     }
 
     #[test]
@@ -443,6 +490,7 @@ mod tests {
                 payloads_sent: 1,
                 wire_bytes: 3,
                 partial_sends: 0,
+                complete: true,
             },
         );
 

--- a/bin/correctness/millstone/src/config.rs
+++ b/bin/correctness/millstone/src/config.rs
@@ -32,6 +32,19 @@ pub enum TargetAddress {
     Grpc(String),
 }
 
+impl TargetAddress {
+    /// Returns the name of the transport this address uses.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Tcp(_) => "tcp",
+            Self::Udp(_) => "udp",
+            Self::UnixDatagram(_) => "unixgram",
+            Self::Unix(_) => "unix",
+            Self::Grpc(_) => "grpc",
+        }
+    }
+}
+
 impl TryFrom<String> for TargetAddress {
     type Error = String;
 

--- a/bin/correctness/millstone/src/driver.rs
+++ b/bin/correctness/millstone/src/driver.rs
@@ -96,13 +96,23 @@ impl Driver {
 
         let send_delay = (self.config.send_delay_us > 0).then(|| Duration::from_micros(self.config.send_delay_us));
 
+        // A send failure breaks the loop instead of returning immediately, so the prefix that did make it onto the
+        // wire is still captured below before the error is reported.
+        let mut send_error = None;
+
         loop {
             if payloads_sent >= max_payloads {
                 break;
             }
 
             let payload = borrowed_payloads.next().unwrap();
-            let bytes_sent = self.sender.send(payload)?;
+            let bytes_sent = match self.sender.send(payload) {
+                Ok(bytes_sent) => bytes_sent,
+                Err(e) => {
+                    send_error = Some(e);
+                    break;
+                }
+            };
 
             trace!(payload_len = payload.len(), bytes_sent, "Payload sent.");
 
@@ -118,21 +128,24 @@ impl Driver {
         }
 
         let send_duration = start.elapsed();
-        let throughput_bps = ByteSize((payload_bytes_sent as f64 / send_duration.as_secs_f64()) as u64);
 
-        let payload_bytes_sent_human = ByteSize(payload_bytes_sent);
-        let pct_partial_sends = (partial_sends as f64 / payloads_sent as f64) * 100.0;
-        info!(
-            "Sent {} payloads ({}), with {} partial sends ({}% of total), over {:?} ({}/s).",
-            payloads_sent,
-            payload_bytes_sent_human.display().si(),
-            partial_sends,
-            pct_partial_sends,
-            send_duration,
-            throughput_bps.display().si()
-        );
+        if send_error.is_none() {
+            let throughput_bps = ByteSize((payload_bytes_sent as f64 / send_duration.as_secs_f64()) as u64);
+            let payload_bytes_sent_human = ByteSize(payload_bytes_sent);
+            let pct_partial_sends = (partial_sends as f64 / payloads_sent as f64) * 100.0;
+            info!(
+                "Sent {} payloads ({}), with {} partial sends ({}% of total), over {:?} ({}/s).",
+                payloads_sent,
+                payload_bytes_sent_human.display().si(),
+                partial_sends,
+                pct_partial_sends,
+                send_duration,
+                throughput_bps.display().si()
+            );
+        }
 
-        // Written after the run is measured, so the capture stays out of the reported send timing.
+        // Written after the run is measured, so the capture stays out of the reported send timing. Written on a send
+        // error too: the payloads already sent are exactly the input this diagnostic exists to preserve.
         if let Some(dir) = self.traffic_capture_dir.as_deref() {
             let facts = RunFacts {
                 seed: self.config.seed.iter().map(|b| format!("{:02x}", b)).collect(),
@@ -143,6 +156,7 @@ impl Driver {
                 payloads_sent,
                 wire_bytes: payload_bytes_sent,
                 partial_sends,
+                complete: send_error.is_none(),
             };
 
             // A lost capture is a lost diagnostic, not a failed run.
@@ -151,6 +165,9 @@ impl Driver {
             }
         }
 
-        Ok(())
+        match send_error {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
     }
 }

--- a/bin/correctness/millstone/src/driver.rs
+++ b/bin/correctness/millstone/src/driver.rs
@@ -6,9 +6,14 @@ use std::{
 
 use bytesize::ByteSize;
 use saluki_error::{ErrorContext as _, GenericError};
-use tracing::{info, trace};
+use tracing::{info, trace, warn};
 
-use crate::{config::Config, corpus::Corpus, target::TargetSender};
+use crate::{
+    capture::{self, RunFacts},
+    config::Config,
+    corpus::Corpus,
+    target::TargetSender,
+};
 
 /// Load driver.
 ///
@@ -18,6 +23,7 @@ pub struct Driver {
     config: Config,
     corpus: Corpus,
     sender: TargetSender,
+    traffic_capture_dir: Option<PathBuf>,
 }
 
 impl Driver {
@@ -37,7 +43,21 @@ impl Driver {
             None => TargetSender::from_config(&config).error_context("Failed to create target sender.")?,
         };
 
-        Ok(Self { config, corpus, sender })
+        Ok(Self {
+            config,
+            corpus,
+            sender,
+            traffic_capture_dir: None,
+        })
+    }
+
+    /// Captures the payload stream this run sent into `dir`.
+    ///
+    /// The capture is written after the send loop has been timed, so requesting one cannot skew the run's reported
+    /// send rate.
+    pub fn with_traffic_capture_dir(mut self, dir: PathBuf) -> Self {
+        self.traffic_capture_dir = Some(dir);
+        self
     }
 
     /// Runs the driver, sending all generated payloads to the target until the configured target volume has been reached.
@@ -111,6 +131,25 @@ impl Driver {
             send_duration,
             throughput_bps.display().si()
         );
+
+        // Written after the run is measured, so the capture stays out of the reported send timing.
+        if let Some(dir) = self.traffic_capture_dir.as_deref() {
+            let facts = RunFacts {
+                seed: self.config.seed.iter().map(|b| format!("{:02x}", b)).collect(),
+                payload_kind: self.config.corpus.payload.name(),
+                target_kind: self.config.target.kind(),
+                send_delay_us: self.config.send_delay_us,
+                volume: max_payloads,
+                payloads_sent,
+                wire_bytes: payload_bytes_sent,
+                partial_sends,
+            };
+
+            // A lost capture is a lost diagnostic, not a failed run.
+            if let Err(e) = capture::write_input_capture(dir, &payloads, facts) {
+                warn!(error = %e, "Failed to write input traffic capture.");
+            }
+        }
 
         Ok(())
     }

--- a/bin/correctness/millstone/src/main.rs
+++ b/bin/correctness/millstone/src/main.rs
@@ -11,6 +11,9 @@ use tracing::{error, info};
 use tracing_subscriber::{filter::LevelFilter, EnvFilter};
 
 const COMPLETION_FILE_ARG: &str = "--completion-file";
+const TRAFFIC_CAPTURE_DIR_ARG: &str = "--traffic-capture-dir";
+
+mod capture;
 
 mod config;
 use self::config::Config;
@@ -53,8 +56,8 @@ fn run() -> Result<(), GenericError> {
         Some(path) => path,
         None => {
             error!(
-                "Usage: millstone <config-path> [--output-file <path>] [{} <path>]",
-                COMPLETION_FILE_ARG
+                "Usage: millstone <config-path> [--output-file <path>] [{} <path>] [{} <dir>]",
+                COMPLETION_FILE_ARG, TRAFFIC_CAPTURE_DIR_ARG
             );
             std::process::exit(1);
         }
@@ -85,8 +88,23 @@ fn run() -> Result<(), GenericError> {
         })
         .map(PathBuf::from);
 
+    // Optional directory for the input traffic capture, written after the run is measured.
+    let traffic_capture_dir = args
+        .iter()
+        .position(|a| a == TRAFFIC_CAPTURE_DIR_ARG)
+        .map(|i| {
+            args.get(i + 1).unwrap_or_else(|| {
+                error!("{} requires a directory path argument.", TRAFFIC_CAPTURE_DIR_ARG);
+                std::process::exit(1);
+            })
+        })
+        .map(PathBuf::from);
+
     let config = Config::try_from_file(config_path)?;
-    let driver = Driver::new(config, output_file)?;
+    let mut driver = Driver::new(config, output_file)?;
+    if let Some(dir) = traffic_capture_dir {
+        driver = driver.with_traffic_capture_dir(dir);
+    }
     driver.run()?;
 
     if let Some(completion_file) = completion_file {

--- a/bin/correctness/panoramic/Cargo.toml
+++ b/bin/correctness/panoramic/Cargo.toml
@@ -48,6 +48,7 @@ tracing-subscriber = { workspace = true, features = [
   "tracing-log",
 ] }
 treediff = { workspace = true, features = ["with-serde-json"] }
+zstd = { workspace = true }
 
 [target.'cfg(not(windows))'.dependencies]
 rustls = { workspace = true, features = ["aws_lc_rs"] }

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -27,6 +27,7 @@ use crate::{
         analysis::{AnalysisMode, AnalysisRunner, CollectedData, TracesAnalysisOptions},
         config::{Config, TargetConfig},
         runner::make_error_result,
+        traffic::{self, Side},
     },
     reporter::TestResult,
     test::TestContext,
@@ -357,6 +358,22 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
         }
         (Err(e), _) | (_, Err(e)) => return make_error_result(name, started, phases.completed(), e),
     };
+
+    // Persist what each side decoded before the analysis consumes it.
+    let traffic_dir = traffic::traffic_dir(tctx.log_dir());
+    for (side, data) in [(Side::Baseline, &baseline_data), (Side::Comparison, &comparison_data)] {
+        if let Err(e) = traffic::write_decoded(&traffic_dir, side, data) {
+            warn!(side = side.name(), error = %e, "Failed to write decoded telemetry capture.");
+        }
+    }
+
+    // The millstone container writes its input capture inside the pod, and the pod has already terminated by this
+    // point, so there is nothing left to read it out of. Say so in the manifest instead of leaving a silent gap.
+    traffic::record_input_unavailable(
+        &traffic_dir,
+        "This runtime does not capture millstone's input: the millstone pod exits when it finishes sending, so no \
+         running container is left to read the capture from.",
+    );
 
     let phase = phases.enter("analysis");
     let traces_options = match config.analysis_mode {

--- a/bin/correctness/panoramic/src/correctness/mod.rs
+++ b/bin/correctness/panoramic/src/correctness/mod.rs
@@ -3,3 +3,4 @@ pub mod config;
 pub mod k8s;
 pub mod runner;
 pub mod sync;
+pub(crate) mod traffic;

--- a/bin/correctness/panoramic/src/correctness/runner.rs
+++ b/bin/correctness/panoramic/src/correctness/runner.rs
@@ -16,12 +16,13 @@ use rand_distr::Alphanumeric;
 use saluki_error::{generic_error, GenericError};
 use tokio::{select, task::JoinHandle, time::sleep};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, info_span, Instrument as _, Span};
+use tracing::{debug, error, info, info_span, warn, Instrument as _, Span};
 
 use crate::correctness::{
     analysis::{AnalysisMode, AnalysisRunner, CollectedData, TracesAnalysisOptions},
     config::{Config, Runtime},
     sync::Coordinator,
+    traffic::{self, Side},
 };
 use crate::{
     assertions::AssertionResult,
@@ -36,6 +37,9 @@ const MILLSTONE_CONFIG_INTERNAL: &str = "/etc/millstone/config.toml";
 const MILLSTONE_BASELINE_COMPLETION_FILE: &str = "/tmp/millstone-baseline-complete";
 const MILLSTONE_COMPARISON_COMPLETION_FILE: &str = "/tmp/millstone-comparison-complete";
 const MILLSTONE_COMPLETION_FILE: &str = "/tmp/millstone-complete";
+
+/// Where the test's traffic directory is mounted inside the shared millstone container.
+const MILLSTONE_TRAFFIC_INTERNAL: &str = "/traffic";
 const MILLSTONE_HEALTHCHECK_INTERVAL: Duration = Duration::from_secs(1);
 const MILLSTONE_HEALTHCHECK_TIMEOUT: Duration = Duration::from_secs(1);
 const MILLSTONE_HEALTHCHECK_RETRIES: i64 = 3;
@@ -59,6 +63,8 @@ pub async fn run_correctness_test(name: String, config: Config, tctx: TestContex
 async fn run_docker_correctness_test(name: String, config: Config, tctx: TestContext) -> TestResult {
     let started = Instant::now();
 
+    let log_dir = tctx.log_dir().to_path_buf();
+
     // Phases are marked on the shared tracker so the runner can name the one a test was in when a
     // deadline fires, and so their timings survive a test that never returns.
     let phases = tctx.phases.clone();
@@ -78,6 +84,14 @@ async fn run_docker_correctness_test(name: String, config: Config, tctx: TestCon
         Err(e) => return make_error_result(name, started, phase.finish_and_collect(), e),
     };
     phase.finish();
+
+    // Persist what each side decoded before the analysis consumes it.
+    let traffic_dir = traffic::traffic_dir(&log_dir);
+    for (side, data) in [(Side::Baseline, &baseline_data), (Side::Comparison, &comparison_data)] {
+        if let Err(e) = traffic::write_decoded(&traffic_dir, side, data) {
+            warn!(side = side.name(), error = %e, "Failed to write decoded telemetry capture.");
+        }
+    }
 
     // Phase 3: analysis
     let phase = phases.enter("analysis");
@@ -257,6 +271,17 @@ impl CorrectnessRunner {
     ) -> Result<GroupRunner, GenericError> {
         debug!("Creating shared millstone group runner...");
 
+        // The capture lands in the test's log directory through a bind mount, so nothing has to be copied out of
+        // the container afterwards.
+        let host_traffic_dir = traffic::traffic_dir(self.tctx.log_dir());
+        let capture_args = match std::fs::create_dir_all(&host_traffic_dir) {
+            Ok(()) => format!(" --traffic-capture-dir {}", MILLSTONE_TRAFFIC_INTERNAL),
+            Err(e) => {
+                warn!(path = %host_traffic_dir.display(), error = %e, "Failed to create traffic capture directory. Continuing without an input capture.");
+                String::new()
+            }
+        };
+
         let millstone_binary = self
             .millstone_config
             .binary_path
@@ -269,7 +294,7 @@ impl CorrectnessRunner {
         let cmd = format!(
             "sed 's/\\$GROUP/baseline/g' {cfg} > /tmp/millstone-baseline.toml || exit 1; \
              sed 's/\\$GROUP/comparison/g' {cfg} > /tmp/millstone-comparison.toml || exit 1; \
-             {bin} /tmp/millstone-baseline.toml --completion-file {baseline_complete} & P1=$!; \
+             {bin} /tmp/millstone-baseline.toml --completion-file {baseline_complete}{capture_args} & P1=$!; \
              {bin} /tmp/millstone-comparison.toml --completion-file {comparison_complete} & P2=$!; \
              trap 'trap - TERM INT; kill \"$P1\" \"$P2\" 2>/dev/null; \
                    wait \"$P1\" 2>/dev/null; wait \"$P2\" 2>/dev/null; exit 0' TERM INT; \
@@ -287,6 +312,7 @@ impl CorrectnessRunner {
             baseline_complete = MILLSTONE_BASELINE_COMPLETION_FILE,
             comparison_complete = MILLSTONE_COMPARISON_COMPLETION_FILE,
             complete = MILLSTONE_COMPLETION_FILE,
+            capture_args = capture_args,
         );
 
         let driver_config = DriverConfig::from_image("millstone", self.millstone_config.image.clone())
@@ -306,6 +332,8 @@ impl CorrectnessRunner {
             )
             // Bind-mount the original millstone.yaml—same as the single-millstone setup.
             .with_bind_mount(&self.millstone_config.config_path, MILLSTONE_CONFIG_INTERNAL)
+            // Only the baseline run captures its input: both runs send byte-identical payloads from the same seed.
+            .with_bind_mount(&host_traffic_dir, MILLSTONE_TRAFFIC_INTERNAL)
             // Mount both agent isolation-group volumes so millstone can reach their DSD sockets.
             .with_volume_mount(format!("airlock-{}", baseline_isolation_group_id), "/baseline-airlock")
             .with_volume_mount(

--- a/bin/correctness/panoramic/src/correctness/traffic.rs
+++ b/bin/correctness/panoramic/src/correctness/traffic.rs
@@ -1,0 +1,666 @@
+//! Traffic artifacts for a correctness test: what went in, and what each side decoded out of it.
+//!
+//! A failed correctness test says two sides disagreed, but not what they were fed or what they produced. These
+//! artifacts answer both, under a test's `traffic/` directory:
+//!
+//! - `input.jsonl.zst` and `input-manifest.json`: the input payload stream, written by one Millstone run. Both
+//!   arms are fed byte-identical payloads from the same seed, so capturing one arm describes both.
+//! - `baseline-decoded.jsonl.zst` and `comparison-decoded.jsonl.zst`: the telemetry each side's `datadog-intake`
+//!   decoded, as the analysis saw it.
+//! - `manifest.json`: what each artifact is and whether it is still on disk.
+//!
+//! # Retention
+//!
+//! The captures are large, so [`finalize`] deletes them once a test passes and keeps them for any other outcome.
+//! `manifest.json` survives either way, written last so it reports the state a reader will find.
+//!
+//! # Ordering
+//!
+//! Input records are in send order. Decoded records are grouped by kind and ordered within each kind as
+//! `datadog-intake` dumped them; there is no global receive order across kinds.
+
+use std::{
+    fs::File,
+    io::BufWriter,
+    path::{Path, PathBuf},
+};
+
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use serde::Serialize;
+use serde_json::Value;
+use tracing::warn;
+
+use crate::correctness::analysis::CollectedData;
+use crate::reporter::TestOutcome;
+
+const TRAFFIC_DIR_NAME: &str = "traffic";
+
+/// Must match `millstone::capture::INPUT_RECORDS_FILE_NAME`.
+const INPUT_RECORDS_FILE_NAME: &str = "input.jsonl.zst";
+
+/// Must match `millstone::capture::INPUT_MANIFEST_FILE_NAME`.
+const INPUT_MANIFEST_FILE_NAME: &str = "input-manifest.json";
+
+/// File a runtime writes to explain why it produced no input capture.
+const INPUT_UNAVAILABLE_FILE_NAME: &str = "input-unavailable.txt";
+
+/// The merged manifest, the one artifact every completed test keeps.
+const MANIFEST_FILE_NAME: &str = "manifest.json";
+
+const MANIFEST_FORMAT: &str = "panoramic-traffic-manifest";
+
+/// Bump whenever a merged manifest field changes meaning.
+const MANIFEST_FORMAT_VERSION: u32 = 1;
+
+const DECODED_FORMAT: &str = "panoramic-decoded-capture";
+
+/// Bump whenever a decoded record or manifest field changes meaning.
+const DECODED_FORMAT_VERSION: u32 = 1;
+
+const ZSTD_LEVEL: i32 = 3;
+
+/// How decoded records are ordered, as reported to a reader.
+const DECODED_ORDERING: &str = "grouped_by_kind_then_intake_dump_order";
+
+const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+/// Which side of a correctness comparison a decoded capture came from.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Side {
+    /// The core Agent alone, which the comparison side is measured against.
+    Baseline,
+
+    /// The Agent and ADP working together.
+    Comparison,
+}
+
+impl Side {
+    /// Returns the side's name, used as its file-name prefix and reported in its manifest.
+    pub(crate) const fn name(&self) -> &'static str {
+        match self {
+            Self::Baseline => "baseline",
+            Self::Comparison => "comparison",
+        }
+    }
+
+    /// Returns what the side runs, so a reader doesn't have to know the convention.
+    const fn role(&self) -> &'static str {
+        match self {
+            Self::Baseline => "core Agent alone (reference side)",
+            Self::Comparison => "core Agent with ADP (side under test)",
+        }
+    }
+
+    fn records_file_name(&self) -> String {
+        format!("{}-decoded.jsonl.zst", self.name())
+    }
+
+    fn manifest_file_name(&self) -> String {
+        format!("{}-decoded-manifest.json", self.name())
+    }
+}
+
+/// Returns the traffic directory for a test's log directory.
+pub(crate) fn traffic_dir(log_dir: &Path) -> PathBuf {
+    log_dir.join(TRAFFIC_DIR_NAME)
+}
+
+/// A single decoded telemetry item.
+#[derive(Serialize)]
+struct DecodedRecord<'a, T> {
+    kind: &'static str,
+
+    /// Position within this kind's collection, starting at zero. Not a global receive order.
+    index: usize,
+
+    value: &'a T,
+}
+
+/// What a decoded capture holds, written alongside it and later merged into [`MANIFEST_FILE_NAME`].
+#[derive(Serialize)]
+struct DecodedManifest {
+    format: &'static str,
+    version: u32,
+    side: &'static str,
+    role: &'static str,
+    records_file: String,
+    compression: &'static str,
+    ordering: &'static str,
+    source: &'static str,
+    records: usize,
+
+    /// Number of records per kind, in the order the kinds were written.
+    records_by_kind: Vec<KindCount>,
+
+    /// Uncompressed size of the record stream, in bytes.
+    uncompressed_bytes: u64,
+
+    digest: Digest,
+}
+
+/// How many records of one kind a capture holds.
+#[derive(Serialize)]
+struct KindCount {
+    kind: &'static str,
+    count: usize,
+}
+
+/// A named, non-cryptographic digest of the record stream. It identifies a stream cheaply, so two captures can be
+/// compared without shipping both.
+#[derive(Serialize)]
+struct Digest {
+    algorithm: &'static str,
+    value: String,
+}
+
+/// The merged manifest, describing every traffic artifact a test produced.
+#[derive(Debug, Serialize)]
+struct TrafficManifest {
+    format: &'static str,
+    version: u32,
+
+    /// Outcome the retention decision was made against.
+    outcome: TestOutcome,
+
+    /// What the retention policy decided. Each artifact's own `file.present` reports what is on disk, which can
+    /// differ if a deletion failed.
+    captures_retained: bool,
+    retention_reason: &'static str,
+
+    /// The input capture's own manifest with its file's state folded in, or `null` when there is no usable input
+    /// capture.
+    input: Option<Value>,
+
+    /// Why there is no usable input capture, when `input` is `null`.
+    input_unavailable_reason: Option<String>,
+
+    /// One entry per decoded capture, each with its file's state folded in.
+    decoded: Vec<Value>,
+}
+
+/// Writes one side's decoded telemetry into `dir`, creating it if necessary.
+///
+/// # Errors
+///
+/// If the directory can't be created, or either file can't be written, an error is returned. Callers treat this as
+/// non-fatal: a missing artifact is a lost diagnostic, not a failed verdict.
+pub(crate) fn write_decoded(dir: &Path, side: Side, data: &CollectedData) -> Result<(), GenericError> {
+    std::fs::create_dir_all(dir)
+        .with_error_context(|| format!("Failed to create traffic directory '{}'.", dir.display()))?;
+
+    let records_path = dir.join(side.records_file_name());
+    let manifest = match write_decoded_records(&records_path, side, data) {
+        Ok(manifest) => manifest,
+        Err(e) => {
+            // A half-written file can't be read back, and leaving it would look like a complete capture.
+            let _ = std::fs::remove_file(&records_path);
+            return Err(e);
+        }
+    };
+
+    write_json_file(&dir.join(side.manifest_file_name()), &manifest)
+}
+
+fn write_decoded_records(path: &Path, side: Side, data: &CollectedData) -> Result<DecodedManifest, GenericError> {
+    let file =
+        File::create(path).with_error_context(|| format!("Failed to create decoded capture '{}'.", path.display()))?;
+
+    let mut writer = RecordWriter::new(
+        zstd::stream::write::Encoder::new(BufWriter::new(file), ZSTD_LEVEL)
+            .error_context("Failed to initialize zstd encoder for decoded capture.")?,
+    );
+
+    let counts = vec![
+        writer.write_kind("event", data.events())?,
+        writer.write_kind("metric", data.metrics())?,
+        writer.write_kind("service_check", data.service_checks())?,
+        writer.write_kind("span", data.spans())?,
+        writer.write_kind("trace_stats", std::slice::from_ref(data.trace_stats()))?,
+        writer.write_kind("dogstatsd_forwarded_packet", data.dogstatsd_forwarded_packets())?,
+    ];
+
+    let (records, uncompressed_bytes, digest, encoder) = writer.finish();
+    encoder
+        .finish()
+        .error_context("Failed to finalize zstd stream for decoded capture.")?
+        .into_inner()
+        .map_err(|e| generic_error!("Failed to flush decoded capture: {}", e))?
+        .sync_all()
+        .error_context("Failed to sync decoded capture.")?;
+
+    Ok(DecodedManifest {
+        format: DECODED_FORMAT,
+        version: DECODED_FORMAT_VERSION,
+        side: side.name(),
+        role: side.role(),
+        records_file: side.records_file_name(),
+        compression: "zstd",
+        ordering: DECODED_ORDERING,
+        source: "datadog-intake dump endpoints",
+        records,
+        records_by_kind: counts,
+        uncompressed_bytes,
+        digest: Digest {
+            algorithm: "fnv1a64",
+            value: format!("{:016x}", digest),
+        },
+    })
+}
+
+/// Records why a runtime produced no input capture, for [`finalize`] to fold into the manifest.
+///
+/// Failures are logged, never fatal.
+pub(crate) fn record_input_unavailable(dir: &Path, reason: &str) {
+    if let Err(e) =
+        std::fs::create_dir_all(dir).and_then(|()| std::fs::write(dir.join(INPUT_UNAVAILABLE_FILE_NAME), reason))
+    {
+        warn!(path = %dir.display(), error = %e, "Failed to record missing input capture.");
+    }
+}
+
+/// Merges the traffic sidecars into [`MANIFEST_FILE_NAME`] and applies the outcome's retention policy.
+///
+/// Called for every test, and a no-op for a test that produced no traffic directory. Failures are logged, never
+/// fatal, so an artifact problem can't change a verdict.
+pub(crate) fn finalize(log_dir: &Path, outcome: TestOutcome) {
+    let dir = traffic_dir(log_dir);
+    if !dir.is_dir() {
+        return;
+    }
+
+    let retain = !outcome.is_passed();
+    let mut sidecars = Vec::new();
+
+    let input_sidecar = dir.join(INPUT_MANIFEST_FILE_NAME);
+    let input_manifest = read_json_file(&input_sidecar);
+    if input_manifest.is_some() {
+        sidecars.push(input_sidecar);
+    }
+
+    let mut decoded_manifests = Vec::new();
+    for side in [Side::Baseline, Side::Comparison] {
+        let sidecar = dir.join(side.manifest_file_name());
+        if let Some(manifest) = read_json_file(&sidecar) {
+            decoded_manifests.push((side, manifest));
+            sidecars.push(sidecar);
+        }
+    }
+
+    // Sizes come from before the deletion and presence from after it, so the manifest reports both what the
+    // captures held and whether a reader can still open them.
+    let input_records = dir.join(INPUT_RECORDS_FILE_NAME);
+    let input_bytes = file_size(&input_records);
+    let decoded_bytes = decoded_manifests
+        .iter()
+        .map(|(side, _)| file_size(&dir.join(side.records_file_name())))
+        .collect::<Vec<_>>();
+
+    if !retain {
+        remove_file(&input_records);
+        for side in [Side::Baseline, Side::Comparison] {
+            remove_file(&dir.join(side.records_file_name()));
+        }
+    }
+
+    let input_unavailable_reason = input_manifest
+        .is_none()
+        .then(|| missing_input_reason(&dir, input_bytes.is_some()));
+    let input =
+        input_manifest.map(|manifest| with_file_state(manifest, INPUT_RECORDS_FILE_NAME, input_bytes, &input_records));
+    let decoded = decoded_manifests
+        .into_iter()
+        .zip(decoded_bytes)
+        .map(|((side, manifest), bytes)| {
+            let records_file = side.records_file_name();
+            let path = dir.join(&records_file);
+            with_file_state(manifest, &records_file, bytes, &path)
+        })
+        .collect();
+
+    let manifest = TrafficManifest {
+        format: MANIFEST_FORMAT,
+        version: MANIFEST_FORMAT_VERSION,
+        outcome,
+        captures_retained: retain,
+        retention_reason: if retain {
+            "kept: the test did not pass"
+        } else {
+            "deleted: the test passed, so only this manifest remains"
+        },
+        input,
+        input_unavailable_reason,
+        decoded,
+    };
+
+    if let Err(e) = write_json_file(&dir.join(MANIFEST_FILE_NAME), &manifest) {
+        warn!(path = %dir.display(), error = %e, "Failed to write traffic manifest.");
+        // The sidecars are the only remaining record of the captures, so they stay.
+        return;
+    }
+
+    for sidecar in sidecars {
+        remove_file(&sidecar);
+    }
+    remove_file(&dir.join(INPUT_UNAVAILABLE_FILE_NAME));
+}
+
+/// Explains an unusable input capture: a runtime's own note if it left one, otherwise what the directory shows.
+fn missing_input_reason(dir: &Path, has_orphaned_records: bool) -> String {
+    match std::fs::read_to_string(dir.join(INPUT_UNAVAILABLE_FILE_NAME)) {
+        Ok(reason) => reason.trim().to_string(),
+        Err(_) if has_orphaned_records => format!(
+            "'{}' has no readable '{}', so the capture cannot be interpreted.",
+            INPUT_RECORDS_FILE_NAME, INPUT_MANIFEST_FILE_NAME
+        ),
+        Err(_) => "No input capture was written for this test.".to_string(),
+    }
+}
+
+/// Folds a capture file's state into its producer's manifest, under a `file` key.
+fn with_file_state(mut manifest: Value, name: &str, bytes: Option<u64>, path: &Path) -> Value {
+    let file = serde_json::json!({
+        "name": name,
+        "compressed_bytes": bytes,
+        "present": path.exists(),
+    });
+
+    match manifest.as_object_mut() {
+        Some(object) => {
+            object.insert("file".to_string(), file);
+            manifest
+        }
+        // A manifest that isn't an object came from something other than a producer; keep both rather than
+        // discarding either.
+        None => serde_json::json!({ "manifest": manifest, "file": file }),
+    }
+}
+
+fn file_size(path: &Path) -> Option<u64> {
+    std::fs::metadata(path).map(|meta| meta.len()).ok()
+}
+
+fn read_json_file(path: &Path) -> Option<Value> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    match serde_json::from_str(&raw) {
+        Ok(value) => Some(value),
+        Err(e) => {
+            warn!(path = %path.display(), error = %e, "Failed to parse traffic manifest sidecar.");
+            None
+        }
+    }
+}
+
+fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<(), GenericError> {
+    let json = serde_json::to_string_pretty(value)
+        .with_error_context(|| format!("Failed to serialize '{}'.", path.display()))?;
+    std::fs::write(path, format!("{}\n", json)).with_error_context(|| format!("Failed to write '{}'.", path.display()))
+}
+
+fn remove_file(path: &Path) {
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => warn!(path = %path.display(), error = %e, "Failed to delete traffic capture."),
+    }
+}
+
+/// Serializes records into a writer, one JSON object per line, tallying what it wrote.
+struct RecordWriter<W> {
+    writer: W,
+    scratch: Vec<u8>,
+    records: usize,
+    bytes: u64,
+    digest: u64,
+}
+
+impl<W: std::io::Write> RecordWriter<W> {
+    fn new(writer: W) -> Self {
+        Self {
+            writer,
+            scratch: Vec::new(),
+            records: 0,
+            bytes: 0,
+            digest: FNV_OFFSET_BASIS,
+        }
+    }
+
+    /// Writes every item in `items` as a record of `kind`.
+    ///
+    /// Each record is serialized into a reused buffer and streamed out, so a large collection never becomes a
+    /// large JSON string.
+    fn write_kind<T: Serialize>(&mut self, kind: &'static str, items: &[T]) -> Result<KindCount, GenericError> {
+        for (index, value) in items.iter().enumerate() {
+            self.scratch.clear();
+            serde_json::to_writer(&mut self.scratch, &DecodedRecord { kind, index, value })
+                .with_error_context(|| format!("Failed to serialize decoded {}.", kind))?;
+            self.scratch.push(b'\n');
+
+            self.writer
+                .write_all(&self.scratch)
+                .with_error_context(|| format!("Failed to write decoded {}.", kind))?;
+
+            self.records += 1;
+            self.bytes += self.scratch.len() as u64;
+            // The newline separator is part of what the digest covers, so record boundaries are too.
+            self.digest = fnv1a64_update(self.digest, &self.scratch);
+        }
+
+        Ok(KindCount {
+            kind,
+            count: items.len(),
+        })
+    }
+
+    /// Returns the tallies and the underlying writer, which the caller still has to finalize.
+    fn finish(self) -> (usize, u64, u64, W) {
+        (self.records, self.bytes, self.digest, self.writer)
+    }
+}
+
+fn fnv1a64_update(mut digest: u64, bytes: &[u8]) -> u64 {
+    for byte in bytes {
+        digest ^= u64::from(*byte);
+        digest = digest.wrapping_mul(FNV_PRIME);
+    }
+    digest
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Writes the sidecars a finished capture would have left behind, plus stand-in record files.
+    fn seed_traffic_dir(log_dir: &Path, with_input: bool) -> PathBuf {
+        let dir = traffic_dir(log_dir);
+        std::fs::create_dir_all(&dir).expect("traffic dir should be created");
+
+        if with_input {
+            std::fs::write(dir.join(INPUT_RECORDS_FILE_NAME), b"compressed-input").expect("input should be written");
+            std::fs::write(
+                dir.join(INPUT_MANIFEST_FILE_NAME),
+                br#"{"format":"millstone-input-capture","records":5,"ordering":"logical_send_order"}"#,
+            )
+            .expect("input manifest should be written");
+        }
+
+        for side in [Side::Baseline, Side::Comparison] {
+            std::fs::write(dir.join(side.records_file_name()), b"compressed-decoded")
+                .expect("decoded records should be written");
+            std::fs::write(
+                dir.join(side.manifest_file_name()),
+                format!(r#"{{"format":"panoramic-decoded-capture","side":"{}"}}"#, side.name()),
+            )
+            .expect("decoded manifest should be written");
+        }
+
+        dir
+    }
+
+    fn read_manifest(dir: &Path) -> Value {
+        let raw = std::fs::read_to_string(dir.join(MANIFEST_FILE_NAME)).expect("manifest should be readable");
+        serde_json::from_str(&raw).expect("manifest should be valid JSON")
+    }
+
+    #[test]
+    fn a_failed_test_keeps_its_captures_and_merges_the_sidecars() {
+        let log_dir = tempfile::tempdir().expect("temp dir should be created");
+        let dir = seed_traffic_dir(log_dir.path(), true);
+
+        finalize(log_dir.path(), TestOutcome::Failed);
+
+        let manifest = read_manifest(&dir);
+        assert_eq!(manifest["format"], MANIFEST_FORMAT);
+        assert_eq!(manifest["outcome"], "failed");
+        assert_eq!(manifest["captures_retained"], true);
+        assert_eq!(manifest["input"]["records"], 5);
+        assert_eq!(manifest["input"]["ordering"], "logical_send_order");
+        assert_eq!(manifest["input"]["file"]["name"], INPUT_RECORDS_FILE_NAME);
+        assert_eq!(manifest["input"]["file"]["compressed_bytes"], 16);
+        assert_eq!(manifest["input"]["file"]["present"], true);
+        assert!(manifest["input_unavailable_reason"].is_null());
+        assert_eq!(manifest["decoded"][0]["side"], "baseline");
+        assert_eq!(manifest["decoded"][1]["side"], "comparison");
+        assert_eq!(manifest["decoded"][0]["file"]["present"], true);
+
+        assert!(dir.join(INPUT_RECORDS_FILE_NAME).exists());
+        assert!(dir.join(Side::Baseline.records_file_name()).exists());
+        assert!(dir.join(Side::Comparison.records_file_name()).exists());
+        // The sidecars are folded into the manifest, so they no longer stand on their own.
+        assert!(!dir.join(INPUT_MANIFEST_FILE_NAME).exists());
+        assert!(!dir.join(Side::Baseline.manifest_file_name()).exists());
+    }
+
+    #[test]
+    fn a_passing_test_keeps_only_the_manifest() {
+        let log_dir = tempfile::tempdir().expect("temp dir should be created");
+        let dir = seed_traffic_dir(log_dir.path(), true);
+
+        finalize(log_dir.path(), TestOutcome::Passed);
+
+        let manifest = read_manifest(&dir);
+        assert_eq!(manifest["outcome"], "passed");
+        assert_eq!(manifest["captures_retained"], false);
+        // The manifest still describes the sizes of the captures it outlived, and reports them as gone.
+        assert_eq!(manifest["input"]["file"]["compressed_bytes"], 16);
+        assert_eq!(manifest["input"]["file"]["present"], false);
+        assert_eq!(manifest["decoded"][0]["file"]["present"], false);
+
+        let remaining = std::fs::read_dir(&dir)
+            .expect("traffic dir should be readable")
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(remaining, vec![MANIFEST_FILE_NAME.to_string()]);
+    }
+
+    #[test]
+    fn a_timed_out_test_keeps_its_captures() {
+        let log_dir = tempfile::tempdir().expect("temp dir should be created");
+        let dir = seed_traffic_dir(log_dir.path(), true);
+
+        finalize(log_dir.path(), TestOutcome::TimedOut);
+
+        assert_eq!(read_manifest(&dir)["captures_retained"], true);
+        assert!(dir.join(INPUT_RECORDS_FILE_NAME).exists());
+    }
+
+    #[test]
+    fn an_errored_test_keeps_its_captures() {
+        let log_dir = tempfile::tempdir().expect("temp dir should be created");
+        let dir = seed_traffic_dir(log_dir.path(), true);
+
+        finalize(log_dir.path(), TestOutcome::Errored);
+
+        assert_eq!(read_manifest(&dir)["captures_retained"], true);
+        assert!(dir.join(INPUT_RECORDS_FILE_NAME).exists());
+    }
+
+    #[test]
+    fn a_missing_input_capture_is_reported_with_its_reason() {
+        let log_dir = tempfile::tempdir().expect("temp dir should be created");
+        let dir = seed_traffic_dir(log_dir.path(), false);
+
+        record_input_unavailable(&dir, "the kind runtime cannot extract it");
+        finalize(log_dir.path(), TestOutcome::Failed);
+
+        let manifest = read_manifest(&dir);
+        assert!(manifest["input"].is_null());
+        assert_eq!(
+            manifest["input_unavailable_reason"],
+            "the kind runtime cannot extract it"
+        );
+        // The decoded captures are unaffected by a missing input capture.
+        assert_eq!(manifest["decoded"].as_array().map(Vec::len), Some(2));
+        assert!(!dir.join(INPUT_UNAVAILABLE_FILE_NAME).exists());
+    }
+
+    #[test]
+    fn an_input_capture_with_no_readable_manifest_is_reported_as_unusable() {
+        let log_dir = tempfile::tempdir().expect("temp dir should be created");
+        let dir = seed_traffic_dir(log_dir.path(), false);
+        std::fs::write(dir.join(INPUT_RECORDS_FILE_NAME), b"partial").expect("records should be written");
+
+        finalize(log_dir.path(), TestOutcome::Failed);
+
+        let manifest = read_manifest(&dir);
+        assert!(manifest["input"].is_null());
+        let reason = manifest["input_unavailable_reason"]
+            .as_str()
+            .expect("reason should be a string");
+        assert!(reason.contains("cannot be interpreted"), "{}", reason);
+    }
+
+    #[test]
+    fn a_test_with_no_traffic_directory_is_left_alone() {
+        let log_dir = tempfile::tempdir().expect("temp dir should be created");
+
+        finalize(log_dir.path(), TestOutcome::Failed);
+
+        assert!(!traffic_dir(log_dir.path()).exists());
+    }
+
+    #[test]
+    fn decoded_records_are_grouped_by_kind_and_indexed_within_it() {
+        let mut buffer = Vec::new();
+        let mut writer = RecordWriter::new(&mut buffer);
+
+        let events = writer
+            .write_kind("event", &["first".to_string(), "second".to_string()])
+            .expect("events should be written");
+        let packets = writer
+            .write_kind("dogstatsd_forwarded_packet", &["packet".to_string()])
+            .expect("packets should be written");
+        let (records, bytes, digest, _) = writer.finish();
+
+        assert_eq!(events.count, 2);
+        assert_eq!(packets.count, 1);
+        assert_eq!(records, 3);
+        assert_eq!(bytes, buffer.len() as u64);
+        assert_ne!(digest, FNV_OFFSET_BASIS);
+
+        let text = String::from_utf8(buffer).expect("records should be valid UTF-8");
+        let parsed = text
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).expect("record should be valid JSON"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(parsed[0]["kind"], "event");
+        assert_eq!(parsed[0]["index"], 0);
+        assert_eq!(parsed[0]["value"], "first");
+        assert_eq!(parsed[1]["kind"], "event");
+        assert_eq!(parsed[1]["index"], 1);
+        assert_eq!(parsed[2]["kind"], "dogstatsd_forwarded_packet");
+        // Indexes restart per kind: they are positions within a kind, not a global receive order.
+        assert_eq!(parsed[2]["index"], 0);
+    }
+
+    #[test]
+    fn each_side_names_itself_and_its_role() {
+        assert_eq!(Side::Baseline.records_file_name(), "baseline-decoded.jsonl.zst");
+        assert_eq!(Side::Comparison.records_file_name(), "comparison-decoded.jsonl.zst");
+        assert_ne!(Side::Baseline.role(), Side::Comparison.role());
+        assert!(Side::Baseline.role().contains("reference"));
+        assert!(Side::Comparison.role().contains("ADP"));
+    }
+}

--- a/bin/correctness/panoramic/src/runner.rs
+++ b/bin/correctness/panoramic/src/runner.rs
@@ -485,6 +485,8 @@ impl Runner {
         result.log_dir = Some(log_dir.clone());
 
         write_result_log(&result, &log_dir);
+        // Traffic retention runs before the report, so `result.json` lists the artifacts that are on disk.
+        crate::correctness::traffic::finalize(&log_dir, result.outcome);
         crate::machine_output::write_test_report(&result, &log_dir);
 
         if let Some(ref tx) = event_sender {


### PR DESCRIPTION
## Human Summary

Adds panoramic output in correctness tests including the input corpus and the decoded datadog-intake data from both sides. The theory is that, in a difficult debugging case, this can be useful for the analysis. The contrived experiment showed this to be true: more-or-less. More tokens were used, but fewer tool calls, less analysis time, and it gave a more confident answer and did not have to rerun the test (as the others did). Less wall clock time. It seems like a step in the right direction to me.

While I was at it, I decided an in-tree test/output directory would be nice, by default, from the Makefile, since it's super annoying when agents run with `/tmp/whatever` as the log dir on a macOS and that ends up either not being mounted, or it's inside the VM, or whatever it is that always happens.

I placed it under `target/test-output` temporarily while adding `test/output` to the `.gitignore`. After a week or two, when everyone has it in their `.gitignore` on all their branches, I'll change the canonical location to `test/output` in the `Makefile`. There is `make clean-test-output` that runs along with `make clean`.

My thinking behind this canonical output directory is to, eventually, add `cargo run -p panoramic analyze` commands that could look at the traffic and output data. TBD, but the change seems solid either way.

## AI Summary

- Capture Millstone's logical send stream during Docker correctness tests.
- Persist compressed JSONL for the input and decoded baseline/comparison output when a test does not pass.
- Write a traffic manifest that describes retention, ordering, record counts, sizes, and digests.
- Use a workspace-local Panoramic output directory by default so Docker can write captures on macOS.
- Document artifact discovery, ordering limits, overrides, and cleanup in the Panoramic skill.

Passing tests retain only the manifest. Failed, errored, and timed-out tests retain the traffic files for diagnosis. Kubernetes-in-Docker cases report that input capture is unavailable instead of implying that it was recorded.

## Change Type

- [x] New feature

## How did you test this PR?

### Standard checks

- `make fmt`
- `make check-docs`
- `make check-clippy`
- `cargo nextest run -p millstone -p panoramic`
- Manual Millstone capture smoke test, including zstd decompression and record inspection
- Docker `dsd-plain` correctness runs with host-visible traffic captures

### Diagnostic-agent experiment

I compared three cases using history-free source snapshots:

- **Case A:** `main`, before the Panoramic interface changes.
- **Case B:** the previous PR in this stack, #2513.
- **Case C:** this PR.

Each case received the same experiment-only production mutation. In `MetricValues::collapse_non_timestamped`, packed gauge values used `merge_scalar_sum` instead of `merge_scalar_latest`. Cross-packet gauge merging remained unchanged. The mutation creates a narrow defect: a multi-value DogStatsD gauge is summed within one payload instead of keeping its final value. All normal unit tests passed in every case, so the failure was unobservable through unit tests.

Two preflight `dsd-plain` runs each produced the same 45 gauge-only mismatches. Their context/value payloads were identical after removing run timestamps. The `dsd-tag-filterlist` negative control passed.

I then gave one fresh Claude Opus 5 agent per case the same neutral task: run `dsd-plain`, decide whether it passed, and diagnose the failure without modifying source. All agents used high thinking, the same read-only tools, prebuilt per-case binaries and images, and serial Docker execution. The execution order was A, C, then B.

| Result | A | B | C |
|---|---:|---:|---:|
| Correct diagnosis | Yes | Yes | Yes |
| Correctness runs | 2 | 2 | 1 |
| Wall time | 379s | 292s | 226s |
| LLM calls | 33 | 21 | 22 |
| Tool calls | 37 | 28 | 24 |
| Time from first failed run to explicit diagnosis | 256s | 147s | 102s |
| Reported tokens, including cache | 975k | 625k | 838k |

All three agents found the responsible gauge-collapse behavior and source line. The evidence supporting that conclusion differed:

- In case A, the agent inferred summation from gauge-only mismatch values, source inconsistency, and the close fit between the corpus's 8% packing probability and 45 failures. It reran the case because the available logs could not reconstruct an input payload.
- In case B, the agent followed `run.json` to `result.json` and the uncapped assertion details. This made the verdict and gauge-only failure class easier to establish, but it still reran because the original input was unavailable.
- In case C, the agent used the first failed run's manifest, ordered logical input, and decoded outputs. It proved one example directly: a packed gauge ended in `8525448`, while all 20 values summed to `20876042.871336013`; those were exactly the baseline and comparison outputs. It then predicted the complete mismatch set from the capture and did not rerun.

I independently audited that correlation rather than relying on the agent report. The captures contained 10,000 logical sends and 3,032 decoded metrics per side. Of 558 input gauge contexts, exactly 45 ended with a packed logical send. Those 45 contexts exactly matched the 45 output mismatches. Across all 45, baseline output matched the packed payload's final value and comparison output matched its sum within floating-point representation tolerance.

The comparison is small (`n=1` per case), so it does not establish a general agent-performance result. Case B reduced navigation effort relative to case A. Case C made the failure mechanism auditable from the first run, removed the reason to rerun, and produced the most specific diagnosis with the lowest wall time and tool count. Diagnostic correctness was the same across all three cases.

## References

- Progresses: #1536

DADP-90
