### PR TITLE
fix(sources): eliminate bind race in dogstatsd supervision tests

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -4212,7 +4212,7 @@ mod supervision {
     use saluki_core::support::SubsystemIdentifier;
     use saluki_core::topology::{EventsBuffer, EventsDispatcher, OutputName, TopologyContext};
     use saluki_io::net::listener::Listener;
-    use saluki_io::net::ListenAddress;
+    use saluki_io::net::{BoundListenAddress, ListenAddress};
     use stringtheory::MetaString;
     use tokio::net::UdpSocket;
     use tokio::runtime::Handle;
@@ -4274,16 +4274,17 @@ mod supervision {
     ) -> Harness {
         let component_context = ComponentContext::test_source("dogstatsd");
 
-        // Bind an ephemeral port and read back what we got, so parallel tests don't collide on a fixed one.
-        let probe = UdpSocket::bind("127.0.0.1:0")
-            .await
-            .expect("should bind a probe socket");
-        let listen_addr = probe.local_addr().expect("probe should have an address");
-        drop(probe);
-
-        let listener = Listener::from_listen_address(ListenAddress::Udp(listen_addr), None)
+        // Bind directly to an ephemeral port and read back what the OS assigned. Binding a probe socket to learn a
+        // free port and then dropping it before rebinding leaves a window where another socket -- in this process or
+        // elsewhere on the host -- can claim that port first, which is exactly the kind of bind race that made this
+        // flaky under parallel test execution.
+        let listener = Listener::from_listen_address(ListenAddress::Udp("127.0.0.1:0".parse().unwrap()), None)
             .await
             .expect("listener should bind");
+        let listen_addr = match listener.bound_listen_address() {
+            BoundListenAddress::Udp(addr) => addr,
+            other => panic!("expected a bound UDP address, got {other:?}"),
+        };
 
         let (io_buffer_pool, io_buffer_pool_shrinker) = build_io_buffer_pool(
             io_buffer_count,
@@ -4512,17 +4513,19 @@ mod supervision {
         let supervisor = TestComponentSupervisor::start("dogstatsd").await;
         let health_registry = HealthRegistry::new();
 
-        // A TCP listener, so there are real connections to accept.
-        let probe = tokio::net::TcpListener::bind("127.0.0.1:0")
+        // A TCP listener, so there are real connections to accept. Bind directly to an ephemeral port and read back
+        // what the OS assigned, rather than probing a port and dropping the probe before rebinding -- that leaves a
+        // window for another socket to claim the port first.
+        let tcp_listener = Listener::from_listen_address(ListenAddress::Tcp("127.0.0.1:0".parse().unwrap()), None)
             .await
-            .expect("should bind a probe socket");
-        let listen_addr = probe.local_addr().expect("probe should have an address");
-        drop(probe);
+            .expect("listener should bind");
+        let listen_addr = match tcp_listener.bound_listen_address() {
+            BoundListenAddress::Tcp(addr) => addr,
+            other => panic!("expected a bound TCP address, got {other:?}"),
+        };
 
         let mut harness = build_source(&health_registry).await;
-        harness.source.listeners = vec![Listener::from_listen_address(ListenAddress::Tcp(listen_addr), None)
-            .await
-            .expect("listener should bind")];
+        harness.source.listeners = vec![tcp_listener];
 
         let Harness {
             source,

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -4274,10 +4274,6 @@ mod supervision {
     ) -> Harness {
         let component_context = ComponentContext::test_source("dogstatsd");
 
-        // Bind directly to an ephemeral port and read back what the OS assigned. Binding a probe socket to learn a
-        // free port and then dropping it before rebinding leaves a window where another socket -- in this process or
-        // elsewhere on the host -- can claim that port first, which is exactly the kind of bind race that made this
-        // flaky under parallel test execution.
         let listener = Listener::from_listen_address(ListenAddress::Udp("127.0.0.1:0".parse().unwrap()), None)
             .await
             .expect("listener should bind");
@@ -4513,9 +4509,7 @@ mod supervision {
         let supervisor = TestComponentSupervisor::start("dogstatsd").await;
         let health_registry = HealthRegistry::new();
 
-        // A TCP listener, so there are real connections to accept. Bind directly to an ephemeral port and read back
-        // what the OS assigned, rather than probing a port and dropping the probe before rebinding -- that leaves a
-        // window for another socket to claim the port first.
+        // A TCP listener, so there are real connections to accept.
         let tcp_listener = Listener::from_listen_address(ListenAddress::Tcp("127.0.0.1:0".parse().unwrap()), None)
             .await
             .expect("listener should bind");


### PR DESCRIPTION
## Summary

Fix racey tests that bind to an ephemeral port and then release it and expect it to still be available later. Instead keep the binding.

## Test plan
- [x] `run_does_not_return_until_the_decoders_have_drained` and the other `supervision` tests pass
- [x] Existing tests cover the affected paths; no new tests needed since this only changes how the test harness picks its listening port