### PR TITLE
fix(cgroups): detect host-mapped cgroupfs independently of procfs

### DIFF
--- a/lib/saluki-env/src/features/detector.rs
+++ b/lib/saluki-env/src/features/detector.rs
@@ -59,7 +59,7 @@ impl FeatureDetector {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "linux"))]
 impl FeatureDetector {
     /// Creates a `FeatureDetector` that reports exactly the given features.
     ///

--- a/lib/saluki-env/src/features/detector.rs
+++ b/lib/saluki-env/src/features/detector.rs
@@ -58,3 +58,15 @@ impl FeatureDetector {
         detected_features
     }
 }
+
+#[cfg(test)]
+impl FeatureDetector {
+    /// Creates a `FeatureDetector` that reports exactly the given features.
+    ///
+    /// Detection probes the real filesystem, so tests that need a specific set of features -- the host-mapped ones in
+    /// particular, which depend on running inside a container -- can't reach them through the normal constructors
+    /// without becoming dependent on the environment the tests run in.
+    pub(crate) fn from_detected_features(detected_features: Feature) -> Self {
+        Self { detected_features }
+    }
+}

--- a/lib/saluki-env/src/workload/helpers/cgroups.rs
+++ b/lib/saluki-env/src/workload/helpers/cgroups.rs
@@ -66,13 +66,12 @@ impl CgroupsConfiguration {
         let cgroupfs_root = match config.try_get_typed::<PathBuf>("container_cgroup_root")? {
             Some(path) => path,
             None => {
-                if feature_detector.is_feature_available(Feature::HostMappedProcfs) {
+                // Detected separately from procfs: the two are independent mounts, and a deployment can map one
+                // without the other. Keying this off the procfs feature would point us at a cgroupfs path that isn't
+                // there, or make us miss the host's hierarchy in favor of our own container's.
+                if feature_detector.is_feature_available(Feature::HostMappedCgroupfs) {
                     PathBuf::from(DEFAULT_HOST_MAPPED_CGROUPFS_ROOT)
                 } else {
-                    // TODO: Consider if we need to do anything specific for Amazon Linux [1] or does the referenced code only
-                    // matter for cgroups v1?
-                    //
-                    // [1]: https://github.com/DataDog/datadog-agent/blob/fe75b815c2f135f0d2ea85d7a57a8fc8cbf56bd9/pkg/config/setup/config.go#L1172-L1173
                     PathBuf::from(DEFAULT_CGROUPFS_ROOT)
                 }
             }
@@ -764,6 +763,7 @@ mod tests {
         path::{Path, PathBuf},
     };
 
+    use saluki_config::ConfigurationLoader;
     use stringtheory::{
         interning::{GenericMapInterner, InternedString, Interner as _},
         MetaString,
@@ -772,8 +772,9 @@ mod tests {
 
     use super::{
         extract_container_id, extract_container_id_from_path, get_container_id_from_cgroup_lines,
-        is_usable_controller_inode, visit_subdirectories, CgroupControllerEntry, CgroupsReader, HierarchyReader,
-        TraversalResult, DEFAULT_PROCFS_ROOT,
+        is_usable_controller_inode, visit_subdirectories, CgroupControllerEntry, CgroupsConfiguration, CgroupsReader,
+        Feature, FeatureDetector, HierarchyReader, TraversalResult, DEFAULT_CGROUPFS_ROOT,
+        DEFAULT_HOST_MAPPED_CGROUPFS_ROOT, DEFAULT_HOST_MAPPED_PROCFS_ROOT, DEFAULT_PROCFS_ROOT,
     };
 
     #[test]
@@ -1323,5 +1324,44 @@ mod tests {
         // collector reap every alias it holds.
         assert!(!traversal.is_complete());
         assert!(traversal.cgroups.is_empty());
+    }
+
+    async fn cgroups_config_with(detected: Feature) -> CgroupsConfiguration {
+        let (config, _updates_tx) = ConfigurationLoader::for_tests(None, None, false).await;
+
+        CgroupsConfiguration::from_configuration(&config, FeatureDetector::from_detected_features(detected))
+            .expect("configuration should load")
+    }
+
+    #[tokio::test]
+    async fn cgroupfs_root_defaults_to_local_when_nothing_is_host_mapped() {
+        let config = cgroups_config_with(Feature::none()).await;
+
+        assert_eq!(config.procfs_path(), Path::new(DEFAULT_PROCFS_ROOT));
+        assert_eq!(config.cgroupfs_path(), Path::new(DEFAULT_CGROUPFS_ROOT));
+    }
+
+    #[tokio::test]
+    async fn cgroupfs_root_follows_host_mapped_cgroupfs() {
+        let config = cgroups_config_with(Feature::HostMappedCgroupfs).await;
+
+        assert_eq!(config.cgroupfs_path(), Path::new(DEFAULT_HOST_MAPPED_CGROUPFS_ROOT));
+    }
+
+    #[tokio::test]
+    async fn cgroupfs_root_ignores_host_mapped_procfs() {
+        // procfs and cgroupfs are independent mounts. A deployment that maps one without the other used to get the
+        // host cgroupfs path off the back of the procfs mount, pointing the reader at a path that isn't there.
+        let config = cgroups_config_with(Feature::HostMappedProcfs).await;
+
+        assert_eq!(config.procfs_path(), Path::new(DEFAULT_HOST_MAPPED_PROCFS_ROOT));
+        assert_eq!(config.cgroupfs_path(), Path::new(DEFAULT_CGROUPFS_ROOT));
+    }
+
+    #[tokio::test]
+    async fn procfs_root_ignores_host_mapped_cgroupfs() {
+        let config = cgroups_config_with(Feature::HostMappedCgroupfs).await;
+
+        assert_eq!(config.procfs_path(), Path::new(DEFAULT_PROCFS_ROOT));
     }
 }

--- a/releasenotes/notes/fix-cgroupfs-root-detection-2adf54a0216d0fd3.yaml
+++ b/releasenotes/notes/fix-cgroupfs-root-detection-2adf54a0216d0fd3.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Detect the host-mapped cgroup filesystem independently of the host-mapped proc filesystem when choosing where to
+    read control groups from. Previously, a deployment that mounted one without the other could read control groups
+    from a path that doesn't exist, or read the container's own hierarchy instead of the host's, leaving container
+    origin detection unable to resolve workloads. Set ``container_cgroup_root`` to override the detected path.


### PR DESCRIPTION
## Summary

ADP picks between the host's cgroup filesystem and its own container's by feature detection. That decision was reading the wrong flag — it checked whether *procfs* was host-mapped — so a deployment that mounts one of the two filesystems without the other ends up pointed at the wrong hierarchy and can't resolve container workloads at all. The flag it should have been reading already exists and is already detected.

## Problem

`CgroupsConfiguration::from_configuration` chose both roots off a single feature:

```rust
let cgroupfs_root = match config.try_get_typed::<PathBuf>("container_cgroup_root")? {
    Some(path) => path,
    None => {
        if feature_detector.is_feature_available(Feature::HostMappedProcfs) {   // <-- procfs
            PathBuf::from(DEFAULT_HOST_MAPPED_CGROUPFS_ROOT)
```

Meanwhile `Feature::HostMappedCgroupfs` is declared in `features/mod.rs`, probes `/host/sys/fs/cgroup` via `has_host_mapped_cgroupfs()`, and is wired into `FeatureDetector::detect_features` — and then nothing ever read it.

procfs and cgroupfs are independent mounts, so the two can disagree, and it breaks in both directions:

| Mounted | Before | Consequence |
|---|---|---|
| `/host/proc` only | cgroupfs root → `/host/sys/fs/cgroup` | Path doesn't exist; no hierarchy found, collector fails to start |
| `/host/sys/fs/cgroup` only | cgroupfs root → `/sys/fs/cgroup` | Reads the container's own hierarchy, silently missing every workload on the host |

Both end with container origin detection unable to resolve workloads to a container ID.

## What the Agent does

It probes the two independently. From the code ADP's own `TODO` linked to:

```go
if pathExists("/host/sys/fs/cgroup/") {
    config.SetDefault("container_cgroup_root", "/host/sys/fs/cgroup/")
} else {
    config.SetDefault("container_cgroup_root", "/sys/fs/cgroup/")
}
```

## What changed

- The cgroupfs root now consults `Feature::HostMappedCgroupfs`. One flag swap; the detection machinery was already in place and `FeatureDetector::automatic` enables all features, so nothing else needed wiring.
- Resolved the adjacent `TODO` asking whether the Agent's Amazon Linux cgroup root handling applies here. It doesn't, and the answer is worth recording rather than leaving the question open: that path probes `/cgroup/memory/memory.stat`, a cgroups **v1** layout on Amazon Linux **1**, which reached EOL in December 2020.
- Added a `#[cfg(test)]` `FeatureDetector::from_detected_features` constructor. Detection probes the real filesystem, so without it these branches can't be tested without the result depending on whether the test process happens to be running in a container — which is exactly the variable under test.

## Test plan

- [x] Four new tests covering the matrix: neither feature, cgroupfs only, procfs only, and that procfs resolution is unaffected by the cgroupfs flag.
- [x] Mutation-checked against the old behavior — reverting the single flag makes both directions fail with the wrong path (`left: "/host/sys/fs/cgroup"` where `/sys/fs/cgroup` is expected, and the inverse), confirming the tests pin the fix rather than passing incidentally.
- [x] `cargo test -p saluki-env` (70 tests), `cargo clippy --all-targets -p saluki-env -- -D warnings`, and `cargo check --workspace --tests` in a Linux container, since this module is `#[cfg(target_os = "linux")]`.
- [x] `make check-release-notes` and `reno lint` clean.

## Context

Found while auditing ADP's cgroups implementation against `pkg/util/cgroups` after the DADP-98 work (#2460, #2461, #2462, #2464). One other gap came out of that audit and is **not** addressed here: self-container detection has no cgroup-namespace fallback, so on cgroups v2 with a private cgroup namespace — the containerd/CRI-O default on modern hosts — `/proc/self/cgroup` reads `0::/` and `get_self_container_id` returns `None`. The Agent falls back to parsing `/proc/self/mountinfo` in that case. That needs its own change and its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
