### PR TITLE
chore(deps): update der to 0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
 dependencies = [
  "const-oid 0.10.2",
  "zeroize",
@@ -4288,7 +4288,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der 0.8.0",
+ "der 0.8.2",
  "spki 0.8.0",
 ]
 
@@ -5513,7 +5513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
- "der 0.8.0",
+ "der 0.8.2",
  "hybrid-array",
  "zeroize",
 ]
@@ -5972,7 +5972,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
- "der 0.8.0",
+ "der 0.8.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Human Summary

Minimal fix for a `check-deny` error.

## AI Summary

Updates only `der` from the yanked `0.8.0` release to `0.8.2` in `Cargo.lock`.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `cargo check --workspace`
- `cargo check --workspace --tests`
- `make check-clippy`
- `make check-deny`
- `make check-docs`

## References

None.
