### PR TITLE
fix(deps): bump `h2` to 0.4.19 to fix spurious connection termination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,9 +2679,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/releasenotes/notes/bump-h2-0-4-19-117b225186769f83.yaml
+++ b/releasenotes/notes/bump-h2-0-4-19-117b225186769f83.yaml
@@ -1,0 +1,6 @@
+fixes:
+  - |
+    Updated ``h2`` to 0.4.19, which relaxes the small DATA frame protection that was added in 0.4.16 and
+    was spuriously terminating legitimate HTTP/2 client connections with a ``too_many_data_frames``
+    ``ENHANCE_YOUR_CALM`` GOAWAY error. This caused connection drops and elevated retries when talking
+    to the metrics intake, and could result in dropped payloads under load.


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ed245921-f5c2-4751-b9d1-5eb9d95e524b","source":"chat","resourceId":"429d2498-2012-4d3b-8f35-b2da00020d05","workflowId":"23c4de37-41d1-4534-8dbb-5c448aec7b20","codeChangeId":"23c4de37-41d1-4534-8dbb-5c448aec7b20","sourceType":"slack"} -->
## Summary
Bump `h2` to 0.4.19 to pick up the fix for hyperium/h2#939: h2 `0.4.16` added a small-DATA-frame protection that spuriously terminates legitimate HTTP/2 client connections with a `too_many_data_frames` `ENHANCE_YOUR_CALM` GOAWAY error.

When testing ADP 1.6.0 in staging, we observed an elevated rate of HTTP retries, specifically for HTTP/2. We debugged the issue and landed on `h2` as being the proximate cause. We further wittled down the search by checking our logs for instances of the "too many small DATA frames" debug log that was added in the aforementioned `h2` PR, which then completely confirmed the aforementioned PR as being the root cause.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing tests.

## References

- Upstream issue: hyperium/h2#939
- Related error-logging enrichment: DataDog/saluki#2572