### PR TITLE
chore: Prepare 1.6.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
 dependencies = [
  "const-oid 0.10.2",
  "zeroize",
@@ -3380,7 +3380,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der 0.8.0",
+ "der 0.8.2",
  "spki 0.8.0",
 ]
 
@@ -4599,7 +4599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
- "der 0.8.0",
+ "der 0.8.2",
  "hybrid-array",
  "zeroize",
 ]
@@ -5039,7 +5039,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
- "der 0.8.0",
+ "der 0.8.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,9 +1839,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-data-plane"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "agent-data-plane-config",
  "agent-data-plane-config-system",

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-data-plane"
-version = "1.6.0"
+version = "1.6.1"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/releasenotes/notes/bump-h2-0-4-19-117b225186769f83.yaml
+++ b/releasenotes/notes/bump-h2-0-4-19-117b225186769f83.yaml
@@ -1,0 +1,6 @@
+fixes:
+  - |
+    Updated ``h2`` to 0.4.19, which relaxes the small DATA frame protection that was added in 0.4.16 and
+    was spuriously terminating legitimate HTTP/2 client connections with a ``too_many_data_frames``
+    ``ENHANCE_YOUR_CALM`` GOAWAY error. This caused connection drops and elevated retries when talking
+    to the metrics intake, and could result in dropped payloads under load.


### PR DESCRIPTION
## Summary

Backports two dependency fixes to `releases/1.6.x` ahead of the 1.6.1 patch release: a `der` bump that replaces a yanked crate version, and an `h2` bump that fixes spurious HTTP/2 connection termination caused by an overly aggressive small-DATA-frame protection upstream.

- #2554
- #2573

## Test plan

- [x] Cherry-picked #2554 (`0f80faddbd`) and #2573 (`6680c5c409`) from `main` cleanly onto `releases/1.6.x`
- [x] `cargo check --workspace` passes on the resulting branch