### PR TITLE
fix(forwarder): count bytes after successful requests

### DIFF
--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -65,6 +65,7 @@ type EndpointNameFn = dyn Fn(&Uri) -> Option<MetaString> + Send + Sync;
 
 struct InFlightTransaction<R> {
     metadata: Metadata,
+    body_size: u64,
     retry_counters: Option<TransactionRetryCounters>,
     result: R,
 }
@@ -120,6 +121,7 @@ async fn handle_in_flight_transaction_result<B>(
 {
     let InFlightTransaction {
         metadata,
+        body_size,
         retry_counters,
         result,
     } = match task_result {
@@ -144,7 +146,15 @@ async fn handle_in_flight_transaction_result<B>(
         // surfaced by the inspection layer in the service stack rather than here, since a retriable 403 becomes a
         // `Retry` result and never reaches this arm.
         Ok(http_response) => {
-            process_http_response(http_response, metadata, telemetry, endpoint_url, endpoint_domain).await
+            process_http_response(
+                http_response,
+                metadata,
+                body_size,
+                telemetry,
+                endpoint_url,
+                endpoint_domain,
+            )
+            .await
         }
 
         // The service itself encountered an error while sending the request or receiving the response:
@@ -368,7 +378,6 @@ where
             .with_min_tls_version(config.min_tls_version())
             .with_tls_handshake_timeout(config.tls_handshake_timeout())
             .with_http_protocol(config.http_protocol())
-            .with_bytes_sent_counter(telemetry.bytes_sent().clone())
             .with_endpoint_telemetry(
                 metrics_builder.clone(),
                 Some(move |uri: &Uri| endpoint_name_for_client(uri)),
@@ -777,8 +786,10 @@ async fn run_endpoint_io_loop<B>(
                         &mut retry_telemetry,
                         endpoint_name.as_ref(),
                     );
+                    let body_size = request.body().remaining() as u64;
                     in_flight.spawn(svc.call(request).map(move |result| InFlightTransaction {
                         metadata,
+                        body_size,
                         retry_counters,
                         result,
                     }));
@@ -881,7 +892,8 @@ fn track_queue_drops(telemetry: &ComponentTelemetry, domain: &str, push_result: 
 
 /// Processes an HTTP response to a forwarded intake request, updating telemetry and logging as appropriate.
 async fn process_http_response(
-    response: Response<Incoming>, metadata: Metadata, telemetry: &ComponentTelemetry, endpoint_url: &str, domain: &str,
+    response: Response<Incoming>, metadata: Metadata, body_size: u64, telemetry: &ComponentTelemetry,
+    endpoint_url: &str, domain: &str,
 ) {
     let status = response.status();
     if status.is_success() {
@@ -899,7 +911,7 @@ async fn process_http_response(
             { "domain": domain }
         );
 
-        telemetry.track_successful_transaction(&metadata, domain);
+        telemetry.track_successful_transaction(&metadata, body_size, domain);
     } else {
         telemetry.track_permanently_failed_transaction(&metadata, Some(status), domain);
 
@@ -1487,6 +1499,7 @@ mod tests {
         handle_in_flight_transaction_result::<FrozenChunkedBytesBuffer>(
             Ok(InFlightTransaction {
                 metadata,
+                body_size: 0,
                 retry_counters,
                 result: Err(RetryCircuitBreakerError::Service(
                     Box::new(std::io::Error::other("request failed")) as BoxError,
@@ -1510,6 +1523,7 @@ mod tests {
         handle_in_flight_transaction_result::<FrozenChunkedBytesBuffer>(
             Ok(InFlightTransaction {
                 metadata,
+                body_size: 0,
                 retry_counters,
                 result: Err(RetryCircuitBreakerError::Service(
                     Box::new(std::io::Error::other("request failed")) as BoxError,
@@ -1594,6 +1608,7 @@ mod tests {
         handle_in_flight_transaction_result::<FrozenChunkedBytesBuffer>(
             Ok(InFlightTransaction {
                 metadata,
+                body_size: 0,
                 retry_counters,
                 result,
             }),
@@ -1638,6 +1653,7 @@ mod tests {
         handle_in_flight_transaction_result::<FrozenChunkedBytesBuffer>(
             Ok(InFlightTransaction {
                 metadata,
+                body_size: 0,
                 retry_counters,
                 result: Err(RetryCircuitBreakerError::Service(
                     Box::new(std::io::Error::other("request failed")) as BoxError,
@@ -2200,7 +2216,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn forwarder_counts_only_dispatched_retries_after_server_errors() {
+    async fn forwarder_counts_successful_body_bytes_once_after_retries() {
         let recorder = TestRecorder::default();
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let (server_url, counter) = start_recording_http_server(vec![
@@ -2242,6 +2258,25 @@ mod tests {
         assert_eq!(
             recorder.counter(retry_metric_key("network_http_requests_requeued_total")),
             Some(0)
+        );
+
+        let component_metric_key = |name: &str| {
+            metrics::Key::from_parts(
+                name.to_string(),
+                vec![
+                    metrics::Label::new("component_id", "test_forwarder"),
+                    metrics::Label::new("component_type", "forwarder"),
+                ],
+            )
+        };
+        assert_eq!(
+            recorder.counter(component_metric_key("component_events_sent_total")),
+            Some(1)
+        );
+        // Regression: socket-write accounting counted every retry. Successful bytes must count the request body once.
+        assert_eq!(
+            recorder.counter(component_metric_key("component_bytes_sent_total")),
+            Some(12)
         );
     }
 

--- a/lib/saluki-components/src/common/datadog/telemetry.rs
+++ b/lib/saluki-components/src/common/datadog/telemetry.rs
@@ -139,11 +139,6 @@ impl ComponentTelemetry {
         }
     }
 
-    /// Returns a reference to the "bytes sent" counter.
-    pub fn bytes_sent(&self) -> &Counter {
-        &self.bytes_sent
-    }
-
     /// Creates telemetry handles for transactions entering the forwarder queue.
     pub(super) fn register_transaction_input_telemetry(
         &self, domain: &str, endpoint: &str,
@@ -165,9 +160,10 @@ impl ComponentTelemetry {
     }
 
     /// Tracks a successful transaction.
-    pub fn track_successful_transaction(&self, metadata: &Metadata, domain: &str) {
+    pub fn track_successful_transaction(&self, metadata: &Metadata, body_size: u64, domain: &str) {
         self.events_sent.increment(metadata.event_count as u64);
         self.events_sent_batch_size.record(metadata.event_count as f64);
+        self.bytes_sent.increment(body_size);
         self.track_data_points_sent(domain, metadata.data_point_count as u64);
     }
 
@@ -598,10 +594,11 @@ mod tests {
         let telemetry = component_telemetry();
 
         let metadata = Metadata::from_event_and_data_point_count(4, 9);
-        telemetry.track_successful_transaction(&metadata, "datadoghq.com");
+        telemetry.track_successful_transaction(&metadata, 42, "datadoghq.com");
 
         assert_eq!(recorder.counter("component_events_sent_total"), Some(4));
         assert_eq!(recorder.histogram("component_events_sent_batch_size"), Some(vec![4.0]));
+        assert_eq!(recorder.counter("component_bytes_sent_total"), Some(42));
         assert_eq!(
             recorder.gauge(("component_data_points_sent_total", &[("domain", "datadoghq.com")])),
             Some(9.0)

--- a/lib/saluki-io/src/net/client/http/client.rs
+++ b/lib/saluki-io/src/net/client/http/client.rs
@@ -17,7 +17,6 @@ use hyper_util::{
     client::legacy::{connect::capture_connection, Builder},
     rt::{TokioExecutor, TokioTimer},
 };
-use metrics::Counter;
 use pin_project::pin_project;
 use rustls::ClientConfig;
 use saluki_error::GenericError;
@@ -346,17 +345,6 @@ impl HttpClientBuilder {
         F: FnOnce(&mut Builder),
     {
         f(&mut self.hyper_builder);
-        self
-    }
-
-    /// Sets a counter that gets incremented with the number of bytes sent over the connection.
-    ///
-    /// This tracks bytes sent at the HTTP client level, which includes headers and body but doesn't include underlying
-    /// transport overhead, such as TLS handshaking, and so on.
-    ///
-    /// Defaults to unset.
-    pub fn with_bytes_sent_counter(mut self, counter: Counter) -> Self {
-        self.connector_builder = self.connector_builder.with_bytes_sent_counter(counter);
         self
     }
 

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -15,7 +15,6 @@ use hyper_util::{
     client::legacy::connect::{CaptureConnection, Connected, Connection, HttpConnector},
     rt::TokioIo,
 };
-use metrics::Counter;
 use pin_project_lite::pin_project;
 use rustls::{pki_types::ServerName, ClientConfig};
 use saluki_error::GenericError;
@@ -154,7 +153,6 @@ pin_project! {
     pub struct HttpsCapableConnection {
         #[pin]
         inner: MaybeHttpsStream<Transport>,
-        bytes_sent: Option<Counter>,
         error_telemetry: Option<HttpTransactionErrorTelemetry>,
         conn_age_limit: Option<Duration>,
     }
@@ -186,12 +184,7 @@ impl hyper::rt::Write for HttpsCapableConnection {
     fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
         let this = self.project();
         match this.inner.poll_write(cx, buf) {
-            Poll::Ready(Ok(n)) => {
-                if let Some(bytes_sent) = this.bytes_sent {
-                    bytes_sent.increment(n as u64);
-                }
-                Poll::Ready(Ok(n))
-            }
+            Poll::Ready(Ok(n)) => Poll::Ready(Ok(n)),
             Poll::Ready(Err(error)) => {
                 if let Some(error_telemetry) = this.error_telemetry.as_ref() {
                     error_telemetry.increment_wrote_request_error();
@@ -229,12 +222,7 @@ impl hyper::rt::Write for HttpsCapableConnection {
     ) -> Poll<io::Result<usize>> {
         let this = self.project();
         match this.inner.poll_write_vectored(cx, bufs) {
-            Poll::Ready(Ok(n)) => {
-                if let Some(bytes_sent) = this.bytes_sent {
-                    bytes_sent.increment(n as u64);
-                }
-                Poll::Ready(Ok(n))
-            }
+            Poll::Ready(Ok(n)) => Poll::Ready(Ok(n)),
             Poll::Ready(Err(error)) => {
                 if let Some(error_telemetry) = this.error_telemetry.as_ref() {
                     error_telemetry.increment_wrote_request_error();
@@ -370,7 +358,6 @@ pub struct HttpsCapableConnector {
     inner: InnerConnector,
     tls_config: Arc<ClientConfig>,
     tls_handshake_timeout: Duration,
-    bytes_sent: Option<Counter>,
     error_telemetry: Option<HttpTransactionErrorTelemetry>,
     conn_age_limit: Option<Duration>,
 }
@@ -408,7 +395,6 @@ impl Service<Uri> for HttpsCapableConnector {
         let transport_fut = self.inner.call(dst.clone());
         let tls_config = Arc::clone(&self.tls_config);
         let tls_handshake_timeout = self.tls_handshake_timeout;
-        let bytes_sent = self.bytes_sent.clone();
         let error_telemetry = self.error_telemetry.clone();
         let conn_age_limit = self.conn_age_limit;
 
@@ -441,7 +427,6 @@ impl Service<Uri> for HttpsCapableConnector {
 
             Ok(HttpsCapableConnection {
                 inner,
-                bytes_sent,
                 error_telemetry,
                 conn_age_limit,
             })
@@ -490,7 +475,6 @@ fn build_dns_resolver(error_telemetry: &Option<HttpTransactionErrorTelemetry>) -
 pub struct HttpsCapableConnectorBuilder {
     connect_timeout: Option<Duration>,
     tls_handshake_timeout: Option<Duration>,
-    bytes_sent: Option<Counter>,
     error_telemetry: Option<HttpTransactionErrorTelemetry>,
     conn_age_limit: Option<Duration>,
     http_protocol: HttpProtocol,
@@ -536,17 +520,6 @@ impl HttpsCapableConnectorBuilder {
         L: Into<Option<Duration>>,
     {
         self.conn_age_limit = limit.into();
-        self
-    }
-
-    /// Sets a counter that gets incremented with the number of bytes sent over the connection.
-    ///
-    /// This tracks bytes sent at the HTTP client level, which includes headers and body but doesn't include underlying
-    /// transport overhead, such as TLS handshaking, and so on.
-    ///
-    /// Defaults to unset.
-    pub fn with_bytes_sent_counter(mut self, counter: Counter) -> Self {
-        self.bytes_sent = Some(counter);
         self
     }
 
@@ -610,7 +583,6 @@ impl HttpsCapableConnectorBuilder {
             inner: inner_connector,
             tls_config: Arc::new(tls_config),
             tls_handshake_timeout,
-            bytes_sent: self.bytes_sent,
             error_telemetry: self.error_telemetry,
             conn_age_limit: self.conn_age_limit,
         })
@@ -737,7 +709,6 @@ mod tests {
             inner,
             tls_config,
             tls_handshake_timeout: Duration::from_secs(1),
-            bytes_sent: None,
             error_telemetry: None,
             conn_age_limit: None,
         };

--- a/releasenotes/notes/fix-forwarder-sent-byte-telemetry-ba9aac0b088022a8.yaml
+++ b/releasenotes/notes/fix-forwarder-sent-byte-telemetry-ba9aac0b088022a8.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fix ``component_bytes_sent_total`` to exclude failed forwarder attempts, so retries no longer inflate sent-byte telemetry.


### PR DESCRIPTION
## Human Summary

Alters the behavior of telemetry accounting of bytes sent to not include failed transaction bytes as "sent". The background is that during a retry event, we saw an increase in bytes per metric, which was actually an artifact of the inflated counting of bytes that were never sent.

I am not entirely certain this is better than having `saluki_io::net::HttpClient` only count bytes from successful sends in the `with_bytes_sent_counter` but the models seem to agree that is not the right layer for this accounting.

## AI Summary

Move `component_bytes_sent_total` accounting from socket writes to successful forwarder transaction handling. Failed and retried attempts no longer inflate the counter.

Add regression coverage for two server-error retries followed by a successful response.

## Change Type

- [x] Bug fix

## How did you test this PR?

- `make fmt`
- `make check-docs`
- `make check-clippy`
- `cargo nextest run -p saluki-components 'common::datadog::io::tests'`
- `cargo nextest run -p saluki-components 'common::datadog::telemetry::tests'`
- `make check-release-notes`
- `.venv/bin/reno lint`

## References

- Closes: #2581
