### PR TITLE
chore(docs): update reno statement in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,9 @@ of software projects, in addition to making them harder to maintain and debug ov
   not for production use and supporting it need not be a blocker during feature development.
 - We have customized our use of `cargo fmt` and `clippy`. The `Makefile` is authoritative.
 - Our Rust code wraps at 120 characters.
-- Customer-visible changes need a Reno release note under `releasenotes/notes/`, created with `reno new` and written in
-  reStructuredText; read `.claude/skills/create-release-note/SKILL.md`.
-- For configuration work, read `.claude/skills/config-system/SKILL.md`.
+- Some changes require a note in `releasenotes/notes/` using `reno new` in `reStructuredText`;
+  see `.agents/skills/create-release-note/SKILL.md`.
+- For configuration work, read `.agents/skills/config-system/SKILL.md`.
   - Keys in `lib/datadog-agent/config/schema/core/` are Datadog; absent keys are Saluki-only.
   - Edit `schema_overlay.yaml` for Datadog inventory; generated code files are output.
 - Name every proptest function with the literal `property_test_` prefix: the `test`/`test-property` Make targets run


### PR DESCRIPTION


## Summary

I saw a P1 finding from codex asking for a reno release note pointing at AGENTS.md. We do not need them for unreleased stuff, like when we're implementing OTLP and Traces for the first time.

- Note in AGENTS.md that unreleased subsystems are exempt from Reno release notes.
- Updated file paths for release note and configuration skills.

## Change Type
- [x] Non-functional (chore, refactoring, docs)


## How did you test this PR?
N/A

## References
N/A