### PR TITLE
feat(otlp): normalize span duration, start time, IDs, and type

### DIFF
--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -64,6 +64,7 @@ pub struct Metrics {
     logs_received: Counter,
     bytes_received: Counter,
     spans_received: Counter,
+    traces_dropped_span_id_zero: Counter,
     metrics_errors_decode: Counter,
     metrics_errors_channel: Counter,
     metrics_errors_dispatch: Counter,
@@ -81,6 +82,11 @@ impl Metrics {
 
     pub fn spans_received(&self) -> &Counter {
         &self.spans_received
+    }
+
+    /// Counter for traces dropped because they contained a span with a span ID of zero.
+    pub fn traces_dropped_span_id_zero(&self) -> &Counter {
+        &self.traces_dropped_span_id_zero
     }
 
     pub fn bytes_received(&self) -> &Counter {
@@ -111,6 +117,7 @@ impl Metrics {
             logs_received: Counter::noop(),
             bytes_received: Counter::noop(),
             spans_received: Counter::noop(),
+            traces_dropped_span_id_zero: Counter::noop(),
             metrics_errors_decode: Counter::noop(),
             metrics_errors_channel: Counter::noop(),
             metrics_errors_dispatch: Counter::noop(),
@@ -131,6 +138,10 @@ pub fn build_metrics(component_context: &ComponentContext) -> Metrics {
         bytes_received: builder.register_counter_with_tags("component_bytes_received_total", [("source", "otlp")]),
         spans_received: builder
             .register_counter_with_tags("component_events_received_total", [("message_type", "otlp_spans")]),
+        traces_dropped_span_id_zero: builder.register_counter_with_tags(
+            "component_events_dropped_total",
+            ["intentional:true", "drop_reason:span_id_zero"],
+        ),
         metrics_errors_decode: builder.register_counter_with_tags("component_errors_total", [("reason", "decode")]),
         metrics_errors_channel: builder.register_counter_with_tags("component_errors_total", [("reason", "channel")]),
         metrics_errors_dispatch: builder.register_counter_with_tags("component_errors_total", [("reason", "dispatch")]),

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -65,6 +65,7 @@ pub struct Metrics {
     bytes_received: Counter,
     spans_received: Counter,
     traces_dropped_span_id_zero: Counter,
+    spans_dropped_span_id_zero: Counter,
     metrics_errors_decode: Counter,
     metrics_errors_channel: Counter,
     metrics_errors_dispatch: Counter,
@@ -87,6 +88,13 @@ impl Metrics {
     /// Counter for traces dropped because they contained a span with a span ID of zero.
     pub fn traces_dropped_span_id_zero(&self) -> &Counter {
         &self.traces_dropped_span_id_zero
+    }
+
+    /// Counter for individual spans dropped as part of a trace dropped for containing a span ID of
+    /// zero. Mirrors the Go trace-agent's separate `TracesDropped.SpanIDZero` and `SpansDropped`
+    /// counters, since `component_events_received_total{message_type:otlp_spans}` counts spans.
+    pub fn spans_dropped_span_id_zero(&self) -> &Counter {
+        &self.spans_dropped_span_id_zero
     }
 
     pub fn bytes_received(&self) -> &Counter {
@@ -118,6 +126,7 @@ impl Metrics {
             bytes_received: Counter::noop(),
             spans_received: Counter::noop(),
             traces_dropped_span_id_zero: Counter::noop(),
+            spans_dropped_span_id_zero: Counter::noop(),
             metrics_errors_decode: Counter::noop(),
             metrics_errors_channel: Counter::noop(),
             metrics_errors_dispatch: Counter::noop(),
@@ -141,6 +150,14 @@ pub fn build_metrics(component_context: &ComponentContext) -> Metrics {
         traces_dropped_span_id_zero: builder.register_counter_with_tags(
             "component_events_dropped_total",
             ["intentional:true", "drop_reason:span_id_zero"],
+        ),
+        spans_dropped_span_id_zero: builder.register_counter_with_tags(
+            "component_events_dropped_total",
+            [
+                "intentional:true",
+                "drop_reason:span_id_zero",
+                "message_type:otlp_spans",
+            ],
         ),
         metrics_errors_decode: builder.register_counter_with_tags("component_errors_total", [("reason", "decode")]),
         metrics_errors_channel: builder.register_counter_with_tags("component_errors_total", [("reason", "channel")]),

--- a/lib/saluki-components/src/common/otlp/traces/normalize.rs
+++ b/lib/saluki-components/src/common/otlp/traces/normalize.rs
@@ -11,6 +11,19 @@ pub const MAX_SERVICE_LEN: usize = 100;
 pub const MAX_RESOURCE_LEN: usize = 5000;
 pub const MAX_TAG_LEN: usize = 200;
 
+/// Maximum length of `span.type`, mirroring `MaxTypeLen` (`pkg/trace/agent/normalizer.go`).
+pub const MAX_TYPE_LEN: usize = 100;
+
+// Above this, start+duration would overflow a signed 64-bit integer.
+const MAX_START_PLUS_DURATION: u64 = i64::MAX as u64;
+
+/// Below this, a start timestamp predates the reference's `Year2000NanosecTS` floor and is replaced.
+///
+/// `time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano()` (`pkg/trace/agent/normalizer.go`).
+/// Used as the fallback when the system clock is unavailable, so a rewritten start still clears the
+/// year-2000 floor it exists to enforce.
+pub const YEAR_2000_NANOSEC_TS: u64 = 946_684_800_000_000_000;
+
 // default service name we assign a span if it's missing and we have no reasonable fallback
 const DEFAULT_SERVICE_NAME: MetaString = MetaString::from_static("otlpresourcenoservicename");
 // default span name we assign a span if it's missing and we have no reasonable fallback
@@ -340,6 +353,48 @@ const fn is_valid_ascii_tag_char(c: char) -> bool {
     is_valid_ascii_start_char(c) || (c >= '0' && c <= '9') || c == '.' || c == '/' || c == '-'
 }
 
+/// Mirrors `validateAndFixDurationV1` (`pkg/trace/agent/normalizer.go`): a duration that would overflow
+/// a signed 64-bit integer when added to `start` becomes zero.
+///
+/// The reference computes `duration > math.MaxInt64 - uint64(start)` in wrapping `uint64` arithmetic.
+/// When `start > math.MaxInt64`, that subtraction wraps around to a very large number, so the
+/// comparison is false for any realistic duration and the duration survives untouched. This uses
+/// `wrapping_sub` rather than `saturating_sub` for exactly that reason: `saturating_sub` would clamp to
+/// zero for `start > i64::MAX`, making the comparison `duration > 0` and zeroing any non-zero
+/// duration—the opposite of the reference for that boundary. See the regression test at the boundary
+/// below.
+pub(super) fn validate_and_fix_duration(start: u64, duration: u64) -> u64 {
+    if duration > MAX_START_PLUS_DURATION.wrapping_sub(start) {
+        0
+    } else {
+        duration
+    }
+}
+
+/// Mirrors `validateAndFixStartTimeV1` (`pkg/trace/agent/normalizer.go`): a start timestamp before the
+/// year-2000 floor is replaced with the receive time minus `duration`, clamped to the receive time if
+/// that subtraction would go negative.
+pub(super) fn validate_and_fix_start_time(start: u64, duration: u64) -> u64 {
+    if start >= YEAR_2000_NANOSEC_TS {
+        return start;
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        // If the clock is unavailable or predates the epoch, fall back to the year-2000 floor itself
+        // rather than `0`, so the replacement still clears the floor it exists to enforce.
+        .unwrap_or(YEAR_2000_NANOSEC_TS);
+
+    let new_start = now.wrapping_sub(duration);
+    if new_start > now {
+        // Underflow: duration was larger than `now`.
+        now
+    } else {
+        new_start
+    }
+}
+
 /// Truncate string to `max_len` bytes, respecting UTF-8 boundaries.
 pub(super) fn truncate_utf8(s: &MetaString, max_len: usize) -> &str {
     truncate_utf8_str(s, max_len)
@@ -586,5 +641,75 @@ mod tests {
 
         let empty = MetaString::from("");
         assert_eq!(truncate_utf8(&empty, 5), "");
+    }
+
+    #[test]
+    fn validate_and_fix_duration_zeroes_overflowing_duration() {
+        // A wrapped duration (end before start) is astronomically large and overflows `start +
+        // duration`, so it becomes zero.
+        let start = YEAR_2000_NANOSEC_TS;
+        assert_eq!(validate_and_fix_duration(start, u64::MAX), 0);
+        assert_eq!(validate_and_fix_duration(start, u64::MAX - start), 0);
+
+        // A duration that fits in the signed headroom survives.
+        assert_eq!(validate_and_fix_duration(start, 100), 100);
+    }
+
+    #[test]
+    fn validate_and_fix_duration_survives_when_start_exceeds_i64_max() {
+        // Pins the reference's wrapping `uint64` arithmetic: `MaxInt64 - start` wraps around to a huge
+        // number when `start > MaxInt64`, so the overflow check is false and the duration is
+        // preserved. `saturating_sub` would instead clamp that subtraction to zero, making any
+        // non-zero duration look like an overflow and zeroing it—the opposite of the reference.
+        let start = u64::MAX;
+        assert_eq!(validate_and_fix_duration(start, 100), 100);
+        // A duration that's still too large for even the wrapped headroom is zeroed, matching the
+        // reference's own behavior for a duration that overflows twice over.
+        assert_eq!(validate_and_fix_duration(start, u64::MAX), 0);
+    }
+
+    #[test]
+    fn validate_and_fix_start_time_leaves_valid_start_untouched() {
+        let start = YEAR_2000_NANOSEC_TS + 1_000_000_000;
+        assert_eq!(validate_and_fix_start_time(start, 1_000_000), start);
+        assert_eq!(
+            validate_and_fix_start_time(YEAR_2000_NANOSEC_TS, 0),
+            YEAR_2000_NANOSEC_TS
+        );
+    }
+
+    #[test]
+    fn validate_and_fix_start_time_replaces_pre_year_2000_start() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64;
+        let duration = 1_000_000_000;
+
+        let start = validate_and_fix_start_time(1, duration);
+        assert!(
+            start >= YEAR_2000_NANOSEC_TS,
+            "replaced start must clear the year-2000 floor"
+        );
+        assert!(
+            start <= now && now - start < 5_000_000_000,
+            "start: {start}, now: {now}"
+        );
+    }
+
+    #[test]
+    fn validate_and_fix_start_time_clamps_when_duration_exceeds_now() {
+        // A duration larger than the current time cannot be subtracted; the reference clamps to the
+        // receive time rather than wrapping to a far-future timestamp.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64;
+        let start = validate_and_fix_start_time(1, u64::MAX);
+        assert!(
+            start >= YEAR_2000_NANOSEC_TS,
+            "clamped start must clear the year-2000 floor"
+        );
+        assert!(start.abs_diff(now) < 5_000_000_000, "start: {start}, now: {now}");
     }
 }

--- a/lib/saluki-components/src/common/otlp/traces/normalize.rs
+++ b/lib/saluki-components/src/common/otlp/traces/normalize.rs
@@ -386,13 +386,7 @@ pub(super) fn validate_and_fix_start_time(start: u64, duration: u64) -> u64 {
         // rather than `0`, so the replacement still clears the floor it exists to enforce.
         .unwrap_or(YEAR_2000_NANOSEC_TS);
 
-    let new_start = now.wrapping_sub(duration);
-    if new_start > now {
-        // Underflow: duration was larger than `now`.
-        now
-    } else {
-        new_start
-    }
+    now.checked_sub(duration).unwrap_or(now)
 }
 
 /// Truncate string to `max_len` bytes, respecting UTF-8 boundaries.

--- a/lib/saluki-components/src/common/otlp/traces/transform.rs
+++ b/lib/saluki-components/src/common/otlp/traces/transform.rs
@@ -31,7 +31,9 @@ use crate::common::otlp::traces::normalize::{
     is_normalized_tag_value, normalize_service_into, normalize_tag_value_append_unchecked,
     normalize_tag_value_into_unchecked,
 };
-use crate::common::otlp::traces::normalize::{truncate_utf8, MAX_RESOURCE_LEN};
+use crate::common::otlp::traces::normalize::{
+    truncate_utf8, validate_and_fix_duration, validate_and_fix_start_time, MAX_RESOURCE_LEN, MAX_TYPE_LEN,
+};
 use crate::common::otlp::traces::translator::convert_span_id;
 use crate::common::otlp::util::get_string_attribute;
 use crate::common::otlp::util::{
@@ -366,9 +368,22 @@ pub fn otel_to_dd_span_minimal(
     let mut dd_span = DdSpan::default();
 
     let span_id = convert_span_id(&otel_span.span_id);
-    let parent_id = convert_span_id(&otel_span.parent_span_id);
+    let mut parent_id = convert_span_id(&otel_span.parent_span_id);
+
+    // Mirrors `normalizeV1` (`pkg/trace/agent/normalizer.go`): a span that is its own parent is
+    // treated as a root span.
+    if parent_id == span_id {
+        parent_id = 0;
+    }
+
+    // Mirrors `validateAndFixDurationV1` and `validateAndFixStartTimeV1`, in that order: the duration
+    // is fixed first using the original start, then the start is fixed using the corrected duration.
+    // Without the duration fix, a tracer reporting an end time before its start time wraps the `u64`
+    // subtraction and the span carries a duration near `u64::MAX`.
     let start = otel_span.start_time_unix_nano;
-    let duration = otel_span.end_time_unix_nano - otel_span.start_time_unix_nano;
+    let duration = validate_and_fix_duration(start, otel_span.end_time_unix_nano.wrapping_sub(start));
+    let start = validate_and_fix_start_time(start, duration);
+
     let mut attrs: FastHashMap<MetaString, AttributeValue> = FastHashMap::default();
     attrs.reserve(span_attributes.len() + resource_attributes.len());
     let is_top_level = compute_top_level_by_span_kind
@@ -497,6 +512,12 @@ pub fn otel_to_dd_span_minimal(
                 string_builder,
             );
         }
+    }
+
+    // Mirrors `validateAndFixType` (`pkg/trace/agent/normalizer.go`): truncate `span.type` at
+    // `MaxTypeLen` bytes, cutting back to a valid UTF-8 boundary.
+    if span_type.len() > MAX_TYPE_LEN {
+        span_type = MetaString::from(truncate_utf8(&span_type, MAX_TYPE_LEN).to_owned());
     }
 
     dd_span = dd_span
@@ -1741,6 +1762,7 @@ mod tests {
     use otlp_protos::opentelemetry::proto::trace::v1::Span as OtlpSpan;
 
     use super::*;
+    use crate::common::otlp::traces::normalize::YEAR_2000_NANOSEC_TS;
 
     // Helper to create a KeyValue with a string value
     fn kv_str(key: &str, value: &str) -> KeyValue {
@@ -2959,5 +2981,140 @@ mod tests {
                 .map(|s| s.as_ref()),
             Some("500 Internal Server Error")
         );
+    }
+
+    /// An end time before the start time must yield a zero duration, not a wrapped `u64` near
+    /// `u64::MAX`. Mirrors `validateAndFixDurationV1` (`pkg/trace/agent/normalizer.go`).
+    /// https://github.com/DataDog/saluki/issues/2382
+    #[test]
+    fn otel_to_dd_span_zeroes_duration_when_end_time_precedes_start_time() {
+        let (interner, mut sb) = extraction_env();
+        let span = OtlpSpan {
+            name: "span-name".to_string(),
+            start_time_unix_nano: YEAR_2000_NANOSEC_TS + 1_000_000_000,
+            end_time_unix_nano: YEAR_2000_NANOSEC_TS,
+            ..Default::default()
+        };
+        let resource = Resource::default();
+        let dd_span = otel_span_to_dd_span(&span, &resource, None, false, true, &interner, &mut sb, None);
+
+        assert_eq!(dd_span.duration(), 0);
+        // The start is above the year-2000 floor, so it must survive untouched.
+        assert_eq!(dd_span.start(), YEAR_2000_NANOSEC_TS + 1_000_000_000);
+    }
+
+    /// A start time before the year-2000 floor is replaced with the receive time minus the duration.
+    /// Mirrors `validateAndFixStartTimeV1` (`pkg/trace/agent/normalizer.go`).
+    /// https://github.com/DataDog/saluki/issues/2382
+    #[test]
+    fn otel_to_dd_span_rewrites_pre_year_2000_start_time() {
+        let (interner, mut sb) = extraction_env();
+        let duration = 1_000_000_000;
+        let span = OtlpSpan {
+            name: "span-name".to_string(),
+            start_time_unix_nano: 1,
+            end_time_unix_nano: 1 + duration,
+            ..Default::default()
+        };
+        let resource = Resource::default();
+        let dd_span = otel_span_to_dd_span(&span, &resource, None, false, true, &interner, &mut sb, None);
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64;
+        let start = dd_span.start();
+        assert!(
+            start >= YEAR_2000_NANOSEC_TS,
+            "rewritten start must clear the year-2000 floor"
+        );
+        assert!(
+            start <= now && now - start < 5_000_000_000,
+            "start: {start}, now: {now}"
+        );
+        assert_eq!(dd_span.duration(), duration, "a valid duration must survive");
+    }
+
+    /// A parent ID equal to the span ID is cleared to zero, mirroring `normalizeV1`
+    /// (`pkg/trace/agent/normalizer.go`). https://github.com/DataDog/saluki/issues/2382
+    #[test]
+    fn otel_to_dd_span_clears_self_referencing_parent_id() {
+        let (interner, mut sb) = extraction_env();
+        let span = OtlpSpan {
+            name: "span-name".to_string(),
+            span_id: [1u8; 8].to_vec(),
+            parent_span_id: [1u8; 8].to_vec(),
+            ..Default::default()
+        };
+        let resource = Resource::default();
+        let dd_span = otel_span_to_dd_span(&span, &resource, None, false, true, &interner, &mut sb, None);
+
+        assert_eq!(dd_span.parent_id(), 0);
+        assert_eq!(dd_span.span_id(), u64::from_be_bytes([1u8; 8]));
+    }
+
+    /// A distinct parent ID survives the self-referencing check.
+    #[test]
+    fn otel_to_dd_span_keeps_distinct_parent_id() {
+        let (interner, mut sb) = extraction_env();
+        let span = OtlpSpan {
+            name: "span-name".to_string(),
+            span_id: [1u8; 8].to_vec(),
+            parent_span_id: [2u8; 8].to_vec(),
+            ..Default::default()
+        };
+        let resource = Resource::default();
+        let dd_span = otel_span_to_dd_span(&span, &resource, None, false, true, &interner, &mut sb, None);
+
+        assert_eq!(dd_span.parent_id(), u64::from_be_bytes([2u8; 8]));
+    }
+
+    /// A `span.type` longer than 100 bytes is truncated at a UTF-8 boundary, mirroring
+    /// `validateAndFixType` (`pkg/trace/agent/normalizer.go`).
+    /// https://github.com/DataDog/saluki/issues/2382
+    #[test]
+    fn otel_to_dd_span_truncates_long_span_type() {
+        let (interner, mut sb) = extraction_env();
+        // 150 ASCII bytes, well over the limit, and a multibyte character straddling the boundary:
+        // 98 bytes of 'a' plus two 4-byte crabs cut back to the last valid boundary at 98 bytes.
+        let long_ascii = "t".repeat(150);
+        let long_multibyte = "a".repeat(98) + "🦀🦀";
+        for (label, span_type, expected_len) in [("ascii", long_ascii, 100), ("multibyte", long_multibyte, 98)] {
+            let span = OtlpSpan {
+                name: "span-name".to_string(),
+                attributes: vec![kv_str(KEY_DATADOG_TYPE, span_type.as_str())],
+                ..Default::default()
+            };
+            let resource = Resource::default();
+            let dd_span = otel_span_to_dd_span(&span, &resource, None, false, true, &interner, &mut sb, None);
+
+            assert_eq!(
+                dd_span.span_type().len(),
+                expected_len,
+                "{label}: span type must be truncated at a UTF-8 boundary"
+            );
+            // The right length from the wrong bytes would still be wrong: the result must be a prefix
+            // of the input.
+            assert!(
+                span_type.as_bytes().starts_with(dd_span.span_type().as_bytes()),
+                "{label}: truncated span type must be a prefix of the input"
+            );
+        }
+    }
+
+    /// A `span.type` at or below the limit is left untouched.
+    #[test]
+    fn otel_to_dd_span_keeps_span_type_within_limit() {
+        let (interner, mut sb) = extraction_env();
+        let span_type = "x".repeat(MAX_TYPE_LEN);
+        let span = OtlpSpan {
+            name: "span-name".to_string(),
+            attributes: vec![kv_str(KEY_DATADOG_TYPE, span_type.as_str())],
+            ..Default::default()
+        };
+        let resource = Resource::default();
+        let dd_span = otel_span_to_dd_span(&span, &resource, None, false, true, &interner, &mut sb, None);
+
+        assert_eq!(dd_span.span_type(), span_type);
     }
 }

--- a/lib/saluki-components/src/common/otlp/traces/translator.rs
+++ b/lib/saluki-components/src/common/otlp/traces/translator.rs
@@ -161,6 +161,9 @@ struct TraceEntry {
     trace_id_hex: Option<MetaString>,
     /// High 8 bytes of the 128-bit trace ID (captured from the first span).
     trace_id_high: u64,
+    /// Set when any span in the trace has a span ID of zero. Mirrors `normalizeV1`
+    /// (`pkg/trace/agent/normalizer.go`), which drops such a span along with the chunk containing it.
+    dropped: bool,
 }
 
 pub struct OtlpTracesTranslator {
@@ -207,7 +210,14 @@ impl OtlpTracesTranslator {
                     priority: None,
                     trace_id_hex: None,
                     trace_id_high,
+                    dropped: false,
                 });
+
+                // Once a trace is headed for the drop bin, skip the remaining spans entirely rather
+                // than paying for their conversion only to discard the results at emit time.
+                if entry.dropped {
+                    continue;
+                }
 
                 if entry.trace_id_hex.is_none() {
                     entry.trace_id_hex = trace_id_hex_meta(&span.trace_id);
@@ -233,6 +243,16 @@ impl OtlpTracesTranslator {
                     entry.priority = Some(priority as i32);
                 }
 
+                // A span ID of zero is malformed: drop the span and, like the reference normalizer,
+                // the entire chunk containing it.
+                if dd_span.span_id() == 0 {
+                    if !entry.dropped {
+                        entry.dropped = true;
+                        metrics.traces_dropped_span_id_zero().increment(1);
+                    }
+                    continue;
+                }
+
                 entry.spans.push(dd_span);
             }
         }
@@ -254,6 +274,10 @@ impl Iterator for OtlpTraceEventsIter {
 
     fn next(&mut self) -> Option<Self::Item> {
         for (trace_id_low, entry) in self.entries.by_ref() {
+            if entry.dropped {
+                continue;
+            }
+
             if entry.spans.is_empty() {
                 continue;
             }
@@ -301,9 +325,11 @@ mod tests {
     use otlp_protos::opentelemetry::proto::common::v1::{AnyValue, KeyValue};
     use otlp_protos::opentelemetry::proto::resource::v1::Resource;
     use otlp_protos::opentelemetry::proto::trace::v1::{ResourceSpans, ScopeSpans, Span as OtlpSpan};
+    use saluki_core::components::ComponentContext;
+    use saluki_metrics::test::TestRecorder;
 
     use super::*;
-    use crate::common::otlp::Metrics;
+    use crate::common::otlp::{build_metrics, Metrics};
 
     fn string_kv(key: &str, value: &str) -> KeyValue {
         KeyValue {
@@ -449,5 +475,64 @@ mod tests {
         assert_eq!(payload.container_id.as_ref(), "abc123");
         assert_eq!(payload.language_name.as_ref(), "go");
         assert_eq!(payload.tracer_version.as_ref(), "1.0");
+    }
+
+    /// A span whose span ID converts to zero is dropped along with the trace containing it, mirroring
+    /// `normalizeV1` (`pkg/trace/agent/normalizer.go`). https://github.com/DataDog/saluki/issues/2382
+    #[test]
+    fn translate_spans_drops_trace_containing_zero_span_id() {
+        let recorder = TestRecorder::default();
+        let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+
+        let mut translator = OtlpTracesTranslator::new(domains::otlp::Traces {
+            string_interner_size: std::num::NonZeroUsize::new(64 * 1024).unwrap(),
+            ..Default::default()
+        });
+        let metrics = build_metrics(&ComponentContext::test_source("otlp_test"));
+
+        let trace = [0xDDu8; 16];
+        let rs = build_resource_spans(
+            vec![],
+            vec![
+                span(trace, [1u8; 8], vec![]),
+                span(trace, [0u8; 8], vec![]), // zero span ID drops the whole trace
+                span(trace, [2u8; 8], vec![]),
+            ],
+        );
+
+        let traces: Vec<Trace> = translator
+            .translate_spans(rs, &metrics)
+            .filter_map(Event::try_into_trace)
+            .collect();
+        assert!(
+            traces.is_empty(),
+            "the trace containing the zero-ID span must be dropped"
+        );
+
+        // Exactly one drop is counted, with the documented tag set, even though multiple spans were
+        // involved.
+        let tags: &[(&str, &str)] = &[
+            ("component_id", "otlp_test"),
+            ("component_type", "source"),
+            ("intentional", "true"),
+            ("drop_reason", "span_id_zero"),
+        ];
+        assert_eq!(recorder.counter(("component_events_dropped_total", tags)), Some(1));
+    }
+
+    /// A zero-ID span in one trace must not affect a well-formed trace in the same batch.
+    #[test]
+    fn translate_spans_keeps_well_formed_trace_alongside_dropped_trace() {
+        let bad_trace = [0xEEu8; 16];
+        let good_trace = [0xFFu8; 16];
+        let rs = build_resource_spans(
+            vec![],
+            vec![span(bad_trace, [0u8; 8], vec![]), span(good_trace, [1u8; 8], vec![])],
+        );
+
+        let traces = translate(rs);
+        assert_eq!(traces.len(), 1, "only the well-formed trace survives");
+        assert_eq!(traces[0].trace_id_low, u64::from_be_bytes([0xFF; 8]));
+        assert_eq!(traces[0].spans().len(), 1);
     }
 }

--- a/lib/saluki-components/src/common/otlp/traces/translator.rs
+++ b/lib/saluki-components/src/common/otlp/traces/translator.rs
@@ -216,6 +216,7 @@ impl OtlpTracesTranslator {
                 // Once a trace is headed for the drop bin, skip the remaining spans entirely rather
                 // than paying for their conversion only to discard the results at emit time.
                 if entry.dropped {
+                    metrics.spans_dropped_span_id_zero().increment(1);
                     continue;
                 }
 
@@ -249,6 +250,12 @@ impl OtlpTracesTranslator {
                     if !entry.dropped {
                         entry.dropped = true;
                         metrics.traces_dropped_span_id_zero().increment(1);
+                        // Matches the Go trace-agent's separate `SpansDropped += len(chunk)`: count
+                        // every span already accepted into this trace plus the zero-ID span itself.
+                        metrics
+                            .spans_dropped_span_id_zero()
+                            .increment(entry.spans.len() as u64 + 1);
+                        entry.spans.clear();
                     }
                     continue;
                 }
@@ -509,15 +516,28 @@ mod tests {
             "the trace containing the zero-ID span must be dropped"
         );
 
-        // Exactly one drop is counted, with the documented tag set, even though multiple spans were
-        // involved.
-        let tags: &[(&str, &str)] = &[
+        // Exactly one trace-level drop is counted, but all three spans in that trace are counted at
+        // the span level, mirroring the Go trace-agent's separate `TracesDropped`/`SpansDropped`
+        // counters.
+        let trace_tags: &[(&str, &str)] = &[
             ("component_id", "otlp_test"),
             ("component_type", "source"),
             ("intentional", "true"),
             ("drop_reason", "span_id_zero"),
         ];
-        assert_eq!(recorder.counter(("component_events_dropped_total", tags)), Some(1));
+        assert_eq!(
+            recorder.counter(("component_events_dropped_total", trace_tags)),
+            Some(1)
+        );
+
+        let span_tags: &[(&str, &str)] = &[
+            ("component_id", "otlp_test"),
+            ("component_type", "source"),
+            ("intentional", "true"),
+            ("drop_reason", "span_id_zero"),
+            ("message_type", "otlp_spans"),
+        ];
+        assert_eq!(recorder.counter(("component_events_dropped_total", span_tags)), Some(3));
     }
 
     /// A zero-ID span in one trace must not affect a well-formed trace in the same batch.

--- a/releasenotes/notes/otlp-traces-span-normalization-6e1d337695a39f60.yaml
+++ b/releasenotes/notes/otlp-traces-span-normalization-6e1d337695a39f60.yaml
@@ -1,0 +1,9 @@
+enhancements:
+  - |
+    OTLP spans are now normalized the same way the Datadog trace-agent normalizes spans received
+    from tracers. A span whose end time precedes its start time is given a zero duration instead of
+    a duration near ``18446744073709551615``. A span whose start time predates the year 2000 is
+    rewritten to the receive time minus its duration. A span that lists itself as its own parent is
+    treated as a root span, and a ``span.type`` longer than 100 bytes is truncated. Spans with a
+    span ID of zero are dropped along with the rest of their trace, and each such drop increments
+    the new ``component_events_dropped_total`` metric with the ``drop_reason:span_id_zero`` tag.

--- a/releasenotes/notes/otlp-traces-span-normalization-6e1d337695a39f60.yaml
+++ b/releasenotes/notes/otlp-traces-span-normalization-6e1d337695a39f60.yaml
@@ -1,9 +1,0 @@
-enhancements:
-  - |
-    OTLP spans are now normalized the same way the Datadog trace-agent normalizes spans received
-    from tracers. A span whose end time precedes its start time is given a zero duration instead of
-    a duration near ``18446744073709551615``. A span whose start time predates the year 2000 is
-    rewritten to the receive time minus its duration. A span that lists itself as its own parent is
-    treated as a root span, and a ``span.type`` longer than 100 bytes is truncated. Spans with a
-    span ID of zero are dropped along with the rest of their trace, and each such drop increments
-    the new ``component_events_dropped_total`` metric with the ``drop_reason:span_id_zero`` tag.


### PR DESCRIPTION
Closes #2382

## Summary

OTLP spans converted to Datadog spans carried several malformed values that the trace-agent's normalizer would have fixed (#2382):

- A tracer reporting an **end time before its start time** wrapped the `u64` subtraction and produced a duration near `u64::MAX`
- A **start time before the year 2000** passed through untouched
- A span could be **its own parent**
- `span.type` could exceed the **100 bytes** the intake accepts
- Spans whose **span ID converts to zero** were kept, where the reference normalizer drops the span and the whole chunk containing it

There will be a follow up PR later to make this generic for the DD v1 traces pipeline as well (but that pipeline doesn't exist yet :P )

## Changes

Span-level rules are fixed inside `otel_to_dd_span_minimal`, which both the full and minimal OTLP-to-DD conversion paths funnel through, mirroring `validateAndFixDurationV1`, `validateAndFixStartTimeV1`, and `validateAndFixType` (`pkg/trace/agent/normalizer.go`):

- The duration fix deliberately uses **wrapping arithmetic** to match the reference's behavior when `start` exceeds `i64::MAX` (`saturating_sub` would invert the behavior on that boundary), and runs **before** the start fix, which uses the corrected duration — mirroring the reference's rule ordering.
- The zero-span-ID chunk drop lives in `translate_spans`, matching `normalizeTraceChunkV1`'s chunk granularity: the span is dropped along with the entire trace containing it, and the drop increments a new `component_events_dropped_total{intentional:true,drop_reason:span_id_zero}` counter.

New shared helpers (`validate_and_fix_duration`, `validate_and_fix_start_time`, `MAX_TYPE_LEN`, `YEAR_2000_NANOSEC_TS`) live in `common/otlp/traces/normalize.rs` with unit tests, including a regression test pinning the wrapping-arithmetic boundary.

## Testing

- `cargo nextest run -p saluki-components`: 1004/1004 passed (13 new tests covering all five acceptance criteria, the wrapping boundary, UTF-8-boundary truncation, chunk-drop semantics, and the drop counter's tag set)
- `make check-all`: clean (fmt, clippy, style guide, advisories, licenses, unused deps, docs, feature matrix)
- `make check-release-notes`: clean
