### PR TITLE
chore(config): expose datadog schema defaults

### DIFF
--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -778,11 +778,12 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_forwarder_backoff_base(&mut self, value: f64) {
+        // TODO(#2580): the minimum is a literal here; the schema should carry it, ideally as a
+        // mechanical validation
         let value = if value <= 0.0 {
-            warn!("`forwarder_backoff_base` is not positive ({value}); using 2.");
-            // TODO(#2580): either use the schema default here, or upstream a validation to the
-            // schema itself
-            2.0
+            let default = DatadogConfiguration::schema_defaults().forwarder_backoff_base;
+            warn!("`forwarder_backoff_base` is not positive ({value}); using {default}.");
+            default
         } else {
             value
         };
@@ -794,22 +795,24 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_forwarder_backoff_factor(&mut self, value: f64) {
+        // TODO(#2580): the minimum is a literal here; the schema should carry it, ideally as a
+        // mechanical validation
         if value < 2.0 {
-            warn!("`forwarder_backoff_factor` is less than 2 ({value}); using 2.");
-            // TODO(#2580): either use the schema default here, or upstream a validation to the
-            // schema itself
-            self.config.shared.endpoints.forwarder.backoff_factor = 2.0;
+            let default = DatadogConfiguration::schema_defaults().forwarder_backoff_factor;
+            warn!("`forwarder_backoff_factor` is less than 2 ({value}); using {default}.");
+            self.config.shared.endpoints.forwarder.backoff_factor = default;
         } else {
             self.config.shared.endpoints.forwarder.backoff_factor = value;
         }
     }
 
     fn consume_forwarder_backoff_max(&mut self, value: f64) {
+        // TODO(#2580): the minimum is a literal here; the schema should carry it, ideally as a
+        // mechanical validation
         let value = if value <= 0.0 {
-            warn!("`forwarder_backoff_max` is not positive ({value}); using 64.");
-            // TODO(#2580): either use the schema default here, or upstream a validation to the
-            // schema itself
-            64.0
+            let default = DatadogConfiguration::schema_defaults().forwarder_backoff_max;
+            warn!("`forwarder_backoff_max` is not positive ({value}); using {default}.");
+            default
         } else {
             value
         };
@@ -2067,10 +2070,11 @@ mod tests {
         }));
 
         assert!(errors.is_none());
+        let defaults = DatadogConfiguration::schema_defaults();
         let forwarder = &config.shared.endpoints.forwarder;
-        assert_eq!(forwarder.backoff_base, 2.0);
-        assert_eq!(forwarder.backoff_factor, 2.0);
-        assert_eq!(forwarder.backoff_max, 64.0);
+        assert_eq!(forwarder.backoff_base, defaults.forwarder_backoff_base);
+        assert_eq!(forwarder.backoff_factor, defaults.forwarder_backoff_factor);
+        assert_eq!(forwarder.backoff_max, defaults.forwarder_backoff_max);
     }
 
     #[test]

--- a/lib/datadog-agent/config/src/lib.rs
+++ b/lib/datadog-agent/config/src/lib.rs
@@ -19,6 +19,9 @@ pub mod env_reader;
 /// Build-time generated code, produced from `core_schema.yaml` plus `schema_overlay.yaml`.
 mod generated;
 
+/// A shared, immutable view of the vendored schema's defaults.
+mod schema_defaults;
+
 /// The translation error type recorded by the translator and surfaced by the witness driver.
 mod translate_error;
 

--- a/lib/datadog-agent/config/src/schema_defaults.rs
+++ b/lib/datadog-agent/config/src/schema_defaults.rs
@@ -1,0 +1,38 @@
+use std::sync::LazyLock;
+
+use crate::DatadogConfiguration;
+
+static SCHEMA_DEFAULTS: LazyLock<DatadogConfiguration> = LazyLock::new(DatadogConfiguration::default);
+
+impl DatadogConfiguration {
+    /// Returns a shared configuration populated with the vendored schema's defaults.
+    ///
+    /// The configuration is initialized on first use.
+    pub fn schema_defaults() -> &'static Self {
+        &SCHEMA_DEFAULTS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DatadogConfiguration;
+
+    #[test]
+    fn the_defaults_match_an_empty_configuration() {
+        let deserialized: DatadogConfiguration =
+            serde_json::from_value(serde_json::json!({})).expect("an empty object deserializes");
+
+        assert_eq!(
+            serde_json::to_value(&deserialized).expect("the deserialized configuration serializes"),
+            serde_json::to_value(DatadogConfiguration::schema_defaults()).expect("the shared defaults serialize")
+        );
+    }
+
+    #[test]
+    fn the_defaults_are_built_once() {
+        assert!(std::ptr::eq(
+            DatadogConfiguration::schema_defaults(),
+            DatadogConfiguration::schema_defaults()
+        ));
+    }
+}


### PR DESCRIPTION
## Human Summary

A quick follow up to #2562 to use the schema-generated default mechanism instead of magic numbers for clamping fallback values in the translation layer. 

## AI Summary

Expose a shared `DatadogConfiguration` populated from generated schema defaults. Use those defaults when translation rejects invalid forwarder backoff values.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make fmt`
- `cargo check --workspace --tests`
- `make check-docs`
- `make check-clippy`
- `cargo nextest run -p datadog-agent-config -p agent-data-plane-config-system`

## References

- Closes: #2580
