### PR TITLE
feat(config): add APM v1.0 trace pipeline settings

### DIFF
--- a/.vale/styles/config/vocabularies/technical/accept.txt
+++ b/.vale/styles/config/vocabularies/technical/accept.txt
@@ -29,6 +29,7 @@ uds
 apis
 inlined
 json
+msgpack
 backoff
 batcher(s?)
 proxied
@@ -275,3 +276,6 @@ configtls
 keyspace
 Kueue
 plaintext
+normalizer
+suboperation(s?)
+runbook

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -693,45 +693,59 @@ ways that are not yet fully characterized.
 
 The following settings are specific to ADP and have no equivalent in the core agent.
 
-| Config Key                                                      | Description                                | Default        |
-| --------------------------------------------------------------- | ------------------------------------------ | -------------- |
-| `aggregate_context_limit`                                       | Max contexts per aggregation window        |                |
-| `aggregate_flush_interval`                                      | Aggregator flush period                    |                |
-| `aggregate_passthrough_idle_flush_timeout`                      | Passthrough buffer flush delay             |                |
-| `aggregate_window_duration_seconds`                             | Aggregation window size                    |                |
-| `apm_config.obfuscation.sql.dbms`                               | SQL obfuscation DBMS dialect               |                |
-| `apm_config.obfuscation.sql.dollar_quoted_func`                 | Preserve dollar-quoted SQL functions       |                |
-| `apm_config.obfuscation.sql.keep_sql_alias`                     | Preserve SQL aliases in obfuscation        |                |
-| `apm_config.obfuscation.sql.replace_digits`                     | Replace digits in SQL obfuscation          |                |
-| `apm_config.obfuscation.sql.table_names`                        | Collect table names during obfuscation     |                |
-| `data_plane.otlp.receiver_grpc_endpoint_temporary`              | ADP OTLP gRPC listen endpoint              | localhost:6317 |
-| `data_plane.otlp.receiver_http_endpoint_temporary`              | ADP OTLP HTTP listen endpoint              | localhost:6318 |
-| `dogstatsd_allow_context_heap_allocs`                           | Allow heap allocations for contexts        | true           |
-| `dogstatsd_autoscale_udp_listeners`                             | Bind multiple UDP sockets via SO_REUSEPORT | false          |
-| `dogstatsd_buffer_count_max`                                    | Maximum receive buffer count               | 32768          |
-| `dogstatsd_buffer_count`                                        | Baseline receive buffers                   | 128            |
-| `dogstatsd_cached_contexts_limit`                               | Max cached metric contexts                 | 500000         |
-| `dogstatsd_cached_tagsets_limit`                                | Max cached tagsets                         | 500000         |
-| `dogstatsd_mapper_string_interner_size`                         | Mapper string interner byte capacity       | 64KiB          |
-| `dogstatsd_minimum_sample_rate`                                 | Floor for metric sample rates              | 0.000000003845 |
-| `dogstatsd_permissive_decoding`                                 | Relaxes decoder strictness                 | true           |
-| `dogstatsd_string_interner_size_bytes`                          | Explicit byte budget for context interner  |                |
-| `dogstatsd_tcp_port`                                            | DogStatsD TCP listen port; 0 disables TCP  | 0              |
-| `enable_global_limiter`                                         | Global memory limiter toggle               | true           |
-| `flush_timeout_secs`                                            | Encoder flush timeout (secs)               |                |
-| `memory_limit`                                                  | Process memory limit                       |                |
-| `memory_mode`                                                   | Memory bounds validation mode              | disabled       |
-| `memory_slop_factor`                                            | Memory accounting slop fraction            | 0.25           |
-| `metric_tag_value_allowlist`                                    | Per-metric tag value allow-list            | []             |
-| `otlp_allow_context_heap_allocs`                                | Allow heap allocations for OTLP contexts   |                |
-| `otlp_cached_contexts_limit`                                    | Max cached OTLP metric contexts            |                |
-| `otlp_cached_tagsets_limit`                                     | Max cached OTLP tagsets                    |                |
-| `otlp_config.receiver.protocols.http.transport`                 | OTLP HTTP receiver transport               |                |
-| `otlp_config.traces.enable_otlp_compute_top_level_by_span_kind` | Enable OTLP top-level-by-span-kind         |                |
-| `otlp_config.traces.ignore_missing_datadog_fields`              | Ignore missing Datadog fields in OTLP      |                |
-| `otlp_config.traces.string_interner_size`                       | OTLP trace string interner capacity        |                |
-| `otlp_string_interner_size`                                     | OTLP context interner capacity             |                |
-| `serializer_max_metrics_per_payload`                            | Max metrics per payload                    |                |
+| Config Key                                                      | Description                                                                 | Default        |
+| --------------------------------------------------------------- | --------------------------------------------------------------------------- | -------------- |
+| `aggregate_context_limit`                                       | Max contexts per aggregation window                                         |                |
+| `aggregate_flush_interval`                                      | Aggregator flush period                                                     |                |
+| `aggregate_passthrough_idle_flush_timeout`                      | Passthrough buffer flush delay                                              |                |
+| `aggregate_window_duration_seconds`                             | Aggregation window size                                                     |                |
+| `apm_config.obfuscation.sql.dbms`                               | SQL obfuscation DBMS dialect                                                |                |
+| `apm_config.obfuscation.sql.dollar_quoted_func`                 | Preserve dollar-quoted SQL functions                                        |                |
+| `apm_config.obfuscation.sql.keep_sql_alias`                     | Preserve SQL aliases in obfuscation                                         |                |
+| `apm_config.obfuscation.sql.replace_digits`                     | Replace digits in SQL obfuscation                                           |                |
+| `apm_config.obfuscation.sql.table_names`                        | Collect table names during obfuscation                                      |                |
+| `data_plane.apm.dispatch_timeout`                               | How long the v1.0 trace receiver waits for the pipeline to accept a payload | 1 second       |
+| `data_plane.apm.enabled`                                        | Enable the ADP v1.0 APM trace pipeline                                      | false          |
+| `data_plane.apm.max_payload_size`                               | Maximum accepted v1.0 trace request body size                               | 25000000       |
+| `data_plane.apm.non_local_traffic`                              | Allow the v1.0 trace receiver to bind a non-loopback address                | false          |
+| `data_plane.apm.receiver_endpoint`                              | ADP v1.0 trace receiver TCP endpoint                                        | localhost:8127 |
+| `data_plane.apm.receiver_socket`                                | ADP v1.0 trace receiver Unix domain socket path                             |                |
+| `data_plane.otlp.receiver_grpc_endpoint_temporary`              | ADP OTLP gRPC listen endpoint                                               | localhost:6317 |
+| `data_plane.otlp.receiver_http_endpoint_temporary`              | ADP OTLP HTTP listen endpoint                                               | localhost:6318 |
+| `dogstatsd_allow_context_heap_allocs`                           | Allow heap allocations for contexts                                         | true           |
+| `dogstatsd_autoscale_udp_listeners`                             | Bind multiple UDP sockets via SO_REUSEPORT                                  | false          |
+| `dogstatsd_buffer_count_max`                                    | Maximum receive buffer count                                                | 32768          |
+| `dogstatsd_buffer_count`                                        | Baseline receive buffers                                                    | 128            |
+| `dogstatsd_cached_contexts_limit`                               | Max cached metric contexts                                                  | 500000         |
+| `dogstatsd_cached_tagsets_limit`                                | Max cached tagsets                                                          | 500000         |
+| `dogstatsd_mapper_string_interner_size`                         | Mapper string interner byte capacity                                        | 64KiB          |
+| `dogstatsd_minimum_sample_rate`                                 | Floor for metric sample rates                                               | 0.000000003845 |
+| `dogstatsd_permissive_decoding`                                 | Relaxes decoder strictness                                                  | true           |
+| `dogstatsd_string_interner_size_bytes`                          | Explicit byte budget for context interner                                   |                |
+| `dogstatsd_tcp_port`                                            | DogStatsD TCP listen port; 0 disables TCP                                   | 0              |
+| `enable_global_limiter`                                         | Global memory limiter toggle                                                | true           |
+| `flush_timeout_secs`                                            | Encoder flush timeout (secs)                                                |                |
+| `memory_limit`                                                  | Process memory limit                                                        |                |
+| `memory_mode`                                                   | Memory bounds validation mode                                               | disabled       |
+| `memory_slop_factor`                                            | Memory accounting slop fraction                                             | 0.25           |
+| `metric_tag_value_allowlist`                                    | Per-metric tag value allow-list                                             | []             |
+| `otlp_allow_context_heap_allocs`                                | Allow heap allocations for OTLP contexts                                    |                |
+| `otlp_cached_contexts_limit`                                    | Max cached OTLP metric contexts                                             |                |
+| `otlp_cached_tagsets_limit`                                     | Max cached OTLP tagsets                                                     |                |
+| `otlp_config.receiver.protocols.http.transport`                 | OTLP HTTP receiver transport                                                |                |
+| `otlp_config.traces.enable_otlp_compute_top_level_by_span_kind` | Enable OTLP top-level-by-span-kind                                          |                |
+| `otlp_config.traces.ignore_missing_datadog_fields`              | Ignore missing Datadog fields in OTLP                                       |                |
+| `otlp_config.traces.string_interner_size`                       | OTLP trace string interner capacity                                         |                |
+| `otlp_string_interner_size`                                     | OTLP context interner capacity                                              |                |
+| `serializer_max_metrics_per_payload`                            | Max metrics per payload                                                     |                |
+
+### `data_plane.apm.*`
+
+ADP can receive Datadog v1.0 (`idx`/ETP) tracer payloads directly, over `POST /v1.0/traces`, and forward them to the traces intake without going through the Core Agent trace-agent. The pipeline is off by default.
+
+These keys are deliberately separate from `apm_config.receiver_port`, `apm_config.receiver_socket`, `apm_config.max_payload_size`, and `apm_config.apm_non_local_traffic`. Those configure the trace-agent's receiver, which keeps running on port `8126` alongside ADP, so the two listeners need independent settings. Point each tracer at exactly one of the two: fanning the same traffic to both double-counts APM stats.
+
+Only `/v1.0/traces` is served. Tracers that need `/v0.4/traces`, `/v0.5/traces`, or the profiling and telemetry proxy routes must stay pointed at the trace-agent.
 
 ### `data_plane.otlp.receiver_grpc_endpoint_temporary`
 

--- a/docs/agent-data-plane/configuration/configuration.md
+++ b/docs/agent-data-plane/configuration/configuration.md
@@ -741,7 +741,7 @@ The following settings are specific to ADP and have no equivalent in the core ag
 
 ### `data_plane.apm.*`
 
-ADP can receive Datadog v1.0 (`idx`/ETP) tracer payloads directly, over `POST /v1.0/traces`, and forward them to the traces intake without going through the Core Agent trace-agent. The pipeline is off by default.
+ADP can receive Datadog v1.0 (`idx`/ETP) tracer payloads directly, over `POST /v1.0/traces`, and forward them to the traces intake without going through the trace-agent. The pipeline is off by default.
 
 These keys are deliberately separate from `apm_config.receiver_port`, `apm_config.receiver_socket`, `apm_config.max_payload_size`, and `apm_config.apm_non_local_traffic`. Those configure the trace-agent's receiver, which keeps running on port `8126` alongside ADP, so the two listeners need independent settings. Point each tracer at exactly one of the two: fanning the same traffic to both double-counts APM stats.
 

--- a/lib/agent-data-plane-config-system/src/saluki_only.rs
+++ b/lib/agent-data-plane-config-system/src/saluki_only.rs
@@ -245,6 +245,39 @@ pub struct DataPlane {
     pub checks: DataPlaneChecks,
     /// Temporary ADP-only OTLP receiver endpoint settings (`data_plane.otlp.*`).
     pub otlp: DataPlaneOtlp,
+    /// APM v1.0 trace pipeline gate and receiver settings (`data_plane.apm.*`).
+    pub apm: DataPlaneApm,
+}
+
+/// `data_plane.apm.*`: the Datadog v1.0 (`idx`/ETP) trace receiver.
+///
+/// Deliberately not spelled `apm_config.*`. The Datadog schema's `apm_config.receiver_port`,
+/// `apm_config.receiver_socket`, `apm_config.max_payload_size`, and
+/// `apm_config.apm_non_local_traffic` configure the Core Agent trace-agent's receiver, which keeps
+/// running beside ADP, so ADP's own listener needs its own keys rather than a second reading of
+/// those.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct DataPlaneApm {
+    /// Whether the APM v1.0 trace pipeline is built (`data_plane.apm.enabled`).
+    pub enabled: Option<bool>,
+    /// TCP receiver endpoint (`data_plane.apm.receiver_endpoint`).
+    pub receiver_endpoint: Option<String>,
+    /// Unix domain socket path (`data_plane.apm.receiver_socket`).
+    pub receiver_socket: Option<String>,
+    /// Maximum accepted request body size (`data_plane.apm.max_payload_size`), given as a bare
+    /// integer number of bytes or a byte-size string such as `25MB`. `ByteSize` accepts both forms,
+    /// so the plain integer the equivalent Agent key uses does not fail the load.
+    pub max_payload_size: Option<ByteSize>,
+    /// Whether the receiver may bind a non-loopback TCP address (`data_plane.apm.non_local_traffic`).
+    pub non_local_traffic: Option<bool>,
+    /// How long to wait for the pipeline to accept a payload (`data_plane.apm.dispatch_timeout`),
+    /// given as a duration string such as `1s`.
+    ///
+    /// Not interchangeable with the reference trace-agent's `apm_config.decoder_timeout`, whose bare
+    /// integer counts milliseconds: a bare integer here counts nanoseconds, following Go's
+    /// `time.Duration` and the rest of ADP's duration keys. Spell the unit to avoid the ambiguity.
+    pub dispatch_timeout: Option<DurationString>,
 }
 
 // TODO(#2177): Delete these ADP-only defaults when receiver endpoints return to the canonical
@@ -517,6 +550,9 @@ impl SalukiOnly {
         if let Some(v) = self.data_plane.checks.enabled {
             config.control.checks = v;
         }
+        if let Some(v) = self.data_plane.apm.enabled {
+            config.control.apm = v;
+        }
         config.control.memory_limit = self.memory_limit.map(|v| v.as_u64());
         config.control.memory_slop_factor = self.memory_slop_factor.unwrap_or(DEFAULT_MEMORY_SLOP_FACTOR);
         config.control.enable_global_limiter = self.enable_global_limiter.unwrap_or(DEFAULT_ENABLE_GLOBAL_LIMITER);
@@ -673,6 +709,27 @@ impl SalukiOnly {
             };
         }
 
+        // domains.apm
+        let apm = &mut config.domains.apm;
+        if let Some(v) = self.data_plane.apm.receiver_endpoint.clone() {
+            apm.receiver_endpoint = v;
+        }
+        if let Some(v) = self.data_plane.apm.receiver_socket.clone() {
+            apm.receiver_socket = v;
+        }
+        if let Some(v) = self.data_plane.apm.max_payload_size {
+            // Saturating rather than wrapping: on a 32-bit target a configured cap above `usize::MAX`
+            // is unreachable anyway, and clamping to the largest expressible cap is closer to the
+            // operator's intent than truncating it to a small one.
+            apm.max_payload_size = usize::try_from(v.as_u64()).unwrap_or(usize::MAX);
+        }
+        if let Some(v) = self.data_plane.apm.non_local_traffic {
+            apm.non_local_traffic = v;
+        }
+        if let Some(v) = self.data_plane.apm.dispatch_timeout {
+            apm.dispatch_timeout = v.into();
+        }
+
         // domains.checks
         if let Some(v) = &self.checks_ipc_endpoint {
             config.domains.checks.ipc_endpoint = v.clone();
@@ -748,6 +805,14 @@ mod tests {
                 "otlp": {
                     "receiver_grpc_endpoint_temporary": "0.0.0.0:19317",
                     "receiver_http_endpoint_temporary": "0.0.0.0:19318"
+                },
+                "apm": {
+                    "enabled": true,
+                    "receiver_endpoint": "0.0.0.0:18127",
+                    "receiver_socket": "/var/run/datadog/apm.socket",
+                    "max_payload_size": "12MB",
+                    "non_local_traffic": true,
+                    "dispatch_timeout": "3s"
                 }
             },
             // nested: apm_config
@@ -786,6 +851,7 @@ mod tests {
         // control
         assert!(config.control.standalone_mode);
         assert!(config.control.checks);
+        assert!(config.control.apm);
         assert_eq!(config.control.memory_limit, Some(ByteSize::mb(512).as_u64()));
         assert_eq!(config.control.memory_slop_factor, 0.3);
         assert!(!config.control.enable_global_limiter);
@@ -858,8 +924,38 @@ mod tests {
             vec!["set(name, \"x\")".to_string()]
         );
 
+        // domains.apm
+        let apm = &config.domains.apm;
+        assert_eq!(apm.receiver_endpoint, "0.0.0.0:18127");
+        assert_eq!(apm.receiver_socket, "/var/run/datadog/apm.socket");
+        assert_eq!(
+            apm.max_payload_size,
+            usize::try_from(ByteSize::mb(12).as_u64()).expect("12MB fits in usize")
+        );
+        assert!(apm.non_local_traffic);
+        assert_eq!(apm.dispatch_timeout, Duration::from_secs(3));
+
         // domains.checks
         assert_eq!(config.domains.checks.ipc_endpoint, "localhost:5006");
+    }
+
+    /// `data_plane.apm.max_payload_size` is a byte size, but the equivalent Agent key
+    /// (`apm_config.max_payload_size`) is a plain integer number of bytes, so an operator porting a
+    /// value across will write an integer. Both forms must land on the same byte count.
+    #[test]
+    fn the_apm_max_payload_size_accepts_an_integer_or_a_byte_size_string() {
+        for value in [json!(12_000_000), json!("12MB")] {
+            let map = json!({ "data_plane": { "apm": { "max_payload_size": value.clone() } } });
+
+            let saluki_only: SalukiOnly = serde_json::from_value(map).expect("saluki-only source deserializes");
+            let mut config = SalukiConfiguration::default();
+            saluki_only.seed(&mut config);
+
+            assert_eq!(
+                config.domains.apm.max_payload_size, 12_000_000,
+                "unexpected byte count for input: {value:?}"
+            );
+        }
     }
 
     /// `memory_limit` is a byte size the source may express as a bare integer (bytes) or a suffixed

--- a/lib/agent-data-plane-config-system/src/saluki_only.rs
+++ b/lib/agent-data-plane-config-system/src/saluki_only.rs
@@ -251,11 +251,8 @@ pub struct DataPlane {
 
 /// `data_plane.apm.*`: the Datadog v1.0 (`idx`/ETP) trace receiver.
 ///
-/// Deliberately not spelled `apm_config.*`. The Datadog schema's `apm_config.receiver_port`,
-/// `apm_config.receiver_socket`, `apm_config.max_payload_size`, and
-/// `apm_config.apm_non_local_traffic` configure the Core Agent trace-agent's receiver, which keeps
-/// running beside ADP, so ADP's own listener needs its own keys rather than a second reading of
-/// those.
+/// Deliberately not spelled `apm_config.*` — see
+/// [`agent_data_plane_config::domains::apm`] for why those keys can't be reused.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 pub struct DataPlaneApm {

--- a/lib/agent-data-plane-config-system/src/saluki_only.rs
+++ b/lib/agent-data-plane-config-system/src/saluki_only.rs
@@ -251,7 +251,7 @@ pub struct DataPlane {
 
 /// `data_plane.apm.*`: the Datadog v1.0 (`idx`/ETP) trace receiver.
 ///
-/// Deliberately not spelled `apm_config.*` — see
+/// Deliberately not spelled `apm_config.*`: see
 /// [`agent_data_plane_config::domains::apm`] for why those keys can't be reused.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]

--- a/lib/agent-data-plane-config/src/control.rs
+++ b/lib/agent-data-plane-config/src/control.rs
@@ -28,6 +28,13 @@ pub struct ControlConfiguration {
     /// Whether the OTLP pipeline is built.
     pub otlp: bool,
 
+    /// Whether the Datadog v1.0 (`idx`/ETP) APM trace pipeline is built. (not in Datadog Agent
+    /// config schema)
+    ///
+    /// Independent of the Core Agent trace-agent, which keeps serving its own receiver on `8126`.
+    /// Defaults to `false`; the two run side by side, and each tracer points at exactly one of them.
+    pub apm: bool,
+
     /// Whether standalone mode is active, running without a core Agent. (not in Datadog Agent
     /// config schema)
     pub standalone_mode: bool,

--- a/lib/agent-data-plane-config/src/control.rs
+++ b/lib/agent-data-plane-config/src/control.rs
@@ -31,7 +31,7 @@ pub struct ControlConfiguration {
     /// Whether the Datadog v1.0 (`idx`/ETP) APM trace pipeline is built. (not in Datadog Agent
     /// config schema)
     ///
-    /// Independent of the Core Agent trace-agent, which keeps serving its own receiver on `8126`.
+    /// Independent of the trace-agent, which keeps serving its own receiver on `8126`.
     /// Defaults to `false`; the two run side by side, and each tracer points at exactly one of them.
     pub apm: bool,
 

--- a/lib/agent-data-plane-config/src/defaults.rs
+++ b/lib/agent-data-plane-config/src/defaults.rs
@@ -108,3 +108,36 @@ pub const DEFAULT_STRING_INTERNER_SIZE_BYTES: NonZeroUsize = NonZeroUsize::new(5
 
 /// Maximum string interner capacity: 1 GiB. Arbitrary to stop @blt from blowing us up.
 pub const MAX_STRING_INTERNER_SIZE_BYTES: NonZeroUsize = NonZeroUsize::new(1024 * 1024 * 1024).unwrap();
+
+/// Default TCP endpoint the APM v1.0 trace receiver listens on.
+///
+/// Adjacent to the Core Agent trace-agent's `8126` so the side-by-side relationship is obvious, and
+/// deliberately not `8126` itself: the trace-agent keeps that port, and operators roll ADP back by
+/// pointing tracers at it again. Loopback-only, matching
+/// [`DEFAULT_APM_NON_LOCAL_TRAFFIC`]; a containerized deployment that needs to accept traffic from
+/// other containers must set both the endpoint and that gate.
+pub const DEFAULT_APM_RECEIVER_ENDPOINT: &str = "localhost:8127";
+
+/// Default maximum accepted v1.0 trace request body size, in bytes: 25 MB.
+///
+/// Matches `MaxRequestBytes` in the reference trace-agent, which `apm_config.max_payload_size` sets.
+/// This bounds the request body before any decoding, so raising it raises peak memory per in-flight
+/// request; high-volume tracers that batch aggressively may need a larger value, at that cost.
+pub const DEFAULT_APM_MAX_PAYLOAD_SIZE: usize = 25_000_000;
+
+/// Whether the APM v1.0 trace receiver accepts non-local traffic by default.
+///
+/// Defaults to `false`, so the receiver refuses to bind a non-loopback TCP address. Set this only
+/// when tracers run outside the host's network namespace and the port is not reachable from
+/// untrusted networks.
+pub const DEFAULT_APM_NON_LOCAL_TRAFFIC: bool = false;
+
+/// Default time the APM v1.0 trace receiver waits for the pipeline to accept a payload: 1 second.
+///
+/// Matches `DecoderTimeout` in the reference trace-agent (`apm_config.decoder_timeout`), which bounds
+/// the equivalent wait there. Once this elapses the receiver sheds the payload rather than holding
+/// the tracer's connection open: a saturated or wedged pipeline then costs the tracer one refused
+/// request instead of an indefinitely blocked one. Raise it to trade tracer-visible refusals for
+/// tolerance of longer downstream stalls; lower it to shed load sooner. A value of `0` refuses every
+/// payload the pipeline cannot accept instantly.
+pub const DEFAULT_APM_DISPATCH_TIMEOUT: Duration = Duration::from_secs(1);

--- a/lib/agent-data-plane-config/src/defaults.rs
+++ b/lib/agent-data-plane-config/src/defaults.rs
@@ -111,7 +111,7 @@ pub const MAX_STRING_INTERNER_SIZE_BYTES: NonZeroUsize = NonZeroUsize::new(1024 
 
 /// Default TCP endpoint the APM v1.0 trace receiver listens on.
 ///
-/// Adjacent to the Core Agent trace-agent's `8126` so the side-by-side relationship is obvious, and
+/// Adjacent to the trace-agent's `8126` so the side-by-side relationship is obvious, and
 /// deliberately not `8126` itself: the trace-agent keeps that port, and operators roll ADP back by
 /// pointing tracers at it again. Loopback-only, matching
 /// [`DEFAULT_APM_NON_LOCAL_TRAFFIC`]; a containerized deployment that needs to accept traffic from

--- a/lib/agent-data-plane-config/src/domains/apm.rs
+++ b/lib/agent-data-plane-config/src/domains/apm.rs
@@ -1,0 +1,227 @@
+//! APM domain: the Datadog v1.0 (`idx`/ETP) trace receiver.
+//!
+//! This domain covers ingress only: where the receiver listens, how large a request it accepts, and
+//! whether it may bind a non-loopback address. Trace *processing* (obfuscation, sampling, stats) is
+//! shared with the OTLP path and lives in the [`traces`](super::traces) domain.
+//!
+//! Every key here is Saluki-only. The Datadog schema's `apm_config.receiver_port`,
+//! `apm_config.receiver_socket`, `apm_config.max_payload_size`, and
+//! `apm_config.apm_non_local_traffic` all sit in the excluded block of the overlay: they configure
+//! the Core Agent trace-agent's receiver, which keeps running alongside ADP, so reusing them would
+//! create a duplicate source of truth for two listeners that must not collide.
+
+use std::net::{IpAddr, SocketAddr};
+use std::time::Duration;
+
+use serde::Serialize;
+
+use crate::defaults::{
+    DEFAULT_APM_DISPATCH_TIMEOUT, DEFAULT_APM_MAX_PAYLOAD_SIZE, DEFAULT_APM_NON_LOCAL_TRAFFIC,
+    DEFAULT_APM_RECEIVER_ENDPOINT,
+};
+use crate::Error;
+
+/// Host name that always denotes a loopback address, whichever family it resolves to.
+const LOCALHOST: &str = "localhost";
+
+/// Resolved APM configuration.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct Domain {
+    /// TCP address the v1.0 trace receiver listens on, as `host:port`.
+    ///
+    /// Defaults to `localhost:8127`. An empty value disables the TCP listener; when the Unix domain
+    /// socket is also disabled, enabling the APM pipeline is an error rather than a silent no-op.
+    /// Binding a non-loopback address additionally requires
+    /// [`non_local_traffic`](Self::non_local_traffic).
+    pub receiver_endpoint: String,
+
+    /// Unix domain socket path the v1.0 trace receiver listens on.
+    ///
+    /// Defaults to empty, which disables the Unix domain socket listener. Set this for deployments
+    /// where tracers share a filesystem with ADP but not a network namespace. Not subject to
+    /// [`non_local_traffic`](Self::non_local_traffic), which governs TCP only.
+    pub receiver_socket: String,
+
+    /// Maximum accepted v1.0 trace request body size, in bytes.
+    ///
+    /// Defaults to 25 MB, matching the reference trace-agent. Requests over this size are rejected
+    /// before any decoding, so this bounds peak memory per in-flight request. A value of `0` rejects
+    /// every request and is not a way to disable the limit.
+    pub max_payload_size: usize,
+
+    /// Whether the v1.0 trace receiver may bind a non-loopback TCP address.
+    ///
+    /// Defaults to `false`: a [`receiver_endpoint`](Self::receiver_endpoint) whose host is not a
+    /// loopback address is rejected at startup rather than quietly exposing the receiver. Set this to
+    /// `true` when tracers run outside ADP's network namespace, such as application containers
+    /// reaching an agent container, and the port is not reachable from untrusted networks.
+    pub non_local_traffic: bool,
+
+    /// How long the receiver waits for the pipeline to accept a payload before refusing it.
+    ///
+    /// Defaults to 1 second, matching the reference trace-agent's `apm_config.decoder_timeout`. The
+    /// receiver waits this long for memory-limiter capacity and for room in the queue feeding the
+    /// decoder; past it, the payload is dropped and the tracer gets a refusal, so a stalled pipeline
+    /// sheds load instead of holding tracer connections open indefinitely.
+    ///
+    /// Raise this to tolerate longer downstream stalls at the cost of slower refusals; lower it to
+    /// shed load sooner. A value of `0` refuses any payload the pipeline cannot accept immediately.
+    pub dispatch_timeout: Duration,
+}
+
+impl Default for Domain {
+    fn default() -> Self {
+        Self {
+            receiver_endpoint: DEFAULT_APM_RECEIVER_ENDPOINT.to_string(),
+            receiver_socket: String::new(),
+            max_payload_size: DEFAULT_APM_MAX_PAYLOAD_SIZE,
+            non_local_traffic: DEFAULT_APM_NON_LOCAL_TRAFFIC,
+            dispatch_timeout: DEFAULT_APM_DISPATCH_TIMEOUT,
+        }
+    }
+}
+
+impl Domain {
+    /// Validates [`receiver_endpoint`](Self::receiver_endpoint) against the non-local traffic gate.
+    ///
+    /// A disabled TCP listener, or an enabled [`non_local_traffic`](Self::non_local_traffic), permits
+    /// anything. Otherwise the endpoint's host must be a loopback address.
+    ///
+    /// Only the host is examined. A host that is neither `localhost` nor a literal IP address cannot
+    /// be shown to be loopback without resolving it, which startup validation does not do, so such a
+    /// host is rejected while the gate is off.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the TCP listener is enabled, `non_local_traffic` is `false`, and the
+    /// configured host is not a loopback address.
+    pub fn validate_receiver_endpoint(&self) -> Result<(), Error> {
+        if self.non_local_traffic || self.receiver_endpoint.is_empty() {
+            return Ok(());
+        }
+
+        if endpoint_host_is_loopback(&self.receiver_endpoint) {
+            return Ok(());
+        }
+
+        Err(Error::new_without_source(format!(
+            "`data_plane.apm.receiver_endpoint` is `{}`, which is not a loopback address, but \
+             `data_plane.apm.non_local_traffic` is not set. Either bind a loopback address such as \
+             `{DEFAULT_APM_RECEIVER_ENDPOINT}`, or set `data_plane.apm.non_local_traffic` to `true` to accept \
+             traffic from outside this host.",
+            self.receiver_endpoint
+        )))
+    }
+}
+
+/// Returns whether the host portion of a `host:port` endpoint denotes a loopback address.
+///
+/// A bare IP literal (`127.0.0.1:8127`, `[::1]:8127`) and the name `localhost` are loopback. An empty
+/// host (`:8127`), a wildcard (`0.0.0.0:8127`), and any other name are not.
+fn endpoint_host_is_loopback(endpoint: &str) -> bool {
+    // A full socket address parses directly, which also handles the bracketed IPv6 form.
+    if let Ok(address) = endpoint.parse::<SocketAddr>() {
+        return address.ip().is_loopback();
+    }
+
+    let Some(host) = endpoint_host(endpoint) else {
+        return false;
+    };
+
+    if host.eq_ignore_ascii_case(LOCALHOST) {
+        return true;
+    }
+
+    host.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
+}
+
+/// Extracts the host portion of a `host:port` endpoint, unwrapping a bracketed IPv6 literal.
+///
+/// Returns `None` when the endpoint carries no host at all.
+fn endpoint_host(endpoint: &str) -> Option<&str> {
+    let host = if let Some(rest) = endpoint.strip_prefix('[') {
+        // Bracketed IPv6 literal: the host runs to the closing bracket, whatever follows it.
+        rest.split(']').next()?
+    } else {
+        // Split from the right so an unbracketed IPv6 literal, which is full of colons, is not
+        // mistaken for a `host:port` pair and truncated.
+        match endpoint.rsplit_once(':') {
+            Some((host, _port)) => host,
+            None => endpoint,
+        }
+    };
+
+    (!host.is_empty()).then_some(host)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{endpoint_host_is_loopback, Domain};
+    use crate::defaults::DEFAULT_APM_RECEIVER_ENDPOINT;
+
+    #[test]
+    fn the_default_endpoint_is_loopback() {
+        // The gate defaults to off, so the default endpoint has to pass its own validation.
+        assert!(endpoint_host_is_loopback(DEFAULT_APM_RECEIVER_ENDPOINT));
+        assert!(Domain::default().validate_receiver_endpoint().is_ok());
+    }
+
+    #[test]
+    fn loopback_hosts_are_recognized() {
+        for endpoint in [
+            "localhost:8127",
+            "LocalHost:8127",
+            "127.0.0.1:8127",
+            "127.9.9.9:8127",
+            "[::1]:8127",
+            "::1:8127",
+        ] {
+            assert!(endpoint_host_is_loopback(endpoint), "expected loopback: {endpoint:?}");
+        }
+    }
+
+    #[test]
+    fn non_loopback_hosts_are_rejected() {
+        // An unresolvable-at-startup name is treated as non-loopback: validation does not resolve.
+        for endpoint in [
+            "0.0.0.0:8127",
+            "[::]:8127",
+            ":8127",
+            "10.0.0.5:8127",
+            "trace-agent.internal:8127",
+        ] {
+            assert!(
+                !endpoint_host_is_loopback(endpoint),
+                "expected non-loopback: {endpoint:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_non_loopback_endpoint_needs_the_non_local_traffic_gate() {
+        let mut domain = Domain {
+            receiver_endpoint: "0.0.0.0:8127".to_string(),
+            ..Default::default()
+        };
+
+        let error = domain
+            .validate_receiver_endpoint()
+            .expect_err("a wildcard bind must be rejected while the gate is off");
+        assert!(error.to_string().contains("non_local_traffic"));
+
+        domain.non_local_traffic = true;
+        assert!(domain.validate_receiver_endpoint().is_ok());
+    }
+
+    #[test]
+    fn a_disabled_tcp_listener_is_always_valid() {
+        // Nothing is bound, so the gate has nothing to protect.
+        let domain = Domain {
+            receiver_endpoint: String::new(),
+            receiver_socket: "/var/run/datadog/apm.socket".to_string(),
+            ..Default::default()
+        };
+
+        assert!(domain.validate_receiver_endpoint().is_ok());
+    }
+}

--- a/lib/agent-data-plane-config/src/domains/apm.rs
+++ b/lib/agent-data-plane-config/src/domains/apm.rs
@@ -7,8 +7,8 @@
 //! Every key here is Saluki-only. The Datadog schema's `apm_config.receiver_port`,
 //! `apm_config.receiver_socket`, `apm_config.max_payload_size`, and
 //! `apm_config.apm_non_local_traffic` all sit in the excluded block of the overlay: they configure
-//! the Core Agent trace-agent's receiver, which keeps running alongside ADP, so reusing them would
-//! create a duplicate source of truth for two listeners that must not collide.
+//! the trace-agent's receiver, which keeps running alongside ADP, so reusing them would create a
+//! duplicate source of truth for two listeners that must not collide.
 
 use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;

--- a/lib/agent-data-plane-config/src/domains/mod.rs
+++ b/lib/agent-data-plane-config/src/domains/mod.rs
@@ -4,6 +4,7 @@
 
 use serde::Serialize;
 
+pub mod apm;
 pub mod checks;
 pub mod dogstatsd;
 pub mod multi_region_failover;
@@ -13,6 +14,7 @@ pub mod traces;
 /// Per-domain resolved configuration.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct DomainConfiguration {
+    pub apm: apm::Domain,
     pub dogstatsd: dogstatsd::Domain,
     pub otlp: otlp::Domain,
     pub traces: traces::Domain,

--- a/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
+++ b/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
@@ -51,7 +51,7 @@ pub static SALUKI_KEYS: &[SalukiKey] = &[
 \
              ADP can receive Datadog v1.0 (`idx`/ETP) tracer payloads directly, over \
              `POST /v1.0/traces`, and forward them to the traces intake without going through the \
-             Core Agent trace-agent. The pipeline is off by default.
+             trace-agent. The pipeline is off by default.
 
 \
              These keys are deliberately separate from `apm_config.receiver_port`, \

--- a/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
+++ b/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
@@ -24,6 +24,118 @@ pub struct SalukiKey {
 pub static SALUKI_KEYS: &[SalukiKey] = &[
     // ── data_plane.rs ────────────────────────────────────────────────────────
     SalukiKey {
+        yaml_path: "data_plane.apm.dispatch_timeout",
+        description: "How long the v1.0 trace receiver waits for the pipeline to accept a payload",
+        // Spelled out rather than `1s`: this string is rendered into the generated configuration table, where the
+        // style checker requires a nonbreaking space between a number and a unit. `schema_default` below carries the
+        // machine-readable form. Compare `data_plane.stop_timeout`, whose `default` is the prose value "derived".
+        default: "1 second",
+        documentation: None,
+        value_type: "ValueType::String",
+        schema_default: Some("1s"),
+        env_vars: &[],
+        env_var_override: None,
+        additional_yaml_paths: &[],
+        used_by: &["TYPED_CONFIG_SYSTEM"],
+        test_json: None,
+        pipeline_affinity: "PipelineAffinity::Pipelines(&[Pipeline::Traces])",
+        filename: "data_plane.rs",
+    },
+    SalukiKey {
+        yaml_path: "data_plane.apm.enabled",
+        description: "Enable the ADP v1.0 APM trace pipeline",
+        default: "false",
+        documentation: Some(
+            "### `data_plane.apm.*`
+
+\
+             ADP can receive Datadog v1.0 (`idx`/ETP) tracer payloads directly, over \
+             `POST /v1.0/traces`, and forward them to the traces intake without going through the \
+             Core Agent trace-agent. The pipeline is off by default.
+
+\
+             These keys are deliberately separate from `apm_config.receiver_port`, \
+             `apm_config.receiver_socket`, `apm_config.max_payload_size`, and \
+             `apm_config.apm_non_local_traffic`. Those configure the trace-agent's receiver, which \
+             keeps running on port `8126` alongside ADP, so the two listeners need independent \
+             settings. Point each tracer at exactly one of the two: fanning the same traffic to both \
+             double-counts APM stats.
+
+\
+             Only `/v1.0/traces` is served. Tracers that need `/v0.4/traces`, `/v0.5/traces`, or the \
+             profiling and telemetry proxy routes must stay pointed at the trace-agent.",
+        ),
+        value_type: "ValueType::Bool",
+        schema_default: Some("false"),
+        env_vars: &[],
+        env_var_override: None,
+        additional_yaml_paths: &[],
+        used_by: &["TYPED_CONFIG_SYSTEM"],
+        test_json: None,
+        pipeline_affinity: "PipelineAffinity::Pipelines(&[Pipeline::Traces])",
+        filename: "data_plane.rs",
+    },
+    SalukiKey {
+        yaml_path: "data_plane.apm.max_payload_size",
+        description: "Maximum accepted v1.0 trace request body size",
+        default: "25000000",
+        documentation: None,
+        value_type: "ValueType::String",
+        schema_default: Some("25000000"),
+        env_vars: &[],
+        env_var_override: None,
+        additional_yaml_paths: &[],
+        used_by: &["TYPED_CONFIG_SYSTEM"],
+        test_json: None,
+        pipeline_affinity: "PipelineAffinity::Pipelines(&[Pipeline::Traces])",
+        filename: "data_plane.rs",
+    },
+    SalukiKey {
+        yaml_path: "data_plane.apm.non_local_traffic",
+        description: "Allow the v1.0 trace receiver to bind a non-loopback address",
+        default: "false",
+        documentation: None,
+        value_type: "ValueType::Bool",
+        schema_default: Some("false"),
+        env_vars: &[],
+        env_var_override: None,
+        additional_yaml_paths: &[],
+        used_by: &["TYPED_CONFIG_SYSTEM"],
+        test_json: None,
+        pipeline_affinity: "PipelineAffinity::Pipelines(&[Pipeline::Traces])",
+        filename: "data_plane.rs",
+    },
+    SalukiKey {
+        yaml_path: "data_plane.apm.receiver_endpoint",
+        description: "ADP v1.0 trace receiver TCP endpoint",
+        default: "localhost:8127",
+        documentation: None,
+        value_type: "ValueType::String",
+        schema_default: Some("localhost:8127"),
+        env_vars: &[],
+        env_var_override: None,
+        additional_yaml_paths: &[],
+        used_by: &["TYPED_CONFIG_SYSTEM"],
+        test_json: None,
+        pipeline_affinity: "PipelineAffinity::Pipelines(&[Pipeline::Traces])",
+        filename: "data_plane.rs",
+    },
+    SalukiKey {
+        yaml_path: "data_plane.apm.receiver_socket",
+        description: "ADP v1.0 trace receiver Unix domain socket path",
+        default: "",
+        documentation: None,
+        value_type: "ValueType::String",
+        schema_default: None,
+        env_vars: &[],
+        env_var_override: None,
+        additional_yaml_paths: &[],
+        used_by: &["TYPED_CONFIG_SYSTEM"],
+        test_json: None,
+        pipeline_affinity: "PipelineAffinity::Pipelines(&[Pipeline::Traces])",
+        filename: "data_plane.rs",
+    },
+    SalukiKey {
         yaml_path: "data_plane.otlp.receiver_grpc_endpoint_temporary",
         description: "ADP OTLP gRPC listen endpoint",
         default: "localhost:6317",

--- a/lib/datadog-agent/config-testing/src/config_registry/data_plane.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/data_plane.rs
@@ -4,6 +4,54 @@ use super::schema;
 #[allow(unused_imports)]
 use super::*;
 
+static DATA_PLANE_APM_DISPATCH_TIMEOUT_SCHEMA: SchemaEntry = SchemaEntry {
+    schema: Schema::Saluki,
+    yaml_path: "data_plane.apm.dispatch_timeout",
+    env_vars: &[],
+    value_type: ValueType::String,
+    default: Some("1s"),
+};
+
+static DATA_PLANE_APM_ENABLED_SCHEMA: SchemaEntry = SchemaEntry {
+    schema: Schema::Saluki,
+    yaml_path: "data_plane.apm.enabled",
+    env_vars: &[],
+    value_type: ValueType::Bool,
+    default: Some("false"),
+};
+
+static DATA_PLANE_APM_MAX_PAYLOAD_SIZE_SCHEMA: SchemaEntry = SchemaEntry {
+    schema: Schema::Saluki,
+    yaml_path: "data_plane.apm.max_payload_size",
+    env_vars: &[],
+    value_type: ValueType::String,
+    default: Some("25000000"),
+};
+
+static DATA_PLANE_APM_NON_LOCAL_TRAFFIC_SCHEMA: SchemaEntry = SchemaEntry {
+    schema: Schema::Saluki,
+    yaml_path: "data_plane.apm.non_local_traffic",
+    env_vars: &[],
+    value_type: ValueType::Bool,
+    default: Some("false"),
+};
+
+static DATA_PLANE_APM_RECEIVER_ENDPOINT_SCHEMA: SchemaEntry = SchemaEntry {
+    schema: Schema::Saluki,
+    yaml_path: "data_plane.apm.receiver_endpoint",
+    env_vars: &[],
+    value_type: ValueType::String,
+    default: Some("localhost:8127"),
+};
+
+static DATA_PLANE_APM_RECEIVER_SOCKET_SCHEMA: SchemaEntry = SchemaEntry {
+    schema: Schema::Saluki,
+    yaml_path: "data_plane.apm.receiver_socket",
+    env_vars: &[],
+    value_type: ValueType::String,
+    default: None,
+};
+
 static DATA_PLANE_OTLP_RECEIVER_GRPC_ENDPOINT_TEMPORARY_SCHEMA: SchemaEntry = SchemaEntry {
     schema: Schema::Saluki,
     yaml_path: "data_plane.otlp.receiver_grpc_endpoint_temporary",
@@ -75,6 +123,72 @@ crate::declare_annotations! {
         value_type_override: None,
         test_json: None,
         pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
+    /// `data_plane.apm.dispatch_timeout`
+    DATA_PLANE_APM_DISPATCH_TIMEOUT = SalukiAnnotation {
+        schema: &DATA_PLANE_APM_DISPATCH_TIMEOUT_SCHEMA,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Traces]),
+    };
+    /// `data_plane.apm.enabled`
+    DATA_PLANE_APM_ENABLED = SalukiAnnotation {
+        schema: &DATA_PLANE_APM_ENABLED_SCHEMA,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Traces]),
+    };
+    /// `data_plane.apm.max_payload_size`
+    DATA_PLANE_APM_MAX_PAYLOAD_SIZE = SalukiAnnotation {
+        schema: &DATA_PLANE_APM_MAX_PAYLOAD_SIZE_SCHEMA,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Traces]),
+    };
+    /// `data_plane.apm.non_local_traffic`
+    DATA_PLANE_APM_NON_LOCAL_TRAFFIC = SalukiAnnotation {
+        schema: &DATA_PLANE_APM_NON_LOCAL_TRAFFIC_SCHEMA,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Traces]),
+    };
+    /// `data_plane.apm.receiver_endpoint`
+    DATA_PLANE_APM_RECEIVER_ENDPOINT = SalukiAnnotation {
+        schema: &DATA_PLANE_APM_RECEIVER_ENDPOINT_SCHEMA,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Traces]),
+    };
+    /// `data_plane.apm.receiver_socket`
+    DATA_PLANE_APM_RECEIVER_SOCKET = SalukiAnnotation {
+        schema: &DATA_PLANE_APM_RECEIVER_SOCKET_SCHEMA,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::TYPED_CONFIG_SYSTEM],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Traces]),
     };
     /// `data_plane.log_file`-ADP log file path
     DATA_PLANE_LOG_FILE = SalukiAnnotation {


### PR DESCRIPTION
## Summary
- Adds `data_plane.apm.*` config for the Datadog v1.0 (`idx`/ETP) APM trace pipeline: the `enabled` gate, receiver endpoint/socket, max payload size, non-local-traffic gate, and dispatch timeout.
- Keeps these keys deliberately separate from `apm_config.*`, which continues to configure the trace-agent's own receiver on port `8126`.
- Fixes trace-agent terminology (it's a separate process from the Core Agent) and consolidates duplicated doc-comment rationale down to one source of truth in `domains::apm`.

Phase 1 of a multi-PR effort to build the v1 APM trace pipeline in ADP. These config fields are not wired into a running pipeline yet.

## Test plan
- [x] `cargo check -p agent-data-plane-config -p agent-data-plane-config-system -p datadog-agent-config-overlay-model`
- [x] `cargo doc -p agent-data-plane-config-system --no-deps` (verifies intra-doc link resolves)
- [x] `make fmt`
- [ ] Reviewer pass
